### PR TITLE
feat: show resource tier on health page

### DIFF
--- a/infra/modules/web.bicep
+++ b/infra/modules/web.bicep
@@ -92,6 +92,10 @@ resource appService 'Microsoft.Web/sites@2023-12-01' = {
           name: 'AzureAd__ClientId'
           value: azureAdClientId
         }
+        {
+          name: 'RESOURCE_TIER'
+          value: useFreeTier ? 'free' : 'basic'
+        }
       ]
     }
   }

--- a/src/Backend/AHKFlowApp.API/Controllers/HealthController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/HealthController.cs
@@ -14,6 +14,7 @@ public sealed class HealthController(
     IHostEnvironment hostEnvironment,
     TimeProvider timeProvider,
     IVersionService versionService,
+    IConfiguration configuration,
     ILogger<HealthController> logger) : ControllerBase
 {
     [HttpGet]
@@ -45,7 +46,8 @@ public sealed class HealthController(
             Version: version,
             Environment: hostEnvironment.EnvironmentName,
             Timestamp: timeProvider.GetUtcNow(),
-            Checks: checks);
+            Checks: checks,
+            Tier: configuration["RESOURCE_TIER"]);
 
         // Healthy and Degraded both return 200 — the API is functional in both cases.
         // Only Unhealthy (critical dependency down) returns 503.

--- a/src/Backend/AHKFlowApp.API/Models/HealthResponse.cs
+++ b/src/Backend/AHKFlowApp.API/Models/HealthResponse.cs
@@ -5,4 +5,5 @@ public sealed record HealthResponse(
     string Version,
     string Environment,
     DateTimeOffset Timestamp,
-    Dictionary<string, string> Checks);
+    Dictionary<string, string> Checks,
+    string? Tier = null);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HealthResponse.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HealthResponse.cs
@@ -5,4 +5,5 @@ public sealed record HealthResponse(
     string Version,
     string Environment,
     DateTimeOffset Timestamp,
-    Dictionary<string, string> Checks);
+    Dictionary<string, string> Checks,
+    string? Tier = null);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Health.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Health.razor
@@ -41,6 +41,13 @@
                     <td><strong>Timestamp</strong></td>
                     <td>@_healthCheck.Timestamp.ToString("yyyy-MM-dd HH:mm:ss") UTC</td>
                 </tr>
+                @if (_healthCheck.Tier is not null)
+                {
+                    <tr>
+                        <td><strong>Tier</strong></td>
+                        <td>@TierDescription(_healthCheck.Tier)</td>
+                    </tr>
+                }
             </tbody>
         </MudSimpleTable>
 
@@ -135,6 +142,13 @@
     }
 
     private async Task RefreshHealthAsync() => await LoadHealthAsync();
+
+    private static string TierDescription(string tier) => tier switch
+    {
+        "free"  => "Free (App Service F1 + SQL serverless)",
+        "basic" => "Basic (App Service B1 + SQL Basic)",
+        _       => tier
+    };
 
     public void Dispose()
     {

--- a/tests/AHKFlowApp.TestUtilities/Builders/HealthResponseBuilder.cs
+++ b/tests/AHKFlowApp.TestUtilities/Builders/HealthResponseBuilder.cs
@@ -9,6 +9,7 @@ public sealed class HealthResponseBuilder
     private string _environment = "Test";
     private DateTimeOffset _timestamp = DateTimeOffset.UtcNow;
     private readonly Dictionary<string, string> _checks = new() { ["database"] = "Healthy" };
+    private string? _tier;
 
     public HealthResponseBuilder WithStatus(string status)
     {
@@ -46,7 +47,13 @@ public sealed class HealthResponseBuilder
         return this;
     }
 
+    public HealthResponseBuilder WithTier(string? tier)
+    {
+        _tier = tier;
+        return this;
+    }
+
 #pragma warning disable IDE0028 // Simplify collection initialization
-    public HealthResponse Build() => new(_status, _version, _environment, _timestamp, new(_checks));
+    public HealthResponse Build() => new(_status, _version, _environment, _timestamp, new(_checks), _tier);
 #pragma warning restore IDE0028 // Simplify collection initialization
 }


### PR DESCRIPTION
Bicep sets RESOURCE_TIER app setting (free/basic); health endpoint reads it and includes it in the response; health page renders human-readable label. Hidden on local dev where the setting is absent.

## Summary

Brief description of changes.

## Checklist

- [ ] Tests pass (`dotnet test`)
- [ ] Build succeeds (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Breaking changes documented (if any)
