### PR TITLE
fix: force blazor-environment=Production; rename env dev→test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,11 +232,11 @@ Primary way to interact with GitHub is the `gh` CLI.
 - Frontend: `https://localhost:7601`, `http://localhost:5601`
 - Docker Compose API: `http://localhost:5602`
 
-## Production URLs (dev environment)
+## Production URLs (test environment)
 
-- API: `https://ahkflowapp-api-dev.azurewebsites.net`
-- API health: `https://ahkflowapp-api-dev.azurewebsites.net/health`
-- Frontend (SWA): `https://jolly-pond-007f20803.7.azurestaticapps.net`
+- API: `https://ahkflowapp-api-test.azurewebsites.net`
+- API health: `https://ahkflowapp-api-test.azurewebsites.net/health`
+- Frontend (SWA): update after re-provisioning (`az staticwebapp show --name ahkflowapp-swa-test --query defaultHostname -o tsv`)
 
 ## Domain Terms
 

--- a/scripts/azure/01-provision-azure.md
+++ b/scripts/azure/01-provision-azure.md
@@ -1,6 +1,6 @@
 # 01 — Provision Azure resources
 
-This runbook stands up the full Azure environment for a single environment (default: `dev`). All `az X create` calls are idempotent (preceded by `az X show ...`). Re-running a section is safe.
+This runbook stands up the full Azure environment for a single environment (default: `test`). All `az X create` calls are idempotent (preceded by `az X show ...`). Re-running a section is safe.
 
 Prerequisite: you have completed [`00-prerequisites.md`](./00-prerequisites.md) and run `az login`.
 
@@ -13,7 +13,7 @@ Set these once at the top of your shell. Re-export them if you open a new termin
 ```bash
 export MSYS_NO_PATHCONV=1  # Git Bash: prevents /subscriptions/... paths being mangled to C:/Program Files/Git/...
 
-ENVIRONMENT="dev"                                      # dev | prod
+ENVIRONMENT="test"                                     # test | prod
 LOCATION="westeurope"                                  # any Azure region
 BASE_NAME="ahkflowapp"                                    # project prefix
 

--- a/scripts/azure/02-configure-github-oidc.md
+++ b/scripts/azure/02-configure-github-oidc.md
@@ -102,12 +102,12 @@ rm /tmp/create-runtime-user.sql
 2. Sign in with your Entra ID (the account that's a member of the admin group).
 3. Paste and run:
    ```sql
-   CREATE USER [ahkflowapp-uami-runtime-dev] FROM EXTERNAL PROVIDER;
-   ALTER ROLE db_datareader ADD MEMBER [ahkflowapp-uami-runtime-dev];
-   ALTER ROLE db_datawriter ADD MEMBER [ahkflowapp-uami-runtime-dev];
-   GRANT EXECUTE TO [ahkflowapp-uami-runtime-dev];
+   CREATE USER [ahkflowapp-uami-runtime-test] FROM EXTERNAL PROVIDER;
+   ALTER ROLE db_datareader ADD MEMBER [ahkflowapp-uami-runtime-test];
+   ALTER ROLE db_datawriter ADD MEMBER [ahkflowapp-uami-runtime-test];
+   GRANT EXECUTE TO [ahkflowapp-uami-runtime-test];
    ```
-   (Replace `ahkflowapp-uami-runtime-dev` with your actual `$UAMI_RUNTIME_NAME` if different.)
+   (Replace `ahkflowapp-uami-runtime-test` with your actual `$UAMI_RUNTIME_NAME` if different.)
 
 ## 4. GitHub repo secrets
 
@@ -230,7 +230,7 @@ Expected: `Healthy` (or JSON `{"status":"Healthy",...}`).
 
 If `$APP_SERVICE_NAME` is not set, use the literal URL:
 ```bash
-curl -fsS "https://ahkflowapp-api-dev.azurewebsites.net/health"
+curl -fsS "https://ahkflowapp-api-test.azurewebsites.net/health"
 ```
 
 ### Step 7 — Verify the frontend is live
@@ -240,7 +240,7 @@ SWA_HOSTNAME=$(az staticwebapp show --name "$SWA_NAME" --resource-group "$RESOUR
 echo "Frontend: https://${SWA_HOSTNAME}"
 ```
 
-Open the URL in a browser. The Blazor app should load and be able to reach the API (frontend `appsettings.json` points to `https://ahkflowapp-api-dev.azurewebsites.net`).
+Open the URL in a browser. The Blazor app should load and be able to reach the API (frontend `appsettings.json` points to `https://ahkflowapp-api-test.azurewebsites.net`).
 
 ---
 

--- a/scripts/azure/99-teardown.md
+++ b/scripts/azure/99-teardown.md
@@ -7,7 +7,7 @@ Stop paying for dev resources. Deletes the entire resource group, the SQL admin 
 ## Variables
 
 ```bash
-ENVIRONMENT="dev"
+ENVIRONMENT="test"
 BASE_NAME="ahkflowapp"
 RESOURCE_GROUP="rg-${BASE_NAME}-${ENVIRONMENT}"
 SQL_ADMIN_GROUP="${BASE_NAME}-sql-admins-${ENVIRONMENT}"

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.json
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.json
@@ -1,5 +1,5 @@
 {
   "ApiHttpClient": {
-    "BaseAddress": "https://ahkflowapp-api-dev.azurewebsites.net"
+    "BaseAddress": "https://ahkflowapp-api-test.azurewebsites.net"
   }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/staticwebapp.config.json
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/staticwebapp.config.json
@@ -1,0 +1,5 @@
+{
+  "globalHeaders": {
+    "blazor-environment": "Production"
+  }
+}


### PR DESCRIPTION
Root cause: SWA wasn't sending blazor-environment header, so Blazor merged appsettings.Development.json on top of appsettings.json — localhost candidates overwrote the prod API URL.

Fix: staticwebapp.config.json sets blazor-environment: Production globally so appsettings.Development.json is never loaded in Azure.

Also renames all script defaults and hardcoded literals from dev to test (rg-ahkflow-test, ahkflowapp-api-test, etc.) per user request.

## Summary

Brief description of changes.

## Checklist

- [x] Tests pass (`dotnet test`)
- [x] Build succeeds (`dotnet build`)
- [x] No new warnings introduced
- [x] Breaking changes documented (if any)
