### PR TITLE
chore: port still-relevant changes from PR #83 (close #83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dotnet run --project src/Frontend/AHKFlowApp.UI.Blazor
 
 **Option 2 — Docker Compose (recommended):**
 
-See `docs/development/docker-setup.md`.
+See `docs/development/docker-setup.md`. **x64 / amd64 only** — the SQL Server image has no ARM64 build, so this stack does not run on Apple Silicon or Raspberry Pi without changing the database backend.
 
 **Option 3 — Run locally without Azure (homelab / trusted-LAN):**
 

--- a/docs/development/docker-setup.md
+++ b/docs/development/docker-setup.md
@@ -2,6 +2,8 @@
 
 > Looking for the no-sign-in homelab path? See README's "Run locally without Azure" section — same `docker compose up`, with `Auth__UseTestProvider=true` already set in `docker-compose.yml`.
 
+> **Platform**: x64 / amd64 only. `mcr.microsoft.com/mssql/server:2022-latest` has no ARM64 image, so the bundled stack does not run on Apple Silicon (without emulation) or Raspberry Pi. Run the API/UI on x64 hardware, or substitute a different database backend.
+
 ## Quick Start
 
 ```bash

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,279 +1,54 @@
-# Environment Configuration Guide
+# Environments
 
-## Overview
+| Environment | `ASPNETCORE_ENVIRONMENT` | Database | Deploys |
+|---|---|---|---|
+| **DEV** | `Development` | LocalDB or Docker SQL | `dotnet run` / `docker compose up` |
+| **TEST** | `Test` | Azure SQL | Auto on push to `main` |
+| **PROD** | `Production` | Azure SQL | Manual workflow dispatch |
 
-AHKFlowApp supports three distinct environments with environment-specific configuration:
+Local DEV setup: see [README.md](../README.md) and [docs/development/docker-setup.md](development/docker-setup.md).
 
-| Environment | Name | ASPNETCORE_ENVIRONMENT | Location | Database | Deployment |
-|-------------|------|------------------------|----------|----------|------------|
-| **DEV** | Development | `Development` | Local machine | LocalDB or Docker SQL | Manual (`dotnet run`) |
-| **TEST** | Test | `Test` | Azure | Azure SQL Database | Auto (push to `main`) |
-| **PROD** | Production | `Production` | Azure | Azure SQL Database | Manual (workflow dispatch) |
+Azure TEST / PROD provisioning and deployment: see [docs/deployment/getting-started.md](deployment/getting-started.md). After `deploy.ps1`, the deterministic resource names and FQDNs are saved to `scripts/.env.<env>`.
 
-## DEV Environment (Local Development)
+## Configuration file load order
 
-### Configuration
+API backend (`src/Backend/AHKFlowApp.API/appsettings*.json`):
 
-- **ASPNETCORE_ENVIRONMENT**: `Development`
-- **Database**: LocalDB (`(localdb)\mssqllocaldb`) or Docker SQL Server (port 1433)
-- **Connection String**: Configured in `appsettings.Development.json` (not committed) or Docker Compose
-- **CORS**: Allows `https://localhost:7601` and `http://localhost:5601`
-- **Logging**: Debug level for application code, Information for EF Core queries
+1. `appsettings.json`
+2. `appsettings.{Environment}.json` (`Development` / `Test` / `Production`)
+3. Environment variables
+4. Azure App Service configuration (TEST / PROD only)
 
-### Running Locally
+Blazor frontend (`src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings*.json`):
 
-**Option 1 — LocalDB:**
-```bash
-dotnet run --project src/Backend/AHKFlowApp.API --launch-profile "LocalDB SQL"
-```
+1. `appsettings.json`
+2. `appsettings.{BlazorEnvironment}.json` — chosen by the `Blazor-Environment` HTTP header (`Test` via `staticwebapp.config.json`, `Production` patched in by `deploy-frontend.yml`, `Development` from the dev server). For local-install / homelab, `appsettings.Local.json` is baked into the container image.
 
-**Option 2 — Docker SQL (Recommended):**
-```bash
-dotnet run --project src/Backend/AHKFlowApp.API --launch-profile "Docker SQL (Recommended)"
-```
+No secrets live in frontend config; all values are public.
 
-**Option 3 — Full Stack (Docker Compose):**
-```bash
-docker compose up --build
-```
+## Connection strings
 
-**Option 4 — Local-only / Homelab (no Azure AD):**
-Same `docker compose up --build` but with `Auth__UseTestProvider=true` (set in `docker-compose.yml`). Authenticates every request as a synthetic `Local User`. Trusted-LAN / single-user only. See README's "Run locally without Azure" section.
+DEV (LocalDB):
 
-### URLs
-- API: `http://localhost:5600` (single port for VS, docker-compose, Docker-only scenarios)
-- Frontend: `http://localhost:5601`
-
-## TEST Environment (Azure Pre-Production)
-
-### Configuration
-
-- **ASPNETCORE_ENVIRONMENT**: `Test` (set via App Service application setting)
-- **Database**: Azure SQL Database — FQDN captured in `scripts/.env.test` after provisioning
-- **Authentication**: Entra ID (User-Assigned Managed Identity) — no SQL passwords
-- **Connection String**: Set via App Service connection string configuration with `Authentication=Active Directory Default`
-- **CORS**: Configured to allow Static Web App URL
-- **Logging**: Information level for application, Warning for framework
-
-### Azure Resources
-
-All resources are in the `rg-ahkflowapp-test` resource group. App Service and SQL Server names
-include a short deterministic suffix (derived from the subscription, resource group, and
-environment) to avoid global-name collisions — the exact names are emitted by Bicep and saved
-to `scripts/.env.test`:
-- App Service: `ahkflowapp-api-test-<token>`
-- SQL Server: `ahkflowapp-sql-test-<token>`
-- SQL Database: `ahkflowapp-db`
-- Static Web App: `ahkflowapp-swa-test`
-- User-Assigned Managed Identity (deployer): `ahkflowapp-uami-deployer-test`
-- User-Assigned Managed Identity (runtime): `ahkflowapp-uami-runtime-test`
-
-### Provisioning
-
-Provision the TEST environment with:
-
-```powershell
-.\scripts\deploy.ps1 -Environment test
-```
-
-### Deployment
-
-**Automatic:** Push to `main` branch triggers `deploy-api.yml` and `deploy-frontend.yml` workflows.
-
-**Manual:** Use workflow dispatch in GitHub Actions.
-
-### GitHub Secrets & Variables
-
-**Secrets** (shared):
-- `AZURE_TENANT_ID`
-- `AZURE_SUBSCRIPTION_ID`
-- `AZURE_CLIENT_ID_TEST` (deployer managed identity)
-- `AZURE_STATIC_WEB_APPS_API_TOKEN_TEST`
-
-**Variables** (TEST-specific — values populated by `deploy.ps1`; App Service / SQL Server names
-include the deterministic suffix described above):
-- `AZURE_RESOURCE_GROUP_TEST=rg-ahkflowapp-test`
-- `APP_SERVICE_NAME_TEST=ahkflowapp-api-test-<token>`
-- `SQL_SERVER_NAME_TEST=ahkflowapp-sql-test-<token>`
-- `SQL_SERVER_FQDN_TEST=ahkflowapp-sql-test-<token>.database.windows.net`
-- `SQL_DATABASE_NAME_TEST=ahkflowapp-db`
-
-### URLs
-- API / API Health: `https://<APP_SERVICE_NAME_TEST>.azurewebsites.net[/health]` — read from `scripts/.env.test`
-- Frontend: Get from `az staticwebapp show --name ahkflowapp-swa-test --query defaultHostname -o tsv`
-
-## PROD Environment (Azure Production)
-
-### Configuration
-
-- **ASPNETCORE_ENVIRONMENT**: `Production` (set via App Service application setting)
-- **Database**: Azure SQL Database — FQDN captured in `scripts/.env.prod` after provisioning
-- **Authentication**: Entra ID (User-Assigned Managed Identity) — no SQL passwords
-- **Connection String**: Set via App Service connection string configuration with `Authentication=Active Directory Default`
-- **CORS**: Configured to allow Static Web App URL
-- **Logging**: Warning level (minimal logging for performance)
-
-### Azure Resources
-
-All resources are in the `rg-ahkflowapp-prod` resource group. App Service and SQL Server names
-include a short deterministic suffix (derived from the subscription + RG) to avoid global-name
-collisions — the exact names are emitted by Bicep and saved to `scripts/.env.prod`:
-- App Service: `ahkflowapp-api-prod-<token>`
-- SQL Server: `ahkflowapp-sql-prod-<token>`
-- SQL Database: `ahkflowapp-db`
-- Static Web App: `ahkflowapp-swa-prod`
-- User-Assigned Managed Identity (deployer): `ahkflowapp-uami-deployer-prod`
-- User-Assigned Managed Identity (runtime): `ahkflowapp-uami-runtime-prod`
-
-### Provisioning
-
-Provision the PROD environment with:
-
-```powershell
-.\scripts\deploy.ps1 -Environment prod
-```
-
-### Deployment
-
-**Manual Only:** Use workflow dispatch in GitHub Actions:
-1. Go to Actions → Deploy API (or Deploy Frontend)
-2. Click "Run workflow"
-3. Select environment: `prod`
-4. Confirm and run
-
-### GitHub Secrets & Variables
-
-**Secrets** (shared):
-- `AZURE_TENANT_ID`
-- `AZURE_SUBSCRIPTION_ID`
-- `AZURE_CLIENT_ID_PROD` (deployer managed identity)
-- `AZURE_STATIC_WEB_APPS_API_TOKEN_PROD`
-
-**Variables** (PROD-specific — values populated by `deploy.ps1`; App Service / SQL Server names
-include the deterministic suffix described above):
-- `AZURE_RESOURCE_GROUP_PROD=rg-ahkflowapp-prod`
-- `APP_SERVICE_NAME_PROD=ahkflowapp-api-prod-<token>`
-- `SQL_SERVER_NAME_PROD=ahkflowapp-sql-prod-<token>`
-- `SQL_SERVER_FQDN_PROD=ahkflowapp-sql-prod-<token>.database.windows.net`
-- `SQL_DATABASE_NAME_PROD=ahkflowapp-db`
-
-### URLs
-- API / API Health: `https://<APP_SERVICE_NAME_PROD>.azurewebsites.net[/health]` — read from `scripts/.env.prod`
-- Frontend: Get from `az staticwebapp show --name ahkflowapp-swa-prod --query defaultHostname -o tsv`
-
-## Environment-Specific Configuration Files
-
-### API Backend
-
-```
-src/Backend/AHKFlowApp.API/
-  appsettings.json                 # Base configuration (committed)
-  appsettings.Development.json     # DEV overrides (committed, CORS only)
-  appsettings.Test.json            # TEST overrides (committed)
-  appsettings.Production.json      # PROD overrides (committed)
-```
-
-**Load order:** `appsettings.json` → `appsettings.{Environment}.json` → Environment variables → Azure App Configuration (future)
-
-### Frontend Blazor
-
-```
-src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/
-  appsettings.json                     # Base config (committed)
-  appsettings.Development.json         # Optional local override (gitignored — copy from .example)
-  appsettings.Development.json.example # Template for local overrides (committed)
-  appsettings.Test.json                # TEST overrides — TEST Azure API URL (committed)
-  appsettings.Production.json          # PROD overrides — PROD Azure API URL (committed)
-  appsettings.Local.json               # Local-install / homelab override (committed; baked into image)
-```
-
-**Load order:** `appsettings.json` → `appsettings.{BlazorEnvironment}.json`
-
-The active environment is controlled by the `Blazor-Environment` HTTP header:
-- TEST SWA: set to `Test` via `staticwebapp.config.json`
-- PROD SWA: patched to `Production` by `deploy-frontend.yml` before publishing
-- Local dev: set to `Development` automatically by the ASP.NET Core dev server
-
-No secrets are stored in frontend configuration — all values are public.
-
-## Switching Between Environments
-
-### Local Development → TEST
-1. Ensure TEST environment is provisioned in Azure
-2. Ensure GitHub secrets/variables are configured for TEST
-3. Push to `main` branch or manually trigger workflow with environment=test
-
-### TEST → PROD
-1. Provision PROD environment in Azure
-2. Configure GitHub secrets/variables for PROD
-3. Manually trigger Deploy API workflow with environment=prod
-4. Manually trigger Deploy Frontend workflow with environment=prod
-
-## Environment Variable Reference
-
-### All Environments
-
-| Variable | DEV | TEST | PROD |
-|----------|-----|------|------|
-| `ASPNETCORE_ENVIRONMENT` | `Development` | `Test` | `Production` |
-| `AZURE_CLIENT_ID` | (not set) | Runtime UAMI client ID | Runtime UAMI client ID |
-
-### Connection Strings
-
-**DEV:**
 ```
 Server=(localdb)\mssqllocaldb;Database=AHKFlowApp;Trusted_Connection=True;MultipleActiveResultSets=true
 ```
-or (Docker):
+
+DEV (Docker SQL):
+
 ```
 Server=localhost,1433;Database=AHKFlowAppDb;User Id=sa;Password=Dev!LocalOnly_2026;TrustServerCertificate=True
 ```
 
-**TEST/PROD (Azure, Entra ID auth):**
+TEST / PROD (Entra ID auth, set by `deploy.ps1`):
+
 ```
-Server=tcp:{SQL_SERVER_FQDN},1433;Database={SQL_DATABASE_NAME};Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;
+Server=tcp:{SQL_SERVER_FQDN},1433;Database={SQL_DATABASE_NAME};Authentication=Active Directory Default;Encrypt=True;
 ```
 
 ## Troubleshooting
 
-### DEV: Database connection fails
-- Ensure SQL Server LocalDB is installed or Docker is running
-- Run `dotnet ef database update` to apply migrations
-
-### TEST/PROD: Deployment fails
-- Check GitHub secrets and variables are set correctly with `_TEST` or `_PROD` suffix
-- Verify Azure UAMI has correct RBAC permissions
-- Check SQL firewall rules allow GitHub Actions runner IP
-- Expect slower cold starts on App Service Free than on the previous paid tier
-
-### TEST/PROD: API returns 500 errors
-- Check App Service logs: `az webapp log tail --name {APP_SERVICE_NAME} --resource-group {RESOURCE_GROUP}`
-- Verify `ASPNETCORE_ENVIRONMENT` is set correctly in App Service configuration
-- Check Application Insights for exceptions
-
-### Environment not loading correct appsettings
-- Verify `ASPNETCORE_ENVIRONMENT` environment variable is set
-- Check file exists: `appsettings.{Environment}.json`
-- ASP.NET Core is case-sensitive for environment names (use `Development`, `Test`, `Production`)
-
-## Security Considerations
-
-### DEV
-- SQL password in `docker-compose.yml` is for local development only
-- Never commit real secrets to `appsettings.Development.json`
-- Use `dotnet user-secrets` for sensitive local configuration
-
-### TEST/PROD
-- All secrets stored in Azure App Service configuration
-- SQL authentication uses Entra ID only (no SQL logins)
-- Managed identities eliminate long-lived secrets
-- HTTPS enforced via HSTS
-- Connection strings never committed to source control
-
-## Next Steps
-
-1. **Set up DEV:** Clone repo, run `dotnet run` or `docker compose up`. See [docs/development/prerequisites.md](development/prerequisites.md).
-2. **Provision TEST:** `.\scripts\deploy.ps1 -Environment test` — see [docs/deployment/getting-started.md](deployment/getting-started.md).
-3. **Deploy to TEST:** Push to `main` or manually trigger workflow.
-4. **Provision PROD:** `.\scripts\deploy.ps1 -Environment prod`.
-5. **Deploy to PROD:** Manually trigger workflow with `environment=prod`.
+- **DEV: DB connection fails** — ensure LocalDB is installed or Docker is running, then `dotnet ef database update`.
+- **TEST/PROD: deploy fails** — verify GitHub secrets/variables have `_TEST` / `_PROD` suffix, the deployer UAMI has RBAC, and the SQL firewall allows the runner IP.
+- **TEST/PROD: API returns 500** — `az webapp log tail --name <APP_SERVICE_NAME> --resource-group <RESOURCE_GROUP>` and check Application Insights.
+- **Wrong appsettings loaded** — `ASPNETCORE_ENVIRONMENT` is case-sensitive (`Development` / `Test` / `Production`).

--- a/scripts/Common.ps1
+++ b/scripts/Common.ps1
@@ -1,0 +1,28 @@
+#Requires -Version 5.1
+# Shared output and prerequisite helpers for AHKFlowApp deployment scripts.
+# Dot-source from a script: . "$PSScriptRoot\Common.ps1"
+
+function Write-Step([string]$Message) {
+    Write-Host "`n==> $Message" -ForegroundColor Cyan
+}
+
+function Write-Success([string]$Message) {
+    Write-Host "  + $Message" -ForegroundColor Green
+}
+
+function Write-Warn([string]$Message) {
+    Write-Host "  ! $Message" -ForegroundColor Yellow
+}
+
+function Write-Fail([string]$Message) {
+    Write-Host "`n  x $Message" -ForegroundColor Red
+}
+
+function Confirm-Command([string]$Name, [string]$InstallUrl) {
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        Write-Fail "$Name is not installed."
+        Write-Host "    Install from: $InstallUrl" -ForegroundColor Yellow
+        throw "Missing prerequisite: $Name"
+    }
+    Write-Success "$Name found"
+}

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -48,34 +48,11 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+. "$PSScriptRoot\Common.ps1"
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-function Write-Step([string]$Message) {
-    Write-Host "`n==> $Message" -ForegroundColor Cyan
-}
-
-function Write-Success([string]$Message) {
-    Write-Host "  ✓ $Message" -ForegroundColor Green
-}
-
-function Write-Warn([string]$Message) {
-    Write-Host "  ! $Message" -ForegroundColor Yellow
-}
-
-function Write-Fail([string]$Message) {
-    Write-Host "`n  ✗ $Message" -ForegroundColor Red
-}
-
-function Confirm-Command([string]$Name, [string]$InstallUrl) {
-    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
-        Write-Fail "$Name is not installed."
-        Write-Host "    Install from: $InstallUrl" -ForegroundColor Yellow
-        throw "Missing prerequisite: $Name"
-    }
-    Write-Success "$Name found"
-}
 
 function Invoke-Az {
     $output = az @args 2>&1

--- a/scripts/teardown.ps1
+++ b/scripts/teardown.ps1
@@ -25,10 +25,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function Write-Step([string]$Message) { Write-Host "`n==> $Message" -ForegroundColor Cyan }
-function Write-Success([string]$Message) { Write-Host "  ✓ $Message" -ForegroundColor Green }
-function Write-Warn([string]$Message) { Write-Host "  ! $Message" -ForegroundColor Yellow }
-function Write-Fail([string]$Message) { Write-Host "`n  ✗ $Message" -ForegroundColor Red }
+. "$PSScriptRoot\Common.ps1"
 
 # Load saved config
 if (-not $Environment) {

--- a/scripts/update.ps1
+++ b/scripts/update.ps1
@@ -24,9 +24,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function Write-Step([string]$Message) { Write-Host "`n==> $Message" -ForegroundColor Cyan }
-function Write-Success([string]$Message) { Write-Host "  + $Message" -ForegroundColor Green }
-function Write-Fail([string]$Message) { Write-Host "`n  x $Message" -ForegroundColor Red }
+. "$PSScriptRoot\Common.ps1"
 
 if (-not $Environment) {
     $Environment = Read-Host "  Environment [test/prod] (default: test)"

--- a/src/Backend/AHKFlowApp.API/DevEnvironment.cs
+++ b/src/Backend/AHKFlowApp.API/DevEnvironment.cs
@@ -1,5 +1,0 @@
-using AHKFlowApp.Application.Abstractions;
-
-namespace AHKFlowApp.API;
-
-internal sealed record DevEnvironment(bool IsDevelopment) : IDevEnvironment;

--- a/src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs
+++ b/src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs
@@ -71,4 +71,19 @@ internal static class ApiExtensions
 
         return app;
     }
+
+    internal static WebApplication UseRootRedirect(this WebApplication app, string devTarget, string prodTarget)
+    {
+        string target = app.Environment.IsDevelopment() ? devTarget : prodTarget;
+        app.Use(async (context, next) =>
+        {
+            if (context.Request.Path == "/")
+            {
+                context.Response.Redirect(target);
+                return;
+            }
+            await next(context);
+        });
+        return app;
+    }
 }

--- a/src/Backend/AHKFlowApp.API/Program.cs
+++ b/src/Backend/AHKFlowApp.API/Program.cs
@@ -181,28 +181,8 @@ try
     if (app.Environment.IsDevelopment())
     {
         app.UseSwaggerDocs();
-        app.Use(async (context, next) =>
-        {
-            if (context.Request.Path == "/")
-            {
-                context.Response.Redirect("/swagger");
-                return;
-            }
-            await next(context);
-        });
     }
-    else
-    {
-        app.Use(async (context, next) =>
-        {
-            if (context.Request.Path == "/")
-            {
-                context.Response.Redirect("/health");
-                return;
-            }
-            await next(context);
-        });
-    }
+    app.UseRootRedirect(devTarget: "/swagger", prodTarget: "/health");
 
     if (allowedOrigins.Length > 0)
     {

--- a/src/Backend/AHKFlowApp.API/Program.cs
+++ b/src/Backend/AHKFlowApp.API/Program.cs
@@ -86,7 +86,7 @@ try
             });
 
     builder.Services.AddSingleton(TimeProvider.System);
-    builder.Services.AddSingleton<IDevEnvironment>(new DevEnvironment(builder.Environment.IsDevelopment()));
+    builder.Services.AddSingleton(new AppEnvironment(builder.Environment.IsDevelopment()));
 
     if (builder.Environment.IsDevelopment())
     {

--- a/src/Backend/AHKFlowApp.Application/Abstractions/IDevEnvironment.cs
+++ b/src/Backend/AHKFlowApp.Application/Abstractions/IDevEnvironment.cs
@@ -1,6 +1,0 @@
-namespace AHKFlowApp.Application.Abstractions;
-
-public interface IDevEnvironment
-{
-    bool IsDevelopment { get; }
-}

--- a/src/Backend/AHKFlowApp.Application/AppEnvironment.cs
+++ b/src/Backend/AHKFlowApp.Application/AppEnvironment.cs
@@ -1,0 +1,3 @@
+namespace AHKFlowApp.Application;
+
+public sealed record AppEnvironment(bool IsDevelopment);

--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotstringsCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotstringsCommand.cs
@@ -15,7 +15,7 @@ internal sealed class SeedHotstringsCommandHandler(
     IAppDbContext db,
     ICurrentUser currentUser,
     TimeProvider clock,
-    IDevEnvironment env)
+    AppEnvironment env)
     : IRequestHandler<SeedHotstringsCommand, Result<PagedList<HotstringDto>>>
 {
     private static readonly (string Trigger, string Replacement, bool Ending, bool InsideWord)[] s_samples =

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
@@ -3,6 +3,7 @@ using AHKFlowApp.UI.Blazor.Services;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.Extensions.Http.Resilience;
 using MudBlazor.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
@@ -12,34 +13,56 @@ builder.Services.AddMudServices();
 
 builder.RootComponents.Add<AHKFlowApp.UI.Blazor.App>("#app");
 
+void AddApiClient<TInterface, TImpl>(
+    Uri baseAddress,
+    TimeSpan timeout,
+    bool useAuth,
+    Action<HttpStandardResilienceOptions>? configureResilience = null)
+    where TInterface : class
+    where TImpl : class, TInterface
+{
+    IHttpClientBuilder clientBuilder = builder.Services.AddHttpClient<TInterface, TImpl>(client =>
+    {
+        client.BaseAddress = baseAddress;
+        client.Timeout = timeout;
+    });
+
+    if (useAuth)
+    {
+        clientBuilder.AddHttpMessageHandler<ApiAuthorizationMessageHandler>();
+    }
+
+    if (configureResilience is not null)
+    {
+        clientBuilder.AddStandardResilienceHandler(configureResilience);
+    }
+    else
+    {
+        clientBuilder.AddStandardResilienceHandler();
+    }
+}
+
+Action<HttpStandardResilienceOptions> mainClientResilience = options =>
+{
+    options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(32);
+    options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(30);
+    options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(60);
+};
+
 bool useTestAuth = builder.Configuration.GetValue<bool>("Auth:UseTestProvider");
 
 if (useTestAuth)
 {
     string apiBaseUrl = builder.Configuration["ApiBaseUrl"] ?? "/";
+    Uri baseAddress = new(new Uri(builder.HostEnvironment.BaseAddress), apiBaseUrl);
 
     builder.Services.AddAuthorizationCore();
     builder.Services.AddScoped<AuthenticationStateProvider, TestAuthenticationProvider>();
 
-    // No bearer token needed — backend TestAuthHandler authenticates synthetically
-    builder.Services.AddHttpClient<IAhkFlowAppApiHttpClient, AhkFlowAppApiHttpClient>(client =>
-    {
-        client.BaseAddress = new Uri(new Uri(builder.HostEnvironment.BaseAddress), apiBaseUrl);
-        client.Timeout = TimeSpan.FromSeconds(35);
-    })
-        .AddStandardResilienceHandler(options =>
-        {
-            options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(32);
-            options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(30);
-            options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(60);
-        });
-
-    builder.Services.AddHttpClient<IHotstringsApiClient, HotstringsApiClient>(client =>
-    {
-        client.BaseAddress = new Uri(new Uri(builder.HostEnvironment.BaseAddress), apiBaseUrl);
-        client.Timeout = TimeSpan.FromSeconds(30);
-    })
-        .AddStandardResilienceHandler();
+    AddApiClient<IAhkFlowAppApiHttpClient, AhkFlowAppApiHttpClient>(
+        baseAddress, TimeSpan.FromSeconds(35), useAuth: false, mainClientResilience);
+    AddApiClient<IHotstringsApiClient, HotstringsApiClient>(
+        baseAddress, TimeSpan.FromSeconds(30), useAuth: false);
 }
 else
 {
@@ -59,6 +82,7 @@ else
 
     string apiBaseUrl = builder.Configuration["ApiHttpClient:BaseAddress"]!;
     string defaultScope = builder.Configuration["AzureAd:DefaultScope"]!;
+    Uri baseAddress = new(apiBaseUrl);
 
     builder.Services.AddMsalAuthentication(options =>
     {
@@ -69,26 +93,10 @@ else
 
     builder.Services.AddTransient<ApiAuthorizationMessageHandler>();
 
-    builder.Services.AddHttpClient<IAhkFlowAppApiHttpClient, AhkFlowAppApiHttpClient>(client =>
-    {
-        client.BaseAddress = new Uri(apiBaseUrl);
-        client.Timeout = TimeSpan.FromSeconds(35);
-    })
-        .AddHttpMessageHandler<ApiAuthorizationMessageHandler>()
-        .AddStandardResilienceHandler(options =>
-        {
-            options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(32);
-            options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(30);
-            options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(60);
-        });
-
-    builder.Services.AddHttpClient<IHotstringsApiClient, HotstringsApiClient>(client =>
-    {
-        client.BaseAddress = new Uri(apiBaseUrl);
-        client.Timeout = TimeSpan.FromSeconds(30);
-    })
-        .AddHttpMessageHandler<ApiAuthorizationMessageHandler>()
-        .AddStandardResilienceHandler();
+    AddApiClient<IAhkFlowAppApiHttpClient, AhkFlowAppApiHttpClient>(
+        baseAddress, TimeSpan.FromSeconds(35), useAuth: true, mainClientResilience);
+    AddApiClient<IHotstringsApiClient, HotstringsApiClient>(
+        baseAddress, TimeSpan.FromSeconds(30), useAuth: true);
 }
 
 await builder.Build().RunAsync();

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/SeedHotstringsCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/SeedHotstringsCommandHandlerTests.cs
@@ -1,4 +1,4 @@
-using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application;
 using AHKFlowApp.Application.Commands.Dev;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Domain.Entities;
@@ -6,7 +6,6 @@ using AHKFlowApp.Infrastructure.Persistence;
 using Ardalis.Result;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
-using NSubstitute;
 using Xunit;
 
 namespace AHKFlowApp.Application.Tests.Hotstrings;
@@ -14,12 +13,7 @@ namespace AHKFlowApp.Application.Tests.Hotstrings;
 [Collection("HotstringDb")]
 public sealed class SeedHotstringsCommandHandlerTests(HotstringDbFixture fx)
 {
-    private static IDevEnvironment DevEnv(bool isDev)
-    {
-        IDevEnvironment e = Substitute.For<IDevEnvironment>();
-        e.IsDevelopment.Returns(isDev);
-        return e;
-    }
+    private static AppEnvironment DevEnv(bool isDev) => new(isDev);
 
     [Fact]
     public async Task Handle_InDevelopment_SeedsSamples()


### PR DESCRIPTION
## Summary

Ports the changes from #83 that are still relevant given main has independently re-implemented most of the same plan. Six small, focused commits on top of main.

## What's ported

- `refactor(api)`: collapse the two duplicate `app.Use(/)` redirect blocks into a `UseRootRedirect` extension.
- `refactor(api)`: collapse `IDevEnvironment` (single field, single concrete impl) into a public `AppEnvironment` record.
- `refactor(blazor)`: dedupe the four `AddHttpClient<>` blocks across the test-auth and prod paths via a local `AddApiClient` helper.
- `refactor(scripts)`: extract the `Write-Step` / `Write-Success` / `Write-Warn` / `Write-Fail` / `Confirm-Command` helpers (duplicated across `deploy.ps1`, `update.ps1`, `teardown.ps1` with three different glyph sets) into `scripts\Common.ps1`. Glyphs unified on ASCII to avoid BOM-anchored unicode.
- `docs`: compress `docs/environments.md` from 280 lines to ~50 — the rest duplicated README, docker-setup, and getting-started.
- `docs`: classify ARM64 / Raspberry Pi as unsupported for the bundled stack (no SQL Server ARM64 image).

## What's skipped from #83 (already on main)

- `create-github-issues.ps1` move (commit `66fb99a`)
- `#Requires -Version 5.1` across scripts
- `docs/scripts/` removal
- `.NET 10` SDK preflight in `deploy.ps1` (commit `4319410`)
- Auto-dispatch of `deploy-frontend.yml` (commit `19b4fbd`)
- TestUtilities xunit fix (PR #96)
- AGENTS.md alignment (commit `d5d0ea9`)

## What's skipped from #83 (no longer applies)

- Deletion of `AHKFlowApp.Domain.Tests` — main added real `Hotstring` entity tests there since #83 was opened (commit `8ae9a9f`).
- Splitting `Program.cs` into `ConfigureObservability/Services/Middleware` — current 250-line linear bootstrap is readable enough; `UseRootRedirect` already removed the duplication that was the strongest argument for splitting.

## Test plan

- [x] `dotnet build AHKFlowApp.slnx --configuration Release` — 13 projects, 0 errors, 0 warnings
- [x] `dotnet test AHKFlowApp.slnx --configuration Release` — 155 tests, 0 failed
- [x] `dotnet format --verify-no-changes`
- [x] PowerShell parser check on `Common.ps1`, `deploy.ps1`, `update.ps1`, `teardown.ps1`
- [x] `Common.ps1` smoke-test — `. Common.ps1; Write-Step ...; Write-Success ...; Write-Warn ...` produces expected output
- [x] Smoke `docker compose up --build` and verify `http://localhost:5600/` redirects to `/health`, `http://localhost:5601` loads as Local User
- [ ] (optional) Run `deploy.ps1 -SkipPrereqCheck` in dry-run to confirm output helpers still work

After merge: close #83 with a comment pointing to this PR; delete `feature/plan-c-script-standardization`.