### PR TITLE
fix: enable terminal scrollback during github action polling

### DIFF
--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -858,8 +858,10 @@ $seenJobStates = @{}
 $runDone = $false
 while (-not $runDone) {
     Start-Sleep -Seconds 10
-    $runView = gh run view $runId --repo $GitHubOrgRepo --json status,conclusion,jobs 2>&1 | ConvertFrom-Json
-    if (-not $runView) { continue }
+    $runViewJson = gh run view $runId --repo $GitHubOrgRepo --json status,conclusion,jobs
+    if ($LASTEXITCODE -ne 0) { Write-Warning "gh run view failed (exit $LASTEXITCODE). Retrying..."; continue }
+    try { $runView = $runViewJson | ConvertFrom-Json -ErrorAction Stop }
+    catch { Write-Warning "Failed to parse gh run view output. Retrying..."; continue }
 
     foreach ($job in $runView.jobs) {
         $jobKey = $job.name

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -852,8 +852,37 @@ for ($attempt = 1; $attempt -le 12 -and -not $runId; $attempt++) {
 if (-not $runId) { throw "Could not resolve run ID for deploy-api.yml. gh workflow run succeeded, but the follow-up lookup did not return a matching run. Check: gh run list --workflow deploy-api.yml --repo $GitHubOrgRepo --json databaseId,createdAt,event" }
 Write-Host "  Watching run #$runId — this typically takes 8-15 minutes..."
 
-gh run watch $runId --exit-status --repo $GitHubOrgRepo
-if ($LASTEXITCODE -ne 0) { throw "deploy-api.yml run #$runId failed. Check: gh run view $runId --repo $GitHubOrgRepo" }
+# Poll inline so output stays in the scrollback buffer (gh run watch uses an alternate screen)
+$runView = $null
+$seenJobStates = @{}
+$runDone = $false
+while (-not $runDone) {
+    Start-Sleep -Seconds 10
+    $runView = gh run view $runId --repo $GitHubOrgRepo --json status,conclusion,jobs 2>&1 | ConvertFrom-Json
+    if (-not $runView) { continue }
+
+    foreach ($job in $runView.jobs) {
+        $jobKey = $job.name
+        $currentState = "$($job.status)/$($job.conclusion)"
+        if ($seenJobStates[$jobKey] -ne $currentState) {
+            $seenJobStates[$jobKey] = $currentState
+            $label = if ($job.conclusion) { $job.conclusion } else { $job.status }
+            $color = switch ($job.conclusion) {
+                'success'  { 'Green'   }
+                'failure'  { 'Red'     }
+                'skipped'  { 'DarkGray' }
+                default    { 'Yellow'  }
+            }
+            Write-Host "  › $($job.name): $label" -ForegroundColor $color
+        }
+    }
+
+    $runDone = $runView.status -eq 'completed'
+}
+
+if ($runView.conclusion -ne 'success') {
+    throw "deploy-api.yml run #$runId $($runView.conclusion). Check: gh run view $runId --repo $GitHubOrgRepo"
+}
 Write-Success "API deployment complete (run #$runId)"
 
 # Step 9b — Poll health endpoint


### PR DESCRIPTION
## Summary

- Replaces `gh run watch` with an inline polling loop in `deploy.ps1`
- `gh run watch` uses alternate screen mode, which clears previous output and blocks terminal scrollback
- Custom loop streams job status every 10s and preserves all output in the scrollback buffer

## Test plan

- [ ] Run a deploy via `deploy.ps1` and verify terminal output remains scrollable after the GitHub Actions poll completes
- [ ] Confirm deploy succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)