### PR TITLE
fix: make TestUtilities a proper xUnit test-discovery target

### DIFF
--- a/tests/AHKFlowApp.TestUtilities/AHKFlowApp.TestUtilities.csproj
+++ b/tests/AHKFlowApp.TestUtilities/AHKFlowApp.TestUtilities.csproj
@@ -11,7 +11,10 @@
     <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="Testcontainers.MsSql" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Backend\AHKFlowApp.Infrastructure\AHKFlowApp.Infrastructure.csproj" />

--- a/tests/AHKFlowApp.TestUtilities/AHKFlowApp.TestUtilities.csproj
+++ b/tests/AHKFlowApp.TestUtilities/AHKFlowApp.TestUtilities.csproj
@@ -1,16 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="Testcontainers.MsSql" />
     <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Backend\AHKFlowApp.Infrastructure\AHKFlowApp.Infrastructure.csproj" />


### PR DESCRIPTION
VSCode C# Dev Kit treats any assembly under tests/ with xUnit references as a test discovery target. Without Microsoft.NET.Test.Sdk + xunit.runner.visualstudio, testhost fails to resolve transitive packages (e.g. Ardalis.Result) and discovery aborts repeatedly.

Add the test SDK + runner and switch back to the full xunit package. Drop IsTestProject=false (no longer accurate).

## Summary

Brief description of changes.

## Checklist

- [ ] Tests pass (`dotnet test`)
- [ ] Build succeeds (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Breaking changes documented (if any)
