### PR TITLE
fix: pass MinVer version to Docker build for accurate runtime version reporting

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="MediatR" Version="14.1.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
@@ -20,12 +21,12 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore"
-      Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.5" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="MudBlazor" Version="9.2.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/docs/deployment/getting-started.md
+++ b/docs/deployment/getting-started.md
@@ -38,6 +38,8 @@ When done, push to `main` — GitHub Actions will deploy the API container and B
 | Static Web App | `ahkflowapp-swa-{env}` | Free tier |
 | Deployer UAMI | `ahkflowapp-uami-deployer-{env}` | Used by GitHub Actions OIDC |
 | Runtime UAMI | `ahkflowapp-uami-runtime-{env}` | Used by App Service → SQL |
+| Log Analytics Workspace | `ahkflowapp-law-{env}` | Backs Application Insights |
+| Application Insights | `ahkflowapp-ai-{env}` | Production telemetry & diagnostics |
 
 Estimated cost for the `test` environment: **~$15–25/month** (B1 App Service Plan + Basic SQL DB).
 
@@ -59,6 +61,15 @@ Run the script once per environment:
 ```
 
 Each environment gets its own isolated resource group and GitHub secrets.
+
+## Application Insights
+
+Each environment provisions an Application Insights instance backed by a Log Analytics workspace. The API automatically sends structured logs and telemetry when the `ApplicationInsights:ConnectionString` app setting is configured (set by `deploy.ps1`).
+
+- **Local development:** No Application Insights — the connection string is empty in `appsettings.json`, so the sink is not registered.
+- **Test/Prod:** The connection string is set as an App Service configuration value (`ApplicationInsights__ConnectionString`) during provisioning.
+
+To view telemetry, open the Application Insights resource (`ahkflowapp-ai-{env}`) in the Azure Portal.
 
 ## Updating After a Code Change
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -57,6 +57,15 @@ module swa 'modules/swa.bicep' = {
   }
 }
 
+module monitoring 'modules/monitoring.bicep' = {
+  name: 'monitoring'
+  params: {
+    baseName: baseName
+    environment: environment
+    location: location
+  }
+}
+
 // Identity outputs
 output deployerUamiName string = identity.outputs.deployerUamiName
 output deployerUamiId string = identity.outputs.deployerUamiId
@@ -79,3 +88,7 @@ output appServiceDefaultHostname string = web.outputs.appServiceDefaultHostname
 // SWA outputs
 output swaName string = swa.outputs.swaName
 output swaDefaultHostname string = swa.outputs.swaDefaultHostname
+
+// Monitoring outputs
+output appInsightsName string = monitoring.outputs.appInsightsName
+output appInsightsConnectionString string = monitoring.outputs.appInsightsConnectionString

--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -1,0 +1,37 @@
+@description('Base name prefix for all resources.')
+param baseName string
+
+@description('Target environment: test or prod.')
+@allowed(['test', 'prod'])
+param environment string
+
+@description('Azure region for resources.')
+param location string = resourceGroup().location
+
+var workspaceName = '${baseName}-law-${environment}'
+var appInsightsName = '${baseName}-ai-${environment}'
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: workspaceName
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalyticsWorkspace.id
+    IngestionMode: 'LogAnalytics'
+  }
+}
+
+output appInsightsName string = appInsights.name
+output appInsightsConnectionString string = appInsights.properties.ConnectionString

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -237,6 +237,8 @@ $AppServiceName         = $outputs.appServiceName.value
 $AppServiceHostname     = $outputs.appServiceDefaultHostname.value
 $SwaName                = $outputs.swaName.value
 $SwaHostname            = $outputs.swaDefaultHostname.value
+$AppInsightsName        = $outputs.appInsightsName.value
+$AppInsightsConnStr     = $outputs.appInsightsConnectionString.value
 
 Write-Success "Bicep deployment complete"
 
@@ -453,6 +455,13 @@ az webapp config connection-string set `
     --connection-string-type SQLAzure | Out-Null
 Write-Success "Connection string set"
 
+# Application Insights connection string
+az webapp config appsettings set `
+    --name $AppServiceName `
+    --resource-group $ResourceGroup `
+    --settings ApplicationInsights__ConnectionString="$AppInsightsConnStr" | Out-Null
+Write-Success "Application Insights connection string set"
+
 # Set GHCR placeholder image (will be replaced by deploy-api.yml on first CI run)
 $Owner = ($GitHubOrgRepo -split '/')[0]
 $PlaceholderImage = "ghcr.io/${Owner}/ahkflowapp-api:latest-${Environment}"
@@ -499,6 +508,7 @@ SWA_NAME=$SwaName
 SWA_HOSTNAME=$SwaHostname
 DEPLOYER_UAMI_NAME=$DeployerUamiName
 RUNTIME_UAMI_NAME=$RuntimeUamiName
+APP_INSIGHTS_NAME=$AppInsightsName
 "@ | Set-Content -Path $EnvFileOut -Encoding UTF8
 Write-Success "Config saved to scripts/.env.$Environment"
 

--- a/src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj
+++ b/src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj
@@ -3,6 +3,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ardalis.Result.AspNetCore" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -13,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>

--- a/src/Backend/AHKFlowApp.API/Program.cs
+++ b/src/Backend/AHKFlowApp.API/Program.cs
@@ -4,6 +4,7 @@ using AHKFlowApp.API.Middleware;
 using AHKFlowApp.Application;
 using AHKFlowApp.Infrastructure;
 using AHKFlowApp.Infrastructure.Persistence;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
@@ -24,12 +25,29 @@ try
 
     WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
+    // Application Insights — only when a connection string is configured (Test/Prod)
+    string? appInsightsConnectionString = builder.Configuration["ApplicationInsights:ConnectionString"];
+    if (!string.IsNullOrWhiteSpace(appInsightsConnectionString))
+    {
+        builder.Services.AddApplicationInsightsTelemetry(options =>
+            options.ConnectionString = appInsightsConnectionString);
+    }
+
     // Stage 2: Full logger configured from appsettings.json, with DI integration
-    builder.Services.AddSerilog((services, lc) => lc
-        .ReadFrom.Configuration(builder.Configuration)
-        .ReadFrom.Services(services)
-        .Enrich.FromLogContext()
-        .Enrich.WithProperty("Application", "AHKFlowApp.API"));
+    builder.Services.AddSerilog((services, lc) =>
+    {
+        lc.ReadFrom.Configuration(builder.Configuration)
+          .ReadFrom.Services(services)
+          .Enrich.FromLogContext()
+          .Enrich.WithProperty("Application", "AHKFlowApp.API");
+
+        // Route Serilog events to Application Insights when configured
+        if (!string.IsNullOrWhiteSpace(appInsightsConnectionString))
+        {
+            TelemetryConfiguration telemetryConfig = services.GetRequiredService<TelemetryConfiguration>();
+            lc.WriteTo.ApplicationInsights(telemetryConfig, TelemetryConverter.Traces);
+        }
+    });
 
     // Start SQL Server in Docker if requested (for "https + Docker SQL" launch profile)
     if (builder.Environment.IsDevelopment() &&

--- a/src/Backend/AHKFlowApp.API/appsettings.json
+++ b/src/Backend/AHKFlowApp.API/appsettings.json
@@ -2,6 +2,9 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=AHKFlowApp;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
+  "ApplicationInsights": {
+    "ConnectionString": ""
+  },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
     "MinimumLevel": {


### PR DESCRIPTION
## Problem

The Dockerfile correctly skips MinVer (MinVerSkip=true) since .git/ is not in the build context. However, this caused the \Version\ property to fall back to the SDK default of **1.0.0**, which was baked into the assembly.

This incorrect version was returned by the \/api/v1/health\ and \/api/v1/version\ endpoints, even though MinVer correctly calculated the real version as \