### PR TITLE
fix: deploy-api workflow broken after PR #88

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -53,7 +53,7 @@ jobs:
     needs: build-test-publish
     runs-on: ubuntu-latest
     env:
-      ENV_SUFFIX: ${{ env.TARGET_ENV == 'test' && 'TEST' || 'PROD' }}
+      ENV_SUFFIX: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.environment || 'test') == 'test' && 'TEST' || 'PROD' }}
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
@@ -110,7 +110,7 @@ jobs:
     needs: [build-test-publish, migrate-db]
     runs-on: ubuntu-latest
     env:
-      ENV_SUFFIX: ${{ env.TARGET_ENV == 'test' && 'TEST' || 'PROD' }}
+      ENV_SUFFIX: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.environment || 'test') == 'test' && 'TEST' || 'PROD' }}
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- GitHub Actions does not allow workflow-level `env` context in job-level `env:` definitions
- `ENV_SUFFIX: ${{ env.TARGET_ENV == ... }}` in `migrate-db` and `deploy` jobs caused run #46 to fail with 0 jobs started
- Fixed by inlining the `github` context expression directly (same logic, bypasses `env` context limitation)

## Root cause

The same failure was happening on every push to the feature branch (`24934482996`, `24933475704`) but went unnoticed since those don't gate PRs — only `ci.yml` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)