### PR TITLE
fix: use DefaultConnection as Azure connection string name

### DIFF
--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -432,7 +432,7 @@ $ConnectionString = "Server=$SqlServerFqdn;Database=$SqlDatabaseName;Authenticat
 az webapp config connection-string set `
     --name $AppServiceName `
     --resource-group $ResourceGroup `
-    --settings ConnectionStrings__DefaultConnection="$ConnectionString" `
+    --settings DefaultConnection="$ConnectionString" `
     --connection-string-type SQLAzure | Out-Null
 Write-Success "Connection string set"
 

--- a/src/Backend/AHKFlowApp.Infrastructure/DependencyInjection.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/DependencyInjection.cs
@@ -14,7 +14,7 @@ public static class DependencyInjection
     {
         services.AddDbContext<AppDbContext>(options =>
             options.UseSqlServer(
-                configuration.GetConnectionString("ConnectionStrings__DefaultConnection"),
+                configuration.GetConnectionString("DefaultConnection"),
                 sql => sql.EnableRetryOnFailure()));
 
         services.AddSingleton<IVersionService, VersionService>();


### PR DESCRIPTION
ConnectionStrings__DefaultConnection as an App Service connection string name maps to ConnectionStrings:ConnectionStrings__DefaultConnection in .NET config — GetConnectionString("DefaultConnection") sees null.

Using DefaultConnection maps correctly via SQLAZURECONNSTR_ prefix. migrate-db workflow already works: it sets ConnectionStrings__DefaultConnection as an env var which maps to ConnectionStrings:DefaultConnection.

## Summary

Brief description of changes.

## Checklist

- [x] Tests pass (`dotnet test`)
- [x] Build succeeds (`dotnet build`)
- [x] No new warnings introduced
- [x] Breaking changes documented (if any)
