### PR TITLE
fix: pass MinVer version to Docker build for accurate runtime version…

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -68,6 +68,13 @@ jobs:
             type=raw,value=latest-${{ env.TARGET_ENV }},enable={{is_default_branch}}
             type=raw,value=${{ env.TARGET_ENV }}-{{date 'YYYYMMDD-HHmmss'}}
             type=ref,event=branch
+      - name: Calculate version with MinVer
+        id: minver
+        run: |
+          dotnet tool install --global minver-cli
+          version=$(minver --tag-prefix v)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "MinVer version: $version"
       - id: build
         uses: docker/build-push-action@v6
         with:
@@ -78,6 +85,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            MINVER_VERSION=${{ steps.minver.outputs.version }}
       - name: Verify digest is set
         run: |
           digest="${{ steps.build.outputs.digest }}"

--- a/docs/development/versioning.md
+++ b/docs/development/versioning.md
@@ -70,8 +70,8 @@ minver --tag-prefix v
 Once deployed, the version is available via the API:
 
 ```
-GET /api/v1/version   → { "version": "0.1.0" }
-GET /api/v1/health    → { ..., "version": "0.1.0", ... }
+GET /api/v1/version   → { "version": "<minver-version>" }
+GET /api/v1/health    → { ..., "version": "<minver-version>", ... }
 ```
 
 ## References

--- a/docs/development/versioning.md
+++ b/docs/development/versioning.md
@@ -53,13 +53,25 @@ Follow [SemVer 2.0.0](https://semver.org/):
 - **MINOR** (`v1.1.0`): New features, backward compatible
 - **PATCH** (`v1.0.1`): Bug fixes
 
+## Checking the Version Locally
+
+Use the `minver-cli` dotnet global tool to inspect the current version without building:
+
+```powershell
+# Install once
+dotnet tool install --global minver-cli
+
+# Run from the repo root
+minver --tag-prefix v
+```
+
 ## Checking the Version at Runtime
 
 Once deployed, the version is available via the API:
 
 ```
-GET /api/v1/version   → { "version": "1.0.0" }
-GET /api/v1/health    → { ..., "version": "1.0.0", ... }
+GET /api/v1/version   → { "version": "0.1.0" }
+GET /api/v1/health    → { ..., "version": "0.1.0", ... }
 ```
 
 ## References

--- a/src/Backend/AHKFlowApp.API/Dockerfile
+++ b/src/Backend/AHKFlowApp.API/Dockerfile
@@ -29,16 +29,18 @@ COPY . .
 # publish — produce final binaries
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
+ARG MINVER_VERSION=0.0.0-local
 WORKDIR "/src/src/Backend/AHKFlowApp.API"
 # MinVerSkip=true: .git/ is excluded from build context (.dockerignore), so MinVer cannot
-# read tags. Skipping it prevents MINVER0001 — which would fail the build under
-# TreatWarningsAsErrors=true. Local dev containers don't need real versions; CI/CD owns that.
+# read tags. The version is passed in as MINVER_VERSION from CI (computed by minver-cli).
+# For local dev, defaults to 0.0.0-local.
 RUN dotnet publish "AHKFlowApp.API.csproj" \
     -c $BUILD_CONFIGURATION \
     -o /app/publish \
     --no-restore \
     /p:UseAppHost=false \
-    /p:MinVerSkip=true
+    /p:MinVerSkip=true \
+    /p:Version=$MINVER_VERSION
 
 # final — runtime image used by docker compose / production
 FROM base AS final

--- a/src/Backend/AHKFlowApp.API/Dockerfile
+++ b/src/Backend/AHKFlowApp.API/Dockerfile
@@ -40,7 +40,7 @@ RUN dotnet publish "AHKFlowApp.API.csproj" \
     --no-restore \
     /p:UseAppHost=false \
     /p:MinVerSkip=true \
-    /p:Version=$MINVER_VERSION
+    "/p:Version=${MINVER_VERSION}"
 
 # final — runtime image used by docker compose / production
 FROM base AS final


### PR DESCRIPTION
… reporting

The Dockerfile correctly skips MinVer (MinVerSkip=true) since .git/ is not in the build context. However, this caused the Version property to fall back to the SDK default of 1.0.0, which was baked into the assembly and returned by the /api/v1/health and /api/v1/version endpoints.

This fix:
- Computes the real MinVer version in CI using minver-cli (where git history is available)
- Passes it as MINVER_VERSION build arg to Docker
- Uses it with /p:Version=\ in dotnet publish
- Defaults to 0.0.0-local for local docker compose builds

After deployment, the health/version endpoints will return the correct MinVer-calculated version instead of 1.0.0.

Also updated versioning.md documentation to clarify that minver-cli is the authoritative way to check versions locally, and that dotnet build -getProperty can return stale cached values.

## Summary

Brief description of changes.

## Checklist

- [ ] Tests pass (`dotnet test`)
- [ ] Build succeeds (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Breaking changes documented (if any)
