### PR TITLE
fix: health endpoint auth + swagger launch

### DIFF
--- a/src/Backend/AHKFlowApp.API/Properties/launchSettings.json
+++ b/src/Backend/AHKFlowApp.API/Properties/launchSettings.json
@@ -3,7 +3,6 @@
   "profiles": {
     "Docker SQL (Recommended)": {
       "commandName": "Project",
-      "launchBrowser": true,
       "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
@@ -15,7 +14,6 @@
     },
     "LocalDB SQL": {
       "commandName": "Project",
-      "launchBrowser": true,
       "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Auth/ApiAuthorizationMessageHandler.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Auth/ApiAuthorizationMessageHandler.cs
@@ -1,18 +1,31 @@
-using Microsoft.AspNetCore.Components;
+using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 
 namespace AHKFlowApp.UI.Blazor.Auth;
 
-internal sealed class ApiAuthorizationMessageHandler : AuthorizationMessageHandler
+/// <summary>
+/// Attaches a Bearer token to outgoing API requests when the user is authenticated.
+/// Requests proceed unauthenticated when no token is available, allowing [AllowAnonymous]
+/// endpoints (e.g. /health) to work without a login.
+/// </summary>
+internal sealed class ApiAuthorizationMessageHandler(
+    IAccessTokenProvider tokenProvider,
+    IConfiguration configuration) : DelegatingHandler
 {
-    public ApiAuthorizationMessageHandler(
-        IAccessTokenProvider provider,
-        NavigationManager navigationManager,
-        IConfiguration configuration)
-        : base(provider, navigationManager)
+    private readonly string[] _scopes = [configuration["AzureAd:DefaultScope"]!];
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
     {
-        ConfigureHandler(
-            authorizedUrls: [configuration["ApiHttpClient:BaseAddress"]!],
-            scopes: [configuration["AzureAd:DefaultScope"]!]);
+        AccessTokenResult tokenResult = await tokenProvider.RequestAccessToken(
+            new AccessTokenRequestOptions { Scopes = _scopes });
+
+        if (tokenResult.TryGetToken(out AccessToken? token))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);
+        }
+
+        return await base.SendAsync(request, cancellationToken);
     }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Health.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Health.razor
@@ -1,6 +1,8 @@
 @page "/health"
 @using AHKFlowApp.UI.Blazor.Services
 @using AHKFlowApp.UI.Blazor.DTOs
+@using Microsoft.AspNetCore.Authorization
+@attribute [AllowAnonymous]
 
 @implements IDisposable
 


### PR DESCRIPTION
- Health.razor: add [AllowAnonymous] for unauthenticated access
- ApiAuthorizationMessageHandler: optional Bearer token (don't fail without auth)
- launchSettings.json: remove launchBrowser (single launch via Process.Start)

Fixes: health page requiring auth post-PR#63, swagger opening twice in VS, and missing auto-launch in VS Code full stack debug.

## Summary

Brief description of changes.

## Checklist

- [ ] Tests pass (`dotnet test`)
- [ ] Build succeeds (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Breaking changes documented (if any)
