### PR TITLE
fix: clean up test coverage warnings

### DIFF
--- a/tests/AHKFlowApp.E2E.Tests/AHKFlowApp.E2E.Tests.csproj
+++ b/tests/AHKFlowApp.E2E.Tests/AHKFlowApp.E2E.Tests.csproj
@@ -7,6 +7,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/AHKFlowApp.TestUtilities/AHKFlowApp.TestUtilities.csproj
+++ b/tests/AHKFlowApp.TestUtilities/AHKFlowApp.TestUtilities.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="Testcontainers.MsSql" />
     <PackageReference Include="xunit" />


### PR DESCRIPTION
## Summary
- add coverlet.collector to the E2E test project
- stop treating AHKFlowApp.TestUtilities as a test project
- remove the related coverage and test-discovery warnings from solution test runs

## Testing
- dotnet test AHKFlowApp.slnx --configuration Release --collect:"XPlat Code Coverage" --results-directory .\TestResults --settings coverlet.runsettings -m:1

## Notes
- AHKFlowApp.Domain.Tests still has no test cases, so that project continues to report a separate No test is available warning
