### PR TITLE
fix: bake Blazor WASM environment at publish time for .NET 10

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -31,31 +31,23 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ENV_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.environment == 'test' && 'TEST' || 'PROD') || 'TEST' }}
+      APPSETTINGS_ENV: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.environment == 'prod' && 'Production' || 'Test') || 'Test' }}
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: actions/setup-dotnet@v4
         with: { global-json-file: global.json }
-      - name: Set Blazor environment for prod
-        if: env.TARGET_ENV == 'prod'
-        run: |
-          jq '.globalHeaders["blazor-environment"] = "Production"' \
-            src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/staticwebapp.config.json > /tmp/swa.tmp
-          mv /tmp/swa.tmp src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/staticwebapp.config.json
       - name: Substitute API base URL
         env:
           API_BASE_URL: ${{ secrets[format('AZURE_API_BASE_URL_{0}', env.ENV_SUFFIX)] }}
         run: |
-          if [ "${{ env.TARGET_ENV }}" = "prod" ]; then
-            APPSETTINGS_ENV="Production"
-          else
-            APPSETTINGS_ENV="Test"
-          fi
           sed -i "s|#{AZURE_API_BASE_URL}#|${API_BASE_URL}|g" \
             "src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.${APPSETTINGS_ENV}.json"
       - name: Publish Blazor WASM
         # Oryx (used by the SWA action) cannot build Blazor WASM — publish explicitly first.
-        run: dotnet publish src/Frontend/AHKFlowApp.UI.Blazor --configuration Release --output publish
+        # .NET 10 bakes the Blazor WASM environment in at publish time via WasmApplicationEnvironmentName
+        # (the blazor-environment HTTP header is no longer read by standalone WASM).
+        run: dotnet publish src/Frontend/AHKFlowApp.UI.Blazor --configuration Release --output publish -p:WasmApplicationEnvironmentName=${{ env.APPSETTINGS_ENV }}
       - uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets[format('AZURE_STATIC_WEB_APPS_API_TOKEN_{0}', env.ENV_SUFFIX)] }}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/staticwebapp.config.json
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/staticwebapp.config.json
@@ -1,5 +1,1 @@
-{
-  "globalHeaders": {
-    "blazor-environment": "Test"
-  }
-}
+{}


### PR DESCRIPTION
.NET 10 standalone Blazor WASM no longer reads the blazor-environment HTTP header; env is set via WasmApplicationEnvironmentName at publish. Without this, publish defaults to Production and loads appsettings.Production.json with an unsubstituted placeholder, causing the resolver to fall back to localhost candidates.

## Summary

Brief description of changes.

## Checklist

- [x] Tests pass (`dotnet test`)
- [x] Build succeeds (`dotnet build`)
- [x] No new warnings introduced
- [x] Breaking changes documented (if any)
