### PR TITLE
feat(016): RFC 9457 Problem Details for hotstring domain errors

### DIFF
--- a/.claude/backlog/016-hotstrings-problem-details.md
+++ b/.claude/backlog/016-hotstrings-problem-details.md
@@ -16,11 +16,11 @@ As a client developer, I want consistent error responses so that UI and CLI can 
 
 ## Acceptance criteria
 
-- [ ] Validation errors return problem details with field-level information.
-- [ ] Domain errors return problem details with stable types/titles.
-- [ ] OpenAPI documents common error responses.
-- [ ] Integration tests confirm validation and domain errors return RFC 9457 Problem Details with expected fields.
-- [ ] Unit tests validate error mapping behavior for known domain exceptions.
+- [x] Validation errors return problem details with field-level information.
+- [x] Domain errors return problem details with stable types/titles.
+- [x] OpenAPI documents common error responses.
+- [x] Integration tests confirm validation and domain errors return RFC 9457 Problem Details with expected fields.
+- [x] Unit tests validate error mapping behavior for known domain exceptions.
 
 ## Out of scope
 

--- a/src/Backend/AHKFlowApp.API/Controllers/DevController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/DevController.cs
@@ -1,6 +1,6 @@
+using AHKFlowApp.API.Extensions;
 using AHKFlowApp.Application.Commands.Dev;
 using AHKFlowApp.Application.DTOs;
-using Ardalis.Result.AspNetCore;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -17,9 +17,9 @@ public sealed class DevController(IMediator mediator) : ControllerBase
     /// <summary>Seeds a curated set of sample hotstrings for the authenticated user. Development only.</summary>
     [HttpPost("hotstrings/seed")]
     [ProducesResponseType(typeof(PagedList<HotstringDto>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<PagedList<HotstringDto>>> SeedHotstrings(
         [FromQuery] bool reset = false,
         CancellationToken ct = default) =>
-        (await mediator.Send(new SeedHotstringsCommand(reset), ct)).ToActionResult(this);
+        (await mediator.Send(new SeedHotstringsCommand(reset), ct)).ToProblemActionResult(this);
 }

--- a/src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs
@@ -1,8 +1,8 @@
+using AHKFlowApp.API.Extensions;
 using AHKFlowApp.Application.Commands.Hotstrings;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Application.Queries.Hotstrings;
 using Ardalis.Result;
-using Ardalis.Result.AspNetCore;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -27,14 +27,14 @@ public sealed class HotstringsController(IMediator mediator) : ControllerBase
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 50,
         CancellationToken ct = default) =>
-        (await mediator.Send(new ListHotstringsQuery(profileId, page, pageSize), ct)).ToActionResult(this);
+        (await mediator.Send(new ListHotstringsQuery(profileId, page, pageSize), ct)).ToProblemActionResult(this);
 
     /// <summary>Get a hotstring by id.</summary>
     [HttpGet("{id:guid}", Name = "GetHotstring")]
     [ProducesResponseType(typeof(HotstringDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<HotstringDto>> Get(Guid id, CancellationToken ct) =>
-        (await mediator.Send(new GetHotstringQuery(id), ct)).ToActionResult(this);
+        (await mediator.Send(new GetHotstringQuery(id), ct)).ToProblemActionResult(this);
 
     /// <summary>Create a new hotstring for the current user.</summary>
     [HttpPost]
@@ -47,7 +47,7 @@ public sealed class HotstringsController(IMediator mediator) : ControllerBase
 
         return result.IsSuccess
             ? CreatedAtRoute("GetHotstring", new { id = result.Value.Id }, result.Value)
-            : result.ToActionResult(this);
+            : result.ToProblemActionResult(this);
     }
 
     /// <summary>Update an existing hotstring. Returns the updated representation.</summary>
@@ -57,7 +57,7 @@ public sealed class HotstringsController(IMediator mediator) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     public async Task<ActionResult<HotstringDto>> Update(Guid id, [FromBody] UpdateHotstringDto dto, CancellationToken ct) =>
-        (await mediator.Send(new UpdateHotstringCommand(id, dto), ct)).ToActionResult(this);
+        (await mediator.Send(new UpdateHotstringCommand(id, dto), ct)).ToProblemActionResult(this);
 
     /// <summary>Delete a hotstring.</summary>
     [HttpDelete("{id:guid}")]
@@ -66,6 +66,6 @@ public sealed class HotstringsController(IMediator mediator) : ControllerBase
     public async Task<ActionResult> Delete(Guid id, CancellationToken ct)
     {
         Result result = await mediator.Send(new DeleteHotstringCommand(id), ct);
-        return result.IsSuccess ? NoContent() : result.ToActionResult(this);
+        return (ActionResult)(result.IsSuccess ? NoContent() : result.ToProblemActionResult(this));
     }
 }

--- a/src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs
@@ -66,6 +66,6 @@ public sealed class HotstringsController(IMediator mediator) : ControllerBase
     public async Task<ActionResult> Delete(Guid id, CancellationToken ct)
     {
         Result result = await mediator.Send(new DeleteHotstringCommand(id), ct);
-        return (ActionResult)(result.IsSuccess ? NoContent() : result.ToProblemActionResult(this));
+        return result.IsSuccess ? NoContent() : result.ToProblemActionResult(this);
     }
 }

--- a/src/Backend/AHKFlowApp.API/Extensions/ProblemDetailsResultExtensions.cs
+++ b/src/Backend/AHKFlowApp.API/Extensions/ProblemDetailsResultExtensions.cs
@@ -1,0 +1,83 @@
+using Ardalis.Result;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AHKFlowApp.API.Extensions;
+
+/// <summary>
+/// Maps Ardalis.Result outcomes to IActionResult values carrying RFC 9457 Problem Details
+/// for all non-success statuses. Controllers use this instead of the default
+/// <c>Ardalis.Result.AspNetCore.ToActionResult</c> so every error response shares the
+/// same shape as <c>GlobalExceptionMiddleware</c>: type, title, status, detail, instance, traceId.
+/// </summary>
+internal static class ProblemDetailsResultExtensions
+{
+    // RFC 9110 section URIs — same pattern the exception middleware uses.
+    internal const string TypeBadRequest = "https://tools.ietf.org/html/rfc9110#section-15.5.1";
+    internal const string TypeUnauthorized = "https://tools.ietf.org/html/rfc9110#section-15.5.2";
+    internal const string TypeForbidden = "https://tools.ietf.org/html/rfc9110#section-15.5.4";
+    internal const string TypeNotFound = "https://tools.ietf.org/html/rfc9110#section-15.5.5";
+    internal const string TypeConflict = "https://tools.ietf.org/html/rfc9110#section-15.5.10";
+    internal const string TypeServerError = "https://tools.ietf.org/html/rfc9110#section-15.6.1";
+
+    public static ActionResult<T> ToProblemActionResult<T>(this Result<T> result, ControllerBase controller) =>
+        result.IsSuccess
+            ? new OkObjectResult(result.Value)
+            : BuildProblem(result.Status, result.Errors, result.ValidationErrors, controller.HttpContext);
+
+    public static ActionResult ToProblemActionResult(this Result result, ControllerBase controller) =>
+        result.IsSuccess
+            ? new OkResult()
+            : BuildProblem(result.Status, result.Errors, result.ValidationErrors, controller.HttpContext);
+
+    private static ObjectResult BuildProblem(
+        ResultStatus status,
+        IEnumerable<string> errors,
+        IEnumerable<ValidationError> validationErrors,
+        HttpContext http)
+    {
+        ProblemDetails pd = status switch
+        {
+            ResultStatus.NotFound => Build(StatusCodes.Status404NotFound, TypeNotFound, "Resource not found", errors.FirstOrDefault()),
+            ResultStatus.Conflict => Build(StatusCodes.Status409Conflict, TypeConflict, "Conflict", errors.FirstOrDefault()),
+            ResultStatus.Unauthorized => Build(StatusCodes.Status401Unauthorized, TypeUnauthorized, "Unauthorized", null),
+            ResultStatus.Forbidden => Build(StatusCodes.Status403Forbidden, TypeForbidden, "Forbidden", null),
+            ResultStatus.Invalid => BuildValidation(validationErrors),
+            _ => Build(StatusCodes.Status500InternalServerError, TypeServerError, "An unexpected error occurred", errors.FirstOrDefault())
+        };
+
+        pd.Instance = http.Request.Path;
+        pd.Extensions["traceId"] = http.TraceIdentifier;
+
+        return new ObjectResult(pd)
+        {
+            StatusCode = pd.Status,
+            ContentTypes = { "application/problem+json" }
+        };
+    }
+
+    private static ProblemDetails Build(int status, string type, string title, string? detail) =>
+        new()
+        {
+            Status = status,
+            Type = type,
+            Title = title,
+            Detail = detail
+        };
+
+    private static ValidationProblemDetails BuildValidation(IEnumerable<ValidationError> errors)
+    {
+        var pd = new ValidationProblemDetails
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Type = TypeBadRequest,
+            Title = "Validation failed"
+        };
+
+        foreach (IGrouping<string, ValidationError> g in errors.GroupBy(e => e.Identifier ?? string.Empty))
+        {
+            pd.Errors[g.Key] = g.Select(e => e.ErrorMessage).ToArray();
+        }
+
+        return pd;
+    }
+}

--- a/src/Backend/AHKFlowApp.API/Extensions/ProblemDetailsResultExtensions.cs
+++ b/src/Backend/AHKFlowApp.API/Extensions/ProblemDetailsResultExtensions.cs
@@ -70,7 +70,8 @@ internal static class ProblemDetailsResultExtensions
         {
             Status = StatusCodes.Status400BadRequest,
             Type = TypeBadRequest,
-            Title = "Validation failed"
+            Title = "Validation failed",
+            Detail = "See the errors field for details."
         };
 
         foreach (IGrouping<string, ValidationError> g in errors.GroupBy(e => e.Identifier ?? string.Empty))

--- a/tests/AHKFlowApp.API.Tests/Extensions/ProblemDetailsResultExtensionsTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Extensions/ProblemDetailsResultExtensionsTests.cs
@@ -1,0 +1,143 @@
+using AHKFlowApp.API.Extensions;
+using Ardalis.Result;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Xunit;
+
+namespace AHKFlowApp.API.Tests.Extensions;
+
+public sealed class ProblemDetailsResultExtensionsTests
+{
+    private static ControllerBase NewController(string path = "/api/v1/hotstrings", string traceId = "trace-xyz")
+    {
+        var ctx = new DefaultHttpContext
+        {
+            TraceIdentifier = traceId
+        };
+        ctx.Request.Path = path;
+        return new TestController { ControllerContext = new ControllerContext { HttpContext = ctx } };
+    }
+
+    private sealed class TestController : ControllerBase { }
+
+    private static IActionResult Unwrap<T>(ActionResult<T> result) =>
+        ((IConvertToActionResult)result).Convert();
+
+    private static ProblemDetails ProblemOf(IActionResult result)
+    {
+        ObjectResult obj = result.Should().BeOfType<ObjectResult>().Subject;
+        obj.ContentTypes.Should().Contain("application/problem+json");
+        return obj.Value.Should().BeAssignableTo<ProblemDetails>().Subject;
+    }
+
+    [Fact]
+    public void Success_WithValue_ReturnsOkObjectResult()
+    {
+        var result = Result<string>.Success("payload");
+
+        IActionResult action = Unwrap(result.ToProblemActionResult(NewController()));
+
+        OkObjectResult ok = action.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().Be("payload");
+    }
+
+    [Fact]
+    public void Success_NonGeneric_ReturnsOkResult()
+    {
+        ActionResult action = Result.Success().ToProblemActionResult(NewController());
+
+        action.Should().BeOfType<OkResult>();
+    }
+
+    [Fact]
+    public void NotFound_MapsTo404_WithStableTypeAndTitle()
+    {
+        ActionResult action = Result.NotFound().ToProblemActionResult(NewController());
+
+        ProblemDetails pd = ProblemOf(action);
+        pd.Status.Should().Be(StatusCodes.Status404NotFound);
+        pd.Type.Should().Be(ProblemDetailsResultExtensions.TypeNotFound);
+        pd.Title.Should().Be("Resource not found");
+        pd.Instance.Should().Be("/api/v1/hotstrings");
+        pd.Extensions["traceId"].Should().Be("trace-xyz");
+    }
+
+    [Fact]
+    public void NotFound_WithMessage_PopulatesDetail()
+    {
+        ActionResult action = Result.NotFound("Hotstring 42 does not exist").ToProblemActionResult(NewController());
+
+        ProblemDetails pd = ProblemOf(action);
+        pd.Detail.Should().Be("Hotstring 42 does not exist");
+    }
+
+    [Fact]
+    public void Conflict_MapsTo409_WithDetailFromErrors()
+    {
+        ActionResult action = Result
+            .Conflict("A hotstring with this trigger already exists for the specified profile.")
+            .ToProblemActionResult(NewController());
+
+        ProblemDetails pd = ProblemOf(action);
+        pd.Status.Should().Be(StatusCodes.Status409Conflict);
+        pd.Type.Should().Be(ProblemDetailsResultExtensions.TypeConflict);
+        pd.Title.Should().Be("Conflict");
+        pd.Detail.Should().Contain("already exists");
+    }
+
+    [Fact]
+    public void Unauthorized_MapsTo401()
+    {
+        ActionResult action = Result.Unauthorized().ToProblemActionResult(NewController());
+
+        ProblemDetails pd = ProblemOf(action);
+        pd.Status.Should().Be(StatusCodes.Status401Unauthorized);
+        pd.Type.Should().Be(ProblemDetailsResultExtensions.TypeUnauthorized);
+        pd.Title.Should().Be("Unauthorized");
+    }
+
+    [Fact]
+    public void Forbidden_MapsTo403()
+    {
+        ActionResult action = Result.Forbidden().ToProblemActionResult(NewController());
+
+        ProblemDetails pd = ProblemOf(action);
+        pd.Status.Should().Be(StatusCodes.Status403Forbidden);
+        pd.Type.Should().Be(ProblemDetailsResultExtensions.TypeForbidden);
+        pd.Title.Should().Be("Forbidden");
+    }
+
+    [Fact]
+    public void Invalid_MapsTo400_WithFieldLevelErrors()
+    {
+        var result = Result<string>.Invalid(
+            new ValidationError { Identifier = "Trigger", ErrorMessage = "required" },
+            new ValidationError { Identifier = "Trigger", ErrorMessage = "too short" },
+            new ValidationError { Identifier = "Replacement", ErrorMessage = "required" });
+
+        IActionResult action = Unwrap(result.ToProblemActionResult(NewController()));
+
+        ValidationProblemDetails pd = ProblemOf(action).Should().BeOfType<ValidationProblemDetails>().Subject;
+        pd.Status.Should().Be(StatusCodes.Status400BadRequest);
+        pd.Type.Should().Be(ProblemDetailsResultExtensions.TypeBadRequest);
+        pd.Title.Should().Be("Validation failed");
+        pd.Errors["Trigger"].Should().BeEquivalentTo(new[] { "required", "too short" });
+        pd.Errors["Replacement"].Should().BeEquivalentTo(new[] { "required" });
+    }
+
+    [Fact]
+    public void Error_MapsTo500_WithDetailFromErrors()
+    {
+        var result = Result<string>.Error("Downstream dependency failed");
+
+        IActionResult action = Unwrap(result.ToProblemActionResult(NewController()));
+
+        ProblemDetails pd = ProblemOf(action);
+        pd.Status.Should().Be(StatusCodes.Status500InternalServerError);
+        pd.Type.Should().Be(ProblemDetailsResultExtensions.TypeServerError);
+        pd.Title.Should().Be("An unexpected error occurred");
+        pd.Detail.Should().Be("Downstream dependency failed");
+    }
+}

--- a/tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs
@@ -46,7 +46,7 @@ public sealed class HotstringsEndpointsTests(SqlContainerFixture sqlFixture) : I
     }
 
     [Fact]
-    public async Task Post_DuplicateTrigger_Returns409()
+    public async Task Post_DuplicateTrigger_Returns409_WithProblemDetails()
     {
         var owner = Guid.NewGuid();
         using HttpClient client = CreateAuthed(owner);
@@ -58,18 +58,38 @@ public sealed class HotstringsEndpointsTests(SqlContainerFixture sqlFixture) : I
         HttpResponseMessage second = await client.PostAsJsonAsync("/api/v1/hotstrings", dto);
 
         second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        second.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+
+        using var doc = JsonDocument.Parse(await second.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("type").GetString().Should().Be("https://tools.ietf.org/html/rfc9110#section-15.5.10");
+        root.GetProperty("title").GetString().Should().Be("Conflict");
+        root.GetProperty("status").GetInt32().Should().Be(409);
+        root.GetProperty("detail").GetString().Should().Contain("already exists");
+        root.GetProperty("instance").GetString().Should().Be("/api/v1/hotstrings");
+        root.GetProperty("traceId").GetString().Should().NotBeNullOrEmpty();
     }
 
     [Fact]
-    public async Task Put_UnknownId_Returns404()
+    public async Task Put_UnknownId_Returns404_WithProblemDetails()
     {
         using HttpClient client = CreateAuthed();
         var dto = new UpdateHotstringDto("x", "y", null, true, true);
 
+        var unknownId = Guid.NewGuid();
         HttpResponseMessage response = await client.PutAsJsonAsync(
-            $"/api/v1/hotstrings/{Guid.NewGuid()}", dto);
+            $"/api/v1/hotstrings/{unknownId}", dto);
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("type").GetString().Should().Be("https://tools.ietf.org/html/rfc9110#section-15.5.5");
+        root.GetProperty("title").GetString().Should().Be("Resource not found");
+        root.GetProperty("status").GetInt32().Should().Be(404);
+        root.GetProperty("instance").GetString().Should().Be($"/api/v1/hotstrings/{unknownId}");
+        root.GetProperty("traceId").GetString().Should().NotBeNullOrEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
Replace Ardalis.Result.AspNetCore ToActionResult with project-owned ProblemDetailsResultExtensions mapper so 404/409/401/403 responses carry the same shape as the validation/500 paths already produce via GlobalExceptionMiddleware: stable RFC 9110 section type URIs, title, status, detail, instance, traceId.

## Summary

Brief description of changes.

## Checklist

- [ ] Tests pass (`dotnet test`)
- [ ] Build succeeds (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Breaking changes documented (if any)
