### PR TITLE
fix: wire SWA hostname into API CORS config via bicep

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -36,6 +36,15 @@ module sql 'modules/sql.bicep' = {
   }
 }
 
+module swa 'modules/swa.bicep' = {
+  name: 'swa'
+  params: {
+    baseName: baseName
+    environment: environment
+    location: location
+  }
+}
+
 module web 'modules/web.bicep' = {
   name: 'web'
   params: {
@@ -45,15 +54,7 @@ module web 'modules/web.bicep' = {
     runtimeUamiId: identity.outputs.runtimeUamiId
     runtimeUamiClientId: identity.outputs.runtimeUamiClientId
     aspnetcoreEnvironment: aspnetcoreEnvironment
-  }
-}
-
-module swa 'modules/swa.bicep' = {
-  name: 'swa'
-  params: {
-    baseName: baseName
-    environment: environment
-    location: location
+    swaDefaultHostname: swa.outputs.swaDefaultHostname
   }
 }
 

--- a/infra/modules/web.bicep
+++ b/infra/modules/web.bicep
@@ -17,6 +17,9 @@ param runtimeUamiClientId string
 @description('ASPNETCORE_ENVIRONMENT value for the App Service.')
 param aspnetcoreEnvironment string
 
+@description('Default hostname of the Static Web App frontend, used as an allowed CORS origin.')
+param swaDefaultHostname string
+
 var planName = '${baseName}-plan-${environment}'
 var appName = '${baseName}-api-${environment}'
 
@@ -64,6 +67,10 @@ resource appService 'Microsoft.Web/sites@2023-12-01' = {
         {
           name: 'ASPNETCORE_ENVIRONMENT'
           value: aspnetcoreEnvironment
+        }
+        {
+          name: 'Cors__AllowedOrigins__0'
+          value: 'https://${swaDefaultHostname}'
         }
       ]
     }


### PR DESCRIPTION
Move swa module before web in main.bicep to access its output. Add swaDefaultHostname param to web.bicep and inject as Cors__AllowedOrigins__0 app setting. Browser can now reach health endpoint and other APIs from deployed SWA frontend.

## Summary

Brief description of changes.

## Checklist

- [ ] Tests pass (`dotnet test`)
- [ ] Build succeeds (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Breaking changes documented (if any)
