### PR TITLE
fix: remove @secure() from appInsightsConnectionString Bicep output

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -91,5 +91,4 @@ output swaDefaultHostname string = swa.outputs.swaDefaultHostname
 
 // Monitoring outputs
 output appInsightsName string = monitoring.outputs.appInsightsName
-@secure()
 output appInsightsConnectionString string = monitoring.outputs.appInsightsConnectionString

--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -34,5 +34,4 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
 }
 
 output appInsightsName string = appInsights.name
-@secure()
 output appInsightsConnectionString string = appInsights.properties.ConnectionString

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -360,7 +360,7 @@ GRANT EXECUTE TO [$RuntimeUamiName];
         Write-Host "  │  ACTION REQUIRED: Browser authentication window opening...      │" -ForegroundColor Cyan
         Write-Host "  │                                                                 │" -ForegroundColor Cyan
         Write-Host "  │  sqlcmd will open a Microsoft Entra login window to connect     │" -ForegroundColor Cyan
-        Write-Host "  │  to Azure SQL. Please sign in with: $userEmail" -ForegroundColor Cyan
+        Write-Host "  │$("  to Azure SQL. Please sign in with: $userEmail".PadRight(65))│" -ForegroundColor Cyan
         Write-Host "  │                                                                 │" -ForegroundColor Cyan
         Write-Host "  │  The window may appear BEHIND this terminal — check your        │" -ForegroundColor Cyan
         Write-Host "  │  taskbar if nothing appears on screen.                          │" -ForegroundColor Cyan


### PR DESCRIPTION
## Problem

\deploy.ps1\ fails with \PropertyNotFoundStrict\ when accessing \\.appInsightsConnectionString.value\ after parsing the \z deployment group create\ response.

## Root Cause

Azure ARM **omits the \alue\ field** from secure outputs (\@secure()\) in the deployment API response. With \Set-StrictMode -Version Latest\ active in \deploy.ps1\, accessing a missing \alue\ property throws:

\\\
The property 'value' cannot be found on this object.
FullyQualifiedErrorId : PropertyNotFoundStrict
\\\

## Fix

Removed \@secure()\ from \ppInsightsConnectionString\ in:
- \infra/main.bicep\
- \infra/modules/monitoring.bicep\

Application Insights connection strings are not true secrets — they are routinely embedded in app configs and client-side telemetry code. Microsoft's own guidance treats them as non-sensitive identifiers.