### PR TITLE
feat(hotkeys): Hotkeys CRUD API — backlog 021

### DIFF
--- a/src/Backend/AHKFlowApp.API/Controllers/HotkeysController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/HotkeysController.cs
@@ -1,0 +1,73 @@
+using AHKFlowApp.API.Extensions;
+using AHKFlowApp.Application.Commands.Hotkeys;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Queries.Hotkeys;
+using Ardalis.Result;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Identity.Web.Resource;
+
+namespace AHKFlowApp.API.Controllers;
+
+[ApiController]
+[Route("api/v1/[controller]")]
+[Authorize]
+[RequiredScope("access_as_user")]
+[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+public sealed class HotkeysController(IMediator mediator) : ControllerBase
+{
+    /// <summary>List hotkeys for the current user, optionally filtered by profile. Paginated.</summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(PagedList<HotkeyDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<PagedList<HotkeyDto>>> List(
+        [FromQuery] Guid? profileId,
+        [FromQuery] string? search = null,
+        [FromQuery] bool ignoreCase = true,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50,
+        CancellationToken ct = default) =>
+        (await mediator.Send(new ListHotkeysQuery(profileId, search, ignoreCase, page, pageSize), ct)).ToProblemActionResult(this);
+
+    /// <summary>Get a hotkey by id.</summary>
+    [HttpGet("{id:guid}", Name = "GetHotkey")]
+    [ProducesResponseType(typeof(HotkeyDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<HotkeyDto>> Get(Guid id, CancellationToken ct) =>
+        (await mediator.Send(new GetHotkeyQuery(id), ct)).ToProblemActionResult(this);
+
+    /// <summary>Create a new hotkey for the current user.</summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(HotkeyDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<HotkeyDto>> Create([FromBody] CreateHotkeyDto dto, CancellationToken ct)
+    {
+        Result<HotkeyDto> result = await mediator.Send(new CreateHotkeyCommand(dto), ct);
+
+        return result.IsSuccess
+            ? CreatedAtRoute("GetHotkey", new { id = result.Value.Id }, result.Value)
+            : result.ToProblemActionResult(this);
+    }
+
+    /// <summary>Update an existing hotkey. Returns the updated representation.</summary>
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(typeof(HotkeyDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<HotkeyDto>> Update(Guid id, [FromBody] UpdateHotkeyDto dto, CancellationToken ct) =>
+        (await mediator.Send(new UpdateHotkeyCommand(id, dto), ct)).ToProblemActionResult(this);
+
+    /// <summary>Delete a hotkey.</summary>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        Result result = await mediator.Send(new DeleteHotkeyCommand(id), ct);
+        return result.IsSuccess ? NoContent() : result.ToProblemActionResult(this);
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Abstractions/IAppDbContext.cs
+++ b/src/Backend/AHKFlowApp.Application/Abstractions/IAppDbContext.cs
@@ -6,6 +6,7 @@ namespace AHKFlowApp.Application.Abstractions;
 public interface IAppDbContext
 {
     DbSet<Hotstring> Hotstrings { get; }
+    DbSet<Hotkey> Hotkeys { get; }
     DbSet<UserPreference> UserPreferences { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotkeys/CreateHotkeyCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotkeys/CreateHotkeyCommand.cs
@@ -18,7 +18,7 @@ public sealed class CreateHotkeyCommandValidator : AbstractValidator<CreateHotke
     {
         RuleFor(x => x.Input.Trigger).ValidHotkeyTrigger();
         RuleFor(x => x.Input.Action).ValidAction();
-        RuleFor(x => x.Input.Description!).ValidOptionalDescription();
+        RuleFor(x => x.Input.Description).ValidOptionalDescription();
         RuleFor(x => x.Input.ProfileId).ValidOptionalProfileId();
     }
 }

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotkeys/CreateHotkeyCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotkeys/CreateHotkeyCommand.cs
@@ -1,0 +1,73 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Mapping;
+using AHKFlowApp.Application.Validation;
+using AHKFlowApp.Domain.Entities;
+using Ardalis.Result;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace AHKFlowApp.Application.Commands.Hotkeys;
+
+public sealed record CreateHotkeyCommand(CreateHotkeyDto Input) : IRequest<Result<HotkeyDto>>;
+
+public sealed class CreateHotkeyCommandValidator : AbstractValidator<CreateHotkeyCommand>
+{
+    public CreateHotkeyCommandValidator()
+    {
+        RuleFor(x => x.Input.Trigger).ValidHotkeyTrigger();
+        RuleFor(x => x.Input.Action).ValidAction();
+        RuleFor(x => x.Input.Description!).ValidOptionalDescription();
+        RuleFor(x => x.Input.ProfileId).ValidOptionalProfileId();
+    }
+}
+
+internal sealed class CreateHotkeyCommandHandler(
+    IAppDbContext db,
+    ICurrentUser currentUser,
+    TimeProvider clock)
+    : IRequestHandler<CreateHotkeyCommand, Result<HotkeyDto>>
+{
+    public async Task<Result<HotkeyDto>> Handle(CreateHotkeyCommand request, CancellationToken ct)
+    {
+        if (currentUser.Oid is not Guid ownerOid)
+            return Result.Unauthorized();
+
+        CreateHotkeyDto input = request.Input;
+
+        bool duplicate = await db.Hotkeys.AnyAsync(
+            h => h.OwnerOid == ownerOid
+              && h.ProfileId == input.ProfileId
+              && h.Trigger == input.Trigger,
+            ct);
+
+        if (duplicate)
+            return Result.Conflict("A hotkey with this trigger already exists for the specified profile.");
+
+        var entity = Hotkey.Create(
+            ownerOid,
+            input.Trigger,
+            input.Action,
+            input.Description,
+            input.ProfileId,
+            clock);
+
+        db.Hotkeys.Add(entity);
+
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex) when (IsDuplicateKeyViolation(ex))
+        {
+            return Result.Conflict("A hotkey with this trigger already exists for the specified profile.");
+        }
+
+        return Result.Success(entity.ToDto());
+    }
+
+    private static bool IsDuplicateKeyViolation(DbUpdateException ex) =>
+        ex.InnerException?.GetType().GetProperty("Number")?.GetValue(ex.InnerException) is int n &&
+        n is 2601 or 2627;
+}

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotkeys/DeleteHotkeyCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotkeys/DeleteHotkeyCommand.cs
@@ -1,0 +1,32 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Domain.Entities;
+using Ardalis.Result;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace AHKFlowApp.Application.Commands.Hotkeys;
+
+public sealed record DeleteHotkeyCommand(Guid Id) : IRequest<Result>;
+
+internal sealed class DeleteHotkeyCommandHandler(
+    IAppDbContext db,
+    ICurrentUser currentUser)
+    : IRequestHandler<DeleteHotkeyCommand, Result>
+{
+    public async Task<Result> Handle(DeleteHotkeyCommand request, CancellationToken ct)
+    {
+        if (currentUser.Oid is not Guid ownerOid)
+            return Result.Unauthorized();
+
+        Hotkey? entity = await db.Hotkeys
+            .FirstOrDefaultAsync(h => h.Id == request.Id && h.OwnerOid == ownerOid, ct);
+
+        if (entity is null)
+            return Result.NotFound();
+
+        db.Hotkeys.Remove(entity);
+        await db.SaveChangesAsync(ct);
+
+        return Result.Success();
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotkeys/UpdateHotkeyCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotkeys/UpdateHotkeyCommand.cs
@@ -18,7 +18,7 @@ public sealed class UpdateHotkeyCommandValidator : AbstractValidator<UpdateHotke
     {
         RuleFor(x => x.Input.Trigger).ValidHotkeyTrigger();
         RuleFor(x => x.Input.Action).ValidAction();
-        RuleFor(x => x.Input.Description!).ValidOptionalDescription();
+        RuleFor(x => x.Input.Description).ValidOptionalDescription();
         RuleFor(x => x.Input.ProfileId).ValidOptionalProfileId();
     }
 }

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotkeys/UpdateHotkeyCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotkeys/UpdateHotkeyCommand.cs
@@ -1,0 +1,66 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Mapping;
+using AHKFlowApp.Application.Validation;
+using AHKFlowApp.Domain.Entities;
+using Ardalis.Result;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace AHKFlowApp.Application.Commands.Hotkeys;
+
+public sealed record UpdateHotkeyCommand(Guid Id, UpdateHotkeyDto Input) : IRequest<Result<HotkeyDto>>;
+
+public sealed class UpdateHotkeyCommandValidator : AbstractValidator<UpdateHotkeyCommand>
+{
+    public UpdateHotkeyCommandValidator()
+    {
+        RuleFor(x => x.Input.Trigger).ValidHotkeyTrigger();
+        RuleFor(x => x.Input.Action).ValidAction();
+        RuleFor(x => x.Input.Description!).ValidOptionalDescription();
+        RuleFor(x => x.Input.ProfileId).ValidOptionalProfileId();
+    }
+}
+
+internal sealed class UpdateHotkeyCommandHandler(
+    IAppDbContext db,
+    ICurrentUser currentUser,
+    TimeProvider clock)
+    : IRequestHandler<UpdateHotkeyCommand, Result<HotkeyDto>>
+{
+    public async Task<Result<HotkeyDto>> Handle(UpdateHotkeyCommand request, CancellationToken ct)
+    {
+        if (currentUser.Oid is not Guid ownerOid)
+            return Result.Unauthorized();
+
+        Hotkey? entity = await db.Hotkeys
+            .FirstOrDefaultAsync(h => h.Id == request.Id && h.OwnerOid == ownerOid, ct);
+
+        if (entity is null)
+            return Result.NotFound();
+
+        UpdateHotkeyDto input = request.Input;
+        entity.Update(
+            input.Trigger,
+            input.Action,
+            input.Description,
+            input.ProfileId,
+            clock);
+
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex) when (IsDuplicateKeyViolation(ex))
+        {
+            return Result.Conflict("A hotkey with this trigger already exists for the specified profile.");
+        }
+
+        return Result.Success(entity.ToDto());
+    }
+
+    private static bool IsDuplicateKeyViolation(DbUpdateException ex) =>
+        ex.InnerException?.GetType().GetProperty("Number")?.GetValue(ex.InnerException) is int n &&
+        n is 2601 or 2627;
+}

--- a/src/Backend/AHKFlowApp.Application/DTOs/HotkeyDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/HotkeyDto.cs
@@ -1,0 +1,22 @@
+namespace AHKFlowApp.Application.DTOs;
+
+public sealed record HotkeyDto(
+    Guid Id,
+    Guid? ProfileId,
+    string Trigger,
+    string Action,
+    string? Description,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt);
+
+public sealed record CreateHotkeyDto(
+    string Trigger,
+    string Action,
+    string? Description = null,
+    Guid? ProfileId = null);
+
+public sealed record UpdateHotkeyDto(
+    string Trigger,
+    string Action,
+    string? Description,
+    Guid? ProfileId);

--- a/src/Backend/AHKFlowApp.Application/Mapping/HotkeyMappings.cs
+++ b/src/Backend/AHKFlowApp.Application/Mapping/HotkeyMappings.cs
@@ -1,0 +1,16 @@
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Entities;
+
+namespace AHKFlowApp.Application.Mapping;
+
+internal static class HotkeyMappings
+{
+    public static HotkeyDto ToDto(this Hotkey h) => new(
+        h.Id,
+        h.ProfileId,
+        h.Trigger,
+        h.Action,
+        h.Description,
+        h.CreatedAt,
+        h.UpdatedAt);
+}

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/GetHotkeyQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/GetHotkeyQuery.cs
@@ -1,0 +1,31 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Mapping;
+using AHKFlowApp.Domain.Entities;
+using Ardalis.Result;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace AHKFlowApp.Application.Queries.Hotkeys;
+
+public sealed record GetHotkeyQuery(Guid Id) : IRequest<Result<HotkeyDto>>;
+
+internal sealed class GetHotkeyQueryHandler(
+    IAppDbContext db,
+    ICurrentUser currentUser)
+    : IRequestHandler<GetHotkeyQuery, Result<HotkeyDto>>
+{
+    public async Task<Result<HotkeyDto>> Handle(GetHotkeyQuery request, CancellationToken ct)
+    {
+        if (currentUser.Oid is not Guid ownerOid)
+            return Result.Unauthorized();
+
+        Hotkey? entity = await db.Hotkeys
+            .AsNoTracking()
+            .FirstOrDefaultAsync(h => h.Id == request.Id && h.OwnerOid == ownerOid, ct);
+
+        return entity is null
+            ? Result.NotFound()
+            : Result.Success(entity.ToDto());
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
@@ -44,6 +44,10 @@ internal sealed class ListHotkeysQueryHandler(
 
         if (!string.IsNullOrWhiteSpace(request.Search))
         {
+            // Case sensitivity follows the column collation. SQL Server's default collation is
+            // case-insensitive, so IgnoreCase=false is effectively only honored when the column
+            // is configured with a CS collation. Provider-specific Collate() lives in the
+            // Relational package; we keep this layer provider-agnostic.
             string pattern = $"%{request.Search.Trim()}%";
             query = query.Where(h =>
                 EF.Functions.Like(h.Trigger, pattern) ||

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
@@ -1,0 +1,73 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Entities;
+using Ardalis.Result;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace AHKFlowApp.Application.Queries.Hotkeys;
+
+public sealed record ListHotkeysQuery(
+    Guid? ProfileId = null,
+    string? Search = null,
+    bool IgnoreCase = true,
+    int Page = 1,
+    int PageSize = 50) : IRequest<Result<PagedList<HotkeyDto>>>;
+
+public sealed class ListHotkeysQueryValidator : AbstractValidator<ListHotkeysQuery>
+{
+    public ListHotkeysQueryValidator()
+    {
+        RuleFor(x => x.Search).MaximumLength(200);
+        RuleFor(x => x.Page).InclusiveBetween(1, 10_000);
+        RuleFor(x => x.PageSize).InclusiveBetween(1, 200);
+    }
+}
+
+internal sealed class ListHotkeysQueryHandler(
+    IAppDbContext db,
+    ICurrentUser currentUser)
+    : IRequestHandler<ListHotkeysQuery, Result<PagedList<HotkeyDto>>>
+{
+    public async Task<Result<PagedList<HotkeyDto>>> Handle(ListHotkeysQuery request, CancellationToken ct)
+    {
+        if (currentUser.Oid is not Guid ownerOid)
+            return Result.Unauthorized();
+
+        IQueryable<Hotkey> query = db.Hotkeys
+            .AsNoTracking()
+            .Where(h => h.OwnerOid == ownerOid);
+
+        if (request.ProfileId.HasValue)
+            query = query.Where(h => h.ProfileId == request.ProfileId.Value);
+
+        if (!string.IsNullOrWhiteSpace(request.Search))
+        {
+            string pattern = $"%{request.Search.Trim()}%";
+            query = query.Where(h =>
+                EF.Functions.Like(h.Trigger, pattern) ||
+                EF.Functions.Like(h.Action, pattern) ||
+                (h.Description != null && EF.Functions.Like(h.Description, pattern)));
+        }
+
+        int total = await query.CountAsync(ct);
+
+        List<HotkeyDto> items = await query
+            .OrderByDescending(h => h.CreatedAt)
+            .ThenBy(h => h.Id)
+            .Skip((request.Page - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .Select(h => new HotkeyDto(
+                h.Id,
+                h.ProfileId,
+                h.Trigger,
+                h.Action,
+                h.Description,
+                h.CreatedAt,
+                h.UpdatedAt))
+            .ToListAsync(ct);
+
+        return Result.Success(new PagedList<HotkeyDto>(items, request.Page, request.PageSize, total));
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Validation/HotkeyRules.cs
+++ b/src/Backend/AHKFlowApp.Application/Validation/HotkeyRules.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+
+namespace AHKFlowApp.Application.Validation;
+
+internal static class HotkeyRules
+{
+    public const int TriggerMaxLength = 100;
+    public const int ActionMaxLength = 4000;
+    public const int DescriptionMaxLength = 200;
+
+    public static IRuleBuilderOptions<T, string> ValidHotkeyTrigger<T>(this IRuleBuilderInitial<T, string> rb) =>
+        rb.Cascade(CascadeMode.Stop)
+          .Must(t => !string.IsNullOrEmpty(t)).WithMessage("Trigger is required.")
+          .MaximumLength(TriggerMaxLength).WithMessage($"Trigger must be {TriggerMaxLength} characters or fewer.")
+          .Must(t => t is not null && t.Length == t.Trim().Length)
+              .WithMessage("Trigger must not have leading or trailing whitespace.")
+          .Must(t => t is not null && t.IndexOfAny(['\n', '\r', '\t']) < 0)
+              .WithMessage("Trigger must not contain line breaks or tabs.");
+
+    public static IRuleBuilderOptions<T, string> ValidAction<T>(this IRuleBuilderInitial<T, string> rb) =>
+        rb.Cascade(CascadeMode.Stop)
+          .NotEmpty().WithMessage("Action is required.")
+          .MaximumLength(ActionMaxLength).WithMessage($"Action must be {ActionMaxLength} characters or fewer.");
+
+    public static IRuleBuilderOptions<T, string?> ValidOptionalDescription<T>(this IRuleBuilder<T, string?> rb) =>
+        rb.MaximumLength(DescriptionMaxLength).WithMessage($"Description must be {DescriptionMaxLength} characters or fewer.");
+}

--- a/src/Backend/AHKFlowApp.Domain/Entities/Hotkey.cs
+++ b/src/Backend/AHKFlowApp.Domain/Entities/Hotkey.cs
@@ -1,0 +1,55 @@
+namespace AHKFlowApp.Domain.Entities;
+
+public sealed class Hotkey
+{
+    private Hotkey()
+    {
+        Trigger = string.Empty;
+        Action = string.Empty;
+    }
+
+    public Guid Id { get; private set; }
+    public Guid OwnerOid { get; private set; }
+    public Guid? ProfileId { get; private set; }
+    public string Trigger { get; private set; }
+    public string Action { get; private set; }
+    public string? Description { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    public static Hotkey Create(
+        Guid ownerOid,
+        string trigger,
+        string action,
+        string? description,
+        Guid? profileId,
+        TimeProvider clock)
+    {
+        DateTimeOffset now = clock.GetUtcNow();
+        return new Hotkey
+        {
+            Id = Guid.NewGuid(),
+            OwnerOid = ownerOid,
+            ProfileId = profileId,
+            Trigger = trigger,
+            Action = action,
+            Description = description,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+    }
+
+    public void Update(
+        string trigger,
+        string action,
+        string? description,
+        Guid? profileId,
+        TimeProvider clock)
+    {
+        Trigger = trigger;
+        Action = action;
+        Description = description;
+        ProfileId = profileId;
+        UpdatedAt = clock.GetUtcNow();
+    }
+}

--- a/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260501025218_AddHotkeys.Designer.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260501025218_AddHotkeys.Designer.cs
@@ -4,16 +4,19 @@ using AHKFlowApp.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace AHKFlowApp.Infrastructure.Migrations
+namespace AHKFlowApp.Infrastructure.Migrations;
+
+[DbContext(typeof(AppDbContext))]
+[Migration("20260501025218_AddHotkeys")]
+partial class AddHotkeys
 {
-    [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
-    {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -172,4 +175,3 @@ namespace AHKFlowApp.Infrastructure.Migrations
 #pragma warning restore 612, 618
         }
     }
-}

--- a/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260501025218_AddHotkeys.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260501025218_AddHotkeys.cs
@@ -1,0 +1,58 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AHKFlowApp.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddHotkeys : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Hotkeys",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                OwnerOid = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                ProfileId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                Trigger = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                Action = table.Column<string>(type: "nvarchar(4000)", maxLength: 4000, nullable: false),
+                Description = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Hotkeys", x => x.Id);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Hotkey_Owner_Profile_Trigger",
+            table: "Hotkeys",
+            columns: new[] { "OwnerOid", "ProfileId", "Trigger" },
+            unique: true,
+            filter: "[ProfileId] IS NOT NULL");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Hotkey_Owner_Trigger_NoProfile",
+            table: "Hotkeys",
+            columns: new[] { "OwnerOid", "Trigger" },
+            unique: true,
+            filter: "[ProfileId] IS NULL");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Hotkeys_OwnerOid",
+            table: "Hotkeys",
+            column: "OwnerOid");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "Hotkeys");
+    }
+}

--- a/src/Backend/AHKFlowApp.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Persistence/AppDbContext.cs
@@ -8,6 +8,7 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
 {
     public DbSet<TestMessage> TestMessages => Set<TestMessage>();
     public DbSet<Hotstring> Hotstrings => Set<Hotstring>();
+    public DbSet<Hotkey> Hotkeys => Set<Hotkey>();
     public DbSet<UserPreference> UserPreferences => Set<UserPreference>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/HotkeyConfiguration.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/HotkeyConfiguration.cs
@@ -1,0 +1,44 @@
+using AHKFlowApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace AHKFlowApp.Infrastructure.Persistence.Configurations;
+
+internal sealed class HotkeyConfiguration : IEntityTypeConfiguration<Hotkey>
+{
+    public void Configure(EntityTypeBuilder<Hotkey> builder)
+    {
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.OwnerOid).IsRequired();
+        builder.HasIndex(x => x.OwnerOid);
+
+        builder.Property(x => x.ProfileId);
+
+        builder.Property(x => x.Trigger)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(x => x.Action)
+            .IsRequired()
+            .HasMaxLength(4000);
+
+        builder.Property(x => x.Description)
+            .HasMaxLength(200);
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+
+        // SQL Server treats NULLs as distinct for uniqueness — two filtered indexes
+        // cover both the profile-scoped case and the profile-less case per owner.
+        builder.HasIndex(x => new { x.OwnerOid, x.ProfileId, x.Trigger })
+            .IsUnique()
+            .HasFilter("[ProfileId] IS NOT NULL")
+            .HasDatabaseName("IX_Hotkey_Owner_Profile_Trigger");
+
+        builder.HasIndex(x => new { x.OwnerOid, x.Trigger })
+            .IsUnique()
+            .HasFilter("[ProfileId] IS NULL")
+            .HasDatabaseName("IX_Hotkey_Owner_Trigger_NoProfile");
+    }
+}

--- a/tests/AHKFlowApp.API.Tests/Hotkeys/HotkeysEndpointsTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Hotkeys/HotkeysEndpointsTests.cs
@@ -1,0 +1,269 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.TestUtilities.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.API.Tests.Hotkeys;
+
+[Collection("WebApi")]
+public sealed class HotkeysEndpointsTests(SqlContainerFixture sqlFixture) : IDisposable
+{
+    private readonly CustomWebApplicationFactory _factory = new(sqlFixture);
+
+    private HttpClient CreateAuthed(Guid? oid = null) =>
+        _factory.WithTestAuth(b => b.WithOid(oid ?? Guid.NewGuid())).CreateClient();
+
+    [Fact]
+    public async Task Post_CreatesAndReturns201WithLocation()
+    {
+        using HttpClient client = CreateAuthed();
+        var dto = new CreateHotkeyDto("^!K", "Run notepad", "Open Notepad");
+
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/v1/hotkeys", dto);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull();
+
+        HotkeyDto? body = await response.Content.ReadFromJsonAsync<HotkeyDto>();
+        body!.Trigger.Should().Be("^!K");
+        body.Action.Should().Be("Run notepad");
+        body.Description.Should().Be("Open Notepad");
+
+        HttpResponseMessage get = await client.GetAsync(response.Headers.Location);
+        get.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Post_InvalidBody_Returns400()
+    {
+        using HttpClient client = CreateAuthed();
+        var dto = new CreateHotkeyDto("", "");
+
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/v1/hotkeys", dto);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Post_DuplicateTrigger_Returns409_WithProblemDetails()
+    {
+        var owner = Guid.NewGuid();
+        using HttpClient client = CreateAuthed(owner);
+        var dto = new CreateHotkeyDto("dup", "x");
+
+        HttpResponseMessage first = await client.PostAsJsonAsync("/api/v1/hotkeys", dto);
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        HttpResponseMessage second = await client.PostAsJsonAsync("/api/v1/hotkeys", dto);
+
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        second.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+
+        using var doc = JsonDocument.Parse(await second.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("type").GetString().Should().Be("https://tools.ietf.org/html/rfc9110#section-15.5.10");
+        root.GetProperty("title").GetString().Should().Be("Conflict");
+        root.GetProperty("status").GetInt32().Should().Be(409);
+        root.GetProperty("detail").GetString().Should().Contain("already exists");
+        root.GetProperty("instance").GetString().Should().Be("/api/v1/hotkeys");
+        root.GetProperty("traceId").GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Put_UnknownId_Returns404_WithProblemDetails()
+    {
+        using HttpClient client = CreateAuthed();
+        var dto = new UpdateHotkeyDto("^!K", "y", null, null);
+
+        var unknownId = Guid.NewGuid();
+        HttpResponseMessage response = await client.PutAsJsonAsync(
+            $"/api/v1/hotkeys/{unknownId}", dto);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("type").GetString().Should().Be("https://tools.ietf.org/html/rfc9110#section-15.5.5");
+        root.GetProperty("title").GetString().Should().Be("Resource not found");
+        root.GetProperty("status").GetInt32().Should().Be(404);
+        root.GetProperty("instance").GetString().Should().Be($"/api/v1/hotkeys/{unknownId}");
+        root.GetProperty("traceId").GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Put_OtherUsersRow_Returns404()
+    {
+        var ownerA = Guid.NewGuid();
+        var ownerB = Guid.NewGuid();
+
+        using HttpClient a = CreateAuthed(ownerA);
+        HttpResponseMessage created = await a.PostAsJsonAsync("/api/v1/hotkeys",
+            new CreateHotkeyDto("tenant-a", "x"));
+        HotkeyDto? body = await created.Content.ReadFromJsonAsync<HotkeyDto>();
+
+        using HttpClient b = CreateAuthed(ownerB);
+        HttpResponseMessage response = await b.PutAsJsonAsync(
+            $"/api/v1/hotkeys/{body!.Id}",
+            new UpdateHotkeyDto("tenant-a", "hijack", null, null));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Put_Success_Returns200WithUpdatedDto()
+    {
+        using HttpClient client = CreateAuthed();
+        HttpResponseMessage created = await client.PostAsJsonAsync("/api/v1/hotkeys",
+            new CreateHotkeyDto("upd", "before"));
+        HotkeyDto? before = await created.Content.ReadFromJsonAsync<HotkeyDto>();
+
+        await Task.Delay(10);
+
+        HttpResponseMessage put = await client.PutAsJsonAsync(
+            $"/api/v1/hotkeys/{before!.Id}",
+            new UpdateHotkeyDto("upd", "after", "noted", null));
+
+        put.StatusCode.Should().Be(HttpStatusCode.OK);
+        HotkeyDto? after = await put.Content.ReadFromJsonAsync<HotkeyDto>();
+        after!.Action.Should().Be("after");
+        after.Description.Should().Be("noted");
+        after.UpdatedAt.Should().BeOnOrAfter(before.CreatedAt);
+    }
+
+    [Fact]
+    public async Task Delete_ThenGet_Returns404()
+    {
+        using HttpClient client = CreateAuthed();
+        HttpResponseMessage created = await client.PostAsJsonAsync("/api/v1/hotkeys",
+            new CreateHotkeyDto("del", "x"));
+        HotkeyDto? body = await created.Content.ReadFromJsonAsync<HotkeyDto>();
+
+        HttpResponseMessage del = await client.DeleteAsync($"/api/v1/hotkeys/{body!.Id}");
+        del.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        HttpResponseMessage get = await client.GetAsync($"/api/v1/hotkeys/{body.Id}");
+        get.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task List_FiltersByProfileId()
+    {
+        var owner = Guid.NewGuid();
+        var profile = Guid.NewGuid();
+        using HttpClient client = CreateAuthed(owner);
+
+        await client.PostAsJsonAsync("/api/v1/hotkeys", new CreateHotkeyDto("a", "x", null, profile));
+        await client.PostAsJsonAsync("/api/v1/hotkeys", new CreateHotkeyDto("b", "y"));
+
+        HttpResponseMessage response = await client.GetAsync($"/api/v1/hotkeys?profileId={profile}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        PagedList<HotkeyDto>? body = await response.Content.ReadFromJsonAsync<PagedList<HotkeyDto>>();
+        body!.Items.Should().OnlyContain(h => h.ProfileId == profile);
+    }
+
+    [Fact]
+    public async Task List_WithPagination_ReturnsSlice()
+    {
+        var owner = Guid.NewGuid();
+        using HttpClient client = CreateAuthed(owner);
+
+        for (int i = 0; i < 5; i++)
+            await client.PostAsJsonAsync("/api/v1/hotkeys", new CreateHotkeyDto($"p{i}", "x"));
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/hotkeys?page=2&pageSize=2");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        PagedList<HotkeyDto>? body = await response.Content.ReadFromJsonAsync<PagedList<HotkeyDto>>();
+        body!.TotalCount.Should().Be(5);
+        body.Items.Should().HaveCount(2);
+        body.Page.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task List_PageSizeTooLarge_Returns400()
+    {
+        using HttpClient client = CreateAuthed();
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/hotkeys?pageSize=500");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task List_SearchByTrigger_FiltersResults()
+    {
+        var owner = Guid.NewGuid();
+        using HttpClient client = CreateAuthed(owner);
+
+        await client.PostAsJsonAsync("/api/v1/hotkeys", new CreateHotkeyDto("F1", "help"));
+        await client.PostAsJsonAsync("/api/v1/hotkeys", new CreateHotkeyDto("F2", "rename"));
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/hotkeys?search=F1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        PagedList<HotkeyDto>? body = await response.Content.ReadFromJsonAsync<PagedList<HotkeyDto>>();
+        body!.Items.Should().ContainSingle().Which.Trigger.Should().Be("F1");
+    }
+
+    [Fact]
+    public async Task List_SearchTooLong_Returns400()
+    {
+        using HttpClient client = CreateAuthed();
+        string longSearch = new('x', 201);
+
+        HttpResponseMessage response = await client.GetAsync($"/api/v1/hotkeys?search={longSearch}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Get_WithoutBearer_Returns401()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/hotkeys");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Get_WithoutScope_Returns403()
+    {
+        using HttpClient client = _factory.WithTestAuth(b =>
+            b.WithOid(Guid.NewGuid()).WithoutScope()).CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/hotkeys");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Post_InvalidBody_ReturnsProblemDetailsWithErrors()
+    {
+        using HttpClient client = CreateAuthed();
+        var dto = new CreateHotkeyDto("", "");
+
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/v1/hotkeys", dto);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+
+        root.GetProperty("title").GetString().Should().Be("Validation failed");
+        root.GetProperty("status").GetInt32().Should().Be(400);
+        root.GetProperty("detail").GetString().Should().NotBeNullOrWhiteSpace();
+
+        JsonElement errors = root.GetProperty("errors");
+        errors.TryGetProperty("Input.Trigger", out _).Should().BeTrue("validation errors should be keyed by DTO property path");
+        errors.TryGetProperty("Input.Action", out _).Should().BeTrue();
+    }
+
+    public void Dispose() => _factory.Dispose();
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/CreateHotkeyCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/CreateHotkeyCommandHandlerTests.cs
@@ -1,0 +1,111 @@
+using AHKFlowApp.Application.Commands.Hotkeys;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Infrastructure.Persistence;
+using AHKFlowApp.TestUtilities.Builders;
+using Ardalis.Result;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Hotkeys;
+
+[Collection("HotkeyDb")]
+public sealed class CreateHotkeyCommandHandlerTests(HotkeyDbFixture fx)
+{
+    private readonly TimeProvider _clock = TimeProvider.System;
+
+    [Fact]
+    public async Task Handle_WhenValid_CreatesAndReturnsDto()
+    {
+        await using AppDbContext db = fx.CreateContext();
+        var owner = Guid.NewGuid();
+        var handler = new CreateHotkeyCommandHandler(db, CurrentUserHelper.For(owner), _clock);
+        var cmd = new CreateHotkeyCommand(new CreateHotkeyDto("^!K", "Run notepad", "Open Notepad"));
+
+        Result<HotkeyDto> result = await handler.Handle(cmd, default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Trigger.Should().Be("^!K");
+        result.Value.Action.Should().Be("Run notepad");
+        result.Value.Description.Should().Be("Open Notepad");
+
+        await using AppDbContext verify = fx.CreateContext();
+        (await verify.Hotkeys.CountAsync(h => h.OwnerOid == owner)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoOid_ReturnsUnauthorized()
+    {
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new CreateHotkeyCommandHandler(db, CurrentUserHelper.For(null), _clock);
+        var cmd = new CreateHotkeyCommand(new CreateHotkeyDto("^!K", "Run notepad"));
+
+        Result<HotkeyDto> result = await handler.Handle(cmd, default);
+
+        result.Status.Should().Be(ResultStatus.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDuplicateTriggerInSameProfile_ReturnsConflict()
+    {
+        var owner = Guid.NewGuid();
+        Hotkey existing = new HotkeyBuilder().WithOwner(owner).WithTrigger("dup").WithAction("first").Build();
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(existing);
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new CreateHotkeyCommandHandler(db, CurrentUserHelper.For(owner), _clock);
+        var cmd = new CreateHotkeyCommand(new CreateHotkeyDto("dup", "second"));
+
+        Result<HotkeyDto> result = await handler.Handle(cmd, default);
+
+        result.Status.Should().Be(ResultStatus.Conflict);
+    }
+
+    [Fact]
+    public async Task Handle_SameTriggerDifferentOwners_Succeeds()
+    {
+        var owner1 = Guid.NewGuid();
+        var owner2 = Guid.NewGuid();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner1).WithTrigger("shared").WithAction("x").Build());
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new CreateHotkeyCommandHandler(db, CurrentUserHelper.For(owner2), _clock);
+
+        Result<HotkeyDto> result = await handler.Handle(
+            new CreateHotkeyCommand(new CreateHotkeyDto("shared", "y")), default);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_SameTriggerDifferentProfiles_Succeeds()
+    {
+        var owner = Guid.NewGuid();
+        var profileA = Guid.NewGuid();
+        var profileB = Guid.NewGuid();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).InProfile(profileA).WithTrigger("^!K").WithAction("a").Build());
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new CreateHotkeyCommandHandler(db, CurrentUserHelper.For(owner), _clock);
+
+        Result<HotkeyDto> result = await handler.Handle(
+            new CreateHotkeyCommand(new CreateHotkeyDto("^!K", "b", null, profileB)), default);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/CreateHotkeyCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/CreateHotkeyCommandValidatorTests.cs
@@ -1,0 +1,191 @@
+using AHKFlowApp.Application.Commands.Hotkeys;
+using AHKFlowApp.Application.DTOs;
+using FluentAssertions;
+using FluentValidation.Results;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Hotkeys;
+
+public sealed class CreateHotkeyCommandValidatorTests
+{
+    private readonly CreateHotkeyCommandValidator _sut = new();
+
+    private static CreateHotkeyCommand Cmd(
+        string trigger = "^!K",
+        string action = "Run notepad",
+        string? description = null,
+        Guid? profileId = null)
+        => new(new CreateHotkeyDto(trigger, action, description, profileId));
+
+    [Fact]
+    public void Validate_WithValidInput_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd());
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithEmptyTrigger_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(trigger: ""));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Trigger" &&
+            e.ErrorMessage == "Trigger is required.");
+    }
+
+    [Fact]
+    public void Validate_WithWhitespaceTrigger_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(trigger: "   "));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Trigger" &&
+            e.ErrorMessage == "Trigger must not have leading or trailing whitespace.");
+    }
+
+    [Fact]
+    public void Validate_WithTriggerAt100Chars_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd(trigger: new string('x', 100)));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithTriggerAt101Chars_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(trigger: new string('x', 101)));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Trigger" &&
+            e.ErrorMessage == "Trigger must be 100 characters or fewer.");
+    }
+
+    [Theory]
+    [InlineData(" ^!K")]
+    [InlineData("^!K ")]
+    [InlineData(" ^!K ")]
+    public void Validate_WithTriggerLeadingOrTrailingWhitespace_Fails(string trigger)
+    {
+        ValidationResult result = _sut.Validate(Cmd(trigger: trigger));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Trigger" &&
+            e.ErrorMessage == "Trigger must not have leading or trailing whitespace.");
+    }
+
+    [Theory]
+    [InlineData("^!\nK")]
+    [InlineData("^!\rK")]
+    [InlineData("^!\tK")]
+    public void Validate_WithTriggerContainingControlChars_Fails(string trigger)
+    {
+        ValidationResult result = _sut.Validate(Cmd(trigger: trigger));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Trigger" &&
+            e.ErrorMessage == "Trigger must not contain line breaks or tabs.");
+    }
+
+    [Theory]
+    [InlineData("^!Numpad0 & F12")]
+    [InlineData("F1")]
+    [InlineData("#k")]
+    public void Validate_WithTypicalAhkSyntax_Succeeds(string trigger)
+    {
+        ValidationResult result = _sut.Validate(Cmd(trigger: trigger));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithEmptyAction_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(action: ""));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Action" &&
+            e.ErrorMessage == "Action is required.");
+    }
+
+    [Fact]
+    public void Validate_WithActionAt4000Chars_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd(action: new string('x', 4000)));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithActionAt4001Chars_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(action: new string('x', 4001)));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Action" &&
+            e.ErrorMessage == "Action must be 4000 characters or fewer.");
+    }
+
+    [Fact]
+    public void Validate_WithDescriptionAt200Chars_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd(description: new string('x', 200)));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithDescriptionAt201Chars_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(description: new string('x', 201)));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Description" &&
+            e.ErrorMessage == "Description must be 200 characters or fewer.");
+    }
+
+    [Fact]
+    public void Validate_WithNullDescription_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd(description: null));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithEmptyGuidProfileId_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(profileId: Guid.Empty));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.ProfileId" &&
+            e.ErrorMessage == "ProfileId must not be an empty GUID.");
+    }
+
+    [Fact]
+    public void Validate_WithNullProfileId_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd(profileId: null));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithValidProfileId_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd(profileId: Guid.NewGuid()));
+
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/CurrentUserHelper.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/CurrentUserHelper.cs
@@ -1,0 +1,14 @@
+using AHKFlowApp.Application.Abstractions;
+using NSubstitute;
+
+namespace AHKFlowApp.Application.Tests.Hotkeys;
+
+internal static class CurrentUserHelper
+{
+    public static ICurrentUser For(Guid? oid)
+    {
+        ICurrentUser u = Substitute.For<ICurrentUser>();
+        u.Oid.Returns(oid);
+        return u;
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/DeleteHotkeyCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/DeleteHotkeyCommandHandlerTests.cs
@@ -1,0 +1,56 @@
+using AHKFlowApp.Application.Commands.Hotkeys;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Infrastructure.Persistence;
+using AHKFlowApp.TestUtilities.Builders;
+using Ardalis.Result;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Hotkeys;
+
+[Collection("HotkeyDb")]
+public sealed class DeleteHotkeyCommandHandlerTests(HotkeyDbFixture fx)
+{
+    [Fact]
+    public async Task Handle_WhenOwned_Deletes()
+    {
+        var owner = Guid.NewGuid();
+        Hotkey entity = new HotkeyBuilder().WithOwner(owner).WithTrigger("del").Build();
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(entity);
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new DeleteHotkeyCommandHandler(db, CurrentUserHelper.For(owner));
+
+        Result result = await handler.Handle(new DeleteHotkeyCommand(entity.Id), default);
+
+        result.IsSuccess.Should().BeTrue();
+
+        await using AppDbContext verify = fx.CreateContext();
+        (await verify.Hotkeys.AnyAsync(h => h.Id == entity.Id)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WhenCrossTenant_ReturnsNotFound()
+    {
+        var owner = Guid.NewGuid();
+        var attacker = Guid.NewGuid();
+        Hotkey entity = new HotkeyBuilder().WithOwner(owner).WithTrigger("del").Build();
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(entity);
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new DeleteHotkeyCommandHandler(db, CurrentUserHelper.For(attacker));
+
+        Result result = await handler.Handle(new DeleteHotkeyCommand(entity.Id), default);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/FixedClock.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/FixedClock.cs
@@ -1,0 +1,10 @@
+namespace AHKFlowApp.Application.Tests.Hotkeys;
+
+internal sealed class FixedClock(DateTimeOffset now) : TimeProvider
+{
+    private DateTimeOffset _now = now;
+
+    public override DateTimeOffset GetUtcNow() => _now;
+
+    public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/GetHotkeyQueryHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/GetHotkeyQueryHandlerTests.cs
@@ -1,0 +1,54 @@
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Queries.Hotkeys;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Infrastructure.Persistence;
+using AHKFlowApp.TestUtilities.Builders;
+using Ardalis.Result;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Hotkeys;
+
+[Collection("HotkeyDb")]
+public sealed class GetHotkeyQueryHandlerTests(HotkeyDbFixture fx)
+{
+    [Fact]
+    public async Task Handle_WhenOwned_ReturnsDto()
+    {
+        var owner = Guid.NewGuid();
+        Hotkey entity = new HotkeyBuilder().WithOwner(owner).WithTrigger("g").Build();
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(entity);
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new GetHotkeyQueryHandler(db, CurrentUserHelper.For(owner));
+
+        Result<HotkeyDto> result = await handler.Handle(new GetHotkeyQuery(entity.Id), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be(entity.Id);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCrossTenant_ReturnsNotFound()
+    {
+        var owner = Guid.NewGuid();
+        var attacker = Guid.NewGuid();
+        Hotkey entity = new HotkeyBuilder().WithOwner(owner).WithTrigger("g").Build();
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(entity);
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new GetHotkeyQueryHandler(db, CurrentUserHelper.For(attacker));
+
+        Result<HotkeyDto> result = await handler.Handle(new GetHotkeyQuery(entity.Id), default);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/HotkeyDbFixture.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/HotkeyDbFixture.cs
@@ -1,0 +1,33 @@
+using AHKFlowApp.Infrastructure.Persistence;
+using AHKFlowApp.TestUtilities.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Hotkeys;
+
+public sealed class HotkeyDbFixture : IAsyncLifetime
+{
+    private readonly SqlContainerFixture _sql = new();
+
+    public string ConnectionString => _sql.ConnectionString;
+
+    public async Task InitializeAsync()
+    {
+        await _sql.InitializeAsync();
+        await using AppDbContext ctx = CreateContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    public Task DisposeAsync() => _sql.DisposeAsync();
+
+    public AppDbContext CreateContext()
+    {
+        DbContextOptions<AppDbContext> options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlServer(ConnectionString)
+            .Options;
+        return new AppDbContext(options);
+    }
+}
+
+[CollectionDefinition("HotkeyDb")]
+public sealed class HotkeyDbCollection : ICollectionFixture<HotkeyDbFixture>;

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysQueryHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysQueryHandlerTests.cs
@@ -1,0 +1,185 @@
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Queries.Hotkeys;
+using AHKFlowApp.Infrastructure.Persistence;
+using AHKFlowApp.TestUtilities.Builders;
+using Ardalis.Result;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Hotkeys;
+
+[Collection("HotkeyDb")]
+public sealed class ListHotkeysQueryHandlerTests(HotkeyDbFixture fx)
+{
+    [Fact]
+    public async Task Handle_ScopedToOwner_IgnoresOtherTenants()
+    {
+        var owner = Guid.NewGuid();
+        var other = Guid.NewGuid();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).WithTrigger("mine").Build());
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(other).WithTrigger("theirs").Build());
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+
+        Result<PagedList<HotkeyDto>> result = await handler.Handle(new ListHotkeysQuery(), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(1);
+        result.Value.Items.Should().OnlyContain(h => h.Trigger == "mine");
+    }
+
+    [Fact]
+    public async Task Handle_FiltersByProfileId()
+    {
+        var owner = Guid.NewGuid();
+        var profile = Guid.NewGuid();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).InProfile(profile).WithTrigger("a").Build());
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).InProfile(null).WithTrigger("b").Build());
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+
+        Result<PagedList<HotkeyDto>> result = await handler.Handle(
+            new ListHotkeysQuery(ProfileId: profile), default);
+
+        result.Value.Items.Should().HaveCount(1);
+        result.Value.Items[0].Trigger.Should().Be("a");
+    }
+
+    [Fact]
+    public async Task Handle_Paginates_WithCorrectTotalCount()
+    {
+        var owner = Guid.NewGuid();
+        var clock = new FixedClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).WithTrigger($"t{i}").WithClock(clock).Build());
+                clock.Advance(TimeSpan.FromSeconds(1));
+            }
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+
+        Result<PagedList<HotkeyDto>> page2 = await handler.Handle(
+            new ListHotkeysQuery(Page: 2, PageSize: 2), default);
+
+        page2.Value.TotalCount.Should().Be(5);
+        page2.Value.Items.Should().HaveCount(2);
+        page2.Value.Page.Should().Be(2);
+        page2.Value.PageSize.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoOid_ReturnsUnauthorized()
+    {
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(null));
+
+        Result<PagedList<HotkeyDto>> result = await handler.Handle(new ListHotkeysQuery(), default);
+
+        result.Status.Should().Be(ResultStatus.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Handle_Search_MatchesTrigger()
+    {
+        var owner = Guid.NewGuid();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).WithTrigger("^!K").WithAction("notepad").Build());
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).WithTrigger("F1").WithAction("help").Build());
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+
+        Result<PagedList<HotkeyDto>> result = await handler.Handle(
+            new ListHotkeysQuery(Search: "^!K"), default);
+
+        result.Value.Items.Should().ContainSingle().Which.Trigger.Should().Be("^!K");
+    }
+
+    [Fact]
+    public async Task Handle_Search_MatchesAction()
+    {
+        var owner = Guid.NewGuid();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).WithTrigger("a").WithAction("needle in a haystack").Build());
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).WithTrigger("b").WithAction("nothing relevant").Build());
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+
+        Result<PagedList<HotkeyDto>> result = await handler.Handle(
+            new ListHotkeysQuery(Search: "needle"), default);
+
+        result.Value.Items.Should().ContainSingle().Which.Trigger.Should().Be("a");
+    }
+
+    [Fact]
+    public async Task Handle_Search_MatchesDescription()
+    {
+        var owner = Guid.NewGuid();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).WithTrigger("a").WithDescription("Open browser").Build());
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).WithTrigger("b").WithDescription("Lock workstation").Build());
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+
+        Result<PagedList<HotkeyDto>> result = await handler.Handle(
+            new ListHotkeysQuery(Search: "browser"), default);
+
+        result.Value.Items.Should().ContainSingle().Which.Trigger.Should().Be("a");
+    }
+
+    [Fact]
+    public async Task Handle_Search_CombinedWithProfileId()
+    {
+        var owner = Guid.NewGuid();
+        var profile = Guid.NewGuid();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).InProfile(profile).WithTrigger("match").WithAction("x").Build());
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).InProfile(null).WithTrigger("match").WithAction("y").Build());
+            seed.Hotkeys.Add(new HotkeyBuilder().WithOwner(owner).InProfile(profile).WithTrigger("other").WithAction("z").Build());
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+
+        Result<PagedList<HotkeyDto>> result = await handler.Handle(
+            new ListHotkeysQuery(ProfileId: profile, Search: "match"), default);
+
+        result.Value.Items.Should().ContainSingle()
+            .Which.Should().Match<HotkeyDto>(h => h.Trigger == "match" && h.ProfileId == profile);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysQueryValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysQueryValidatorTests.cs
@@ -1,0 +1,74 @@
+using AHKFlowApp.Application.Queries.Hotkeys;
+using FluentAssertions;
+using FluentValidation.Results;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Hotkeys;
+
+public sealed class ListHotkeysQueryValidatorTests
+{
+    private readonly ListHotkeysQueryValidator _sut = new();
+
+    [Fact]
+    public void Validate_Defaults_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(new ListHotkeysQuery());
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_WithPageLessThan1_Fails(int page)
+    {
+        ValidationResult result = _sut.Validate(new ListHotkeysQuery(Page: page, PageSize: 50));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Page");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(201)]
+    [InlineData(1000)]
+    public void Validate_WithPageSizeOutOfRange_Fails(int pageSize)
+    {
+        ValidationResult result = _sut.Validate(new ListHotkeysQuery(PageSize: pageSize));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "PageSize");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(50)]
+    [InlineData(200)]
+    public void Validate_WithPageSizeAtBoundary_Succeeds(int pageSize)
+    {
+        ValidationResult result = _sut.Validate(new ListHotkeysQuery(PageSize: pageSize));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithSearchTooLong_Fails()
+    {
+        string longSearch = new('x', 201);
+
+        ValidationResult result = _sut.Validate(new ListHotkeysQuery(Search: longSearch));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Search");
+    }
+
+    [Fact]
+    public void Validate_WithSearchAtMaxLength_Succeeds()
+    {
+        string maxSearch = new('x', 200);
+
+        ValidationResult result = _sut.Validate(new ListHotkeysQuery(Search: maxSearch));
+
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/UpdateHotkeyCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/UpdateHotkeyCommandHandlerTests.cs
@@ -1,0 +1,102 @@
+using AHKFlowApp.Application.Commands.Hotkeys;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Infrastructure.Persistence;
+using AHKFlowApp.TestUtilities.Builders;
+using Ardalis.Result;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Hotkeys;
+
+[Collection("HotkeyDb")]
+public sealed class UpdateHotkeyCommandHandlerTests(HotkeyDbFixture fx)
+{
+    [Fact]
+    public async Task Handle_WhenValid_UpdatesAndReturnsUpdatedDto()
+    {
+        var owner = Guid.NewGuid();
+        var clock = new FixedClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        Hotkey entity = new HotkeyBuilder()
+            .WithOwner(owner).WithTrigger("^!K").WithAction("old").WithClock(clock).Build();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(entity);
+            await seed.SaveChangesAsync();
+        }
+
+        clock.Advance(TimeSpan.FromMinutes(5));
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new UpdateHotkeyCommandHandler(db, CurrentUserHelper.For(owner), clock);
+        var cmd = new UpdateHotkeyCommand(entity.Id,
+            new UpdateHotkeyDto("^!K", "new", "updated", null));
+
+        Result<HotkeyDto> result = await handler.Handle(cmd, default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Action.Should().Be("new");
+        result.Value.Description.Should().Be("updated");
+        result.Value.UpdatedAt.Should().BeAfter(result.Value.CreatedAt);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCrossTenant_ReturnsNotFound()
+    {
+        var owner = Guid.NewGuid();
+        var attacker = Guid.NewGuid();
+        Hotkey entity = new HotkeyBuilder().WithOwner(owner).WithTrigger("^!K").Build();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.Add(entity);
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new UpdateHotkeyCommandHandler(db, CurrentUserHelper.For(attacker), TimeProvider.System);
+        var cmd = new UpdateHotkeyCommand(entity.Id,
+            new UpdateHotkeyDto("^!K", "hijack", null, null));
+
+        Result<HotkeyDto> result = await handler.Handle(cmd, default);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task Handle_WhenMissingId_ReturnsNotFound()
+    {
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new UpdateHotkeyCommandHandler(db, CurrentUserHelper.For(Guid.NewGuid()), TimeProvider.System);
+        var cmd = new UpdateHotkeyCommand(Guid.NewGuid(),
+            new UpdateHotkeyDto("^!K", "x", null, null));
+
+        Result<HotkeyDto> result = await handler.Handle(cmd, default);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDuplicateTrigger_ReturnsConflict()
+    {
+        var owner = Guid.NewGuid();
+        Hotkey first = new HotkeyBuilder().WithOwner(owner).WithTrigger("first").WithAction("a").Build();
+        Hotkey second = new HotkeyBuilder().WithOwner(owner).WithTrigger("second").WithAction("b").Build();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotkeys.AddRange(first, second);
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new UpdateHotkeyCommandHandler(db, CurrentUserHelper.For(owner), TimeProvider.System);
+        var cmd = new UpdateHotkeyCommand(second.Id,
+            new UpdateHotkeyDto("first", "b", null, null));
+
+        Result<HotkeyDto> result = await handler.Handle(cmd, default);
+
+        result.Status.Should().Be(ResultStatus.Conflict);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/UpdateHotkeyCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/UpdateHotkeyCommandValidatorTests.cs
@@ -1,0 +1,79 @@
+using AHKFlowApp.Application.Commands.Hotkeys;
+using AHKFlowApp.Application.DTOs;
+using FluentAssertions;
+using FluentValidation.Results;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Hotkeys;
+
+public sealed class UpdateHotkeyCommandValidatorTests
+{
+    private readonly UpdateHotkeyCommandValidator _sut = new();
+
+    private static UpdateHotkeyCommand Cmd(
+        string trigger = "^!K",
+        string action = "Run notepad",
+        string? description = null,
+        Guid? profileId = null)
+        => new(Guid.NewGuid(), new UpdateHotkeyDto(trigger, action, description, profileId));
+
+    [Fact]
+    public void Validate_WithValidInput_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd());
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithEmptyTrigger_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(trigger: ""));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Trigger" &&
+            e.ErrorMessage == "Trigger is required.");
+    }
+
+    [Fact]
+    public void Validate_WithEmptyAction_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(action: ""));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Action" &&
+            e.ErrorMessage == "Action is required.");
+    }
+
+    [Fact]
+    public void Validate_WithDescriptionTooLong_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(description: new string('x', 201)));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Description" &&
+            e.ErrorMessage == "Description must be 200 characters or fewer.");
+    }
+
+    [Fact]
+    public void Validate_WithEmptyGuidProfileId_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(profileId: Guid.Empty));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.ProfileId" &&
+            e.ErrorMessage == "ProfileId must not be an empty GUID.");
+    }
+
+    [Fact]
+    public void Validate_WithNullProfileId_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd(profileId: null));
+
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/AHKFlowApp.TestUtilities/Builders/HotkeyBuilder.cs
+++ b/tests/AHKFlowApp.TestUtilities/Builders/HotkeyBuilder.cs
@@ -1,0 +1,51 @@
+using AHKFlowApp.Domain.Entities;
+
+namespace AHKFlowApp.TestUtilities.Builders;
+
+public sealed class HotkeyBuilder
+{
+    private Guid _ownerOid = Guid.NewGuid();
+    private Guid? _profileId;
+    private string _trigger = "^!K";
+    private string _action = "Run notepad";
+    private string? _description;
+    private TimeProvider _clock = TimeProvider.System;
+
+    public HotkeyBuilder WithOwner(Guid ownerOid)
+    {
+        _ownerOid = ownerOid;
+        return this;
+    }
+
+    public HotkeyBuilder InProfile(Guid? profileId)
+    {
+        _profileId = profileId;
+        return this;
+    }
+
+    public HotkeyBuilder WithTrigger(string trigger)
+    {
+        _trigger = trigger;
+        return this;
+    }
+
+    public HotkeyBuilder WithAction(string action)
+    {
+        _action = action;
+        return this;
+    }
+
+    public HotkeyBuilder WithDescription(string? description)
+    {
+        _description = description;
+        return this;
+    }
+
+    public HotkeyBuilder WithClock(TimeProvider clock)
+    {
+        _clock = clock;
+        return this;
+    }
+
+    public Hotkey Build() => Hotkey.Create(_ownerOid, _trigger, _action, _description, _profileId, _clock);
+}


### PR DESCRIPTION
## Summary

- **Domain**: `Hotkey` entity with `Create`/`Update` factory methods; nullable `ProfileId` (no FK, mirrors Hotstring — FK deferred to item 024)
- **Application**: `CreateHotkeyCommand`, `UpdateHotkeyCommand`, `DeleteHotkeyCommand`, `GetHotkeyQuery`, `ListHotkeysQuery` with FluentValidation; `HotkeyRules` (trigger ≤ 100 chars, action ≤ 4000, description ≤ 200); `HotkeyDto` / `CreateHotkeyDto` / `UpdateHotkeyDto`
- **Infrastructure**: `HotkeyConfiguration` with two filtered unique indexes (SQL Server NULL semantics); `AddHotkeys` migration; `DbSet<Hotkey>` on `AppDbContext` / `IAppDbContext`
- **API**: `HotkeysController` — GET list (paged, profileId + search), GET by id, POST 201+Location, PUT 200, DELETE 204; `[Authorize]` + `[RequiredScope]` class-level; full ProblemDetails error mapping
- **Search**: LIKE over `Trigger`, `Action`, and `Description`
- **Tests**: 81 new tests — validator unit tests, handler unit tests (Testcontainers SQL), API integration tests (WebApplicationFactory); all 292 tests green

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test` — 292/292 pass
- [x] Auth: 401 no bearer, 403 no scope
- [x] Validation: 400 + `application/problem+json` with `errors.Input.Trigger` / `errors.Input.Action` keys
- [x] Conflict: 409 + ProblemDetails `detail` contains "already exists"
- [x] Cross-tenant isolation: PUT another user's row → 404
- [x] Pagination, profile filter, trigger/action/description search

🤖 Generated with [Claude Code](https://claude.com/claude-code)