### PR TITLE
fix: include error detail in health check response

### DIFF
--- a/src/Backend/AHKFlowApp.API/Controllers/HealthController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/HealthController.cs
@@ -25,7 +25,9 @@ public sealed class HealthController(
 
         var checks = report.Entries.ToDictionary(
             e => e.Key,
-            e => e.Value.Status.ToString());
+            e => e.Value.Status == HealthStatus.Healthy
+                ? e.Value.Status.ToString()
+                : $"{e.Value.Status}: {e.Value.Description ?? e.Value.Exception?.Message ?? e.Value.Exception?.GetType().Name ?? "unknown error"}");
 
         var response = new HealthResponse(
             Status: report.Status.ToString(),


### PR DESCRIPTION
Unhealthy checks now return description or exception message instead of just "Unhealthy", making connection failures immediately diagnosable.

## Summary

Brief description of changes.

## Checklist

- [x] Tests pass (`dotnet test`)
- [x] Build succeeds (`dotnet build`)
- [x] No new warnings introduced
- [x] Breaking changes documented (if any)
