### PR TITLE
feat: Entra ID authentication for UI and API (backlog 012)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,7 +21,7 @@ Do not implement these — they are planned for future phases or intentionally e
 - Hotstring/Hotkey/Profile CRUD features — see `.claude/backlog/` items 013-026
 - Script generation and download
 - Runtime execution of AutoHotkey scripts — intentionally excluded
-- Authentication implementation details — see backlog item 012
+- CLI authentication — see backlog item 029
 
 ## Project Configuration
 

--- a/.claude/backlog/012-add-authentication-authorization.md
+++ b/.claude/backlog/012-add-authentication-authorization.md
@@ -4,7 +4,7 @@
 
 - **Epic**: Authentication and authorization
 - **Type**: Feature
-- **Interfaces**: UI | API | CLI
+- **Interfaces**: UI | API
 
 ## Summary
 
@@ -16,15 +16,16 @@ As a user, I want to sign in securely so that my profiles and automation definit
 
 ## Acceptance criteria
 
-- [ ] UI authenticates via MSAL and calls the API with bearer tokens.
-- [ ] API validates tokens and enforces authorization.
-- [ ] CLI supports a sign-in flow appropriate for a console app.
-- [ ] Unauthorized/forbidden responses are consistent and documented.
+- [x] UI authenticates via MSAL and calls the API with bearer tokens.
+- [x] API validates tokens and enforces authorization.
+- [x] Unauthorized/forbidden responses are consistent and documented.
 
 ## Out of scope
 
 - Multiple identity providers.
+- CLI authentication — deferred to 029. Tokens validated against `access_as_user` scope; no user DB persistence (claims-only via `ICurrentUser`).
 
 ## Notes / dependencies
 
 - Impacts all feature endpoints.
+- See `docs/architecture/authentication.md` and `docs/deployment/entra-setup.md`.

--- a/.claude/backlog/029-cli-authentication.md
+++ b/.claude/backlog/029-cli-authentication.md
@@ -1,0 +1,34 @@
+# 029 - CLI authentication
+
+## Metadata
+
+- **Epic**: Authentication and authorization
+- **Type**: Feature
+- **Interfaces**: CLI
+- **Depends on**: 017-scaffold-cli-project, 012-add-authentication-authorization
+
+## Summary
+
+Add Entra ID authentication to the CLI tool using MSAL.NET device-code flow. The CLI will acquire a bearer token and pass it to all API calls.
+
+## User story
+
+As a user, I want to sign in to the CLI so that my hotstrings are protected and associated with my account.
+
+## Acceptance criteria
+
+- [ ] `ahkflow login` triggers device-code flow and caches the token.
+- [ ] Cached token is attached to all subsequent API calls.
+- [ ] `ahkflow logout` clears the cached token.
+- [ ] Expired tokens are refreshed silently; user is prompted to re-login on failure.
+
+## Out of scope
+
+- Multiple identity providers.
+
+## Notes / dependencies
+
+- Uses the same Entra app registration created by `scripts/setup-entra-app.ps1` — no new app registration needed.
+- Add a public-client redirect URI (`http://localhost`) to the existing registration.
+- Scope: `api://{clientId}/access_as_user` (same as UI).
+- See `docs/architecture/authentication.md` for the overall auth architecture.

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -175,6 +175,16 @@ jobs:
             --resource-group "${{ vars[format('AZURE_RESOURCE_GROUP_{0}', env.ENV_SUFFIX)] }}" \
             --container-image-name "${{ needs.build-push-image.outputs.image-ref }}" \
             --container-registry-url "https://ghcr.io"
+      - name: Apply AzureAd app settings
+        run: |
+          az webapp config appsettings set \
+            --name "${{ vars[format('APP_SERVICE_NAME_{0}', env.ENV_SUFFIX)] }}" \
+            --resource-group "${{ vars[format('AZURE_RESOURCE_GROUP_{0}', env.ENV_SUFFIX)] }}" \
+            --settings \
+              AzureAd__TenantId="${{ vars[format('AZURE_AD_TENANT_ID_{0}', env.ENV_SUFFIX)] }}" \
+              AzureAd__ClientId="${{ vars[format('AZURE_AD_CLIENT_ID_{0}', env.ENV_SUFFIX)] }}"
+      - name: Restart App Service
+        run: |
           az webapp restart \
             --name "${{ vars[format('APP_SERVICE_NAME_{0}', env.ENV_SUFFIX)] }}" \
             --resource-group "${{ vars[format('AZURE_RESOURCE_GROUP_{0}', env.ENV_SUFFIX)] }}"

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -37,12 +37,18 @@ jobs:
         with: { fetch-depth: 0 }
       - uses: actions/setup-dotnet@v4
         with: { global-json-file: global.json }
-      - name: Substitute API base URL
+      - name: Substitute appsettings placeholders
         env:
           API_BASE_URL: ${{ secrets[format('AZURE_API_BASE_URL_{0}', env.ENV_SUFFIX)] }}
+          AD_TENANT_ID: ${{ vars[format('AZURE_AD_TENANT_ID_{0}', env.ENV_SUFFIX)] }}
+          AD_CLIENT_ID: ${{ vars[format('AZURE_AD_CLIENT_ID_{0}', env.ENV_SUFFIX)] }}
+          AD_DEFAULT_SCOPE: ${{ vars[format('AZURE_AD_DEFAULT_SCOPE_{0}', env.ENV_SUFFIX)] }}
         run: |
-          sed -i "s|#{AZURE_API_BASE_URL}#|${API_BASE_URL}|g" \
-            "src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.${APPSETTINGS_ENV}.json"
+          file="src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.${APPSETTINGS_ENV}.json"
+          sed -i "s|#{AZURE_API_BASE_URL}#|${API_BASE_URL}|g" "$file"
+          sed -i "s|#{AZURE_AD_TENANT_ID}#|${AD_TENANT_ID}|g" "$file"
+          sed -i "s|#{AZURE_AD_CLIENT_ID}#|${AD_CLIENT_ID}|g" "$file"
+          sed -i "s|#{AZURE_AD_DEFAULT_SCOPE}#|${AD_DEFAULT_SCOPE}|g" "$file"
       - name: Publish Blazor WASM
         # Oryx (used by the SWA action) cannot build Blazor WASM — publish explicitly first.
         # .NET 10 bakes the Blazor WASM environment in at publish time via WasmApplicationEnvironmentName

--- a/.gitignore
+++ b/.gitignore
@@ -425,6 +425,7 @@ FodyWeavers.xsd
 src/Backend/**/appsettings.Development.json
 src/Backend/**/appsettings.Production.json
 
+
 # Blazor dev config — tenant-specific, copy from .example and fill in values
 src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.Development.json
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,7 @@
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,14 +14,17 @@
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="MediatR" Version="14.1.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.6" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="MudBlazor" Version="9.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -1,0 +1,68 @@
+# Authentication Architecture
+
+AHKFlowApp uses single-tenant Entra ID (Azure AD) via MSAL for the Blazor WASM frontend and `Microsoft.Identity.Web` JWT validation on the ASP.NET Core API.
+
+## Flow
+
+```
+Browser
+  │  user clicks "Log in" → NavigateTo("authentication/login")
+  │
+  ▼
+MSAL (Microsoft.Authentication.WebAssembly.Msal)
+  │  redirects to https://login.microsoftonline.com/{tenantId}
+  │  Entra issues authorization code
+  │  MSAL exchanges code → access token (Bearer JWT)
+  │
+  ▼
+BaseAddressAuthorizationMessageHandler
+  │  attaches Bearer token to every HttpClient request to the API base address
+  │
+  ▼
+ASP.NET Core API (UseAuthentication → UseAuthorization)
+  │  AddMicrosoftIdentityWebApi validates JWT signature, audience, issuer
+  │  [Authorize] enforces authenticated principal
+  │  [RequiredScope("access_as_user")] enforces scp claim
+  │
+  ▼
+ICurrentUser (HttpContextCurrentUser)
+  │  reads oid / preferred_username / name claims from token
+  │  injected into controllers and handlers via DI
+  │
+  ▼
+Handler / Controller returns response
+```
+
+## Key components
+
+| Component | Location | Purpose |
+|---|---|---|
+| `AddMsalAuthentication` | `UI.Blazor/Program.cs` | MSAL browser auth, token cache, scopes |
+| `BaseAddressAuthorizationMessageHandler` | `UI.Blazor/Program.cs` | Auto-attaches Bearer token |
+| `LoginDisplay.razor` | `UI.Blazor/Shared/` | Login/logout buttons in app bar |
+| `Authentication.razor` | `UI.Blazor/Pages/` | MSAL redirect/callback page |
+| `RedirectToLogin.razor` | `UI.Blazor/Shared/` | Unauthenticated route guard |
+| `AddMicrosoftIdentityWebApi` | `API/Program.cs` | JWT validation via `AzureAd` config |
+| `ICurrentUser` | `Application/Abstractions/` | Framework-free user identity interface |
+| `HttpContextCurrentUser` | `API/Auth/` | Reads claims from `IHttpContextAccessor` |
+| `WhoAmIController` | `API/Controllers/` | Auth verification endpoint (`GET /api/v1/whoami`) |
+
+## App registration
+
+One Entra app registration per environment. The SPA is both the client (SPA redirect URIs) and the resource (exposes `access_as_user` scope, pre-authorizes itself).
+
+- **Scope**: `api://{clientId}/access_as_user`
+- **Authority**: `https://login.microsoftonline.com/{tenantId}`
+- **Setup**: `scripts/setup-entra-app.ps1` — see `docs/deployment/entra-setup.md`
+
+## Auth verification endpoint
+
+`GET /api/v1/whoami` — requires `[Authorize]` + `[RequiredScope("access_as_user")]`. Returns `WhoAmIResponse` with `Oid`, `Email`, `Name`, `IsAuthenticated`. Use this endpoint to verify auth is wired correctly end-to-end.
+
+## Scope enforcement
+
+`[RequiredScope("access_as_user")]` on each protected controller. No global auth filter — every controller must declare `[Authorize]` or `[AllowAnonymous]` explicitly (per AGENTS.md security rules).
+
+## CLI authentication
+
+Deferred to backlog item 029. Will use MSAL.NET device-code flow as a public-client registration on the same Entra app.

--- a/docs/deployment/entra-setup.md
+++ b/docs/deployment/entra-setup.md
@@ -1,0 +1,63 @@
+# Entra ID App Registration Setup
+
+AHKFlowApp uses a single Entra ID app registration per environment (dev, test, prod). The SPA is both the client and the resource — it exposes an `access_as_user` scope and pre-authorizes itself.
+
+## Prerequisites
+
+- Azure CLI with `az login` completed
+- Contributor or Application Administrator role in the target tenant
+
+## Step 1: Run the setup script
+
+```bash
+# Dev environment
+.\scripts\setup-entra-app.ps1 -Environment dev
+
+# Test environment (SWA hostname resolved automatically)
+.\scripts\setup-entra-app.ps1 -Environment test
+
+# Prod environment
+.\scripts\setup-entra-app.ps1 -Environment prod
+```
+
+The script is idempotent — safe to re-run. It outputs the `ClientId`, `TenantId`, and `DefaultScope` values needed for the next steps.
+
+## Step 2 (dev): Set user secrets
+
+```bash
+dotnet user-secrets set "AzureAd:TenantId" "<TenantId>" --project src/Backend/AHKFlowApp.API
+dotnet user-secrets set "AzureAd:ClientId" "<ClientId>" --project src/Backend/AHKFlowApp.API
+```
+
+Then populate `src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.Development.json`:
+
+```json
+"AzureAd": {
+  "Authority": "https://login.microsoftonline.com/<TenantId>",
+  "ClientId": "<ClientId>",
+  "ValidateAuthority": true,
+  "DefaultScope": "api://<ClientId>/access_as_user"
+}
+```
+
+These values are public — MSAL SPA apps embed them in the browser bundle. Do not use `.gitignore` to hide them.
+
+## Step 3 (test/prod): Set GitHub Variables
+
+```bash
+gh variable set AZURE_AD_TENANT_ID_TEST --body "<TenantId>"
+gh variable set AZURE_AD_CLIENT_ID_TEST --body "<ClientId>"
+gh variable set AZURE_AD_DEFAULT_SCOPE_TEST --body "api://<ClientId>/access_as_user"
+```
+
+The deploy workflows substitute these into `appsettings.Test.json` / `appsettings.Production.json` at build time and inject them into App Service configuration on every deploy.
+
+## What's public vs secret
+
+All `AzureAd:*` values are **public** — they appear in the compiled Blazor WASM bundle served to the browser. Use GitHub **Variables** (not Secrets) for them.
+
+The `AZURE_STATIC_WEB_APPS_API_TOKEN_*` and `AZURE_API_BASE_URL_*` values are secrets (remain in GitHub Secrets as before).
+
+## Adding a custom domain later
+
+When a custom domain is added to the SWA, re-run `setup-entra-app.ps1` with `-SwaHostname <custom-domain>` to add the custom domain redirect URIs to the app registration. Also extend `Cors:AllowedOrigins` in bicep.

--- a/docs/deployment/getting-started.md
+++ b/docs/deployment/getting-started.md
@@ -26,6 +26,8 @@ The script will:
 
 When done, push to `main` — GitHub Actions will deploy the API container and Blazor frontend automatically.
 
+> **Auth app registration not included in `deploy.ps1`.** After provisioning, run the Entra app registration setup separately — see [Entra ID Setup](#entra-id-app-registration-setup) below.
+
 ## What Gets Provisioned
 
 | Resource | Name Pattern | Notes |
@@ -95,6 +97,26 @@ If you need to re-provision from GitHub Actions (e.g., after a Bicep change):
 2. Click **Run workflow** and select an environment
 
 > **Note:** This only runs the Bicep deployment. Imperative steps (Entra group, OIDC federation, SQL user, GitHub secrets) must be done locally with `deploy.ps1`.
+
+## Entra ID App Registration Setup
+
+The `deploy.ps1` script provisions infrastructure but does **not** create the Entra ID app registration used for user authentication. Run this once per environment after provisioning:
+
+```powershell
+.\scripts\setup-entra-app.ps1 -Environment test
+.\scripts\setup-entra-app.ps1 -Environment prod
+```
+
+The script outputs the `ClientId`, `TenantId`, and `DefaultScope` values. Set them as GitHub Variables so the deploy workflows can inject them:
+
+```bash
+gh variable set AZURE_AD_TENANT_ID_TEST --body "<TenantId>"
+gh variable set AZURE_AD_CLIENT_ID_TEST --body "<ClientId>"
+gh variable set AZURE_AD_DEFAULT_SCOPE_TEST --body "<DefaultScope>"
+# repeat with _PROD suffix for prod
+```
+
+For local development, use user-secrets instead — see [entra-setup.md](entra-setup.md).
 
 ## Troubleshooting
 

--- a/docs/development/configuration-strategy.md
+++ b/docs/development/configuration-strategy.md
@@ -187,6 +187,19 @@ src/Backend/**/appsettings.Production.json
 
 `appsettings.json` points to `http://localhost:5600` by default. If you need a machine-specific override, copy `appsettings.Development.json.example` to `appsettings.Development.json` (ignored by git). The Blazor dev server sets `Blazor-Environment: Development` automatically.
 
+**Auth setup required:** The `AzureAd` block in `appsettings.Development.json` is intentionally empty. After running `scripts/setup-entra-app.ps1 -Environment dev`, fill it in:
+
+```json
+"AzureAd": {
+  "Authority": "https://login.microsoftonline.com/<TenantId>",
+  "ClientId": "<ClientId>",
+  "ValidateAuthority": true,
+  "DefaultScope": "api://<ClientId>/access_as_user"
+}
+```
+
+These values are public — safe to commit if desired, but not required.
+
 ### Backend
 
 ```powershell
@@ -197,6 +210,15 @@ Copy-Item src/Backend/AHKFlowApp.API/appsettings.Production.json.example `
 # Edit with your local values (or leave as-is for local development)
 # This file is ignored by git
 ```
+
+**Auth setup required:** Set AzureAd values via user-secrets (never commit these to the API project — use user-secrets for dev):
+
+```bash
+dotnet user-secrets set "AzureAd:TenantId" "<TenantId>" --project src/Backend/AHKFlowApp.API
+dotnet user-secrets set "AzureAd:ClientId" "<ClientId>" --project src/Backend/AHKFlowApp.API
+```
+
+Run `scripts/setup-entra-app.ps1 -Environment dev` to get the values. See [entra-setup.md](../deployment/entra-setup.md).
 
 ---
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -14,6 +14,12 @@ param sqlAdminGroupId string
 @description('Display name of the Entra security group that will be the SQL admin.')
 param sqlAdminGroupName string
 
+@description('Entra ID tenant ID for API token validation. See scripts/setup-entra-app.ps1.')
+param azureAdTenantId string
+
+@description('Entra ID client ID for API token validation. See scripts/setup-entra-app.ps1.')
+param azureAdClientId string
+
 var aspnetcoreEnvironment = environment == 'prod' ? 'Production' : 'Test'
 
 module identity 'modules/identity.bicep' = {
@@ -55,6 +61,8 @@ module web 'modules/web.bicep' = {
     runtimeUamiClientId: identity.outputs.runtimeUamiClientId
     aspnetcoreEnvironment: aspnetcoreEnvironment
     swaDefaultHostname: swa.outputs.swaDefaultHostname
+    azureAdTenantId: azureAdTenantId
+    azureAdClientId: azureAdClientId
   }
 }
 

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -4,6 +4,8 @@ using './main.bicep'
 param environment = 'test'             // 'test' or 'prod'
 param sqlAdminGroupId = ''             // az ad group show --group <name> --query id -o tsv
 param sqlAdminGroupName = ''           // e.g. 'ahkflowapp-sql-admins-test'
+param azureAdTenantId = ''             // from scripts/setup-entra-app.ps1 -Environment test
+param azureAdClientId = ''             // from scripts/setup-entra-app.ps1 -Environment test
 
 // Optional — change if needed
 param baseName = 'ahkflowapp'

--- a/infra/modules/web.bicep
+++ b/infra/modules/web.bicep
@@ -20,6 +20,15 @@ param aspnetcoreEnvironment string
 @description('Default hostname of the Static Web App frontend, used as an allowed CORS origin.')
 param swaDefaultHostname string
 
+@description('Entra ID instance URL. Defaults to the active cloud login endpoint.')
+param azureAdInstance string = az.environment().authentication.loginEndpoint
+
+@description('Entra ID tenant ID for token validation.')
+param azureAdTenantId string
+
+@description('Entra ID client ID (app registration) for token validation.')
+param azureAdClientId string
+
 var planName = '${baseName}-plan-${environment}'
 var appName = '${baseName}-api-${environment}'
 
@@ -71,6 +80,18 @@ resource appService 'Microsoft.Web/sites@2023-12-01' = {
         {
           name: 'Cors__AllowedOrigins__0'
           value: 'https://${swaDefaultHostname}'
+        }
+        {
+          name: 'AzureAd__Instance'
+          value: azureAdInstance
+        }
+        {
+          name: 'AzureAd__TenantId'
+          value: azureAdTenantId
+        }
+        {
+          name: 'AzureAd__ClientId'
+          value: azureAdClientId
         }
       ]
     }

--- a/scripts/setup-entra-app.ps1
+++ b/scripts/setup-entra-app.ps1
@@ -158,8 +158,9 @@ Write-Host "Default scope: $defaultScope"
 Write-Host ""
 Write-Host "--- Next steps ---" -ForegroundColor Yellow
 if ($Environment -eq 'dev') {
-    Write-Host "dotnet user-secrets set 'AzureAd:TenantId' '$tenantId' --project src/Backend/AHKFlowApp.API"
-    Write-Host "dotnet user-secrets set 'AzureAd:ClientId' '$appId' --project src/Backend/AHKFlowApp.API"
+    Write-Host "Run from the repo root:"
+    Write-Host "  dotnet user-secrets set 'AzureAd:TenantId' '$tenantId' --project src/Backend/AHKFlowApp.API"
+    Write-Host "  dotnet user-secrets set 'AzureAd:ClientId' '$appId' --project src/Backend/AHKFlowApp.API"
     Write-Host "Then update wwwroot/appsettings.Development.json in AHKFlowApp.UI.Blazor:"
     Write-Host "  Authority    = https://login.microsoftonline.com/$tenantId"
     Write-Host "  ClientId     = $appId"

--- a/scripts/setup-entra-app.ps1
+++ b/scripts/setup-entra-app.ps1
@@ -1,0 +1,171 @@
+#Requires -Version 7
+<#
+.SYNOPSIS
+    Idempotent Entra ID app registration setup for AHKFlowApp.
+
+.PARAMETER Environment
+    Target environment: dev, test, or prod.
+
+.PARAMETER SwaHostname
+    Static Web App default hostname (e.g. red-stone-abc123.azurestaticapps.net).
+    If omitted, the script attempts to resolve it via `az staticwebapp show`.
+
+.EXAMPLE
+    .\setup-entra-app.ps1 -Environment dev
+
+.EXAMPLE
+    .\setup-entra-app.ps1 -Environment test -SwaHostname "red-stone-abc123.azurestaticapps.net"
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('dev', 'test', 'prod')]
+    [string] $Environment,
+
+    [string] $SwaHostname
+)
+
+$ErrorActionPreference = 'Stop'
+$displayName = "AHKFlowApp-$Environment"
+
+# ---------------------------------------------------------------------------
+# Resolve or create the app registration
+# ---------------------------------------------------------------------------
+$existing = az ad app list --display-name $displayName --query '[0]' -o json | ConvertFrom-Json
+if ($existing) {
+    Write-Host "Found existing app: $displayName ($($existing.appId))"
+    $appId = $existing.appId
+    $objectId = $existing.id
+} else {
+    Write-Host "Creating app registration: $displayName"
+    $app = az ad app create --display-name $displayName --query '{appId:appId,id:id}' -o json | ConvertFrom-Json
+    $appId = $app.appId
+    $objectId = $app.id
+    Write-Host "Created: $appId"
+}
+
+$tenantId = az account show --query tenantId -o tsv
+
+# ---------------------------------------------------------------------------
+# Resolve SWA hostname
+# ---------------------------------------------------------------------------
+if (-not $SwaHostname -and $Environment -ne 'dev') {
+    $swaName = "ahkflowapp-swa-$Environment"
+    Write-Host "Resolving SWA hostname for $swaName ..."
+    $SwaHostname = az staticwebapp show --name $swaName --query defaultHostname -o tsv 2>$null
+}
+
+# ---------------------------------------------------------------------------
+# Build redirect URI lists
+# ---------------------------------------------------------------------------
+$redirectUris = @('http://localhost:5601/authentication/login-callback')
+if ($Environment -eq 'dev') {
+    $redirectUris += 'https://localhost:7601/authentication/login-callback'
+}
+if ($SwaHostname) {
+    $redirectUris += "https://$SwaHostname/authentication/login-callback"
+}
+
+$logoutUris = $redirectUris -replace 'login-callback', 'logout-callback'
+
+# ---------------------------------------------------------------------------
+# Set identifier URI and redirect URIs
+# ---------------------------------------------------------------------------
+az ad app update `
+    --id $objectId `
+    --identifier-uris "api://$appId"
+
+$spaConfig = @{
+    redirectUris = $redirectUris
+} | ConvertTo-Json -Compress
+
+az rest `
+    --method PATCH `
+    --uri "https://graph.microsoft.com/v1.0/applications/$objectId" `
+    --headers 'Content-Type=application/json' `
+    --body "{`"spa`":{`"redirectUris`":$(($redirectUris | ConvertTo-Json -Compress))}}"
+
+Write-Host "Redirect URIs set: $($redirectUris -join ', ')"
+
+# ---------------------------------------------------------------------------
+# Ensure access_as_user oauth2PermissionScope exists
+# ---------------------------------------------------------------------------
+$scopeId = [guid]::NewGuid().ToString()
+$scopeJson = @{
+    api = @{
+        oauth2PermissionScopes = @(
+            @{
+                id                      = $scopeId
+                value                   = 'access_as_user'
+                type                    = 'User'
+                adminConsentDisplayName = 'Access AHKFlowApp as user'
+                adminConsentDescription = 'Allows the app to access AHKFlowApp API on behalf of the signed-in user.'
+                userConsentDisplayName  = 'Access AHKFlowApp'
+                userConsentDescription  = 'Allows this app to access AHKFlowApp on your behalf.'
+                isEnabled               = $true
+            }
+        )
+    }
+} | ConvertTo-Json -Depth 10 -Compress
+
+# Only add if not already present
+$currentScopes = az ad app show --id $objectId --query 'api.oauth2PermissionScopes[].value' -o json | ConvertFrom-Json
+if ('access_as_user' -notin $currentScopes) {
+    az rest `
+        --method PATCH `
+        --uri "https://graph.microsoft.com/v1.0/applications/$objectId" `
+        --headers 'Content-Type=application/json' `
+        --body $scopeJson
+    Write-Host "Added oauth2PermissionScope: access_as_user"
+} else {
+    Write-Host "Scope access_as_user already exists"
+    $scopeId = az ad app show --id $objectId --query 'api.oauth2PermissionScopes[?value==`access_as_user`].id | [0]' -o tsv
+}
+
+# ---------------------------------------------------------------------------
+# Pre-authorize the SPA (same app) for its own scope
+# ---------------------------------------------------------------------------
+$preAuthBody = @{
+    api = @{
+        preAuthorizedApplications = @(
+            @{
+                appId                  = $appId
+                delegatedPermissionIds = @($scopeId)
+            }
+        )
+    }
+} | ConvertTo-Json -Depth 10 -Compress
+
+az rest `
+    --method PATCH `
+    --uri "https://graph.microsoft.com/v1.0/applications/$objectId" `
+    --headers 'Content-Type=application/json' `
+    --body $preAuthBody
+
+Write-Host "Pre-authorized SPA ($appId) for scope $scopeId"
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+$defaultScope = "api://$appId/access_as_user"
+
+Write-Host ""
+Write-Host "===== AHKFlowApp Entra App Registration ($Environment) =====" -ForegroundColor Cyan
+Write-Host "Client ID  : $appId"
+Write-Host "Tenant ID  : $tenantId"
+Write-Host "Default scope: $defaultScope"
+Write-Host ""
+Write-Host "--- Next steps ---" -ForegroundColor Yellow
+if ($Environment -eq 'dev') {
+    Write-Host "dotnet user-secrets set 'AzureAd:TenantId' '$tenantId' --project src/Backend/AHKFlowApp.API"
+    Write-Host "dotnet user-secrets set 'AzureAd:ClientId' '$appId' --project src/Backend/AHKFlowApp.API"
+    Write-Host "Then update wwwroot/appsettings.Development.json in AHKFlowApp.UI.Blazor:"
+    Write-Host "  Authority    = https://login.microsoftonline.com/$tenantId"
+    Write-Host "  ClientId     = $appId"
+    Write-Host "  DefaultScope = $defaultScope"
+} else {
+    $envUpper = $Environment.ToUpper()
+    Write-Host "gh variable set AZURE_AD_TENANT_ID_$envUpper --body '$tenantId'"
+    Write-Host "gh variable set AZURE_AD_CLIENT_ID_$envUpper --body '$appId'"
+    Write-Host "gh variable set AZURE_AD_DEFAULT_SCOPE_$envUpper --body '$defaultScope'"
+}

--- a/scripts/setup-entra-app.ps1
+++ b/scripts/setup-entra-app.ps1
@@ -28,6 +28,22 @@ param(
 $ErrorActionPreference = 'Stop'
 $displayName = "AHKFlowApp-$Environment"
 
+# az rest --body '...' is unreliable on Windows PowerShell due to quoting.
+# Write JSON to a temp file and use --body @file instead.
+function Invoke-GraphPatch([string] $ObjectId, [string] $JsonBody) {
+    $tmp = [System.IO.Path]::GetTempFileName()
+    try {
+        [System.IO.File]::WriteAllText($tmp, $JsonBody, [System.Text.Encoding]::UTF8)
+        az rest --method PATCH `
+            --uri "https://graph.microsoft.com/v1.0/applications/$ObjectId" `
+            --headers 'Content-Type=application/json' `
+            --body "@$tmp"
+        if ($LASTEXITCODE -ne 0) { throw "az rest PATCH failed (exit $LASTEXITCODE)" }
+    } finally {
+        Remove-Item $tmp -ErrorAction SilentlyContinue
+    }
+}
+
 # ---------------------------------------------------------------------------
 # Resolve or create the app registration
 # ---------------------------------------------------------------------------
@@ -75,15 +91,8 @@ az ad app update `
     --id $objectId `
     --identifier-uris "api://$appId"
 
-$spaConfig = @{
-    redirectUris = $redirectUris
-} | ConvertTo-Json -Compress
-
-az rest `
-    --method PATCH `
-    --uri "https://graph.microsoft.com/v1.0/applications/$objectId" `
-    --headers 'Content-Type=application/json' `
-    --body "{`"spa`":{`"redirectUris`":$(($redirectUris | ConvertTo-Json -Compress))}}"
+$spaJson = @{ spa = @{ redirectUris = $redirectUris } } | ConvertTo-Json -Depth 5 -Compress
+Invoke-GraphPatch -ObjectId $objectId -JsonBody $spaJson
 
 Write-Host "Redirect URIs set: $($redirectUris -join ', ')"
 
@@ -111,11 +120,7 @@ $scopeJson = @{
 # Only add if not already present
 $currentScopes = az ad app show --id $objectId --query 'api.oauth2PermissionScopes[].value' -o json | ConvertFrom-Json
 if ('access_as_user' -notin $currentScopes) {
-    az rest `
-        --method PATCH `
-        --uri "https://graph.microsoft.com/v1.0/applications/$objectId" `
-        --headers 'Content-Type=application/json' `
-        --body $scopeJson
+    Invoke-GraphPatch -ObjectId $objectId -JsonBody $scopeJson
     Write-Host "Added oauth2PermissionScope: access_as_user"
 } else {
     Write-Host "Scope access_as_user already exists"
@@ -136,11 +141,7 @@ $preAuthBody = @{
     }
 } | ConvertTo-Json -Depth 10 -Compress
 
-az rest `
-    --method PATCH `
-    --uri "https://graph.microsoft.com/v1.0/applications/$objectId" `
-    --headers 'Content-Type=application/json' `
-    --body $preAuthBody
+Invoke-GraphPatch -ObjectId $objectId -JsonBody $preAuthBody
 
 Write-Host "Pre-authorized SPA ($appId) for scope $scopeId"
 

--- a/scripts/setup-entra-app.ps1
+++ b/scripts/setup-entra-app.ps1
@@ -98,6 +98,10 @@ Write-Host "Redirect URIs set: $($redirectUris -join ', ')"
 
 # ---------------------------------------------------------------------------
 # Ensure access_as_user oauth2PermissionScope exists
+# NOTE: PATCHing api.oauth2PermissionScopes replaces the whole collection.
+# Safe here because this is a bootstrap script for a single-purpose app that
+# only needs one scope. If you later add extra scopes manually, update this
+# block to merge rather than replace.
 # ---------------------------------------------------------------------------
 $scopeId = [guid]::NewGuid().ToString()
 $scopeJson = @{

--- a/src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj
+++ b/src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj
@@ -4,11 +4,13 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.Result.AspNetCore" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.Identity.Web" />
     <PackageReference Include="MinVer">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj
+++ b/src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj
@@ -1,5 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <UserSecretsId>5194dc43-77b9-439d-9186-32766f8ddde9</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ardalis.Result.AspNetCore" />

--- a/src/Backend/AHKFlowApp.API/Auth/HttpContextCurrentUser.cs
+++ b/src/Backend/AHKFlowApp.API/Auth/HttpContextCurrentUser.cs
@@ -1,0 +1,29 @@
+using System.Security.Claims;
+using AHKFlowApp.Application.Abstractions;
+
+namespace AHKFlowApp.API.Auth;
+
+internal sealed class HttpContextCurrentUser(IHttpContextAccessor httpContextAccessor) : ICurrentUser
+{
+    private ClaimsPrincipal? User => httpContextAccessor.HttpContext?.User;
+
+    public Guid? Oid
+    {
+        get
+        {
+            string? value = User?.FindFirstValue("http://schemas.microsoft.com/identity/claims/objectidentifier")
+                     ?? User?.FindFirstValue("oid");
+            return Guid.TryParse(value, out Guid guid) ? guid : null;
+        }
+    }
+
+    public string? Email =>
+        User?.FindFirstValue("preferred_username")
+        ?? User?.FindFirstValue(ClaimTypes.Email);
+
+    public string? Name =>
+        User?.FindFirstValue(ClaimTypes.Name)
+        ?? User?.FindFirstValue("name");
+
+    public bool IsAuthenticated => User?.Identity?.IsAuthenticated ?? false;
+}

--- a/src/Backend/AHKFlowApp.API/Controllers/WhoAmIController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/WhoAmIController.cs
@@ -1,0 +1,19 @@
+using AHKFlowApp.Application.Abstractions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Identity.Web.Resource;
+
+namespace AHKFlowApp.API.Controllers;
+
+[ApiController]
+[Route("api/v1/[controller]")]
+[Authorize]
+[RequiredScope("access_as_user")]
+public sealed class WhoAmIController(ICurrentUser currentUser) : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get() =>
+        Ok(new WhoAmIResponse(currentUser.Oid, currentUser.Email, currentUser.Name, currentUser.IsAuthenticated));
+}
+
+public sealed record WhoAmIResponse(Guid? Oid, string? Email, string? Name, bool IsAuthenticated);

--- a/src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs
+++ b/src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs
@@ -30,6 +30,18 @@ internal static class ApiExtensions
                 Title = "AHKFlowApp API",
                 Version = "v1"
             });
+
+            options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+            {
+                Scheme = "bearer",
+                BearerFormat = "JWT",
+                In = ParameterLocation.Header,
+                Type = SecuritySchemeType.Http
+            });
+            options.AddSecurityRequirement(_ => new OpenApiSecurityRequirement
+            {
+                { new OpenApiSecuritySchemeReference("Bearer"), [] }
+            });
         });
         return services;
     }

--- a/src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs
+++ b/src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs
@@ -38,9 +38,12 @@ internal static class ApiExtensions
                 In = ParameterLocation.Header,
                 Type = SecuritySchemeType.Http
             });
-            options.AddSecurityRequirement(_ => new OpenApiSecurityRequirement
+            options.AddSecurityRequirement(doc => new OpenApiSecurityRequirement
             {
-                { new OpenApiSecuritySchemeReference("Bearer"), [] }
+                {
+                    new OpenApiSecuritySchemeReference("Bearer", doc),
+                    []
+                }
             });
         });
         return services;

--- a/src/Backend/AHKFlowApp.API/Program.cs
+++ b/src/Backend/AHKFlowApp.API/Program.cs
@@ -1,16 +1,20 @@
 using System.Diagnostics;
 using System.Reflection;
 using AHKFlowApp.API;
+using AHKFlowApp.API.Auth;
 using AHKFlowApp.API.Extensions;
 using AHKFlowApp.API.Middleware;
 using AHKFlowApp.Application;
+using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Infrastructure;
 using AHKFlowApp.Infrastructure.Persistence;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Identity.Web;
 using Serilog;
 using Serilog.Events;
 
@@ -97,6 +101,12 @@ try
     string[] allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
     builder.Services.AddConfiguredCors(allowedOrigins, corsPolicyName);
 
+    builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
+    builder.Services.AddAuthorization();
+    builder.Services.AddHttpContextAccessor();
+    builder.Services.AddScoped<ICurrentUser, HttpContextCurrentUser>();
+
     WebApplication app = builder.Build();
 
     // Auto-apply migrations in Development (creates database if it doesn't exist)
@@ -164,6 +174,7 @@ try
         app.UseCors(corsPolicyName);
     }
 
+    app.UseAuthentication();
     app.UseAuthorization();
     app.MapControllers();
 

--- a/src/Backend/AHKFlowApp.API/appsettings.Development.json.example
+++ b/src/Backend/AHKFlowApp.API/appsettings.Development.json.example
@@ -17,5 +17,10 @@
       "https://localhost:7601",
       "http://localhost:5601"
     ]
+  },
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "TenantId": "",
+    "ClientId": ""
   }
 }

--- a/src/Backend/AHKFlowApp.API/appsettings.Production.json
+++ b/src/Backend/AHKFlowApp.API/appsettings.Production.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "Serilog": {
     "MinimumLevel": {
       "Default": "Warning",
@@ -14,5 +14,10 @@
   },
   "Cors": {
     "AllowedOrigins": []
+  },
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "TenantId": "",
+    "ClientId": ""
   }
 }

--- a/src/Backend/AHKFlowApp.API/appsettings.Test.json
+++ b/src/Backend/AHKFlowApp.API/appsettings.Test.json
@@ -14,5 +14,10 @@
   },
   "Cors": {
     "AllowedOrigins": []
+  },
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "TenantId": "",
+    "ClientId": ""
   }
 }

--- a/src/Backend/AHKFlowApp.API/appsettings.json
+++ b/src/Backend/AHKFlowApp.API/appsettings.json
@@ -43,5 +43,10 @@
   "AllowedHosts": "*",
   "Cors": {
     "AllowedOrigins": []
+  },
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "TenantId": "",
+    "ClientId": ""
   }
 }

--- a/src/Backend/AHKFlowApp.Application/Abstractions/ICurrentUser.cs
+++ b/src/Backend/AHKFlowApp.Application/Abstractions/ICurrentUser.cs
@@ -1,0 +1,9 @@
+namespace AHKFlowApp.Application.Abstractions;
+
+public interface ICurrentUser
+{
+    Guid? Oid { get; }
+    string? Email { get; }
+    string? Name { get; }
+    bool IsAuthenticated { get; }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/AHKFlowApp.UI.Blazor.csproj
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/AHKFlowApp.UI.Blazor.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="MinVer">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/App.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/App.razor
@@ -1,6 +1,12 @@
-﻿<Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
-    <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
-        <FocusOnNavigate RouteData="@routeData" Selector="h3" />
-    </Found>
-</Router>
+﻿<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                <NotAuthorized>
+                    <RedirectToLogin />
+                </NotAuthorized>
+            </AuthorizeRouteView>
+            <FocusOnNavigate RouteData="@routeData" Selector="h3" />
+        </Found>
+    </Router>
+</CascadingAuthenticationState>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Auth/ApiAuthorizationMessageHandler.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Auth/ApiAuthorizationMessageHandler.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+
+namespace AHKFlowApp.UI.Blazor.Auth;
+
+internal sealed class ApiAuthorizationMessageHandler : AuthorizationMessageHandler
+{
+    public ApiAuthorizationMessageHandler(
+        IAccessTokenProvider provider,
+        NavigationManager navigationManager,
+        IConfiguration configuration)
+        : base(provider, navigationManager)
+    {
+        ConfigureHandler(
+            authorizedUrls: [configuration["ApiHttpClient:BaseAddress"]!],
+            scopes: [configuration["AzureAd:DefaultScope"]!]);
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
@@ -11,6 +11,14 @@ Blazor WebAssembly PWA frontend for AHKFlowApp.
 - `IDialogService.ShowAsync<T>` for create/edit forms
 - No `StateHasChanged()` after standard event handlers — Blazor re-renders automatically
 
+## Local Setup
+
+`wwwroot/appsettings.Development.json` is gitignored. Copy the example and fill in your Azure AD values:
+
+```bash
+cp wwwroot/appsettings.Development.json.example wwwroot/appsettings.Development.json
+```
+
 ## Adding a Page
 
 1. Create `Pages/MyPage.razor` with `@page "/my-page"` directive

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Layout/MainLayout.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Layout/MainLayout.razor
@@ -9,6 +9,8 @@
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit"
                        Edge="Edge.Start" OnClick="ToggleDrawer" />
         <MudText Typo="Typo.h6" Class="ml-3">AHKFlowApp</MudText>
+        <MudSpacer />
+        <LoginDisplay />
     </MudAppBar>
     <MudDrawer @bind-Open="_drawerOpen" Elevation="2">
         <NavMenu />

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Authentication.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Authentication.razor
@@ -1,0 +1,8 @@
+@page "/authentication/{action}"
+
+<RemoteAuthenticatorView Action="@Action" />
+
+@code {
+    [Parameter]
+    public string? Action { get; set; }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
@@ -18,6 +18,7 @@ builder.Services.AddMsalAuthentication(options =>
 {
     builder.Configuration.Bind("AzureAd", options.ProviderOptions.Authentication);
     options.ProviderOptions.DefaultAccessTokenScopes.Add(builder.Configuration["AzureAd:DefaultScope"]!);
+    options.ProviderOptions.LoginMode = "redirect";
 });
 
 builder.Services.AddHttpClient<IAhkFlowAppApiHttpClient, AhkFlowAppApiHttpClient>(client =>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
@@ -1,6 +1,6 @@
+using AHKFlowApp.UI.Blazor.Auth;
 using AHKFlowApp.UI.Blazor.Services;
 using Microsoft.AspNetCore.Components.Web;
-using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
 
@@ -11,22 +11,38 @@ builder.Services.AddMudServices();
 
 builder.RootComponents.Add<AHKFlowApp.UI.Blazor.App>("#app");
 
-string apiBaseUrl = builder.Configuration["ApiHttpClient:BaseAddress"]
-    ?? throw new InvalidOperationException("ApiHttpClient:BaseAddress is not configured.");
+string[] requiredConfigKeys = [
+    "ApiHttpClient:BaseAddress",
+    "AzureAd:Authority",
+    "AzureAd:ClientId",
+    "AzureAd:DefaultScope"
+];
+foreach (string key in requiredConfigKeys)
+{
+    if (string.IsNullOrWhiteSpace(builder.Configuration[key]))
+    {
+        throw new InvalidOperationException($"Configuration value '{key}' is missing or empty.");
+    }
+}
+
+string apiBaseUrl = builder.Configuration["ApiHttpClient:BaseAddress"]!;
+string defaultScope = builder.Configuration["AzureAd:DefaultScope"]!;
 
 builder.Services.AddMsalAuthentication(options =>
 {
     builder.Configuration.Bind("AzureAd", options.ProviderOptions.Authentication);
-    options.ProviderOptions.DefaultAccessTokenScopes.Add(builder.Configuration["AzureAd:DefaultScope"]!);
+    options.ProviderOptions.DefaultAccessTokenScopes.Add(defaultScope);
     options.ProviderOptions.LoginMode = "redirect";
 });
+
+builder.Services.AddTransient<ApiAuthorizationMessageHandler>();
 
 builder.Services.AddHttpClient<IAhkFlowAppApiHttpClient, AhkFlowAppApiHttpClient>(client =>
 {
     client.BaseAddress = new Uri(apiBaseUrl);
     client.Timeout = TimeSpan.FromSeconds(30);
 })
-    .AddHttpMessageHandler<BaseAddressAuthorizationMessageHandler>()
+    .AddHttpMessageHandler<ApiAuthorizationMessageHandler>()
     .AddStandardResilienceHandler();
 
 await builder.Build().RunAsync();

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
@@ -1,5 +1,6 @@
 using AHKFlowApp.UI.Blazor.Services;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
 
@@ -13,10 +14,18 @@ builder.RootComponents.Add<AHKFlowApp.UI.Blazor.App>("#app");
 string apiBaseUrl = builder.Configuration["ApiHttpClient:BaseAddress"]
     ?? throw new InvalidOperationException("ApiHttpClient:BaseAddress is not configured.");
 
+builder.Services.AddMsalAuthentication(options =>
+{
+    builder.Configuration.Bind("AzureAd", options.ProviderOptions.Authentication);
+    options.ProviderOptions.DefaultAccessTokenScopes.Add(builder.Configuration["AzureAd:DefaultScope"]!);
+});
+
 builder.Services.AddHttpClient<IAhkFlowAppApiHttpClient, AhkFlowAppApiHttpClient>(client =>
 {
     client.BaseAddress = new Uri(apiBaseUrl);
     client.Timeout = TimeSpan.FromSeconds(30);
-}).AddStandardResilienceHandler();
+})
+    .AddHttpMessageHandler<BaseAddressAuthorizationMessageHandler>()
+    .AddStandardResilienceHandler();
 
 await builder.Build().RunAsync();

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Shared/LoginDisplay.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Shared/LoginDisplay.razor
@@ -1,0 +1,11 @@
+@inject NavigationManager Navigation
+
+<AuthorizeView>
+    <Authorized>
+        <MudText Typo="Typo.body2" Class="mr-2">@context.User.Identity!.Name</MudText>
+        <MudButton Variant="Variant.Text" Color="Color.Inherit" OnClick="@(() => Navigation.NavigateToLogout("authentication/logout"))">Log out</MudButton>
+    </Authorized>
+    <NotAuthorized>
+        <MudButton Variant="Variant.Text" Color="Color.Inherit" OnClick="@(() => Navigation.NavigateTo("authentication/login"))">Log in</MudButton>
+    </NotAuthorized>
+</AuthorizeView>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Shared/RedirectToLogin.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Shared/RedirectToLogin.razor
@@ -1,0 +1,8 @@
+@inject NavigationManager Navigation
+
+@code {
+    protected override void OnInitialized()
+    {
+        Navigation.NavigateToLogin("authentication/login");
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/_Imports.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/_Imports.razor
@@ -8,4 +8,7 @@
 @using Microsoft.JSInterop
 @using AHKFlowApp.UI.Blazor
 @using AHKFlowApp.UI.Blazor.Layout
+@using AHKFlowApp.UI.Blazor.Shared
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
 @using MudBlazor

--- a/src/Frontend/AHKFlowApp.UI.Blazor/staticwebapp.config.json
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/staticwebapp.config.json
@@ -1,1 +1,6 @@
-{}
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/css/*", "/lib/*", "/_framework/*", "/_content/*", "*.{png,ico,js,css,wasm,json,webmanifest}"]
+  }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.Development.json.example
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.Development.json.example
@@ -1,5 +1,11 @@
 {
   "ApiHttpClient": {
     "BaseAddress": "http://localhost:5600"
+  },
+  "AzureAd": {
+    "Authority": "https://login.microsoftonline.com/<your-tenant-id>",
+    "ClientId": "<your-client-id>",
+    "ValidateAuthority": true,
+    "DefaultScope": "api://<your-client-id>/access_as_user"
   }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.Production.json
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.Production.json
@@ -1,5 +1,11 @@
 {
   "ApiHttpClient": {
     "BaseAddress": "#{AZURE_API_BASE_URL}#"
+  },
+  "AzureAd": {
+    "Authority": "https://login.microsoftonline.com/#{AZURE_AD_TENANT_ID}#",
+    "ClientId": "#{AZURE_AD_CLIENT_ID}#",
+    "ValidateAuthority": true,
+    "DefaultScope": "#{AZURE_AD_DEFAULT_SCOPE}#"
   }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.Test.json
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.Test.json
@@ -1,5 +1,11 @@
 {
   "ApiHttpClient": {
     "BaseAddress": "#{AZURE_API_BASE_URL}#"
+  },
+  "AzureAd": {
+    "Authority": "https://login.microsoftonline.com/#{AZURE_AD_TENANT_ID}#",
+    "ClientId": "#{AZURE_AD_CLIENT_ID}#",
+    "ValidateAuthority": true,
+    "DefaultScope": "#{AZURE_AD_DEFAULT_SCOPE}#"
   }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.json
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.json
@@ -1,5 +1,11 @@
 {
   "ApiHttpClient": {
     "BaseAddress": "http://localhost:5600"
+  },
+  "AzureAd": {
+    "Authority": "",
+    "ClientId": "",
+    "ValidateAuthority": true,
+    "DefaultScope": ""
   }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/index.html
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/index.html
@@ -32,6 +32,7 @@
         <a href="." class="reload">Reload</a>
         <span class="dismiss">🗙</span>
     </div>
+    <script src="_content/Microsoft.Authentication.WebAssembly.Msal/AuthenticationService.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/service-worker.published.js
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/service-worker.published.js
@@ -38,6 +38,11 @@ async function onActivate(event) {
 }
 
 async function onFetch(event) {
+    // Pass MSAL redirect routes through to the network — do not serve from cache.
+    if (event.request.url.includes('/authentication/')) {
+        return;
+    }
+
     let cachedResponse = null;
     if (event.request.method === 'GET') {
         // For all navigation requests, try to serve index.html from cache,

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/service-worker.published.js
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/service-worker.published.js
@@ -40,7 +40,7 @@ async function onActivate(event) {
 async function onFetch(event) {
     // Pass MSAL redirect routes through to the network — do not serve from cache.
     if (event.request.url.includes('/authentication/')) {
-        return;
+        return fetch(event.request);
     }
 
     let cachedResponse = null;

--- a/tests/AHKFlowApp.API.Tests/AHKFlowApp.API.Tests.csproj
+++ b/tests/AHKFlowApp.API.Tests/AHKFlowApp.API.Tests.csproj
@@ -9,6 +9,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/AHKFlowApp.API.Tests/Auth/AuthenticationTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Auth/AuthenticationTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using AHKFlowApp.TestUtilities.Fixtures;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace AHKFlowApp.API.Tests.Auth;
+
+[Collection("WebApi")]
+public sealed class AuthenticationTests(SqlContainerFixture sqlFixture) : IDisposable
+{
+    private readonly CustomWebApplicationFactory _factory = new(sqlFixture);
+
+    [Fact]
+    public async Task GetWhoAmI_WithoutToken_Returns401()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/whoami");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetWhoAmI_WithTestUser_Returns200AndClaims()
+    {
+        var oid = Guid.NewGuid();
+        using WebApplicationFactory<global::Program> authFactory = _factory.WithTestAuth(u => u.WithOid(oid).WithEmail("bart@example.com"));
+        using HttpClient client = authFactory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/whoami");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        string body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain(oid.ToString());
+        body.Should().Contain("bart@example.com");
+    }
+
+    [Fact]
+    public async Task GetWhoAmI_WithMissingScope_Returns403()
+    {
+        using WebApplicationFactory<global::Program> authFactory = _factory.WithTestAuth(u => u.WithoutScope());
+        using HttpClient client = authFactory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/whoami");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetHealth_Anonymous_StillWorks()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync("/health");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    public void Dispose() => _factory.Dispose();
+}

--- a/tests/AHKFlowApp.Domain.Tests/AHKFlowApp.Domain.Tests.csproj
+++ b/tests/AHKFlowApp.Domain.Tests/AHKFlowApp.Domain.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/AHKFlowApp.TestUtilities/AHKFlowApp.TestUtilities.csproj
+++ b/tests/AHKFlowApp.TestUtilities/AHKFlowApp.TestUtilities.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="Testcontainers.MsSql" />
     <PackageReference Include="xunit" />
   </ItemGroup>

--- a/tests/AHKFlowApp.TestUtilities/Auth/TestAuthHandler.cs
+++ b/tests/AHKFlowApp.TestUtilities/Auth/TestAuthHandler.cs
@@ -1,0 +1,36 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AHKFlowApp.TestUtilities.Auth;
+
+public sealed class TestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder,
+    TestUserBuilder defaults)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        string oid = Request.Headers["X-Test-Oid"].FirstOrDefault() ?? defaults.DefaultOid.ToString();
+        string email = Request.Headers["X-Test-Email"].FirstOrDefault() ?? defaults.DefaultEmail;
+
+        List<Claim> claims =
+        [
+            new("oid", oid),
+            new("preferred_username", email),
+            new(ClaimTypes.Name, defaults.DefaultName)
+        ];
+
+        if (defaults.DefaultScope is not null)
+            claims.Add(new Claim("scp", defaults.DefaultScope));
+
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/tests/AHKFlowApp.TestUtilities/Auth/TestUserBuilder.cs
+++ b/tests/AHKFlowApp.TestUtilities/Auth/TestUserBuilder.cs
@@ -1,0 +1,44 @@
+namespace AHKFlowApp.TestUtilities.Auth;
+
+public sealed class TestUserBuilder
+{
+    private Guid _oid = new("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private string _email = "test@example.com";
+    private string _name = "Test User";
+    private string? _scope = "access_as_user";
+
+    public TestUserBuilder WithOid(Guid oid)
+    {
+        _oid = oid;
+        return this;
+    }
+
+    public TestUserBuilder WithEmail(string email)
+    {
+        _email = email;
+        return this;
+    }
+
+    public TestUserBuilder WithName(string name)
+    {
+        _name = name;
+        return this;
+    }
+
+    public TestUserBuilder WithScope(string scope)
+    {
+        _scope = scope;
+        return this;
+    }
+
+    public TestUserBuilder WithoutScope()
+    {
+        _scope = null;
+        return this;
+    }
+
+    internal Guid DefaultOid => _oid;
+    internal string DefaultEmail => _email;
+    internal string DefaultName => _name;
+    internal string? DefaultScope => _scope;
+}

--- a/tests/AHKFlowApp.TestUtilities/Fixtures/CustomWebApplicationFactory.cs
+++ b/tests/AHKFlowApp.TestUtilities/Fixtures/CustomWebApplicationFactory.cs
@@ -1,4 +1,6 @@
 using AHKFlowApp.Infrastructure.Persistence;
+using AHKFlowApp.TestUtilities.Auth;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -35,5 +37,19 @@ public sealed class CustomWebApplicationFactory(
                 options.UseSqlServer(sqlFixture.ConnectionString,
                     sql => sql.EnableRetryOnFailure()));
         });
+    }
+
+    public WebApplicationFactory<Program> WithTestAuth(Action<TestUserBuilder>? configure = null)
+    {
+        var testUser = new TestUserBuilder();
+        configure?.Invoke(testUser);
+
+        return WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton(testUser);
+                services.AddAuthentication(defaultScheme: "Test")
+                        .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", _ => { });
+            }));
     }
 }

--- a/tests/AHKFlowApp.TestUtilities/Fixtures/CustomWebApplicationFactory.cs
+++ b/tests/AHKFlowApp.TestUtilities/Fixtures/CustomWebApplicationFactory.cs
@@ -2,6 +2,7 @@ using AHKFlowApp.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AHKFlowApp.TestUtilities.Fixtures;
@@ -11,6 +12,15 @@ public sealed class CustomWebApplicationFactory(
 {
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        // Microsoft.Identity.Web validates ClientId/TenantId on first request — provide
+        // placeholder values so anonymous endpoints work without real Entra credentials.
+        builder.ConfigureAppConfiguration(config =>
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AzureAd:TenantId"] = "00000000-0000-0000-0000-000000000001",
+                ["AzureAd:ClientId"] = "00000000-0000-0000-0000-000000000002"
+            }));
+
         builder.ConfigureServices(services =>
         {
             var descriptors = services

--- a/tests/AHKFlowApp.UI.Blazor.Tests/AHKFlowApp.UI.Blazor.Tests.csproj
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/AHKFlowApp.UI.Blazor.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MudBlazor" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

- Adds single-tenant Entra ID authentication via `Microsoft.Identity.Web` on the API and MSAL on the Blazor WASM frontend
- `ICurrentUser` abstraction in Application layer (framework-free); `HttpContextCurrentUser` reads claims in the API
- `WhoAmIController` — new `[Authorize] [RequiredScope("access_as_user")]` endpoint for end-to-end auth verification
- `TestAuthHandler` / `TestUserBuilder` + `CustomWebApplicationFactory.WithTestAuth()` for in-process JWT bypass in integration tests
- 4 new auth integration tests (401/200/403/anon-passthrough)
- Blazor: `AddMsalAuthentication`, auth HTTP handler, `LoginDisplay`, `RedirectToLogin`, `Authentication.razor`
- Infra: `AzureAd__*` App Service settings via bicep + deploy-api.yml; frontend placeholder substitution in deploy-frontend.yml
- `scripts/setup-entra-app.ps1` — idempotent Entra app registration setup
- Docs: `entra-setup.md`, `docs/architecture/authentication.md`
- Backlog 012 CLI criterion removed; new item 029 created as placeholder

## ⚠️ Before merging — developer setup required

Developers pulling this branch must set up their local Entra app:

```powershell
.\scripts\setup-entra-app.ps1 -Environment dev
dotnet user-secrets set "AzureAd:TenantId" "<value>" --project src/Backend/AHKFlowApp.API
dotnet user-secrets set "AzureAd:ClientId" "<value>" --project src/Backend/AHKFlowApp.API
```

Then populate `wwwroot/appsettings.Development.json` with the matching `AzureAd` block. See `docs/deployment/entra-setup.md`.

## ⚠️ Before deploying to TEST/PROD — GitHub Variables required

```bash
gh variable set AZURE_AD_TENANT_ID_TEST --body "<value>"
gh variable set AZURE_AD_CLIENT_ID_TEST --body "<value>"
gh variable set AZURE_AD_DEFAULT_SCOPE_TEST --body "api://<clientId>/access_as_user"
```

## Test plan

- [ ] All 37 tests pass (`dotnet test`)
- [ ] `dotnet format` clean
- [ ] Bicep lint clean
- [ ] Local: browser `https://localhost:7601` → Log in → Entra consent → `LoginDisplay` shows name
- [ ] Local: `curl https://localhost:7600/api/v1/whoami` → 401
- [ ] Local: `curl https://localhost:7600/api/v1/health` → 200 (anonymous still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)