### PR TITLE
ci: add branch coverage gate (>= 40%)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
           reports: 'TestResults/**/coverage.cobertura.xml'
           targetdir: 'CoverageReport'
           reporttypes: 'MarkdownSummaryGithub;JsonSummary;HtmlInline_AzurePipelines;Cobertura'
+      - name: Append thresholds to coverage summary
+        if: always()
+        run: printf '\n---\n**Thresholds:** line ≥ 70%% · branch ≥ 40%%\n' >> CoverageReport/SummaryGithub.md
       - name: Append coverage summary to job summary
         if: always()
         run: cat CoverageReport/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,16 @@ jobs:
           echo "Line coverage: ${LINE}% (threshold: ${THRESHOLD}%)"
           awk -v l="$LINE" -v t="$THRESHOLD" 'BEGIN { exit (l+0 < t+0) }' \
             || { echo "::error::Line coverage ${LINE}% is below threshold ${THRESHOLD}%"; exit 1; }
+      - name: Enforce branch coverage threshold
+        if: always()
+        env:
+          THRESHOLD: '40'
+        run: |
+          set -euo pipefail
+          BRANCH=$(jq -r '.summary.branchcoverage' CoverageReport/Summary.json)
+          echo "Branch coverage: ${BRANCH}% (threshold: ${THRESHOLD}%)"
+          awk -v b="$BRANCH" -v t="$THRESHOLD" 'BEGIN { exit (b+0 < t+0) }' \
+            || { echo "::error::Branch coverage ${BRANCH}% is below threshold ${THRESHOLD}%"; exit 1; }
       - run: dotnet format --verify-no-changes
 
   bicep-lint:

--- a/docs/development/coverage.md
+++ b/docs/development/coverage.md
@@ -33,9 +33,14 @@ To exclude additional code, prefer `[ExcludeFromCodeCoverage]` on the class/meth
 
 ## CI gate
 
-`.github/workflows/ci.yml` fails the PR if merged **line coverage** drops below **70%**. Branch coverage is reported but not gated.
+`.github/workflows/ci.yml` enforces two thresholds on the merged report:
 
-The threshold is a literal in `ci.yml` (step `Enforce line coverage threshold`). Raising it is a normal PR like any other code change.
+| Metric | Threshold |
+|---|---|
+| Line coverage | ≥ 70% |
+| Branch coverage | ≥ 40% |
+
+Both gates must pass. Thresholds are literals in `ci.yml` — raising one is a normal PR change.
 
 ## Where to see coverage on a PR
 


### PR DESCRIPTION
## Summary

- Adds `Enforce branch coverage threshold` step after the existing line coverage gate.
- Initial threshold: 40% (actual measured: 46.8% — ~7% headroom).
- Updates `docs/development/coverage.md` to document both gates.

## Test plan

- [x] CI green on this PR (branch coverage ~46.8% > 40%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)