### PR TITLE
fix: code simplification — rotate dev password, tighten CORS, remove dead refs (plan 3)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="MediatR" Version="14.1.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
@@ -24,7 +25,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="4.8.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="MudBlazor" Version="9.3.0" />
@@ -32,7 +33,7 @@
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,14 @@ services:
     container_name: ahkflowapp-sqlserver
     environment:
       - ACCEPT_EULA=Y
-      - SA_PASSWORD=AHKFlow_Dev!2026
+      - SA_PASSWORD=Dev!LocalOnly_2026
       - MSSQL_PID=Developer
     ports:
       - "1433:1433"
     volumes:
       - sqlserver-data:/var/opt/mssql
     healthcheck:
-      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "AHKFlow_Dev!2026" -Q "SELECT 1" -C || exit 1
+      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "Dev!LocalOnly_2026" -Q "SELECT 1" -C || exit 1
       interval: 10s
       timeout: 5s
       retries: 10
@@ -28,7 +28,7 @@ services:
       # DEV environment — local development only
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_HTTP_PORTS=8080
-      - ConnectionStrings__DefaultConnection=Server=sqlserver,1433;Database=AHKFlowAppDb;User Id=sa;Password=AHKFlow_Dev!2026;TrustServerCertificate=True;MultipleActiveResultSets=true
+      - ConnectionStrings__DefaultConnection=Server=sqlserver,1433;Database=AHKFlowAppDb;User Id=sa;Password=Dev!LocalOnly_2026;TrustServerCertificate=True;MultipleActiveResultSets=true
     ports:
       - "5600:8080"
     depends_on:

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -242,7 +242,7 @@ Server=(localdb)\mssqllocaldb;Database=AHKFlowApp;Trusted_Connection=True;Multip
 ```
 or (Docker):
 ```
-Server=localhost,1433;Database=AHKFlowAppDb;User Id=sa;Password=AHKFlow_Dev!2026;TrustServerCertificate=True
+Server=localhost,1433;Database=AHKFlowAppDb;User Id=sa;Password=Dev!LocalOnly_2026;TrustServerCertificate=True
 ```
 
 **TEST/PROD (Azure, Entra ID auth):**

--- a/src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs
+++ b/src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs
@@ -15,8 +15,8 @@ internal static class ApiExtensions
                 if (allowedOrigins is { Length: > 0 })
                 {
                     policy.WithOrigins(allowedOrigins)
-                          .AllowAnyMethod()
-                          .AllowAnyHeader()
+                          .WithMethods("GET", "POST", "PUT", "DELETE")
+                          .WithHeaders("Content-Type", "Authorization")
                           .AllowCredentials();
                 }
             }));

--- a/src/Backend/AHKFlowApp.API/Properties/launchSettings.json
+++ b/src/Backend/AHKFlowApp.API/Properties/launchSettings.json
@@ -7,7 +7,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "AHKFLOW_START_DOCKER_SQL": "true",
-        "ConnectionStrings__DefaultConnection": "Server=localhost,1433;Database=AHKFlowAppDb;User Id=sa;Password=AHKFlow_Dev!2026;TrustServerCertificate=True;MultipleActiveResultSets=true"
+        "ConnectionStrings__DefaultConnection": "Server=localhost,1433;Database=AHKFlowAppDb;User Id=sa;Password=Dev!LocalOnly_2026;TrustServerCertificate=True;MultipleActiveResultSets=true"
       },
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5600"
@@ -40,7 +40,7 @@
       "useSSL": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "ConnectionStrings__DefaultConnection": "Server=host.docker.internal,1433;Database=AHKFlowAppDb;User Id=sa;Password=AHKFlow_Dev!2026;TrustServerCertificate=True;MultipleActiveResultSets=true"
+        "ConnectionStrings__DefaultConnection": "Server=host.docker.internal,1433;Database=AHKFlowAppDb;User Id=sa;Password=Dev!LocalOnly_2026;TrustServerCertificate=True;MultipleActiveResultSets=true"
       },
       "publishAllPorts": false
     }

--- a/src/Backend/AHKFlowApp.Application/AHKFlowApp.Application.csproj
+++ b/src/Backend/AHKFlowApp.Application/AHKFlowApp.Application.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="MediatR" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="AHKFlowApp.Application.Tests" />

--- a/src/Backend/AHKFlowApp.Domain/AHKFlowApp.Domain.csproj
+++ b/src/Backend/AHKFlowApp.Domain/AHKFlowApp.Domain.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
-  </ItemGroup>
+
 </Project>

--- a/src/Backend/AHKFlowApp.Infrastructure/AHKFlowApp.Infrastructure.csproj
+++ b/src/Backend/AHKFlowApp.Infrastructure/AHKFlowApp.Infrastructure.csproj
@@ -6,7 +6,6 @@
     <ProjectReference Include="..\AHKFlowApp.Application\AHKFlowApp.Application.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
   </ItemGroup>
 </Project>

--- a/src/Backend/AHKFlowApp.Infrastructure/Services/VersionService.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Services/VersionService.cs
@@ -9,9 +9,5 @@ public sealed class VersionService : IVersionService
         .InformationalVersion ?? "0.0.0-dev";
 
     public ValueTask<string> GetVersionAsync(CancellationToken cancellationToken = default)
-    {
-        if (cancellationToken.IsCancellationRequested)
-            return ValueTask.FromCanceled<string>(cancellationToken);
-        return ValueTask.FromResult(_version);
-    }
+        => ValueTask.FromResult(_version);
 }

--- a/tests/AHKFlowApp.E2E.Tests/AHKFlowApp.E2E.Tests.csproj
+++ b/tests/AHKFlowApp.E2E.Tests/AHKFlowApp.E2E.Tests.csproj
@@ -20,7 +20,8 @@
     <PackageReference Include="Microsoft.Playwright" />
     <PackageReference Include="Yarp.ReverseProxy" />
     <PackageReference Include="Testcontainers.MsSql" />
-    <!-- Override transitive reference with known vulnerabilities -->
+    <!-- Override transitive references with known vulnerabilities -->
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/AHKFlowApp.Infrastructure.Tests/Services/VersionServiceTests.cs
+++ b/tests/AHKFlowApp.Infrastructure.Tests/Services/VersionServiceTests.cs
@@ -15,16 +15,4 @@ public sealed class VersionServiceTests
 
         version.Should().NotBeNullOrWhiteSpace();
     }
-
-    [Fact]
-    public async Task GetVersionAsync_WhenAlreadyCancelled_ThrowsOperationCancelledException()
-    {
-        var sut = new VersionService();
-        using var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Func<Task> act = async () => await sut.GetVersionAsync(cts.Token);
-
-        await act.Should().ThrowAsync<OperationCanceledException>();
-    }
 }

--- a/tests/AHKFlowApp.TestUtilities/AHKFlowApp.TestUtilities.csproj
+++ b/tests/AHKFlowApp.TestUtilities/AHKFlowApp.TestUtilities.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="Testcontainers.MsSql" />


### PR DESCRIPTION
## Summary
- **S-1:** Rotates dev SA password in operative config files (`launchSettings.json`, `docker-compose.yml`, `docs/environments.md`) — `AHKFlow_Dev!2026` no longer appears in any executable config or connection string. Historical references remain in audit/plan docs under `docs/superpowers/` (intentional — they are read-only records, not live config).
- **S-3:** Restricts CORS policy from `AllowAnyMethod().AllowAnyHeader()` to explicit `WithMethods("GET","POST","PUT","DELETE").WithHeaders("Content-Type","Authorization")`.
- **Chore:** Removes unused `Microsoft.ApplicationInsights.AspNetCore` package reference from Domain, Application, and Infrastructure .csproj files (never used in those layers).
- **Refactor:** Simplifies `VersionService.GetVersionAsync` — removes overengineered `IsCancellationRequested` guard on a cached string return; removes corresponding test.

### DataProtection security fix (GHSA-9mv3-2cwr-p262)
Also pins transitive dependency upgrades to remediate a high-severity vulnerability in `Microsoft.AspNetCore.DataProtection` 10.0.0 (GHSA-9mv3-2cwr-p262):
- `Microsoft.AspNetCore.DataProtection` → **10.0.7** (explicit PackageReference in TestUtilities and E2E.Tests to force transitive resolution past the vulnerable 10.0.0)
- `System.Security.Cryptography.Xml` → **10.0.7** (required by DataProtection 10.0.7)
- `Microsoft.Identity.Web` → **4.8.0** (upgraded to align with the updated dependency chain; 4.7.0's transitive DataProtection floor was the root cause of the vulnerability)

## Test plan
- [ ] CI passes (build, test, format check, coverage gate).
- [ ] `grep -rn "AHKFlow_Dev" . --include="*.json" --include="*.yml" --include="*.cs"` returns no matches.
- [ ] 148 tests pass (one removed: VersionService cancellation test).