### PR TITLE
fix: retry sqlcmd login on timeout in deploy.ps1

### DIFF
--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -625,30 +625,44 @@ GRANT EXECUTE TO [$RuntimeUamiName];
         # when the local Windows account isn't domain-joined to Entra ID.
         $userEmail = az account show --query user.name -o tsv
 
-        Write-Host ""
-        Write-Host "  ┌─────────────────────────────────────────────────────────────────┐" -ForegroundColor Cyan
-        Write-Host "  │  ACTION REQUIRED: Browser authentication window opening...      │" -ForegroundColor Cyan
-        Write-Host "  │                                                                 │" -ForegroundColor Cyan
-        Write-Host "  │  sqlcmd will open a Microsoft Entra login window to connect     │" -ForegroundColor Cyan
-        Write-Host "  │$("  to Azure SQL. Please sign in with: $userEmail".PadRight(65))│" -ForegroundColor Cyan
-        Write-Host "  │                                                                 │" -ForegroundColor Cyan
-        Write-Host "  │  The window may appear BEHIND this terminal — check your        │" -ForegroundColor Cyan
-        Write-Host "  │  taskbar if nothing appears on screen.                          │" -ForegroundColor Cyan
-        Write-Host "  │                                                                 │" -ForegroundColor Cyan
-        Write-Host "  │  If you close the window without signing in, sqlcmd will fail   │" -ForegroundColor Cyan
-        Write-Host "  │  and the script will print manual Portal instructions instead.  │" -ForegroundColor Cyan
-        Write-Host "  └─────────────────────────────────────────────────────────────────┘" -ForegroundColor Cyan
-        Write-Host ""
+        $sqlcmdExitCode = 1
+        while ($sqlcmdExitCode -ne 0) {
+            Write-Host ""
+            Write-Host "  ┌─────────────────────────────────────────────────────────────────┐" -ForegroundColor Cyan
+            Write-Host "  │  ACTION REQUIRED: Browser authentication window opening...      │" -ForegroundColor Cyan
+            Write-Host "  │                                                                 │" -ForegroundColor Cyan
+            Write-Host "  │  sqlcmd will open a Microsoft Entra login window to connect     │" -ForegroundColor Cyan
+            Write-Host "  │$("  to Azure SQL. Please sign in with: $userEmail".PadRight(65))│" -ForegroundColor Cyan
+            Write-Host "  │                                                                 │" -ForegroundColor Cyan
+            Write-Host "  │  The window may appear BEHIND this terminal — check your        │" -ForegroundColor Cyan
+            Write-Host "  │  taskbar if nothing appears on screen.                          │" -ForegroundColor Cyan
+            Write-Host "  └─────────────────────────────────────────────────────────────────┘" -ForegroundColor Cyan
+            Write-Host ""
 
-        sqlcmd -S $SqlServerFqdn -d $SqlDatabaseName -G -U $userEmail -i $tmpSql
-        $sqlcmdExitCode = $LASTEXITCODE
+            sqlcmd -S $SqlServerFqdn -d $SqlDatabaseName -G -U $userEmail -i $tmpSql
+            $sqlcmdExitCode = $LASTEXITCODE
+
+            if ($sqlcmdExitCode -ne 0) {
+                Write-Warn "sqlcmd failed (login timeout or authentication error)."
+                Write-Host ""
+                Write-Host "  Options:" -ForegroundColor White
+                Write-Host "    [R] Retry — opens a new login popup" -ForegroundColor DarkGray
+                Write-Host "    [M] Manual — create the SQL user via the Azure Portal instead" -ForegroundColor DarkGray
+                Write-Host ""
+                $choice = Read-Host "  Choice [R/M] (default: R)"
+                if ($choice.Trim() -match '^[Mm]') {
+                    break
+                }
+                # Any other input (including blank) retries
+            }
+        }
 
         Remove-Item $tmpSql -ErrorAction SilentlyContinue
 
         if ($sqlcmdExitCode -eq 0) {
             Write-Success "SQL user '$RuntimeUamiName' created/verified via sqlcmd"
         } else {
-            Write-Warn "sqlcmd could not authenticate. Create the SQL user manually in the Azure Portal:"
+            Write-Warn "Create the SQL user manually in the Azure Portal:"
             Write-Host "    URL: https://portal.azure.com" -ForegroundColor Yellow
             Write-Host "    Navigate to: SQL Database '$SqlDatabaseName' > Query Editor" -ForegroundColor Yellow
             Write-Host ""


### PR DESCRIPTION
## Summary

- Wraps the `sqlcmd` call in a retry loop so a login timeout no longer forces a manual Portal detour
- On failure, prompts `[R] Retry / [M] Manual` — Enter or R opens a new Entra login popup, M falls through to the existing Portal instructions
- Removed the now-redundant hint about closing the window leading to manual instructions

## Test plan

- [ ] Run `deploy.ps1` and intentionally wait past the login timeout — confirm the `[R/M]` prompt appears
- [ ] Choose R — confirm a new browser login window opens and sqlcmd retries
- [ ] Choose M — confirm the Portal instructions are printed and script waits for Enter
- [ ] Happy path (sign in promptly) — confirm script continues as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)