### PR TITLE
Plan 6: docs + consistency sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,13 +54,15 @@ dotnet test tests/AHKFlowApp.API.Tests --configuration Release --verbosity norma
 dotnet test tests/AHKFlowApp.API.Tests --filter "FullyQualifiedName~HealthControllerTests"
 
 # Run API locally (recommended: Docker SQL on port 1433)
-dotnet run --project src/Backend/AHKFlowApp.API --launch-profile "https + Docker SQL (Recommended)"
+dotnet run --project src/Backend/AHKFlowApp.API --launch-profile "Docker SQL (Recommended)"
 
 # Run Blazor frontend (separate terminal)
 dotnet run --project src/Frontend/AHKFlowApp.UI.Blazor
 
-# Full stack via Docker Compose (SQL Server + API)
+# Full stack via Docker Compose (SQL Server + API + Blazor UI)
 docker compose up --build
+
+# Local-only stack, no Azure AD: see README "Run locally without Azure"
 
 # EF Core migrations
 dotnet ef migrations add <Name> --project src/Backend/AHKFlowApp.Infrastructure --startup-project src/Backend/AHKFlowApp.API

--- a/AHKFlowApp.slnLaunch
+++ b/AHKFlowApp.slnLaunch
@@ -1,6 +1,6 @@
 [
   {
-    "Name": "Full Stack: https + Docker SQL (Recommended)",
+    "Name": "Full Stack: Docker SQL (Recommended)",
     "Projects": [
       {
         "Path": "src\\Backend\\AHKFlowApp.API\\AHKFlowApp.API.csproj",
@@ -13,7 +13,7 @@
     ]
   },
   {
-    "Name": "Full Stack: https + LocalDB SQL",
+    "Name": "Full Stack: LocalDB SQL",
     "Projects": [
       {
         "Path": "src\\Backend\\AHKFlowApp.API\\AHKFlowApp.API.csproj",

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ dotnet run --project src/Frontend/AHKFlowApp.UI.Blazor
 
 See `docs/development/docker-setup.md`.
 
-**Option 3 — Docker Compose without Azure (homelab / trusted-LAN):**
+**Option 3 — Run locally without Azure (homelab / trusted-LAN):**
 
 Runs the full stack — SQL Server, API, and Blazor frontend — with no Azure AD sign-in. Authentication is bypassed via a synthetic `Local User` identity on every request. nginx in the UI container reverse-proxies `/api/` to the API service, so the browser only ever talks to a single origin.
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 ### Prerequisites
 
-- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
-- SQL Server LocalDB (included with Visual Studio) or Docker
+.NET 10 SDK and Docker (or LocalDB). Full list — including Windows symlink setup — in [docs/development/prerequisites.md](docs/development/prerequisites.md).
 
 ### Running Locally
 

--- a/docs/deployment/getting-started.md
+++ b/docs/deployment/getting-started.md
@@ -29,7 +29,7 @@ When done, push to `main` — GitHub Actions will publish and package-deploy the
 ## What Gets Provisioned
 
 App Service and SQL Server names include a short deterministic `<token>` suffix to avoid Azure
-global-name collisions; the exact names are emitted by Bicep and saved to `scripts/.env.{env}`.
+global-name collisions; the exact names are emitted by Bicep and saved to `scripts/.env.{environment}`.
 
 | Resource | Name Pattern | Notes |
 |----------|-------------|-------|

--- a/docs/deployment/getting-started.md
+++ b/docs/deployment/getting-started.md
@@ -28,13 +28,16 @@ When done, push to `main` — GitHub Actions will publish and package-deploy the
 
 ## What Gets Provisioned
 
+App Service and SQL Server names include a short deterministic `<token>` suffix to avoid Azure
+global-name collisions; the exact names are emitted by Bicep and saved to `scripts/.env.{env}`.
+
 | Resource | Name Pattern | Notes |
 |----------|-------------|-------|
 | Resource Group | `rg-ahkflowapp-{env}` | Contains all resources |
 | App Service Plan | `ahkflowapp-plan-{env}` | Linux Free F1 |
-| App Service | `ahkflowapp-api-{env}` | Built-in .NET 10 code/package deployment |
-| SQL Server | `ahkflowapp-sql-{env}` | Entra-only auth |
-| SQL Database | `ahkflowapp-db-{env}` | Azure SQL free offer (`GP_S_Gen5_1`, serverless) |
+| App Service | `ahkflowapp-api-{env}-<token>` | Built-in .NET 10 code/package deployment |
+| SQL Server | `ahkflowapp-sql-{env}-<token>` | Entra-only auth |
+| SQL Database | `ahkflowapp-db` | Azure SQL free offer (`GP_S_Gen5_1`, serverless) |
 | Static Web App | `ahkflowapp-swa-{env}` | Free tier |
 | Deployer UAMI | `ahkflowapp-uami-deployer-{env}` | Used by GitHub Actions OIDC |
 | Runtime UAMI | `ahkflowapp-uami-runtime-{env}` | Assigned to App Service for SQL auth via Managed Identity |
@@ -121,7 +124,8 @@ For local development, use user-secrets instead — see [entra-setup.md](entra-s
 **Health check fails:**  
 Check App Service logs:
 ```powershell
-az webapp log tail --name ahkflowapp-api-test --resource-group rg-ahkflowapp-test
+az webapp log tail --name ahkflowapp-api-test-<token> --resource-group rg-ahkflowapp-test
+# (replace <token> with the value from scripts/.env.test)
 ```
 
 App Service Free does not support Always On, so a cold deployment can take longer to become healthy than the old paid/container setup.

--- a/docs/development/docker-setup.md
+++ b/docs/development/docker-setup.md
@@ -1,5 +1,7 @@
 # Docker Development Setup
 
+> Looking for the no-sign-in homelab path? See README's "Run locally without Azure" section — same `docker compose up`, with `Auth__UseTestProvider=true` already set in `docker-compose.yml`.
+
 ## Quick Start
 
 ```bash
@@ -72,7 +74,7 @@ docker compose up sqlserver -d --wait
 docker run -d \
   --name ahkflowapp-sqlserver-manual \
   -e "ACCEPT_EULA=Y" \
-  -e "SA_PASSWORD=AHKFlowApp_Dev!2026" \
+  -e "SA_PASSWORD=Dev!LocalOnly_2026" \
   -e "MSSQL_PID=Developer" \
   -p 1433:1433 \
   mcr.microsoft.com/mssql/server:2022-latest

--- a/docs/development/prerequisites.md
+++ b/docs/development/prerequisites.md
@@ -1,0 +1,35 @@
+# Prerequisites
+
+What you need on a fresh checkout before running AHKFlowApp locally.
+
+## Required
+
+- **[.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)** — all projects target `net10.0`.
+- **Git** — for cloning and the symlink-aware checkout below.
+- **Docker** — Docker Desktop (Windows / macOS) or Docker Engine (Linux). Used by the recommended `Docker SQL` launch profile and by the full `docker compose up` stack.
+
+## Windows-specific
+
+The repo uses symlinks so a single set of AI-tool config files is reachable from multiple tools. Without these two settings, the symlinks won't materialize on clone.
+
+- **Windows Developer Mode** enabled — lets non-admin users create symlinks. Settings → For developers → Developer Mode = On.
+- **`git config core.symlinks true`** — set per-repo or globally. Default on Windows is `false`.
+
+After cloning, run the symlink setup once:
+
+```powershell
+.\scripts\setup-copilot-symlinks.ps1
+```
+
+## Optional
+
+- **SQL Server LocalDB** — included with Visual Studio. Alternative to Docker SQL via the `LocalDB SQL` launch profile.
+- **Visual Studio 2022+** — for IDE debugging via the launch profiles in `src/Backend/AHKFlowApp.API/Properties/launchSettings.json`. Not required if you use `dotnet run` from the CLI.
+
+## Once installed
+
+See [README](../../README.md#local-development) for "Run locally" options.
+
+## Deploying to Azure?
+
+Prerequisites for the Azure deploy path (Azure CLI, GitHub CLI, optional sqlcmd) are listed in [docs/deployment/getting-started.md](../deployment/getting-started.md). `scripts/deploy.ps1` checks them and fails fast with install hints if anything is missing.

--- a/docs/development/prerequisites.md
+++ b/docs/development/prerequisites.md
@@ -6,7 +6,7 @@ What you need on a fresh checkout before running AHKFlowApp locally.
 
 - **[.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)** — all projects target `net10.0`.
 - **Git** — for cloning and the symlink-aware checkout below.
-- **Docker** — Docker Desktop (Windows / macOS) or Docker Engine (Linux). Used by the recommended `Docker SQL` launch profile and by the full `docker compose up` stack.
+- **Docker** — Docker Desktop (Windows / macOS) or Docker Engine (Linux). Used by the recommended `Docker SQL (Recommended)` launch profile and by the full `docker compose up` stack.
 
 ## Windows-specific
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -24,18 +24,21 @@ AHKFlowApp supports three distinct environments with environment-specific config
 
 **Option 1 — LocalDB:**
 ```bash
-dotnet run --project src/Backend/AHKFlowApp.API --launch-profile https
+dotnet run --project src/Backend/AHKFlowApp.API --launch-profile "LocalDB SQL"
 ```
 
 **Option 2 — Docker SQL (Recommended):**
 ```bash
-dotnet run --project src/Backend/AHKFlowApp.API --launch-profile "https + Docker SQL (Recommended)"
+dotnet run --project src/Backend/AHKFlowApp.API --launch-profile "Docker SQL (Recommended)"
 ```
 
 **Option 3 — Full Stack (Docker Compose):**
 ```bash
 docker compose up --build
 ```
+
+**Option 4 — Local-only / Homelab (no Azure AD):**
+Same `docker compose up --build` but with `Auth__UseTestProvider=true` (set in `docker-compose.yml`). Authenticates every request as a synthetic `Local User`. Trusted-LAN / single-user only. See README's "Run locally without Azure" section.
 
 ### URLs
 - API: `http://localhost:5600` (single port for VS, docker-compose, Docker-only scenarios)
@@ -176,10 +179,12 @@ src/Backend/AHKFlowApp.API/
 
 ```
 src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/
-  appsettings.json                 # Base config (committed)
-  appsettings.Development.json     # DEV overrides — localhost API (committed)
-  appsettings.Test.json            # TEST overrides — TEST Azure API URL (committed)
-  appsettings.Production.json      # PROD overrides — PROD Azure API URL (committed)
+  appsettings.json                     # Base config (committed)
+  appsettings.Development.json         # Optional local override (gitignored — copy from .example)
+  appsettings.Development.json.example # Template for local overrides (committed)
+  appsettings.Test.json                # TEST overrides — TEST Azure API URL (committed)
+  appsettings.Production.json          # PROD overrides — PROD Azure API URL (committed)
+  appsettings.Local.json               # Local-install / homelab override (committed; baked into image)
 ```
 
 **Load order:** `appsettings.json` → `appsettings.{BlazorEnvironment}.json`
@@ -267,9 +272,8 @@ Server=tcp:{SQL_SERVER_FQDN},1433;Database={SQL_DATABASE_NAME};Authentication=Ac
 
 ## Next Steps
 
-1. **Set up DEV:** Clone repo, run `dotnet run` or `docker compose up`
-2. **Provision TEST:** Run `scripts/azure/01-provision-azure.md` with `ENVIRONMENT=test`
-3. **Configure CI/CD for TEST:** Run `scripts/azure/02-configure-github-oidc.md` with `ENVIRONMENT=test`
-4. **Deploy to TEST:** Push to `main` or manually trigger workflow
-5. **Provision PROD:** Repeat steps 2-3 with `ENVIRONMENT=prod`
-6. **Deploy to PROD:** Manually trigger workflow with `environment=prod`
+1. **Set up DEV:** Clone repo, run `dotnet run` or `docker compose up`. See [docs/development/prerequisites.md](development/prerequisites.md).
+2. **Provision TEST:** `.\scripts\deploy.ps1 -Environment test` — see [docs/deployment/getting-started.md](deployment/getting-started.md).
+3. **Deploy to TEST:** Push to `main` or manually trigger workflow.
+4. **Provision PROD:** `.\scripts\deploy.ps1 -Environment prod`.
+5. **Deploy to PROD:** Manually trigger workflow with `environment=prod`.

--- a/docs/superpowers/plans/2026-04-26-plan-6-docs-consistency-sweep.md
+++ b/docs/superpowers/plans/2026-04-26-plan-6-docs-consistency-sweep.md
@@ -1,0 +1,94 @@
+# Plan 6 — Docs + consistency sweep
+
+**Roadmap:** `docs/superpowers/specs/2026-04-21-codebase-simplification-roadmap-design.md`
+**Date:** 2026-04-26
+**Size:** S
+**Status:** Approved
+
+## Context
+
+Plans 1–5 of the simplification roadmap have shipped. Plan 5 (local-install via `Auth:UseTestProvider`) is the most recent — it added a docker-compose Blazor service, a synthetic-auth toggle, and an `appsettings.Local.json` bake-in for the Blazor image. Plan 4 (script overhaul) consolidated `/scripts/`. Several supporting docs still describe the pre-Plan-4/5 shape and contain commands that no longer work.
+
+This plan closes the loop: align the docs surface with what the code actually does. Pure docs work — no code or test changes. Goal is one PR, reviewable in well under 30 minutes.
+
+## Sources of truth (cross-checked)
+
+- `src/Backend/AHKFlowApp.API/Properties/launchSettings.json` — actual launch profile names
+- `docker-compose.yml` — actual SA password and services
+- `scripts/` — actual script names
+- `.gitignore` — what's actually committed
+- README.md — already correct after Plan 5; treat as the canonical "Run locally" reference
+
+## Scope
+
+**In:**
+- Fix stale commands, broken file references, and contradictions across `README.md`, `AGENTS.md`, `.claude/CLAUDE.md`, `.claude/rules/*.md`, `.github/*`, `docs/**` (excluding `docs/superpowers/` historical content).
+- Single local-dev prerequisites page at `docs/development/prerequisites.md`, linked from README. Azure-deploy prereqs stay inline in `docs/deployment/getting-started.md` (different audience; `deploy.ps1` validates them).
+- AGENTS.md gains one line pointing to README's "Run locally without Azure" section.
+
+**Out:**
+- Rewriting architecture docs (`docs/architecture/*`).
+- New guides.
+- Code, config, test, or workflow changes.
+- Memory-file maintenance (auto-memory, not in repo).
+- `.github/copilot-instructions.md` (intentional stub redirecting to AGENTS.md — leave alone).
+- PR template additions.
+
+## Concrete file changes
+
+### 1. `AGENTS.md` (highest impact — wrong dev command)
+- **L57** Replace `--launch-profile "https + Docker SQL (Recommended)"` with `--launch-profile "Docker SQL (Recommended)"`.
+- **L62** Update compose comment from `(SQL Server + API)` to `(SQL Server + API + Blazor UI)`.
+- Under **Commands**, add one line: `# Local-only stack (no Azure AD): see README "Run locally without Azure"`.
+
+### 2. `docs/environments.md`
+- **L25–33** Fix launch-profile block. Replace `--launch-profile https` (Option 1) with `--launch-profile "LocalDB SQL"`. Replace `--launch-profile "https + Docker SQL (Recommended)"` (Option 2) with `--launch-profile "Docker SQL (Recommended)"`.
+- **Frontend appsettings table (~L177–183)** Mark `appsettings.Development.json` as gitignored (per `.gitignore:436`); add `appsettings.Local.json` row for the local-install path (Plan 5).
+- **L268–275 (Next Steps)** Replace bullets pointing to nonexistent `scripts/azure/01-provision-azure.md` and `02-configure-github-oidc.md` with a single bullet referencing `.\scripts\deploy.ps1 -Environment {test|prod}` and link to `docs/deployment/getting-started.md`.
+- Add brief "Local-only / homelab" subsection under DEV with link to README's "Run locally without Azure".
+
+### 3. `docs/development/docker-setup.md`
+- **L72–78 (Option B SA password)** Change `SA_PASSWORD=AHKFlowApp_Dev!2026` to `SA_PASSWORD=Dev!LocalOnly_2026` to match `docker-compose.yml` and `launchSettings.json`.
+- Add a short pointer at the top to README's "Run locally without Azure" section.
+
+### 4. `docs/deployment/getting-started.md`
+- **L31–42 (resource name table)** Update name patterns to include the deterministic `<token>` suffix where it actually applies: `ahkflowapp-api-{env}-<token>`, `ahkflowapp-sql-{env}-<token>`, `ahkflowapp-db` (not `ahkflowapp-db-{env}`). Match `docs/environments.md`.
+
+### 5. `docs/development/prerequisites.md` (new file)
+Single canonical page for local-dev prereqs. Sections:
+- **Required:** .NET 10 SDK, Docker Desktop (or Docker Engine on Linux), Git.
+- **Windows-specific:** Windows Developer Mode enabled, `git config core.symlinks true`. Reason: cross-tool AI-config symlinks.
+- **Optional:** SQL Server LocalDB (Visual Studio install), Visual Studio 2022+ (for launch profiles in IDE).
+- **Post-clone setup:** run `scripts/setup-copilot-symlinks.ps1` (Windows) to wire AI-tool symlinks.
+- Cross-link: "Deploying to Azure? See `docs/deployment/getting-started.md` for deploy prereqs (Azure CLI, GitHub CLI, sqlcmd)."
+
+### 6. `README.md`
+- Replace the inline `### Prerequisites` block (L5–8) with a link to `docs/development/prerequisites.md` (keeping a one-line summary).
+
+### 7. `.claude/CLAUDE.md`, `.claude/rules/*.md`
+- Verify-only. No drift expected.
+
+### 8. `.github/*`
+- `copilot-instructions.md` — intentional stub. Skip.
+- Workflow files / PR template — out of scope.
+
+## Verification
+
+1. **Link check.** Every link in modified docs resolves; every script reference exists.
+2. **Dev start command from AGENTS.md works verbatim:** `dotnet run --project src/Backend/AHKFlowApp.API --launch-profile "Docker SQL (Recommended)"`.
+3. **Local-only stack:** `docker compose up --build` brings up sqlserver + api + ui; `http://localhost:5601` loads as `Local User`.
+4. **Grep checks (expect 0 hits in tracked files):**
+   - `rg "https \+ Docker SQL"`
+   - `rg "scripts/azure/0[12]-"`
+   - `rg "AHKFlowApp_Dev!2026"`
+   - `rg "old_project_reference"`
+
+## PR shape
+
+- Single PR, branch `feature/plan-6-docs-consistency-sweep`.
+- Conventional commits per logical group.
+- Description links the roadmap.
+
+## Unresolved questions
+
+None at design level. Prereqs page = local-dev + tooling only. AGENTS.md local-install = one-line link.

--- a/docs/superpowers/plans/2026-04-26-plan-6-docs-consistency-sweep.md
+++ b/docs/superpowers/plans/2026-04-26-plan-6-docs-consistency-sweep.md
@@ -9,7 +9,7 @@
 
 Plans 1–5 of the simplification roadmap have shipped. Plan 5 (local-install via `Auth:UseTestProvider`) is the most recent — it added a docker-compose Blazor service, a synthetic-auth toggle, and an `appsettings.Local.json` bake-in for the Blazor image. Plan 4 (script overhaul) consolidated `/scripts/`. Several supporting docs still describe the pre-Plan-4/5 shape and contain commands that no longer work.
 
-This plan closes the loop: align the docs surface with what the code actually does. Pure docs work — no code or test changes. Goal is one PR, reviewable in well under 30 minutes.
+This plan closes the loop: align the docs surface with what the code actually does. Pure docs/consistency work — no functional code or test changes (cosmetic comment / display-label fixes in `Program.cs` and `AHKFlowApp.slnLaunch` are included to remove the same stale "https +" references). Goal is one PR, reviewable in well under 30 minutes.
 
 ## Sources of truth (cross-checked)
 

--- a/src/Backend/AHKFlowApp.API/Program.cs
+++ b/src/Backend/AHKFlowApp.API/Program.cs
@@ -56,7 +56,7 @@ try
         }
     });
 
-    // Start SQL Server in Docker if requested (for "https + Docker SQL" launch profile)
+    // Start SQL Server in Docker if requested (for "Docker SQL (Recommended)" launch profile)
     if (builder.Environment.IsDevelopment() &&
         string.Equals(Environment.GetEnvironmentVariable("AHKFLOW_START_DOCKER_SQL"), "true", StringComparison.OrdinalIgnoreCase))
     {


### PR DESCRIPTION
## Summary

Final plan in the codebase simplification roadmap (`docs/superpowers/specs/2026-04-21-codebase-simplification-roadmap-design.md`). Pure consistency sweep — aligns README, AGENTS.md, and `docs/**` with what the code actually does after Plans 1–5 landed.

## Concrete fixes

- **AGENTS.md** — wrong launch profile (`"https + Docker SQL (Recommended)"` → `"Docker SQL (Recommended)"`); compose comment now lists Blazor UI; pointer to README "Run locally without Azure".
- **docs/environments.md** — wrong launch profile names; frontend appsettings table corrected (Development is gitignored; Local added); broken refs to nonexistent `scripts/azure/01-*.md` / `02-*.md` replaced with `scripts\deploy.ps1`; added Option 4 (homelab) under DEV.
- **docs/development/docker-setup.md** — SA password aligned with `docker-compose.yml` (`Dev!LocalOnly_2026`); pointer to README local-only section.
- **docs/deployment/getting-started.md** — resource-name table now includes the deterministic `<token>` suffix that Bicep actually emits; troubleshooting log-tail example matches.
- **docs/development/prerequisites.md** — new canonical local-dev prereqs page (.NET 10 SDK, Docker, Windows Dev Mode, symlinks). Linked from README. Azure-deploy prereqs stay in `getting-started.md`.
- **README.md** — Prerequisites block reduced to a one-line link to the new page.
- **Program.cs / AHKFlowApp.slnLaunch** — stale `"https +"` profile names in a code comment and in two solution-launch display labels (purely cosmetic; profile resolution unchanged).

## Verification

- `dotnet build` — 13 projects, 0 errors, 0 warnings.
- Grep checks for residual stale strings (`"https + Docker SQL"`, `scripts/azure/01-`, `AHKFlowApp_Dev!2026`, `old_project_reference`) return no hits in tracked non-historical files.
- Launch profile in AGENTS.md now matches `src/Backend/AHKFlowApp.API/Properties/launchSettings.json` verbatim.

## Test plan

- [ ] `dotnet run --project src/Backend/AHKFlowApp.API --launch-profile "Docker SQL (Recommended)"` succeeds (the AGENTS.md command verbatim).
- [ ] `docker compose up --build` brings up sqlserver + ahkflowapp-api + ahkflowapp-ui; `http://localhost:5601` loads as `Local User` with no sign-in prompt.
- [ ] Walk every link in modified docs (README, AGENTS.md, environments.md, docker-setup.md, prerequisites.md, deployment/getting-started.md) — all resolve.

## Out of scope

- Architecture-doc rewrites; new guides; PR template additions.
- Historical content under `docs/superpowers/plans/` and `docs/superpowers/specs/` (point-in-time records — left untouched).
- `.github/copilot-instructions.md` (intentional stub redirecting to AGENTS.md).