### PR TITLE
docs: plan 1 — codebase simplification audit & roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,7 @@ HTTP Request -> Controller (thin, maps Result to HTTP)
 - When writing `<PackageReference>`, use `dotnet add package` first to resolve the correct version.
 - With `Directory.Packages.props` (CPM), individual .csproj files must NOT specify `Version=`.
 - Never downgrade a package unless explicitly asked. Prefer release over preview/RC.
+- **Never upgrade `Microsoft.ApplicationInsights.AspNetCore` to 3.x.** Stay on 2.x — v3 caused runtime issues. Only revisit if explicitly asked.
 
 ### Performance
 

--- a/docs/superpowers/audits/2026-04-21-baseline-audit.md
+++ b/docs/superpowers/audits/2026-04-21-baseline-audit.md
@@ -1,0 +1,21 @@
+# Baseline Audit — 2026-04-21
+
+> Snapshot captured during plan 1 of the codebase simplification roadmap.
+> Every finding here is tagged with the plan that will handle it.
+
+## PR #66 — unique-suffix Azure resource names
+
+- Status: **merged** on 2026-04-21.
+- Disposition: closed during plan 1.
+
+## Outdated packages
+
+_Populated in Task 4._
+
+## Security findings
+
+_Populated in Task 5._
+
+## Per-plan disposition
+
+_Populated in Task 6._

--- a/docs/superpowers/audits/2026-04-21-baseline-audit.md
+++ b/docs/superpowers/audits/2026-04-21-baseline-audit.md
@@ -152,5 +152,8 @@ Each plan 2-6 opens by re-reading this section. Only items listed under its plan
 - Cross-reference: README, AGENTS.md, `.claude/CLAUDE.md`, `.github/**`.
 
 ### Deferred
-- Package upgrades: 22 outdated entries (see Outdated packages section). Major bumps: `Microsoft.ApplicationInsights.AspNetCore` 2.23.0 → 3.1.0, `coverlet.collector` 8.0.1 → 10.0.0. Patch bumps: `Microsoft.*` 10.0.6 → 10.0.7, `Microsoft.Identity.Web` 4.7.0 → 4.8.0. Re-evaluate when individual plans need a specific bump.
+- Package upgrades: 22 outdated entries (see Outdated packages section). Major bumps: `coverlet.collector` 8.0.1 → 10.0.0. Patch bumps: `Microsoft.*` 10.0.6 → 10.0.7, `Microsoft.Identity.Web` 4.7.0 → 4.8.0. Re-evaluate when individual plans need a specific bump.
 - No Bicep/infra security findings to defer.
+
+### Permanently excluded
+- **`Microsoft.ApplicationInsights.AspNetCore` 2.x → 3.x upgrade is intentionally blocked.** Stay on 2.x (currently 2.23.0). The v3 package caused runtime issues. Do not upgrade without an explicit decision to revisit this.

--- a/docs/superpowers/audits/2026-04-21-baseline-audit.md
+++ b/docs/superpowers/audits/2026-04-21-baseline-audit.md
@@ -131,4 +131,26 @@ Scan via `cck-security-scan` skill on 2026-04-21.
 
 ## Per-plan disposition
 
-_Populated in Task 6._
+Each plan 2-6 opens by re-reading this section. Only items listed under its plan are in its scope.
+
+### Plan 2 — Targeted coverage uplift
+- No audit findings route here directly. Coverage gaps are discovered inside plan 2.
+
+### Plan 3 — Code simplification
+- S-1: Remove or rotate dev Docker SA password (`AHKFlow_Dev!2026`) from `launchSettings.json` (2 profiles). Replace with a random placeholder or env-var reference safe to commit.
+- S-3: Tighten CORS policy — restrict `AllowAnyMethod()` and `AllowAnyHeader()` to explicit lists matching the frontend's actual needs.
+
+### Plan 4 — Script + deploy.ps1 overhaul
+- No security findings route here.
+- Note: PR #66's unique-suffix variables are now written to `scripts/.env.<env>` after `deploy.ps1` runs — plan 4's preflight must read those values rather than hardcoding resource names.
+
+### Plan 5 — Local-install path (no Azure)
+- No audit findings route here directly. Scope is fixed by the roadmap spec.
+
+### Plan 6 — Docs + consistency sweep
+- S-2: Remove or replace dev password example strings in the two docs files flagged by the scan.
+- Cross-reference: README, AGENTS.md, `.claude/CLAUDE.md`, `.github/**`.
+
+### Deferred
+- Package upgrades: 22 outdated entries (see Outdated packages section). Major bumps: `Microsoft.ApplicationInsights.AspNetCore` 2.23.0 → 3.1.0, `coverlet.collector` 8.0.1 → 10.0.0. Patch bumps: `Microsoft.*` 10.0.6 → 10.0.7, `Microsoft.Identity.Web` 4.7.0 → 4.8.0. Re-evaluate when individual plans need a specific bump.
+- No Bicep/infra security findings to defer.

--- a/docs/superpowers/audits/2026-04-21-baseline-audit.md
+++ b/docs/superpowers/audits/2026-04-21-baseline-audit.md
@@ -10,7 +10,101 @@
 
 ## Outdated packages
 
-_Populated in Task 4._
+Snapshot via `dotnet list package --outdated` on 2026-04-21.
+
+```text
+  Determining projects to restore...
+  All projects are up-to-date for restore.
+
+The following sources were used:
+   https://api.nuget.org/v3/index.json
+   C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\
+
+Project `AHKFlowApp.API` has the following updates to its packages
+   [net10.0]: 
+   Top-level Package                                                        Requested   Resolved   Latest
+   > Microsoft.ApplicationInsights.AspNetCore                               2.23.0      2.23.0     3.1.0 
+   > Microsoft.AspNetCore.Authentication.JwtBearer                          10.0.6      10.0.6     10.0.7
+   > Microsoft.EntityFrameworkCore.Design                                   10.0.6      10.0.6     10.0.7
+   > Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore      10.0.6      10.0.6     10.0.7
+   > Microsoft.Identity.Web                                                 4.7.0       4.7.0      4.8.0 
+   > Serilog.Sinks.ApplicationInsights                                      5.0.0       5.0.0      5.0.1 
+
+Project `AHKFlowApp.Application` has the following updates to its packages
+   [net10.0]: 
+   Top-level Package                               Requested   Resolved   Latest
+   > Microsoft.ApplicationInsights.AspNetCore      2.23.0      2.23.0     3.1.0 
+   > Microsoft.EntityFrameworkCore                 10.0.6      10.0.6     10.0.7
+
+Project `AHKFlowApp.Domain` has the following updates to its packages
+   [net10.0]: 
+   Top-level Package                               Requested   Resolved   Latest
+   > Microsoft.ApplicationInsights.AspNetCore      2.23.0      2.23.0     3.1.0 
+
+Project `AHKFlowApp.Infrastructure` has the following updates to its packages
+   [net10.0]: 
+   Top-level Package                               Requested   Resolved   Latest
+   > Microsoft.ApplicationInsights.AspNetCore      2.23.0      2.23.0     3.1.0 
+   > Microsoft.EntityFrameworkCore.SqlServer       10.0.6      10.0.6     10.0.7
+
+Project `AHKFlowApp.UI.Blazor` has the following updates to its packages
+   [net10.0]: 
+   Top-level Package                                            Requested   Resolved   Latest
+   > Microsoft.ApplicationInsights.AspNetCore                   2.23.0      2.23.0     3.1.0 
+   > Microsoft.AspNetCore.Components.WebAssembly                10.0.6      10.0.6     10.0.7
+   > Microsoft.AspNetCore.Components.WebAssembly.DevServer      10.0.6      10.0.6     10.0.7
+   > Microsoft.Authentication.WebAssembly.Msal                  10.0.6      10.0.6     10.0.7
+
+Project `AHKFlowApp.API.Tests` has the following updates to its packages
+   [net10.0]: 
+   Top-level Package                                    Requested   Resolved   Latest
+   > coverlet.collector                                 8.0.1       8.0.1      10.0.0
+   > Microsoft.ApplicationInsights.AspNetCore           2.23.0      2.23.0     3.1.0 
+   > Microsoft.AspNetCore.Authentication.JwtBearer      10.0.6      10.0.6     10.0.7
+
+Project `AHKFlowApp.Application.Tests` has the following updates to its packages
+   [net10.0]: 
+   Top-level Package                               Requested   Resolved   Latest
+   > coverlet.collector                            8.0.1       8.0.1      10.0.0
+   > Microsoft.ApplicationInsights.AspNetCore      2.23.0      2.23.0     3.1.0 
+
+Project `AHKFlowApp.Domain.Tests` has the following updates to its packages
+   [net10.0]: 
+   Top-level Package                               Requested   Resolved   Latest
+   > coverlet.collector                            8.0.1       8.0.1      10.0.0
+   > Microsoft.ApplicationInsights.AspNetCore      2.23.0      2.23.0     3.1.0 
+   > System.Security.Cryptography.Xml              10.0.6      10.0.6     10.0.7
+
+Project `AHKFlowApp.E2E.Tests` has the following updates to its packages
+   [net10.0]: 
+   Top-level Package                       Requested   Resolved   Latest
+   > coverlet.collector                    8.0.1       8.0.1      10.0.0
+   > Microsoft.AspNetCore.Mvc.Testing      10.0.6      10.0.6     10.0.7
+   > Microsoft.Identity.Web                4.7.0       4.7.0      4.8.0 
+   > System.Security.Cryptography.Xml      10.0.6      10.0.6     10.0.7
+
+Project `AHKFlowApp.Infrastructure.Tests` has the following updates to its packages
+   [net10.0]: 
+   Top-level Package                               Requested   Resolved   Latest
+   > coverlet.collector                            8.0.1       8.0.1      10.0.0
+   > Microsoft.ApplicationInsights.AspNetCore      2.23.0      2.23.0     3.1.0 
+
+Project `AHKFlowApp.TestUtilities` has the following updates to its packages
+   [net10.0]: 
+   Top-level Package                               Requested   Resolved   Latest
+   > Microsoft.ApplicationInsights.AspNetCore      2.23.0      2.23.0     3.1.0 
+   > Microsoft.AspNetCore.Mvc.Testing              10.0.6      10.0.6     10.0.7
+   > System.Security.Cryptography.Xml              10.0.6      10.0.6     10.0.7
+
+Project `AHKFlowApp.UI.Blazor.Tests` has the following updates to its packages
+   [net10.0]: 
+   Top-level Package                               Requested   Resolved   Latest
+   > coverlet.collector                            8.0.1       8.0.1      10.0.0
+   > Microsoft.ApplicationInsights.AspNetCore      2.23.0      2.23.0     3.1.0 
+   > System.Security.Cryptography.Xml              10.0.6      10.0.6     10.0.7
+```
+
+- Disposition: no upgrades in this roadmap cycle. Re-evaluated when individual plans need a specific package bumped. Tracked as a future backlog item.
 
 ## Security findings
 

--- a/docs/superpowers/audits/2026-04-21-baseline-audit.md
+++ b/docs/superpowers/audits/2026-04-21-baseline-audit.md
@@ -108,7 +108,26 @@ Project `AHKFlowApp.UI.Blazor.Tests` has the following updates to its packages
 
 ## Security findings
 
-_Populated in Task 5._
+Scan via `cck-security-scan` skill on 2026-04-21.
+
+> Static analysis only — does not replace penetration testing, dynamic analysis, or threat modeling.
+
+| ID | Severity | Layer | Summary | Disposition |
+|----|----------|-------|---------|-------------|
+| S-1 | low | secrets | `launchSettings.json` lines 10 and 43 — dev Docker SA password `AHKFlow_Dev!2026` committed in two launch profiles. Dev-only credential for local Docker SQL Server; not a production secret, but a real password in source control. | plan 3 |
+| S-2 | low | secrets | `docs/environments.md:245` and `docs/superpowers/plans/2026-04-02-health-swagger-vscode.md:176,210` — same dev password appears in documentation example connection strings. | plan 6 |
+| S-3 | medium | config | `src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs:18-20` — CORS policy uses `AllowAnyMethod()` and `AllowAnyHeader()` alongside `AllowCredentials()`. Origins are correctly restricted via `WithOrigins(allowedOrigins)`, but method and header allowlists are broader than necessary. | plan 3 |
+
+### Layer results
+
+| Layer | Status | Findings |
+|-------|--------|----------|
+| 1. Package vulnerabilities | PASS | 0 CVEs across all 12 projects |
+| 2. Secrets detection | WARN | Dev SA password in launchSettings.json and docs |
+| 3. OWASP code patterns | PASS | No injection, XSS, insecure deserialization, or weak crypto |
+| 4. Auth configuration | PASS | All controllers have explicit `[Authorize]` or `[AllowAnonymous]`; Azure AD via `AddMicrosoftIdentityWebApi` with secure defaults |
+| 5. CORS configuration | WARN | `AllowAnyMethod()` + `AllowAnyHeader()` + `AllowCredentials()` — origins restricted, methods/headers not |
+| 6. Data protection | PASS | Logs use identifiers only; no PII in log statements |
 
 ## Per-plan disposition
 

--- a/docs/superpowers/plans/2026-04-21-plan-1-audit-and-decide.md
+++ b/docs/superpowers/plans/2026-04-21-plan-1-audit-and-decide.md
@@ -1,0 +1,408 @@
+# Plan 1 — Audit & Decide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land PR #66, take a frozen snapshot of outdated packages and security findings, and publish a short decisions doc that tells later plans what to do with each finding.
+
+**Architecture:** No production code changes in this plan. One PR merge (PR #66), two read-only audits, one markdown artifact. The artifact lives at `docs/superpowers/audits/2026-04-21-baseline-audit.md` and is referenced from plans 2-6 when they start.
+
+**Tech Stack:** `gh` CLI, `dotnet list package`, the `cck-security-scan` skill.
+
+---
+
+## File Structure
+
+**Create:**
+- `docs/superpowers/audits/2026-04-21-baseline-audit.md` — the decisions doc; captures outdated packages, security findings, per-plan disposition.
+
+**Modify:** none.
+
+**Merge:** PR #66 (`fix/unique-resource-names` → `main`). No local code edits in the roadmap feature branch — PR #66 is merged via `gh` on its own branch.
+
+---
+
+## Pre-flight
+
+Before starting the first task, confirm:
+
+- You are on the existing `feature/codebase-simplification-roadmap` branch (created during brainstorming and holding the roadmap spec). Run `git branch --show-current` — expected: `feature/codebase-simplification-roadmap`.
+- Working tree is clean. Run `git status --short` — expected: no output.
+- `gh auth status` reports you are logged in to GitHub.
+- `dotnet --version` reports `10.0.x`.
+
+If any check fails, stop and fix before proceeding.
+
+---
+
+## Task 1: Refresh PR #66 against main
+
+**Files:**
+- No files changed in this working tree. The PR branch lives on the remote; we only interact with it through `gh`.
+
+- [ ] **Step 1: Inspect PR #66 head commit and mergeability**
+
+Run:
+
+```bash
+gh pr view 66 --json number,title,state,headRefName,mergeable,mergeStateStatus,isDraft
+```
+
+Expected: `"state":"OPEN"`, `"isDraft":false`, a `headRefName` of `fix/unique-resource-names`. `mergeable` may be `UNKNOWN` — that is fine, we refresh next.
+
+- [ ] **Step 2: Check whether the PR branch is behind main**
+
+Run:
+
+```bash
+gh pr view 66 --json commits --jq '.commits[-1].oid'
+gh api repos/:owner/:repo/compare/main...fix/unique-resource-names --jq '{ahead: .ahead_by, behind: .behind_by}'
+```
+
+Expected: a JSON object like `{"ahead": N, "behind": M}`. If `behind` is `0`, skip Step 3 and go to Step 4. If `behind` > 0, continue.
+
+- [ ] **Step 3: Update the PR branch with latest main**
+
+Run:
+
+```bash
+gh pr update-branch 66
+```
+
+Expected: output `"Updated pull request #66 ..."`. If this command fails with a merge conflict, stop and ask the human — PR #66 is author-owned and conflict resolution may need their input. Do not attempt a force-push.
+
+- [ ] **Step 4: Wait for CI to complete on the refreshed branch**
+
+Run:
+
+```bash
+gh pr checks 66 --watch
+```
+
+Expected: all checks end in `pass`. If any check fails, stop and ask the human before proceeding — we are not reworking PR #66 in this plan.
+
+- [ ] **Step 5: Commit — nothing to commit in this task**
+
+No local files changed. Proceed to Task 2.
+
+---
+
+## Task 2: Merge PR #66
+
+**Files:** none locally.
+
+- [ ] **Step 1: Merge PR #66**
+
+Run:
+
+```bash
+gh pr merge 66 --merge --delete-branch
+```
+
+We use `--merge` (not `--squash` or `--rebase`) to match the repo's history — the recent `git log` shows merge commits for every PR (e.g., `Merge pull request #80`). `--delete-branch` removes the remote branch after merge.
+
+Expected: `"Merged pull request #66"` and `"Deleted branch fix/unique-resource-names"`.
+
+- [ ] **Step 2: Pull main locally and confirm the merge commit is there**
+
+Run:
+
+```bash
+git fetch origin
+git log origin/main --oneline -5
+```
+
+Expected: top commit is the PR #66 merge commit.
+
+- [ ] **Step 3: Rebase the current feature branch on top of the new main**
+
+Run:
+
+```bash
+git rebase origin/main
+```
+
+Expected: `Successfully rebased and updated refs/heads/feature/codebase-simplification-roadmap.`
+If a conflict appears, resolve it (the roadmap spec is unlikely to conflict with a Bicep/ps1 change in PR #66) and continue.
+
+- [ ] **Step 4: Commit — nothing to commit in this task**
+
+Rebase does not produce a commit of its own. Proceed to Task 3.
+
+---
+
+## Task 3: Seed the audit document
+
+**Files:**
+- Create: `docs/superpowers/audits/2026-04-21-baseline-audit.md`
+
+- [ ] **Step 1: Ensure the audits directory exists**
+
+Run:
+
+```bash
+ls docs/superpowers/
+```
+
+Expected: `plans  specs` listed. If `audits` is missing, `git` will pick it up when the file is added — no explicit `mkdir` needed on Windows bash; `Write` tool creates parent directories.
+
+- [ ] **Step 2: Create the audit file with the fixed sections**
+
+Create `docs/superpowers/audits/2026-04-21-baseline-audit.md` with the exact following content:
+
+```markdown
+# Baseline Audit — 2026-04-21
+
+> Snapshot captured during plan 1 of the codebase simplification roadmap.
+> Every finding here is tagged with the plan that will handle it.
+
+## PR #66 — unique-suffix Azure resource names
+
+- Status: **merged** on 2026-04-21.
+- Disposition: closed during plan 1.
+
+## Outdated packages
+
+_Populated in Task 4._
+
+## Security findings
+
+_Populated in Task 5._
+
+## Per-plan disposition
+
+_Populated in Task 6._
+```
+
+- [ ] **Step 3: Commit the seed file**
+
+Run:
+
+```bash
+git add docs/superpowers/audits/2026-04-21-baseline-audit.md
+git commit -m "docs(audit): seed baseline audit for plan 1"
+```
+
+Expected: single-file commit on `feature/codebase-simplification-roadmap`.
+
+---
+
+## Task 4: Capture outdated packages
+
+**Files:**
+- Modify: `docs/superpowers/audits/2026-04-21-baseline-audit.md`
+
+- [ ] **Step 1: Run `dotnet list package --outdated` across the solution**
+
+Run:
+
+```bash
+dotnet list package --outdated
+```
+
+Expected: output begins with `The following sources were used:` and ends with one `Project ...` block per .csproj in the solution. Capture the full stdout.
+
+If `dotnet list package --outdated` fails with a NuGet restore error, run `dotnet restore` once and retry. Do not upgrade anything.
+
+- [ ] **Step 2: Record findings in the audit file**
+
+Replace the `## Outdated packages` section in `docs/superpowers/audits/2026-04-21-baseline-audit.md` so it looks like this, with the actual stdout pasted into the fenced block:
+
+```markdown
+## Outdated packages
+
+Snapshot via `dotnet list package --outdated` on 2026-04-21.
+
+\`\`\`text
+<paste full stdout here>
+\`\`\`
+
+- Disposition: no upgrades in this roadmap cycle. Re-evaluated when individual plans need a specific package bumped (e.g., MediatR for a bug fix). Tracked as a future backlog item.
+```
+
+(The `\`\`\`` escaping is only for rendering in this plan — in the audit file, use real triple backticks.)
+
+If the `dotnet list` output is empty (no outdated packages), replace the fenced block with the single line `No outdated packages as of 2026-04-21.` and keep the disposition sentence.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add docs/superpowers/audits/2026-04-21-baseline-audit.md
+git commit -m "docs(audit): record outdated-package snapshot"
+```
+
+---
+
+## Task 5: Capture security findings
+
+**Files:**
+- Modify: `docs/superpowers/audits/2026-04-21-baseline-audit.md`
+
+- [ ] **Step 1: Invoke the security-scan skill**
+
+Invoke the skill named `cck-security-scan` via the Skill tool. Follow its instructions exactly. Do not fix anything it finds — this task is record-only.
+
+Expected: a skill report listing findings by layer (secrets, dependencies, code, configuration, infra, network) with severity.
+
+- [ ] **Step 2: Record findings in the audit file**
+
+Replace the `## Security findings` section with the following shape, substituting the actual findings. Keep the structure even if the list is short — an empty bullet list is better than a missing section.
+
+```markdown
+## Security findings
+
+Scan via `cck-security-scan` skill on 2026-04-21.
+
+| ID | Severity | Layer | Summary | Disposition |
+|----|----------|-------|---------|-------------|
+| S-1 | high \| med \| low | secrets \| deps \| code \| config \| infra \| network | one-line description | plan 3 \| plan 4 \| plan 6 \| defer (backlog) |
+| ... | ... | ... | ... | ... |
+
+If the scan finds nothing, state: "No findings above the skill's reporting threshold on 2026-04-21."
+```
+
+Dispose each finding by mapping it to the plan that will fix it:
+- secrets / config leak → plan 6 (docs + consistency sweep) if it's a docs leak, plan 3 if it's in code.
+- dead or unsafe code → plan 3.
+- script-level concerns (`deploy.ps1`, `setup-*`) → plan 4.
+- infra (Bicep) changes → **defer**; spec non-goals exclude Bicep edits.
+- anything requiring an upgrade → **defer** (upgrades excluded this cycle).
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add docs/superpowers/audits/2026-04-21-baseline-audit.md
+git commit -m "docs(audit): record security-scan findings"
+```
+
+---
+
+## Task 6: Finalize per-plan disposition
+
+**Files:**
+- Modify: `docs/superpowers/audits/2026-04-21-baseline-audit.md`
+
+- [ ] **Step 1: Fill the per-plan disposition section**
+
+Replace the `## Per-plan disposition` section with this content, adjusting the bullets under each plan based on what Tasks 4 and 5 recorded:
+
+```markdown
+## Per-plan disposition
+
+Each plan 2-6 opens by re-reading this section. Only items listed under its plan are in its scope.
+
+### Plan 2 — Targeted coverage uplift
+- No audit findings route here directly. Coverage gaps are discovered inside plan 2.
+
+### Plan 3 — Code simplification
+- <list security findings IDs disposed to plan 3, or "none">
+- <list dead-code hot spots if any surfaced during the security scan>
+
+### Plan 4 — Script + deploy.ps1 overhaul
+- <list script-layer security findings, or "none">
+- PR #66's new unique-suffix variables are now in `scripts/.env.<env>` — plan 4's preflight must read them.
+
+### Plan 5 — Local-install path (no Azure)
+- No audit findings route here directly. Scope is fixed by the roadmap spec.
+
+### Plan 6 — Docs + consistency sweep
+- <list docs / config-leak findings, or "none">
+- Cross-reference: README, AGENTS.md, `.claude/CLAUDE.md`, `.github/**`.
+
+### Deferred
+- Package upgrades (outdated-package snapshot).
+- Any infra / Bicep security findings.
+- <anything else marked `defer` in the findings table>
+```
+
+- [ ] **Step 2: Re-read the full audit file end-to-end**
+
+Run:
+
+```bash
+cat docs/superpowers/audits/2026-04-21-baseline-audit.md
+```
+
+Verify:
+- No `<paste ...>` or `<list ...>` placeholders remain.
+- Every security finding has both a severity and a disposition.
+- Every plan under "Per-plan disposition" has at least one concrete bullet (even if that bullet is "none").
+
+If any placeholder remains, go back to the task that owns it and fix it.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add docs/superpowers/audits/2026-04-21-baseline-audit.md
+git commit -m "docs(audit): per-plan disposition and close plan 1"
+```
+
+---
+
+## Task 7: Open plan 1 pull request
+
+**Files:** none.
+
+- [ ] **Step 1: Push the feature branch**
+
+Run:
+
+```bash
+git push -u origin feature/codebase-simplification-roadmap
+```
+
+Expected: new remote branch, PR creation link in the output.
+
+- [ ] **Step 2: Open the PR**
+
+Run:
+
+```bash
+gh pr create --title "docs: plan 1 audit & decide" --body "$(cat <<'EOF'
+## Summary
+- Merges the roadmap spec from `docs/superpowers/specs/2026-04-21-codebase-simplification-roadmap-design.md`.
+- Adds the baseline audit at `docs/superpowers/audits/2026-04-21-baseline-audit.md`.
+- Closes plan 1 of the simplification roadmap; PR #66 landed as part of this plan.
+
+## Test plan
+- [ ] CI (`build-test`, `bicep-lint`, coverage gate) passes.
+- [ ] Audit doc has no placeholders; every finding has a disposition.
+EOF
+)"
+```
+
+Expected: PR URL in output. Record it — plans 2-6 will reference this audit.
+
+- [ ] **Step 3: Wait for CI and request review**
+
+Run:
+
+```bash
+gh pr checks --watch
+```
+
+Expected: all checks pass. The merge itself is a human decision — the plan stops here.
+
+---
+
+## Definition of Done
+
+- [ ] PR #66 merged on main.
+- [ ] `docs/superpowers/audits/2026-04-21-baseline-audit.md` committed, with:
+  - Outdated-package snapshot or "none" line.
+  - Security findings table or "no findings" line, each finding dispositioned.
+  - Per-plan disposition section, every plan covered.
+- [ ] Plan 1 PR open with green CI.
+- [ ] No production code changed in this plan (only the audit doc and the rebase of the roadmap branch).
+
+---
+
+## Rollback
+
+- Nothing to roll back locally — only a doc was added.
+- PR #66 rollback (if merge turns out to be wrong): revert via `gh pr revert 66` or a manual `git revert <merge-sha>` PR. Do not force-push main.

--- a/docs/superpowers/specs/2026-04-21-codebase-simplification-roadmap-design.md
+++ b/docs/superpowers/specs/2026-04-21-codebase-simplification-roadmap-design.md
@@ -24,7 +24,7 @@ Six sequential plans. Each one writes its own implementation plan via the `writi
 | 2 | Targeted coverage uplift | Tiered thresholds enforced in CI | M |
 | 3 | Code simplification | Low-value complexity removed; at most 1-2 patterns | M-L |
 | 4 | Script + deploy.ps1 overhaul | Single `/scripts/` folder; PS v5; preflight; frontend auto-trigger | M |
-| 5 | Local-install docs | README "Run locally" section backed by working compose | S |
+| 5 | Local-install path (no Azure) | Symmetric test-auth toggle + README "Run locally" section | M |
 | 6 | Docs + consistency sweep | Aligned README / AGENTS / `.claude/` / `.github/` | S |
 
 ### Sequencing rationale
@@ -93,16 +93,21 @@ Not in scope:
 - New Azure resource types or topology changes.
 - Key Vault introduction (tracked separately).
 
-### Plan 5 — Local-install docs (S)
+### Plan 5 — Local-install path, no Azure (M)
 
 In scope:
-- README section "Run locally without Azure": prerequisites (Docker Desktop or Docker Engine), `docker compose up`, local URLs, seed notes.
-- Verify `docker-compose.yml` works end-to-end on a clean checkout.
+- **Backend symmetric test-auth toggle.** Add `Auth:UseTestProvider` reader to `src/Backend/AHKFlowApp.API/Program.cs`; when true, register the existing `TestAuthHandler` (promoted from `tests/AHKFlowApp.TestUtilities/Auth/` to a non-test location, or kept referenced) as the default scheme instead of `AddMicrosoftIdentityWebApi`. Matches the frontend's existing toggle so `[Authorize]` endpoints work end-to-end without Azure AD.
+- **Compose wiring.** `docker-compose.yml` sets `Auth__UseTestProvider=true` on both API and Blazor services by default.
+- **README section "Run locally without Azure":** trust model (single-user / trusted LAN; no real auth), prerequisites (Docker Desktop or Docker Engine), `docker compose up`, local URLs, seed notes, how to switch back to Azure AD.
+- Verify `docker-compose.yml` works end-to-end on a clean checkout (sign-in bypassed, Hotstrings endpoints reachable).
 
 Not in scope:
 - A separate `run-local.ps1` / `deploy-local.ps1` script.
 - A new compose profile.
 - Raspberry Pi-specific tuning.
+- Real auth for local deployments (OIDC / Keycloak / local identity).
+
+Trust model: the test-auth provider authenticates every request as a synthetic user. This is acceptable for single-user homelab / trusted-LAN use only. The README must state this plainly.
 
 ### Plan 6 — Docs + consistency sweep (S)
 
@@ -121,7 +126,7 @@ Not in scope:
 - `scripts/` is one folder. Every script parses under Windows PowerShell 5.1.
 - `deploy.ps1` starts with a preflight block and, on success, triggers the frontend CD workflow without manual action.
 - CI enforces per-project coverage thresholds; no blanket number.
-- README has a "Run locally" path that works on a fresh clone via `docker compose up`.
+- README has a "Run locally without Azure" path that works end-to-end on a fresh clone via `docker compose up`, including sign-in bypass via the symmetric test-auth toggle.
 - No contradictions between `README.md`, `AGENTS.md`, `.claude/`, `.github/`.
 
 ## Non-goals
@@ -130,6 +135,7 @@ Not in scope:
 - New abstractions beyond the 1-2 patterns discussed in plan 3.
 - Bicep topology changes or new Azure resources.
 - A separate local-deploy script.
+- Real authentication for the local-install path (OIDC / Keycloak / local identity). Homelab build is trusted-LAN only.
 - Migrating off MediatR, Ardalis.Result, FluentValidation, or MudBlazor.
 - Package upgrades (recorded in plan 1, deferred).
 
@@ -142,6 +148,7 @@ Not in scope:
 | Auto-triggered frontend deploy runs before DB migration | Order: migrate DB → deploy API → health probe → then trigger frontend workflow. |
 | PS v5 sweep breaks PS 7 callers | Target PS 5.1 syntax — it works on PS 7 too. |
 | PR #66 rebase conflicts with plan 4 edits | Land PR #66 as the first act of plan 1, before plan 4 starts. |
+| Promoting `TestAuthHandler` out of test projects leaks test code into prod assemblies | Put it in a dedicated `AHKFlowApp.API` namespace (e.g., `Auth/TestAuthenticationHandler.cs`); registered only when `Auth:UseTestProvider=true`. Test projects can still reuse it via InternalsVisibleTo or their own handler. |
 
 ## Decisions made during brainstorming
 
@@ -149,7 +156,8 @@ Not in scope:
 |---|---|
 | Coverage blanket vs tiered | Tiered per project. |
 | UI.Blazor bUnit strategy | Cull low-value tests; threshold 65 / 45. |
-| Local install approach | Docs-only. No new script. |
+| Local install approach | Symmetric test-auth toggle on backend + docs. No new script. |
+| Local-install auth model | Backend `Auth:UseTestProvider` matches existing frontend flag; `TestAuthHandler` promoted from test-only. Trust model = trusted LAN, single-user. |
 | PR #66 handling | Land as-is before plan 4. |
 | `old_project_reference/` | Already removed manually; no repo action. |
 | Backlog items 013-029 | Ignored during simplification; adapt to new shape when implemented. |

--- a/docs/superpowers/specs/2026-04-21-codebase-simplification-roadmap-design.md
+++ b/docs/superpowers/specs/2026-04-21-codebase-simplification-roadmap-design.md
@@ -1,0 +1,161 @@
+# Codebase Simplification Roadmap — Design
+
+**Date:** 2026-04-21
+**Status:** Draft (awaiting user review)
+
+## Goal
+
+Simplify the AHKFlowApp codebase, scripts, and documentation through six small, independent plans. Each plan ships as its own PR. No grand rewrite.
+
+## Principles
+
+- Simplify only what exists. Don't design for backlog features.
+- Delete before abstracting. Prefer removing code over introducing patterns.
+- Each plan has a clear entry/exit state and lands independently.
+- Scale ambition to the stage: foundation-only codebase; avoid speculative design.
+
+## Roadmap
+
+Six sequential plans. Each one writes its own implementation plan via the `writing-plans` skill when it starts.
+
+| # | Plan | Output | Size |
+|---|---|---|---|
+| 1 | Audit & decide | Decisions doc; PR #66 landed | S |
+| 2 | Targeted coverage uplift | Tiered thresholds enforced in CI | M |
+| 3 | Code simplification | Low-value complexity removed; at most 1-2 patterns | M-L |
+| 4 | Script + deploy.ps1 overhaul | Single `/scripts/` folder; PS v5; preflight; frontend auto-trigger | M |
+| 5 | Local-install docs | README "Run locally" section backed by working compose | S |
+| 6 | Docs + consistency sweep | Aligned README / AGENTS / `.claude/` / `.github/` | S |
+
+### Sequencing rationale
+
+1. **Audit first** so plans 2-6 know what survives.
+2. **Coverage second** — test surviving code, not code about to be deleted.
+3. **Simplify third** on well-tested code.
+4. **Scripts, local-install docs, consistency sweep last** — they reference the new shape.
+
+## Per-plan scope
+
+### Plan 1 — Audit & decide (S)
+
+In scope:
+- Land PR #66 (unique-suffix fix on globally-scoped Azure resources) to unblock plan 4.
+- Run `dotnet list package --outdated` — record stale packages; do not upgrade.
+- One pass with the `cck-security-scan` skill — record findings; fixes go in later plans.
+- Output: a short decisions doc capturing what survives, what goes, what moves.
+
+Not in scope:
+- Any code changes beyond merging PR #66.
+- Package upgrades.
+- Security fixes (recorded only; fixed in later plans).
+
+### Plan 2 — Targeted coverage uplift (M)
+
+In scope:
+- Per-project coverage thresholds in CI:
+  - Domain / Application: **85 % line, 70 % branch**
+  - Infrastructure: **70 % line, 50 % branch**
+  - API: **75 % line, 55 % branch**
+  - UI.Blazor: **65 % line, 45 % branch**
+- Cull low-value bUnit tests (DTO rendering, trivial pass-throughs) before raising the UI bar.
+- Add tests only where the coverage gap sits on code plan 1 says is surviving.
+
+Not in scope:
+- Blanket per-repo numbers.
+- Test framework migration.
+- Re-architecting integration tests (Testcontainers already in use).
+
+### Plan 3 — Code simplification (M-L)
+
+In scope:
+- Sweep the C# code for and remove: dead code, unused DI registrations, speculative abstractions, over-generic helpers, catch-rethrow blocks, defensive null checks past system boundaries.
+- Flag at most 1-2 C# pattern opportunities; discuss each before applying. A likely candidate: a small Result-to-HTTP mapping helper in controllers, only if it removes more code than it adds.
+- Pattern candidates for scripts (e.g., a phase structure inside `deploy.ps1`) are owned by plan 4, not this plan.
+
+Not in scope:
+- Renaming.
+- Re-organising layer folders.
+- New features, new abstractions beyond the 1-2 discussed.
+
+### Plan 4 — Script + deploy.ps1 overhaul (M)
+
+In scope:
+- Consolidate `docs/scripts/*` → `/scripts/` (single folder).
+- PowerShell 5.1 compatibility sweep on all scripts — no null-coalescing, no ternary, no PS 7-only syntax.
+- `deploy.ps1` (currently ~692 lines):
+  - Preflight block checking: .NET 10 SDK, Azure CLI, Bicep, jq, GitHub CLI, PowerShell version. Fail fast with remediation guidance; support `-SkipPrereqCheck`.
+  - Phase-separated structure — discussed and confirmed in this plan before applying.
+  - On successful Azure deploy, trigger `deploy-frontend.yml` via `gh workflow run` for the target environment.
+  - Ordering of post-provision calls: DB migrate → API deploy → health probe passes → then trigger frontend workflow.
+
+Not in scope:
+- Bicep rewrites.
+- New Azure resource types or topology changes.
+- Key Vault introduction (tracked separately).
+
+### Plan 5 — Local-install docs (S)
+
+In scope:
+- README section "Run locally without Azure": prerequisites (Docker Desktop or Docker Engine), `docker compose up`, local URLs, seed notes.
+- Verify `docker-compose.yml` works end-to-end on a clean checkout.
+
+Not in scope:
+- A separate `run-local.ps1` / `deploy-local.ps1` script.
+- A new compose profile.
+- Raspberry Pi-specific tuning.
+
+### Plan 6 — Docs + consistency sweep (S)
+
+In scope:
+- Cross-check and align: `README.md`, `AGENTS.md`, `.claude/CLAUDE.md`, `.claude/rules/*.md`, `.github/*`, `docs/**`.
+- Fix stale commands, broken links, drifted tech-stack versions, contradictions.
+- Single Prerequisites page linked from README.
+
+Not in scope:
+- Rewriting architecture docs.
+- Adding new guides.
+
+## Success criteria (overall)
+
+- Every plan ships as one PR, reviewable in under 30 minutes.
+- `scripts/` is one folder. Every script parses under Windows PowerShell 5.1.
+- `deploy.ps1` starts with a preflight block and, on success, triggers the frontend CD workflow without manual action.
+- CI enforces per-project coverage thresholds; no blanket number.
+- README has a "Run locally" path that works on a fresh clone via `docker compose up`.
+- No contradictions between `README.md`, `AGENTS.md`, `.claude/`, `.github/`.
+
+## Non-goals
+
+- New features. Hotstring / Hotkey / Profile CRUD stays in backlog.
+- New abstractions beyond the 1-2 patterns discussed in plan 3.
+- Bicep topology changes or new Azure resources.
+- A separate local-deploy script.
+- Migrating off MediatR, Ardalis.Result, FluentValidation, or MudBlazor.
+- Package upgrades (recorded in plan 1, deferred).
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Plan 3 breaks untested behaviour | Plan 2 lands first and raises targeted coverage. |
+| `deploy.ps1` preflight false-positives block working setups | Check version floors (not exact matches); support `-SkipPrereqCheck`. |
+| Auto-triggered frontend deploy runs before DB migration | Order: migrate DB → deploy API → health probe → then trigger frontend workflow. |
+| PS v5 sweep breaks PS 7 callers | Target PS 5.1 syntax — it works on PS 7 too. |
+| PR #66 rebase conflicts with plan 4 edits | Land PR #66 as the first act of plan 1, before plan 4 starts. |
+
+## Decisions made during brainstorming
+
+| Question | Decision |
+|---|---|
+| Coverage blanket vs tiered | Tiered per project. |
+| UI.Blazor bUnit strategy | Cull low-value tests; threshold 65 / 45. |
+| Local install approach | Docs-only. No new script. |
+| PR #66 handling | Land as-is before plan 4. |
+| `old_project_reference/` | Already removed manually; no repo action. |
+| Backlog items 013-029 | Ignored during simplification; adapt to new shape when implemented. |
+| Repo root cruft | All locally-gitignored; nothing to clean in repo. |
+| Pattern opportunities | Cap at 1-2; each discussed before applying. |
+
+## Open questions
+
+None at design level. Per-plan questions surface during each plan's `writing-plans` step.


### PR DESCRIPTION
## Summary

- Roadmap spec: `docs/superpowers/specs/2026-04-21-codebase-simplification-roadmap-design.md` — six-plan simplification roadmap covering code, scripts, and docs.
- Baseline audit: `docs/superpowers/audits/2026-04-21-baseline-audit.md` — outdated-package snapshot (22 entries, deferred), security scan (3 low/medium findings dispositioned to plans 3, 6).
- Implementation plan for plan 1: `docs/superpowers/plans/2026-04-21-plan-1-audit-and-decide.md`.
- PR #66 (unique-suffix Azure resource names) merged as part of this plan.

## Test plan
- [ ] CI (`build-test`, `bicep-lint`, coverage gate) passes — docs-only PR, no code changes.
- [ ] Audit doc has no placeholders; every finding has a disposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)