### PR TITLE
fix: repair provision workflow expression syntax

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -20,13 +20,16 @@ jobs:
   provision:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    env:
+      AZURE_CLIENT_ID: ${{ inputs.environment == 'prod' && secrets.AZURE_CLIENT_ID_PROD || secrets.AZURE_CLIENT_ID_TEST }}
+      AZURE_RESOURCE_GROUP: ${{ inputs.environment == 'prod' && vars.AZURE_RESOURCE_GROUP_PROD || vars.AZURE_RESOURCE_GROUP_TEST }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Azure Login (OIDC)
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets[format('AZURE_CLIENT_ID_{0}', upper(inputs.environment))] }}
+          client-id: ${{ env.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
@@ -36,7 +39,7 @@ jobs:
       - name: Deploy Bicep
         run: |
           az deployment group create \
-            --resource-group ${{ vars[format('AZURE_RESOURCE_GROUP_{0}', upper(inputs.environment))] }} \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
             --template-file infra/main.bicep \
             --parameters infra/main.bicepparam \
             --parameters environment=${{ inputs.environment }} \
@@ -46,6 +49,6 @@ jobs:
       - name: Show outputs
         run: |
           az deployment group show \
-            --resource-group ${{ vars[format('AZURE_RESOURCE_GROUP_{0}', upper(inputs.environment))] }} \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
             --name "provision-${{ inputs.environment }}-${{ github.run_id }}" \
             --query properties.outputs


### PR DESCRIPTION
## Summary

Fixes the new provision.yml workflow failing to parse on GitHub.

## Root cause

GitHub Actions expressions support format(...), but they do not support upper(...).
The workflow tried to build dynamic names like AZURE_CLIENT_ID_PROD with an expression using upper(inputs.environment), which makes the workflow invalid before any job starts.

## Fix

- Replace the unsupported upper(...) calls with supported conditional expressions
- Resolve the environment-specific secret and variable once at the job level
- Reuse those values through env.AZURE_CLIENT_ID and env.AZURE_RESOURCE_GROUP

This keeps the TEST/PROD split without relying on unsupported workflow functions.