### PR TITLE
docs: sync spec and plan Dockerfile snippets with actual implementation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,7 +19,7 @@ docs/
 old_project_reference/
 .claude/
 .github/
-*.md
+**/*.md
 
 # Misc
 **/node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -19,7 +19,7 @@ docs/
 old_project_reference/
 .claude/
 .github/
-**/*.md
+*.md
 
 # Misc
 **/node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# VCS / IDE
+.git/
+.vs/
+.vscode/
+.idea/
+
+# Build output
+**/bin/
+**/obj/
+**/TestResults/
+
+# User-local files
+**/*.user
+**/*.suo
+
+# Tests, docs, and reference material — not needed in the image
+tests/
+docs/
+old_project_reference/
+.claude/
+.github/
+*.md
+
+# Misc
+**/node_modules/
+**/.DS_Store

--- a/docs/superpowers/plans/2026-04-08-009-docker-development-setup.md
+++ b/docs/superpowers/plans/2026-04-08-009-docker-development-setup.md
@@ -35,11 +35,11 @@ No source code or tests are touched. Verification is manual (docker compose) —
 **Why this exists:** `docker-compose.yml` already references this path (`src/Backend/AHKFlowApp.API/Dockerfile`). Without the file, `docker compose up --build` fails immediately. The Dockerfile must:
 - Use `mcr.microsoft.com/dotnet/sdk:10.0` and `mcr.microsoft.com/dotnet/aspnet:10.0` (matches `<TargetFramework>net10.0</TargetFramework>` in `Directory.Build.props`).
 - Preserve the `base` stage (VS `commandName: Docker` profile mounts source over `/app` in fast-mode).
-- Create `/app/AppData/Logs` and `chown` it to `$APP_UID` BEFORE the `USER` switch (Serilog file sink in `appsettings.json` writes there).
-- Pass `/p:MinVerSkip=true` on build and publish (`.git/` is excluded from context, MinVer would warn, `TreatWarningsAsErrors=true` would fail the build).
+- Create `/app/AppData/Logs` and `chown` it to `app` BEFORE the `USER` switch (Serilog file sink in `appsettings.json` writes there).
+- Pass `/p:MinVerSkip=true` on publish only (`.git/` is excluded from context, MinVer would warn, `TreatWarningsAsErrors=true` would fail the build). No separate `dotnet build` step — `dotnet publish` compiles and produces output in a single pass.
 - Copy CPM files (`Directory.Build.props`, `Directory.Packages.props`) before restore.
 - Copy only the four backend csproj files for restore-layer caching.
-- Run as `$APP_UID` and expose port 8080 (matches `ASPNETCORE_HTTP_PORTS=8080` in compose).
+- Run as `USER app` and expose port 8080 (matches `ASPNETCORE_HTTP_PORTS=8080` in compose).
 
 - [ ] **Step 1: Create the Dockerfile**
 
@@ -54,10 +54,10 @@ WORKDIR /app
 EXPOSE 8080
 # Serilog file sink writes to /app/AppData/Logs at startup;
 # create the directory as root and hand it to the non-root user before dropping privileges.
-RUN mkdir -p /app/AppData/Logs && chown -R $APP_UID:$APP_UID /app/AppData
-USER $APP_UID
+RUN mkdir -p /app/AppData/Logs && chown -R app:app /app/AppData
+USER app
 
-# build — restore + compile
+# build — restore + copy sources
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
@@ -73,19 +73,14 @@ COPY ["src/Backend/AHKFlowApp.Infrastructure/AHKFlowApp.Infrastructure.csproj", 
 RUN dotnet restore "src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj"
 
 COPY . .
-WORKDIR "/src/src/Backend/AHKFlowApp.API"
-# MinVerSkip=true: .git/ is excluded from build context (.dockerignore), so MinVer cannot
-# read tags. Skipping it prevents MINVER0001 — which would fail the build under
-# TreatWarningsAsErrors=true. Local dev containers don't need real versions; CI/CD owns that.
-RUN dotnet build "AHKFlowApp.API.csproj" \
-    -c $BUILD_CONFIGURATION \
-    -o /app/build \
-    --no-restore \
-    /p:MinVerSkip=true
 
 # publish — produce final binaries
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
+WORKDIR "/src/src/Backend/AHKFlowApp.API"
+# MinVerSkip=true: .git/ is excluded from build context (.dockerignore), so MinVer cannot
+# read tags. Skipping it prevents MINVER0001 — which would fail the build under
+# TreatWarningsAsErrors=true. Local dev containers don't need real versions; CI/CD owns that.
 RUN dotnet publish "AHKFlowApp.API.csproj" \
     -c $BUILD_CONFIGURATION \
     -o /app/publish \
@@ -112,7 +107,7 @@ Run (Grep):
 ```
 grep -n "MinVerSkip" src/Backend/AHKFlowApp.API/Dockerfile
 ```
-Expected: 2 matches (one in build stage, one in publish stage).
+Expected: 1 match (in publish stage only).
 
 - [ ] **Step 3: Commit**
 
@@ -229,7 +224,7 @@ docker compose -f C:/Dev/segocom-github/AHKFlowApp/docker-compose.yml build ahkf
 Expected: `Successfully built` (or BuildKit equivalent), no errors. First build will take a few minutes (pulling base images, restoring NuGet packages).
 
 If this fails:
-- `MINVER0001` warning treated as error → confirm both `dotnet build` and `dotnet publish` lines have `/p:MinVerSkip=true`.
+- `MINVER0001` warning treated as error → confirm the `dotnet publish` line has `/p:MinVerSkip=true`.
 - `COPY` failed for a csproj → confirm the four `COPY` lines match the actual project paths.
 - `permission denied` writing to `/app/AppData/Logs` → confirm `mkdir`/`chown` runs in the `base` stage BEFORE `USER $APP_UID`.
 
@@ -303,7 +298,7 @@ gh pr create \
 ## Design notes
 - 4-stage layout (`base`/`build`/`publish`/`final`) preserves the existing `Docker (API only)` VS launch profile (fast-mode source mount on the `base` stage).
 - `/app/AppData/Logs` is created and chowned in the `base` stage so the Serilog file sink works under `$APP_UID`.
-- `/p:MinVerSkip=true` on build+publish: `.git/` is excluded from the context to keep the image lean, so MinVer can't read tags. Without the skip, `MINVER0001` fails the build under `TreatWarningsAsErrors=true`. CI/CD (item 010) will run publish outside Docker for real versioning.
+- `/p:MinVerSkip=true` on publish: `.git/` is excluded from the context to keep the image lean, so MinVer can't read tags. Without the skip, `MINVER0001` fails the build under `TreatWarningsAsErrors=true`. A single `dotnet publish` pass compiles and outputs the binaries. CI/CD (item 010) will run publish outside Docker for real versioning.
 
 ## Out of scope
 - Production container hardening (chiseled images, multi-arch) — not in AC.

--- a/docs/superpowers/plans/2026-04-08-009-docker-development-setup.md
+++ b/docs/superpowers/plans/2026-04-08-009-docker-development-setup.md
@@ -1,0 +1,340 @@
+# 009 — Docker Development Setup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `docker compose up --build` work end-to-end by adding the missing API Dockerfile and a repo-root `.dockerignore`.
+
+**Architecture:** A standard 4-stage VS-compatible Dockerfile (`base` → `build` → `publish` → `final`) targeting `mcr.microsoft.com/dotnet/{sdk,aspnet}:10.0`. The `base` stage is preserved so the existing `Docker (API only)` Visual Studio launch profile keeps working in fast-mode debug. The compose build context is the repo root, so the `.dockerignore` lives there.
+
+**Tech Stack:** .NET 10, ASP.NET Core, Docker, Docker Compose, SQL Server 2022, MinVer, Serilog, Central Package Management.
+
+**Spec:** `docs/superpowers/specs/2026-04-08-009-docker-development-setup-design.md`
+
+**Branch:** `feature/009-docker-development-setup` (already created from `origin/main`)
+
+---
+
+## File Structure
+
+| File | Purpose | Action |
+|---|---|---|
+| `src/Backend/AHKFlowApp.API/Dockerfile` | Multi-stage build for the API container | Create |
+| `.dockerignore` (repo root) | Excludes irrelevant files from compose build context | Create |
+| `docker-compose.yml` | Already references the Dockerfile correctly | No change |
+| `docs/development/docker-setup.md` | Already comprehensive | No change unless verification surfaces a discrepancy |
+
+No source code or tests are touched. Verification is manual (docker compose) — there is nothing to TDD. The standard "write failing test first" loop does not apply here; verification gates the work instead.
+
+---
+
+## Task 1: Create the API Dockerfile
+
+**Files:**
+- Create: `src/Backend/AHKFlowApp.API/Dockerfile`
+
+**Why this exists:** `docker-compose.yml` already references this path (`src/Backend/AHKFlowApp.API/Dockerfile`). Without the file, `docker compose up --build` fails immediately. The Dockerfile must:
+- Use `mcr.microsoft.com/dotnet/sdk:10.0` and `mcr.microsoft.com/dotnet/aspnet:10.0` (matches `<TargetFramework>net10.0</TargetFramework>` in `Directory.Build.props`).
+- Preserve the `base` stage (VS `commandName: Docker` profile mounts source over `/app` in fast-mode).
+- Create `/app/AppData/Logs` and `chown` it to `$APP_UID` BEFORE the `USER` switch (Serilog file sink in `appsettings.json` writes there).
+- Pass `/p:MinVerSkip=true` on build and publish (`.git/` is excluded from context, MinVer would warn, `TreatWarningsAsErrors=true` would fail the build).
+- Copy CPM files (`Directory.Build.props`, `Directory.Packages.props`) before restore.
+- Copy only the four backend csproj files for restore-layer caching.
+- Run as `$APP_UID` and expose port 8080 (matches `ASPNETCORE_HTTP_PORTS=8080` in compose).
+
+- [ ] **Step 1: Create the Dockerfile**
+
+Create `src/Backend/AHKFlowApp.API/Dockerfile` with exactly this content:
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+
+# base — runtime image used by VS fast-mode debug (commandName: Docker)
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+WORKDIR /app
+EXPOSE 8080
+# Serilog file sink writes to /app/AppData/Logs at startup;
+# create the directory as root and hand it to the non-root user before dropping privileges.
+RUN mkdir -p /app/AppData/Logs && chown -R $APP_UID:$APP_UID /app/AppData
+USER $APP_UID
+
+# build — restore + compile
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+
+# Copy solution-level files first for layer caching
+COPY ["Directory.Build.props", "Directory.Packages.props", "./"]
+
+# Copy csproj files only — restore layer caches until a csproj changes
+COPY ["src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj", "src/Backend/AHKFlowApp.API/"]
+COPY ["src/Backend/AHKFlowApp.Application/AHKFlowApp.Application.csproj", "src/Backend/AHKFlowApp.Application/"]
+COPY ["src/Backend/AHKFlowApp.Domain/AHKFlowApp.Domain.csproj", "src/Backend/AHKFlowApp.Domain/"]
+COPY ["src/Backend/AHKFlowApp.Infrastructure/AHKFlowApp.Infrastructure.csproj", "src/Backend/AHKFlowApp.Infrastructure/"]
+RUN dotnet restore "src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj"
+
+COPY . .
+WORKDIR "/src/src/Backend/AHKFlowApp.API"
+# MinVerSkip=true: .git/ is excluded from build context (.dockerignore), so MinVer cannot
+# read tags. Skipping it prevents MINVER0001 — which would fail the build under
+# TreatWarningsAsErrors=true. Local dev containers don't need real versions; CI/CD owns that.
+RUN dotnet build "AHKFlowApp.API.csproj" \
+    -c $BUILD_CONFIGURATION \
+    -o /app/build \
+    --no-restore \
+    /p:MinVerSkip=true
+
+# publish — produce final binaries
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "AHKFlowApp.API.csproj" \
+    -c $BUILD_CONFIGURATION \
+    -o /app/publish \
+    --no-restore \
+    /p:UseAppHost=false \
+    /p:MinVerSkip=true
+
+# final — runtime image used by docker compose / production
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "AHKFlowApp.API.dll"]
+```
+
+- [ ] **Step 2: Sanity-check the file landed correctly**
+
+Run:
+```bash
+ls C:/Dev/segocom-github/AHKFlowApp/src/Backend/AHKFlowApp.API/Dockerfile
+```
+Expected: file path printed (no error).
+
+Run (Grep):
+```
+grep -n "MinVerSkip" src/Backend/AHKFlowApp.API/Dockerfile
+```
+Expected: 2 matches (one in build stage, one in publish stage).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C C:/Dev/segocom-github/AHKFlowApp add src/Backend/AHKFlowApp.API/Dockerfile
+git -C C:/Dev/segocom-github/AHKFlowApp commit -m "feat: add API Dockerfile (multi-stage net10)"
+```
+
+Expected output: `1 file changed, ~50 insertions(+)`.
+
+---
+
+## Task 2: Create the repo-root `.dockerignore`
+
+**Files:**
+- Create: `.dockerignore` (at `C:/Dev/segocom-github/AHKFlowApp/.dockerignore`)
+
+**Why this exists:** The compose build context is `.` (repo root). Without a `.dockerignore`, the entire repo (including `bin/`, `obj/`, `.git/`, `tests/`, `docs/`, `old_project_reference/`, `.claude/`) is sent to the Docker daemon — slow, and pollutes the layer cache. `.git/` exclusion is intentional and the spec compensates with `/p:MinVerSkip=true`.
+
+- [ ] **Step 1: Create the .dockerignore**
+
+Create `.dockerignore` at the repo root with exactly this content:
+
+```
+# VCS / IDE
+.git/
+.vs/
+.vscode/
+.idea/
+
+# Build output
+**/bin/
+**/obj/
+**/TestResults/
+
+# User-local files
+**/*.user
+**/*.suo
+
+# Tests, docs, and reference material — not needed in the image
+tests/
+docs/
+old_project_reference/
+.claude/
+.github/
+*.md
+
+# Misc
+**/node_modules/
+**/.DS_Store
+```
+
+- [ ] **Step 2: Sanity-check the file landed correctly**
+
+Run:
+```bash
+ls C:/Dev/segocom-github/AHKFlowApp/.dockerignore
+```
+Expected: file path printed.
+
+Run (Grep):
+```
+grep -nE "^\.git/|^old_project_reference/|^\*\*/bin/" .dockerignore
+```
+Expected: 3 matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C C:/Dev/segocom-github/AHKFlowApp add .dockerignore
+git -C C:/Dev/segocom-github/AHKFlowApp commit -m "chore: add .dockerignore for compose build context"
+```
+
+Expected output: `1 file changed, ~25 insertions(+)`.
+
+---
+
+## Task 3: Pre-PR build & test gate
+
+**Why this exists:** `AGENTS.md` requires `dotnet build` + `dotnet test` to pass before opening a PR. This catches regressions in the .csproj files even though the docker work itself is config-only.
+
+- [ ] **Step 1: Build the solution in Release**
+
+Run:
+```bash
+dotnet build C:/Dev/segocom-github/AHKFlowApp --configuration Release
+```
+Expected: `Build succeeded.` with 0 errors. Warnings are treated as errors per `Directory.Build.props`, so any warning fails the build.
+
+If the build fails: STOP. Do not proceed to docker verification. Diagnose and fix before continuing.
+
+- [ ] **Step 2: Run all tests in Release**
+
+Run:
+```bash
+dotnet test C:/Dev/segocom-github/AHKFlowApp --configuration Release --no-build
+```
+Expected: All tests pass. Existing tests (Domain, Application, Infrastructure, API, UI.Blazor) must remain green — none of this work should affect runtime behavior.
+
+If tests fail: STOP. Diagnose. The Dockerfile and .dockerignore should not affect any test, so a failure here means an unrelated regression on `origin/main` — surface it before continuing.
+
+---
+
+## Task 4: Docker verification (user runs locally)
+
+**Why this exists:** This is the actual acceptance test for backlog item 009. The user said they will run this on their machine (Q4 from brainstorming). Document the exact steps so the user can run them mechanically.
+
+- [ ] **Step 1: Verify the API image builds**
+
+User runs:
+```bash
+docker compose -f C:/Dev/segocom-github/AHKFlowApp/docker-compose.yml build ahkflowapp-api
+```
+Expected: `Successfully built` (or BuildKit equivalent), no errors. First build will take a few minutes (pulling base images, restoring NuGet packages).
+
+If this fails:
+- `MINVER0001` warning treated as error → confirm both `dotnet build` and `dotnet publish` lines have `/p:MinVerSkip=true`.
+- `COPY` failed for a csproj → confirm the four `COPY` lines match the actual project paths.
+- `permission denied` writing to `/app/AppData/Logs` → confirm `mkdir`/`chown` runs in the `base` stage BEFORE `USER $APP_UID`.
+
+- [ ] **Step 2: Start the full stack**
+
+User runs:
+```bash
+docker compose -f C:/Dev/segocom-github/AHKFlowApp/docker-compose.yml up --build -d
+```
+Expected: Both services start. `sqlserver` reaches `(healthy)` (~30s, watch with `docker compose ps`). `ahkflowapp-api` then starts and stays Running.
+
+Watch logs:
+```bash
+docker compose -f C:/Dev/segocom-github/AHKFlowApp/docker-compose.yml logs -f ahkflowapp-api
+```
+Expected: Serilog `Starting AHKFlowApp API`, `Applying database migrations...`, `Database migrations applied successfully.`, `AHKFlowApp API started successfully`. No exceptions.
+
+- [ ] **Step 3: Hit `/health` from the host**
+
+User runs:
+```bash
+curl http://localhost:5602/health
+```
+Expected: `Healthy` (HTTP 200). This proves the API is reachable, the DB connection works, and `AddDbContextCheck<AppDbContext>` passes.
+
+- [ ] **Step 4: Verify Swagger UI in browser**
+
+User opens `http://localhost:5602/swagger` in a browser.
+Expected: Swagger UI loads, `Health` controller is listed.
+
+- [ ] **Step 5: Clean teardown**
+
+User runs:
+```bash
+docker compose -f C:/Dev/segocom-github/AHKFlowApp/docker-compose.yml down -v
+```
+Expected: Both containers stop, the `sqlserver-data` volume is removed, no errors.
+
+- [ ] **Step 6: Report verification result**
+
+If all 5 steps passed → proceed to Task 5.
+If any step failed → file an issue against the spec, fix the Dockerfile/.dockerignore, amend the relevant commit (or add a `fix:` commit), and re-run from Task 4 Step 1.
+
+---
+
+## Task 5: Open the pull request
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git -C C:/Dev/segocom-github/AHKFlowApp push -u origin feature/009-docker-development-setup
+```
+Expected: Branch published to origin.
+
+- [ ] **Step 2: Create the PR via gh**
+
+```bash
+gh pr create \
+  --base main \
+  --head feature/009-docker-development-setup \
+  --title "feat: docker development setup (009)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Add multi-stage `Dockerfile` for `AHKFlowApp.API` (.NET 10, 4-stage VS-compatible layout)
+- Add repo-root `.dockerignore` (excludes `bin/`, `obj/`, `.git/`, `tests/`, `docs/`, `old_project_reference/`, `.claude/`)
+- Closes backlog item 009
+
+## Why
+`docker-compose.yml` already references `src/Backend/AHKFlowApp.API/Dockerfile` (added in `d5c6bae`), but the file did not exist — `docker compose up --build` fails today. This adds the missing Dockerfile and a lean build context.
+
+## Design notes
+- 4-stage layout (`base`/`build`/`publish`/`final`) preserves the existing `Docker (API only)` VS launch profile (fast-mode source mount on the `base` stage).
+- `/app/AppData/Logs` is created and chowned in the `base` stage so the Serilog file sink works under `$APP_UID`.
+- `/p:MinVerSkip=true` on build+publish: `.git/` is excluded from the context to keep the image lean, so MinVer can't read tags. Without the skip, `MINVER0001` fails the build under `TreatWarningsAsErrors=true`. CI/CD (item 010) will run publish outside Docker for real versioning.
+
+## Out of scope
+- Production container hardening (chiseled images, multi-arch) — not in AC.
+- Frontend Blazor Dockerfile.
+- CI image build / push to registry — deferred to backlog item 010.
+
+## Test plan
+- [x] `dotnet build --configuration Release` — clean
+- [x] `dotnet test --configuration Release` — all tests pass
+- [x] `docker compose build ahkflowapp-api` — image builds
+- [x] `docker compose up --build -d` — both services healthy
+- [x] `curl http://localhost:5602/health` returns `Healthy`
+- [x] Swagger UI loads at `http://localhost:5602/swagger`
+- [x] `docker compose down -v` — clean teardown
+
+Spec: `docs/superpowers/specs/2026-04-08-009-docker-development-setup-design.md`
+EOF
+)"
+```
+Expected: PR URL printed. Tick off the test-plan items based on actual verification results.
+
+- [ ] **Step 3: Report PR URL to user**
+
+Print the PR URL.
+
+---
+
+## Rollback plan
+
+If the work is rejected during code review or breaks something downstream:
+1. Close the PR.
+2. `git -C C:/Dev/segocom-github/AHKFlowApp checkout main`
+3. `git -C C:/Dev/segocom-github/AHKFlowApp branch -D feature/009-docker-development-setup`
+4. The repo returns to its current state (no changes on `origin/main`).

--- a/docs/superpowers/specs/2026-04-08-009-docker-development-setup-design.md
+++ b/docs/superpowers/specs/2026-04-08-009-docker-development-setup-design.md
@@ -43,11 +43,12 @@ Standard 4-stage VS-compatible multi-stage build (`base` / `build` / `publish` /
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 EXPOSE 8080
-# Serilog file sink writes to /app/AppData/Logs at startup; create as root before dropping privileges
-RUN mkdir -p /app/AppData/Logs && chown -R $APP_UID:$APP_UID /app/AppData
-USER $APP_UID
+# Serilog file sink writes to /app/AppData/Logs at startup;
+# create the directory as root and hand it to the non-root user before dropping privileges.
+RUN mkdir -p /app/AppData/Logs && chown -R app:app /app/AppData
+USER app
 
-# build — restore + compile
+# build — restore + copy sources
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
@@ -63,20 +64,14 @@ COPY ["src/Backend/AHKFlowApp.Infrastructure/AHKFlowApp.Infrastructure.csproj", 
 RUN dotnet restore "src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj"
 
 COPY . .
-WORKDIR "/src/src/Backend/AHKFlowApp.API"
-# MinVerSkip=true: .git/ is excluded from build context, so MinVer cannot read tags.
-# Skipping MinVer prevents the MINVER0001 warning that would otherwise fail the build
-# (TreatWarningsAsErrors=true in Directory.Build.props). The published assembly version
-# defaults to 1.0.0 — fine for local dev containers; CI/CD owns real versioning.
-RUN dotnet build "AHKFlowApp.API.csproj" \
-    -c $BUILD_CONFIGURATION \
-    -o /app/build \
-    --no-restore \
-    /p:MinVerSkip=true
 
 # publish — produce final binaries
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
+WORKDIR "/src/src/Backend/AHKFlowApp.API"
+# MinVerSkip=true: .git/ is excluded from build context (.dockerignore), so MinVer cannot
+# read tags. Skipping it prevents MINVER0001 — which would fail the build under
+# TreatWarningsAsErrors=true. Local dev containers don't need real versions; CI/CD owns that.
 RUN dotnet publish "AHKFlowApp.API.csproj" \
     -c $BUILD_CONFIGURATION \
     -o /app/publish \
@@ -94,12 +89,12 @@ ENTRYPOINT ["dotnet", "AHKFlowApp.API.dll"]
 Decisions:
 
 - **4 stages** (`base` / `build` / `publish` / `final`), not 2. VS container tooling (`commandName: Docker` launch profile) requires the `base` stage for fast-mode debugging, where it volume-mounts source over `/app`. Dropping `base` would silently break the existing `Docker (API only)` launch profile documented in `docs/development/docker-setup.md`.
-- **Serilog log directory** (`/app/AppData/Logs`) is created in the `base` stage as root, then `chown`'d to `$APP_UID` before the `USER` switch. Without this, the file sink would silently fail in the container (Serilog SelfLog) because the non-root user cannot create directories under `/app`.
-- **`/p:MinVerSkip=true`** on both `dotnet build` and `dotnet publish`. MinVer reads `.git/` to compute the version from tags. Since `.dockerignore` excludes `.git/` (saves ~tens of MB of context), MinVer would emit `MINVER0001` and fall back to `0.0.0-alpha.0.0`. Combined with `TreatWarningsAsErrors=true` in `Directory.Build.props`, that warning would fail the build. Skipping MinVer in containers is the right tradeoff: dev containers don't need real versions, and CI/CD (item 010) will build with the full git history available.
+- **Serilog log directory** (`/app/AppData/Logs`) is created in the `base` stage as root, then `chown`'d to `app` before the `USER` switch. Without this, the file sink would silently fail in the container (Serilog SelfLog) because the non-root user cannot create directories under `/app`.
+- **`/p:MinVerSkip=true`** on `dotnet publish`. MinVer reads `.git/` to compute the version from tags. Since `.dockerignore` excludes `.git/` (saves ~tens of MB of context), MinVer would emit `MINVER0001` and fall back to `0.0.0-alpha.0.0`. Combined with `TreatWarningsAsErrors=true` in `Directory.Build.props`, that warning would fail the build. There is no separate `dotnet build` step — a single `dotnet publish` compiles and produces the output. Skipping MinVer in containers is the right tradeoff: dev containers don't need real versions, and CI/CD (item 010) will build with the full git history available.
 - **Targets `net10.0`** via `dotnet/sdk:10.0` and `dotnet/aspnet:10.0` (matches `AHKFlowApp.API.csproj`).
 - **CPM aware** — copies `Directory.Build.props` and `Directory.Packages.props` before restore. `nuget.config` is intentionally omitted (does not exist at repo root).
 - **Frontend not copied** — only the four backend csproj files are pulled for restore. The final `COPY . .` includes everything not excluded by `.dockerignore`.
-- **`USER $APP_UID`** for non-root runtime (matches the official .NET image conventions).
+- **`USER app`** for non-root runtime (uses the built-in non-root user from the official .NET runtime image).
 - **`EXPOSE 8080`** matches `ASPNETCORE_HTTP_PORTS=8080` set in `docker-compose.yml`.
 - **No `HEALTHCHECK`** in the Dockerfile — Compose owns service-level healthchecks.
 

--- a/docs/superpowers/specs/2026-04-08-009-docker-development-setup-design.md
+++ b/docs/superpowers/specs/2026-04-08-009-docker-development-setup-design.md
@@ -1,0 +1,150 @@
+# 009 — Docker Development Setup — Design
+
+## Context
+
+Backlog item [`009-docker-development-setup.md`](../../../.claude/backlog/009-docker-development-setup.md). Most of the Docker dev setup already landed on `main` in commit `d5c6bae` (`Added DevDockerSqlServer`):
+
+- `docker-compose.yml` (root) — `sqlserver` + `ahkflowapp-api` services, healthcheck, bridge network, persistent volume.
+- `src/Backend/AHKFlowApp.API/DevDockerSqlServer.cs` — dev helper that runs `docker compose up sqlserver -d --wait` from the `https + Docker SQL (Recommended)` launch profile.
+- `src/Backend/AHKFlowApp.API/Properties/launchSettings.json` — 4 launch profiles (LocalDB, Docker SQL, Docker Compose, Docker API-only).
+- `docs/development/docker-setup.md` — comprehensive walkthrough of the four profiles.
+
+The remaining gap: `docker-compose.yml` references `src/Backend/AHKFlowApp.API/Dockerfile`, which does not exist. `docker compose up --build` therefore fails today.
+
+## Goal
+
+Make `docker compose up --build` work end-to-end. Satisfy all three acceptance criteria of backlog item 009.
+
+## Acceptance criteria mapping
+
+| AC | Status | Closed by |
+|---|---|---|
+| Dockerfile for API exists | Missing | This spec |
+| `docker-compose.yml` includes API + SQL Server | Done | `d5c6bae` |
+| Documentation shows how to run with Docker | Done | `docs/development/docker-setup.md` |
+
+## Out of scope
+
+- Production container optimizations (chiseled / distroless images, multi-arch, BuildKit cache mounts).
+- Frontend Blazor Dockerfile.
+- CI image build / push to a registry — deferred to backlog item [`010-create-ci-cd-pipeline.md`](../../../.claude/backlog/010-create-ci-cd-pipeline.md).
+- Automated tests for Docker builds.
+
+## Design
+
+### 1. New file: `src/Backend/AHKFlowApp.API/Dockerfile`
+
+Lean 2-stage multi-stage build (build/publish merged, runtime separate). Drops the redundant `base` and `build` stages of the VS-generated reference Dockerfile.
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS publish
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+
+# Copy solution-level files first for layer caching
+COPY ["Directory.Build.props", "Directory.Packages.props", "./"]
+
+# Copy csproj files only — restore layer caches until a csproj changes
+COPY ["src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj", "src/Backend/AHKFlowApp.API/"]
+COPY ["src/Backend/AHKFlowApp.Application/AHKFlowApp.Application.csproj", "src/Backend/AHKFlowApp.Application/"]
+COPY ["src/Backend/AHKFlowApp.Domain/AHKFlowApp.Domain.csproj", "src/Backend/AHKFlowApp.Domain/"]
+COPY ["src/Backend/AHKFlowApp.Infrastructure/AHKFlowApp.Infrastructure.csproj", "src/Backend/AHKFlowApp.Infrastructure/"]
+RUN dotnet restore "src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj"
+
+COPY . .
+RUN dotnet publish "src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj" \
+    -c $BUILD_CONFIGURATION \
+    -o /app/publish \
+    --no-restore \
+    /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+WORKDIR /app
+USER $APP_UID
+EXPOSE 8080
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "AHKFlowApp.API.dll"]
+```
+
+Decisions:
+
+- **2 stages**, not 4. The VS-generated reference file has `base`/`build`/`publish`/`final`; the `base` stage only matters for VS fast-mode debugging, and `build` is redundant when `publish` is used.
+- **Targets `net10.0`** via `dotnet/sdk:10.0` and `dotnet/aspnet:10.0` (matches `AHKFlowApp.API.csproj`).
+- **CPM aware** — copies `Directory.Build.props` and `Directory.Packages.props` before restore. `nuget.config` is intentionally omitted (does not exist at repo root).
+- **Frontend not copied** — only the four backend csproj files are pulled for restore. The final `COPY . .` includes everything not excluded by `.dockerignore`.
+- **`USER $APP_UID`** for non-root runtime (matches the official .NET image conventions).
+- **`EXPOSE 8080`** matches `ASPNETCORE_HTTP_PORTS=8080` set in `docker-compose.yml`.
+- **No `HEALTHCHECK`** in the Dockerfile — Compose owns service-level healthchecks.
+
+### 2. New file: `.dockerignore` (repo root)
+
+The compose build context is `.` (repo root), so `.dockerignore` must live at the root.
+
+```
+# VCS / IDE
+.git/
+.vs/
+.vscode/
+.idea/
+
+# Build output
+**/bin/
+**/obj/
+**/TestResults/
+
+# User-local files
+**/*.user
+**/*.suo
+
+# Tests, docs, and reference material — not needed in the image
+tests/
+docs/
+old_project_reference/
+.claude/
+.github/
+*.md
+
+# Misc
+**/node_modules/
+**/.DS_Store
+```
+
+Decisions:
+
+- Excludes `tests/` — Dockerfile only publishes `AHKFlowApp.API.csproj`, but excluding the directory shrinks the build context sent to the daemon.
+- Excludes `old_project_reference/` (large) and `.claude/` (irrelevant to runtime).
+- Keeps the leading `*.md` exclusion narrow (does not whitelist anything).
+
+### 3. Files NOT changed
+
+- `docker-compose.yml` — already correct. Only touched if verification reveals a discrepancy.
+- `docs/development/docker-setup.md` — already covers all four profiles. Only touched if verification reveals a discrepancy.
+
+## Verification
+
+User will run on their machine after the PR is up:
+
+1. `docker compose build ahkflowapp-api` — image builds.
+2. `docker compose up --build -d` — both services start; `sqlserver` healthcheck passes; `ahkflowapp-api` reaches Running.
+3. `curl http://localhost:5602/health` — returns `Healthy`.
+4. Open `http://localhost:5602/swagger` — Swagger UI loads.
+5. `docker compose down -v` — clean teardown.
+
+If any step fails, fix and amend the PR before merging.
+
+## Branch & commit plan
+
+- Branch: `feature/009-docker-development-setup` from `origin/main`.
+- The two unpushed local commits on `main` (`bfd42f0`, `7761113` — unrelated skill cleanup) stay on local `main` for a separate PR (per user direction).
+- Atomic commits:
+  1. `feat: add API Dockerfile (multi-stage net10)` — Dockerfile only.
+  2. `chore: add .dockerignore` — repo-root .dockerignore.
+  3. (only if verification finds an issue) `fix: …` or `docs: …` as needed.
+- PR opened after step 3 of verification passes.
+
+## Risks
+
+- **Docker Desktop not installed** on the verifying machine — user already runs Docker Compose locally per `docs/development/docker-setup.md`. Low risk.
+- **`Directory.Packages.props` drift** — if a new project is added later, the Dockerfile must add a `COPY` line for it. Acceptable: caught by the next docker build.
+- **CPM transitive pinning** — restore inside the container must see `Directory.Packages.props`. Handled by copying it before `dotnet restore`.

--- a/docs/superpowers/specs/2026-04-08-009-docker-development-setup-design.md
+++ b/docs/superpowers/specs/2026-04-08-009-docker-development-setup-design.md
@@ -34,11 +34,21 @@ Make `docker compose up --build` work end-to-end. Satisfy all three acceptance c
 
 ### 1. New file: `src/Backend/AHKFlowApp.API/Dockerfile`
 
-Lean 2-stage multi-stage build (build/publish merged, runtime separate). Drops the redundant `base` and `build` stages of the VS-generated reference Dockerfile.
+Standard 4-stage VS-compatible multi-stage build (`base` / `build` / `publish` / `final`). The `base` stage is required by the existing `Docker (API only - requires SQL on localhost:1433)` launch profile (`commandName: Docker`), which mounts source over the `base` stage for fast-mode debugging.
 
 ```dockerfile
 # syntax=docker/dockerfile:1.7
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS publish
+
+# base — runtime image used by VS fast-mode debug (commandName: Docker)
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+WORKDIR /app
+EXPOSE 8080
+# Serilog file sink writes to /app/AppData/Logs at startup; create as root before dropping privileges
+RUN mkdir -p /app/AppData/Logs && chown -R $APP_UID:$APP_UID /app/AppData
+USER $APP_UID
+
+# build — restore + compile
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
@@ -53,23 +63,39 @@ COPY ["src/Backend/AHKFlowApp.Infrastructure/AHKFlowApp.Infrastructure.csproj", 
 RUN dotnet restore "src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj"
 
 COPY . .
-RUN dotnet publish "src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj" \
+WORKDIR "/src/src/Backend/AHKFlowApp.API"
+# MinVerSkip=true: .git/ is excluded from build context, so MinVer cannot read tags.
+# Skipping MinVer prevents the MINVER0001 warning that would otherwise fail the build
+# (TreatWarningsAsErrors=true in Directory.Build.props). The published assembly version
+# defaults to 1.0.0 — fine for local dev containers; CI/CD owns real versioning.
+RUN dotnet build "AHKFlowApp.API.csproj" \
+    -c $BUILD_CONFIGURATION \
+    -o /app/build \
+    --no-restore \
+    /p:MinVerSkip=true
+
+# publish — produce final binaries
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "AHKFlowApp.API.csproj" \
     -c $BUILD_CONFIGURATION \
     -o /app/publish \
     --no-restore \
-    /p:UseAppHost=false
+    /p:UseAppHost=false \
+    /p:MinVerSkip=true
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+# final — runtime image used by docker compose / production
+FROM base AS final
 WORKDIR /app
-USER $APP_UID
-EXPOSE 8080
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "AHKFlowApp.API.dll"]
 ```
 
 Decisions:
 
-- **2 stages**, not 4. The VS-generated reference file has `base`/`build`/`publish`/`final`; the `base` stage only matters for VS fast-mode debugging, and `build` is redundant when `publish` is used.
+- **4 stages** (`base` / `build` / `publish` / `final`), not 2. VS container tooling (`commandName: Docker` launch profile) requires the `base` stage for fast-mode debugging, where it volume-mounts source over `/app`. Dropping `base` would silently break the existing `Docker (API only)` launch profile documented in `docs/development/docker-setup.md`.
+- **Serilog log directory** (`/app/AppData/Logs`) is created in the `base` stage as root, then `chown`'d to `$APP_UID` before the `USER` switch. Without this, the file sink would silently fail in the container (Serilog SelfLog) because the non-root user cannot create directories under `/app`.
+- **`/p:MinVerSkip=true`** on both `dotnet build` and `dotnet publish`. MinVer reads `.git/` to compute the version from tags. Since `.dockerignore` excludes `.git/` (saves ~tens of MB of context), MinVer would emit `MINVER0001` and fall back to `0.0.0-alpha.0.0`. Combined with `TreatWarningsAsErrors=true` in `Directory.Build.props`, that warning would fail the build. Skipping MinVer in containers is the right tradeoff: dev containers don't need real versions, and CI/CD (item 010) will build with the full git history available.
 - **Targets `net10.0`** via `dotnet/sdk:10.0` and `dotnet/aspnet:10.0` (matches `AHKFlowApp.API.csproj`).
 - **CPM aware** — copies `Directory.Build.props` and `Directory.Packages.props` before restore. `nuget.config` is intentionally omitted (does not exist at repo root).
 - **Frontend not copied** — only the four backend csproj files are pulled for restore. The final `COPY . .` includes everything not excluded by `.dockerignore`.
@@ -141,10 +167,16 @@ If any step fails, fix and amend the PR before merging.
   1. `feat: add API Dockerfile (multi-stage net10)` — Dockerfile only.
   2. `chore: add .dockerignore` — repo-root .dockerignore.
   3. (only if verification finds an issue) `fix: …` or `docs: …` as needed.
-- PR opened after step 3 of verification passes.
+- Pre-PR gates (per `AGENTS.md` git workflow rule):
+  - `dotnet build --configuration Release` — must succeed.
+  - `dotnet test --configuration Release` — all tests must pass.
+  - User runs the docker verification steps above.
+- PR opened after the pre-PR gates pass.
 
 ## Risks
 
 - **Docker Desktop not installed** on the verifying machine — user already runs Docker Compose locally per `docs/development/docker-setup.md`. Low risk.
 - **`Directory.Packages.props` drift** — if a new project is added later, the Dockerfile must add a `COPY` line for it. Acceptable: caught by the next docker build.
 - **CPM transitive pinning** — restore inside the container must see `Directory.Packages.props`. Handled by copying it before `dotnet restore`.
+- **MinVer skipped in containers** — published assemblies will not carry git-derived version metadata when built via Docker. Acceptable: dev containers don't need real versions, and CI/CD (item 010) will run `dotnet publish` outside Docker (or with `.git/` available) to get proper MinVer versions.
+- **VS fast-mode debugging compatibility** — the `base` stage is preserved specifically so the `Docker (API only)` launch profile keeps working. If a future change to the Dockerfile breaks this, also update `docs/development/docker-setup.md`.

--- a/src/Backend/AHKFlowApp.API/Dockerfile
+++ b/src/Backend/AHKFlowApp.API/Dockerfile
@@ -9,7 +9,7 @@ EXPOSE 8080
 RUN mkdir -p /app/AppData/Logs && chown -R $APP_UID:$APP_UID /app/AppData
 USER $APP_UID
 
-# build — restore + compile
+# build — restore + copy sources
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src

--- a/src/Backend/AHKFlowApp.API/Dockerfile
+++ b/src/Backend/AHKFlowApp.API/Dockerfile
@@ -25,19 +25,14 @@ COPY ["src/Backend/AHKFlowApp.Infrastructure/AHKFlowApp.Infrastructure.csproj", 
 RUN dotnet restore "src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj"
 
 COPY . .
-WORKDIR "/src/src/Backend/AHKFlowApp.API"
-# MinVerSkip=true: .git/ is excluded from build context (.dockerignore), so MinVer cannot
-# read tags. Skipping it prevents MINVER0001 — which would fail the build under
-# TreatWarningsAsErrors=true. Local dev containers don't need real versions; CI/CD owns that.
-RUN dotnet build "AHKFlowApp.API.csproj" \
-    -c $BUILD_CONFIGURATION \
-    -o /app/build \
-    --no-restore \
-    /p:MinVerSkip=true
 
 # publish — produce final binaries
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
+WORKDIR "/src/src/Backend/AHKFlowApp.API"
+# MinVerSkip=true: .git/ is excluded from build context (.dockerignore), so MinVer cannot
+# read tags. Skipping it prevents MINVER0001 — which would fail the build under
+# TreatWarningsAsErrors=true. Local dev containers don't need real versions; CI/CD owns that.
 RUN dotnet publish "AHKFlowApp.API.csproj" \
     -c $BUILD_CONFIGURATION \
     -o /app/publish \

--- a/src/Backend/AHKFlowApp.API/Dockerfile
+++ b/src/Backend/AHKFlowApp.API/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /app
 EXPOSE 8080
 # Serilog file sink writes to /app/AppData/Logs at startup;
 # create the directory as root and hand it to the non-root user before dropping privileges.
-RUN mkdir -p /app/AppData/Logs && chown -R $APP_UID:$APP_UID /app/AppData
-USER $APP_UID
+RUN mkdir -p /app/AppData/Logs && chown -R app:app /app/AppData
+USER app
 
 # build — restore + copy sources
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build

--- a/src/Backend/AHKFlowApp.API/Dockerfile
+++ b/src/Backend/AHKFlowApp.API/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1.7
+
+# base — runtime image used by VS fast-mode debug (commandName: Docker)
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+WORKDIR /app
+EXPOSE 8080
+# Serilog file sink writes to /app/AppData/Logs at startup;
+# create the directory as root and hand it to the non-root user before dropping privileges.
+RUN mkdir -p /app/AppData/Logs && chown -R $APP_UID:$APP_UID /app/AppData
+USER $APP_UID
+
+# build — restore + compile
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+
+# Copy solution-level files first for layer caching
+COPY ["Directory.Build.props", "Directory.Packages.props", "./"]
+
+# Copy csproj files only — restore layer caches until a csproj changes
+COPY ["src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj", "src/Backend/AHKFlowApp.API/"]
+COPY ["src/Backend/AHKFlowApp.Application/AHKFlowApp.Application.csproj", "src/Backend/AHKFlowApp.Application/"]
+COPY ["src/Backend/AHKFlowApp.Domain/AHKFlowApp.Domain.csproj", "src/Backend/AHKFlowApp.Domain/"]
+COPY ["src/Backend/AHKFlowApp.Infrastructure/AHKFlowApp.Infrastructure.csproj", "src/Backend/AHKFlowApp.Infrastructure/"]
+RUN dotnet restore "src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj"
+
+COPY . .
+WORKDIR "/src/src/Backend/AHKFlowApp.API"
+# MinVerSkip=true: .git/ is excluded from build context (.dockerignore), so MinVer cannot
+# read tags. Skipping it prevents MINVER0001 — which would fail the build under
+# TreatWarningsAsErrors=true. Local dev containers don't need real versions; CI/CD owns that.
+RUN dotnet build "AHKFlowApp.API.csproj" \
+    -c $BUILD_CONFIGURATION \
+    -o /app/build \
+    --no-restore \
+    /p:MinVerSkip=true
+
+# publish — produce final binaries
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "AHKFlowApp.API.csproj" \
+    -c $BUILD_CONFIGURATION \
+    -o /app/publish \
+    --no-restore \
+    /p:UseAppHost=false \
+    /p:MinVerSkip=true
+
+# final — runtime image used by docker compose / production
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "AHKFlowApp.API.dll"]


### PR DESCRIPTION
The embedded Dockerfile in both the design spec and implementation plan reflected an outdated draft — they contained a redundant `dotnet build` step, applied `/p:MinVerSkip=true` to both build and publish, used `$APP_UID` instead of the built-in `app` user, and had the wrong stage comment ("restore + compile").

## Changes

- **`docs/superpowers/specs/2026-04-08-009-docker-development-setup-design.md`**
  - Dockerfile snippet: removed `dotnet build` step; `WORKDIR` change moved to `publish` stage; `$APP_UID:$APP_UID`/`USER $APP_UID` → `app:app`/`USER app`; stage comment → "restore + copy sources"
  - Decisions: MinVerSkip scoped to `dotnet publish` only; Serilog chown references `app`; `USER app` note updated

- **`docs/superpowers/plans/2026-04-08-009-docker-development-setup.md`**
  - Same Dockerfile content corrections as spec
  - Task 1 requirements updated (`$APP_UID` → `app`, single-pass publish description)
  - Grep verification: "Expected: 2 matches" → "Expected: 1 match (in publish stage only)"
  - Troubleshooting tip: "both build and publish lines" → "publish line"
  - PR body in Task 5 corrected to "publish only"