### PR TITLE
fix: pin Microsoft.ApplicationInsights.AspNetCore to 2.23.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="MediatR" Version="14.1.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />


### PR DESCRIPTION
Serilog.Sinks.ApplicationInsights 5.0.0 was compiled against Microsoft.ApplicationInsights 2.23.0 and calls TelemetryConfiguration members whose signatures changed in the 3.x binary-breaking release. NuGet had been resolving the transitive SDK to 3.1.0 via Microsoft.ApplicationInsights.AspNetCore 3.1.0, so the API crashed at startup in TEST with MissingMethodException on Program.cs:48 (WriteTo.ApplicationInsights).

Pin AspNetCore to the last 2.x stable (2.23.0) so both packages resolve to Microsoft.ApplicationInsights 2.23.0. No Program.cs change needed — the API surface we use is stable across both majors.

Revisit when serilog-contrib ships a sink release compiled against Application Insights SDK 3.x.

## Summary

Brief description of changes.

## Checklist

- [ ] Tests pass (`dotnet test`)
- [ ] Build succeeds (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Breaking changes documented (if any)
