### PR TITLE
test: add Tier coverage from PR #94 review

### DIFF
--- a/tests/AHKFlowApp.API.Tests/Health/HealthControllerTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Health/HealthControllerTests.cs
@@ -3,6 +3,8 @@ using System.Net.Http.Json;
 using AHKFlowApp.API.Models;
 using AHKFlowApp.TestUtilities.Fixtures;
 using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace AHKFlowApp.API.Tests.Health;
@@ -60,6 +62,39 @@ public sealed class HealthControllerTests(SqlContainerFixture sqlFixture) : IDis
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         body.Should().Be("Healthy");
+    }
+
+    [Fact]
+    public async Task GetHealth_WhenResourceTierSet_ReturnsTierInResponse()
+    {
+        // Arrange
+        using WebApplicationFactory<global::Program> factory = _factory.WithWebHostBuilder(builder =>
+            builder.ConfigureAppConfiguration((_, config) =>
+                config.AddInMemoryCollection(new Dictionary<string, string?> { ["RESOURCE_TIER"] = "free" })));
+        using HttpClient client = factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/api/v1/health");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        HealthResponse? body = await response.Content.ReadFromJsonAsync<HealthResponse>();
+        body!.Tier.Should().Be("free");
+    }
+
+    [Fact]
+    public async Task GetHealth_WhenResourceTierAbsent_ReturnsTierNull()
+    {
+        // Arrange
+        using HttpClient client = _factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/api/v1/health");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        HealthResponse? body = await response.Content.ReadFromJsonAsync<HealthResponse>();
+        body!.Tier.Should().BeNull();
     }
 
     public void Dispose() => _factory.Dispose();

--- a/tests/AHKFlowApp.TestUtilities/Builders/HealthResponseBuilder.cs
+++ b/tests/AHKFlowApp.TestUtilities/Builders/HealthResponseBuilder.cs
@@ -54,6 +54,6 @@ public sealed class HealthResponseBuilder
     }
 
 #pragma warning disable IDE0028 // Simplify collection initialization
-    public HealthResponse Build() => new(_status, _version, _environment, _timestamp, new(_checks), _tier);
+    public HealthResponse Build() => new(_status, _version, _environment, _timestamp, new(_checks), Tier: _tier);
 #pragma warning restore IDE0028 // Simplify collection initialization
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HealthPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HealthPageTests.cs
@@ -109,4 +109,40 @@ public sealed class HealthPageTests : BunitContext
         cut.Markup.Should().Contain("database");
         cut.Markup.Should().Contain("Login failed for user");
     }
+
+    [Fact]
+    public void Health_WhenTierIsNull_DoesNotRenderTierRow()
+    {
+        // Arrange
+        var response = new HealthResponse("Healthy", "1.0.0", "Test", DateTimeOffset.UtcNow, [], Tier: null);
+        _apiClient.GetHealthAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<HealthResponse?>(response));
+
+        // Act
+        IRenderedComponent<Health> cut = Render<Health>();
+        cut.WaitForState(() => !cut.Find(".mud-paper").TextContent.Contains("Checking"));
+
+        // Assert
+        cut.Markup.Should().NotContain("Tier");
+    }
+
+    [Theory]
+    [InlineData("free", "Free (App Service F1 + SQL serverless)")]
+    [InlineData("basic", "Basic (App Service B1 + SQL Basic)")]
+    [InlineData("premium", "premium")]
+    public void Health_WhenTierIsSet_RendersTierLabel(string tier, string expectedLabel)
+    {
+        // Arrange
+        var response = new HealthResponse("Healthy", "1.0.0", "Test", DateTimeOffset.UtcNow, [], Tier: tier);
+        _apiClient.GetHealthAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<HealthResponse?>(response));
+
+        // Act
+        IRenderedComponent<Health> cut = Render<Health>();
+        cut.WaitForState(() => !cut.Find(".mud-paper").TextContent.Contains("Checking"));
+
+        // Assert
+        cut.Markup.Should().Contain("Tier");
+        cut.Markup.Should().Contain(expectedLabel);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds integration tests for `RESOURCE_TIER` round-trip (`GetHealth_WhenResourceTierSet_ReturnsTierInResponse`, `GetHealth_WhenResourceTierAbsent_ReturnsTierNull`)
- Adds bUnit tests for Tier row visibility when null and known/unknown `TierDescription` mappings (`Health_WhenTierIsNull_DoesNotRenderTierRow`, `Health_WhenTierIsSet_RendersTierLabel`)
- Fixes `HealthResponseBuilder.Build()` to use named argument `Tier: _tier`

Addresses Copilot review comments on #94.

## Test plan

- [ ] `dotnet test tests/AHKFlowApp.API.Tests --filter HealthControllerTests` — 5 tests pass
- [ ] `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter HealthPageTests` — 9 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)