### PR TITLE
docs(backlog): realign 014–027 to old-AHKFlow redesign

### DIFF
--- a/.claude/backlog/014-hotstrings-ui-crud.md
+++ b/.claude/backlog/014-hotstrings-ui-crud.md
@@ -31,6 +31,7 @@ As a user, I want to manage hotstrings in the Web UI so that I can maintain my a
 
 - Depends on 013.
 - Assumes at least one profile exists (a seeded default is fine until 024 is implemented).
+- The single-profile picker shipped here will be revisited under **024b** (M2M profile association): the picker becomes a multi-select with an "Any" toggle.
 
 ---
 

--- a/.claude/backlog/019-hotstrings-search-filtering.md
+++ b/.claude/backlog/019-hotstrings-search-filtering.md
@@ -34,3 +34,4 @@ As a user, I want to search and filter hotstrings so I can quickly find, edit, a
 ## Notes / dependencies
 
 - Depends on 013 (list-by-profile endpoint) and 018 (CLI support).
+- The `profileId` filter behavior changes once **024b** lands: filter must include rows whose junction matches OR `AppliesToAllProfiles=true`. Existing tests should be updated then.

--- a/.claude/backlog/021-hotkeys-api-crud.md
+++ b/.claude/backlog/021-hotkeys-api-crud.md
@@ -31,3 +31,4 @@ As a client (UI), I want a hotkey CRUD API so that hotkeys can be managed centra
 
 - Depends on 003 and 012.
 - Assumes profiles exist (a seeded default is fine until 024 is implemented).
+- **Superseded by 022b** (Hotkey schema rebuild). The shape shipped here — free-form `Trigger` + `Action` strings + nullable single `ProfileId` — will be replaced by the structured schema (`Description/Key/Ctrl/Alt/Shift/Win/Action enum/Parameters` + M2M profile association). Kept in the backlog as a historical record.

--- a/.claude/backlog/022-hotkeys-ui-crud.md
+++ b/.claude/backlog/022-hotkeys-ui-crud.md
@@ -32,5 +32,5 @@ As a user, I want to manage hotkeys in the Web UI so that I can define keyboard 
 ## Notes / dependencies
 
 - Depends on **022b** (Hotkey schema rebuild) and **024 + 024b** (Profile entity + M2M association).
-- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 3).
+- Design spec: `docs/superpowers/specs/2026-04-30-ahkflow-alignment-design.md` (Phase 3).
 - An earlier implementation on `feature/022-hotkeys-ui-crud` (unmerged) used a free-form `Trigger`/`Action`/`Description` model. It is superseded by this redesign; ACs above are intentionally reset.

--- a/.claude/backlog/022-hotkeys-ui-crud.md
+++ b/.claude/backlog/022-hotkeys-ui-crud.md
@@ -8,24 +8,29 @@
 
 ## Summary
 
-Implement Web UI screens/components to create, edit, delete, and list hotkeys per profile.
+Implement the Hotkeys page so it matches the old AHKFlow reference UI: inline-edit table with columns **Description, Key, CTRL, ALT, SHIFT, Win, Action (enum dropdown), Profile (multi-select with "Any"), Parameters, Actions**.
 
 ## User story
 
-As a user, I want to manage hotkeys in the Web UI so that I can define shortcuts per profile.
+As a user, I want to manage hotkeys in the Web UI so that I can define keyboard shortcuts and assign them to one or more profiles (or to all profiles via "Any").
 
 ## Acceptance criteria
 
-- [ ] List hotkeys for the active profile.
-- [ ] Create and edit hotkeys with validation feedback.
+- [ ] List hotkeys with the column set above; inline-edit per row (MudTable).
+- [ ] Create and edit hotkeys with client-side validation feedback (Description, Key required; modifier-combo unique per user).
+- [ ] Action column is a dropdown bound to the `HotkeyAction` enum (Send, Run; extensible).
+- [ ] Profile column is a multi-select; an "Any" toggle sets `AppliesToAllProfiles=true` and clears specific selections.
 - [ ] Delete hotkeys with a confirmation step.
-- [ ] Unit/component tests for the main hotkeys UI components covering validation and state transitions.
-- [ ] Integration/E2E tests for create/edit/delete flows against a test API.
+- [ ] bUnit tests cover the main UI components, including modifier checkboxes, Action dropdown, Profile multi-select / "Any" toggle, and validation states.
 
 ## Out of scope
 
-- Blacklist/conflict rules.
+- Key-capture widget — plain text input only (`MudTextField`); user types `n`, `F5`, `Numpad0`. Capture widget can come later.
+- Search/filtering UI (see 023).
+- E2E (Playwright) — bUnit only, matching the 014 precedent.
 
 ## Notes / dependencies
 
-- Depends on 021.
+- Depends on **022b** (Hotkey schema rebuild) and **024 + 024b** (Profile entity + M2M association).
+- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 3).
+- An earlier implementation on `feature/022-hotkeys-ui-crud` (unmerged) used a free-form `Trigger`/`Action`/`Description` model. It is superseded by this redesign; ACs above are intentionally reset.

--- a/.claude/backlog/022b-hotkey-schema-rebuild.md
+++ b/.claude/backlog/022b-hotkey-schema-rebuild.md
@@ -1,0 +1,36 @@
+# 022b - Hotkey schema rebuild
+
+## Metadata
+
+- **Epic**: Hotkeys
+- **Type**: Refactor
+- **Interfaces**: API
+
+## Summary
+
+Rebuild the `Hotkey` domain entity and its API surface to match the AHKFlow reference model. Replaces the free-form `Trigger`/`Action`/`Description` shape from the original 021/022 implementation.
+
+## User story
+
+As a developer, I want the `Hotkey` schema and API to use structured fields (Description, Key, modifier flags, Action enum, Parameters) so the UI can render the screenshot layout and the script generator can emit AutoHotkey syntax directly.
+
+## Acceptance criteria
+
+- [ ] `Hotkey` entity has fields: `Description` (≤200, required), `Key` (≤20, required), `Ctrl`, `Alt`, `Shift`, `Win` (bools), `Action` (HotkeyAction enum), `Parameters` (≤4000), `AppliesToAllProfiles` (bool), plus `Id`, `OwnerOid`, timestamps.
+- [ ] New `HotkeyAction` enum in Domain: `Send=0, Run=1` (extensible).
+- [ ] EF migration drops the old `Trigger`/`Action`/`Description` string columns and the nullable `ProfileId`; adds the new fields. Dev DBs are scratch (per spec D7); no copy-forward SQL.
+- [ ] Unique index on `(OwnerOid, Key, Ctrl, Alt, Shift, Win)`.
+- [ ] API DTOs (`HotkeyDto`, `Create`, `Update`) reflect the new shape; controller + handlers + FluentValidation rebuilt.
+- [ ] Existing 021 + 022 tests are deleted/rewritten; new unit + integration tests cover the rebuilt API.
+
+## Out of scope
+
+- Many-to-many profile association (covered in 024b).
+- UI changes (covered in 022).
+- Adding new `HotkeyAction` enum values beyond `Send` and `Run`.
+
+## Notes / dependencies
+
+- Supersedes 021 in practice. 021 stays in the backlog as a historical record.
+- Depends on **024 + 024b** for profile association (`AppliesToAllProfiles` flag pairs with the `HotkeyProfile` junction).
+- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 3).

--- a/.claude/backlog/022b-hotkey-schema-rebuild.md
+++ b/.claude/backlog/022b-hotkey-schema-rebuild.md
@@ -33,4 +33,4 @@ As a developer, I want the `Hotkey` schema and API to use structured fields (Des
 
 - Supersedes 021 in practice. 021 stays in the backlog as a historical record.
 - Depends on **024 + 024b** for profile association (`AppliesToAllProfiles` flag pairs with the `HotkeyProfile` junction).
-- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 3).
+- Design spec: `docs/superpowers/specs/2026-04-30-ahkflow-alignment-design.md` (Phase 3).

--- a/.claude/backlog/023-hotkeys-search-filtering.md
+++ b/.claude/backlog/023-hotkeys-search-filtering.md
@@ -29,4 +29,4 @@ As a user, I want to search and filter hotkeys so I can quickly find and manage 
 
 ## Notes / dependencies
 
-- Depends on 021 (Hotkeys API CRUD) and 022 (Hotkeys UI CRUD).
+- Depends on **022b** (Hotkey schema rebuild) and **022** (redesigned Hotkeys UI). Search must operate on the new structured fields (`Description`, `Key`, `Parameters`) and respect M2M profile filtering (junction OR `AppliesToAllProfiles=true` per **024b**).

--- a/.claude/backlog/024-profile-management.md
+++ b/.claude/backlog/024-profile-management.md
@@ -17,7 +17,7 @@ As a user, I want to create and manage profiles — each with its own AHK header
 ## Acceptance criteria
 
 - [ ] `Profile` entity: `Id`, `OwnerOid`, `Name` (≤100, unique per owner), `IsDefault` (exactly one true per owner), `HeaderTemplate` (≤8000), `FooterTemplate` (≤4000), timestamps.
-- [ ] On first sign-in, a default profile is seeded for the user (`Name="Default"`, `IsDefault=true`, `HeaderTemplate` from `old_project_reference/AHKFlowOldMAUI/AHKFlow.API/Templates/header_template.txt`, `FooterTemplate=""`).
+- [ ] On first sign-in, a default profile is seeded for the user (`Name="Default"`, `IsDefault=true`, `HeaderTemplate` seeded with the standard AHK v2 boilerplate defined in the design spec, `FooterTemplate=""`).
 - [ ] API endpoints: GET list, GET by id, POST create, PUT update, DELETE — all scoped to the authenticated user.
 - [ ] Setting `IsDefault=true` on one profile clears it on others (single-default invariant).
 - [ ] DELETE blocked while the profile still has hotkey/hotstring associations (returns 409); user must detach first or use cascade in UI.
@@ -36,4 +36,4 @@ As a user, I want to create and manage profiles — each with its own AHK header
 
 - Combines what was previously split across 024 (entity + CRUD) and 025 (header templates) — templates land with the entity in one PR. Item 025 is now narrowed to "footer template addition" (already covered here) and is effectively absorbed; see 025 note.
 - Required for 022, 022b, 024b, 026, 027.
-- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 1).
+- Design spec: `docs/superpowers/specs/2026-04-30-ahkflow-alignment-design.md` (Phase 1).

--- a/.claude/backlog/024-profile-management.md
+++ b/.claude/backlog/024-profile-management.md
@@ -1,4 +1,4 @@
-# 024 - Profile management (CRUD + select default)
+# 024 - Profile management (CRUD + default + templates)
 
 ## Metadata
 
@@ -8,25 +8,32 @@
 
 ## Summary
 
-Create and manage profiles to organize hotstrings/hotkeys and drive per-profile script generation.
+Introduce the `Profile` entity and its CRUD API/UI. A profile groups hotstrings/hotkeys and carries the `HeaderTemplate` + `FooterTemplate` text used during script generation.
 
 ## User story
 
-As a user, I want to create and manage profiles so that I can group automation definitions by context (e.g., work vs personal).
+As a user, I want to create and manage profiles — each with its own AHK header and footer templates — so I can group automation by context (Work, Personal, Gaming) and customize the script boilerplate per group.
 
 ## Acceptance criteria
 
-- [ ] Create, rename/update, list, and delete profiles.
-- [ ] Select an active/default profile in the UI.
-- [ ] API enforces unique profile names per user/tenant.
-- [ ] Deleting a profile defines a clear behavior for attached hotstrings/hotkeys (block unless empty or cascade delete).
-- [ ] Unit tests cover profile business rules (unique name enforcement, delete semantics).
-- [ ] Integration tests verify profile CRUD flows and interactions with profile-scoped resources.
+- [ ] `Profile` entity: `Id`, `OwnerOid`, `Name` (≤100, unique per owner), `IsDefault` (exactly one true per owner), `HeaderTemplate` (≤8000), `FooterTemplate` (≤4000), timestamps.
+- [ ] On first sign-in, a default profile is seeded for the user (`Name="Default"`, `IsDefault=true`, `HeaderTemplate` from `old_project_reference/AHKFlowOldMAUI/AHKFlow.API/Templates/header_template.txt`, `FooterTemplate=""`).
+- [ ] API endpoints: GET list, GET by id, POST create, PUT update, DELETE — all scoped to the authenticated user.
+- [ ] Setting `IsDefault=true` on one profile clears it on others (single-default invariant).
+- [ ] DELETE blocked while the profile still has hotkey/hotstring associations (returns 409); user must detach first or use cascade in UI.
+- [ ] UI: `Pages/Profiles.razor` lists profiles with inline edit; expand-row textareas for `HeaderTemplate` + `FooterTemplate` (large, monospace font).
+- [ ] Unit tests cover invariants (unique name per owner, single-default, delete blocked when associations exist).
+- [ ] Integration tests cover CRUD flows + default seeding on first sign-in.
 
 ## Out of scope
 
+- Many-to-many profile association of hotkeys/hotstrings (see 024b).
 - Profile import/export.
+- Template versioning.
+- A global "active profile" selector — there is no global selection; profiles are picked per-row when creating hotkeys/hotstrings, or via the "Any" toggle.
 
 ## Notes / dependencies
 
-- Required for all profile-scoped features.
+- Combines what was previously split across 024 (entity + CRUD) and 025 (header templates) — templates land with the entity in one PR. Item 025 is now narrowed to "footer template addition" (already covered here) and is effectively absorbed; see 025 note.
+- Required for 022, 022b, 024b, 026, 027.
+- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 1).

--- a/.claude/backlog/024b-profile-association-many-to-many.md
+++ b/.claude/backlog/024b-profile-association-many-to-many.md
@@ -32,4 +32,4 @@ As a user, I want to assign a hotkey or hotstring to multiple profiles, or to "A
 
 - Depends on **024** (Profile entity must exist).
 - Required by **022, 022b, 026**.
-- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 2).
+- Design spec: `docs/superpowers/specs/2026-04-30-ahkflow-alignment-design.md` (Phase 2).

--- a/.claude/backlog/024b-profile-association-many-to-many.md
+++ b/.claude/backlog/024b-profile-association-many-to-many.md
@@ -1,0 +1,35 @@
+# 024b - Many-to-many profile association
+
+## Metadata
+
+- **Epic**: Profiles
+- **Type**: Refactor
+- **Interfaces**: API
+
+## Summary
+
+Replace the single nullable `ProfileId` foreign key on `Hotkey` and `Hotstring` with junction tables (`HotkeyProfile`, `HotstringProfile`) plus an `AppliesToAllProfiles` boolean flag on each parent entity ("Any" semantics).
+
+## User story
+
+As a user, I want to assign a hotkey or hotstring to multiple profiles, or to "Any" (every profile, current and future), so I don't have to duplicate definitions per profile.
+
+## Acceptance criteria
+
+- [ ] `HotkeyProfile (HotkeyId, ProfileId)` and `HotstringProfile (HotstringId, ProfileId)` junction tables with composite primary keys and cascade-delete on the parent side.
+- [ ] `AppliesToAllProfiles` (bool) added to both `Hotkey` and `Hotstring`. When true, the junction is empty for that row and the row is included in every profile's generated script (current and future).
+- [ ] EF migration drops the existing nullable `Hotstring.ProfileId` (and `Hotkey.ProfileId` if 022b hasn't already removed it). Dev DBs are scratch (per spec D7); no copy-forward SQL.
+- [ ] API DTOs gain `Guid[] ProfileIds` and `bool AppliesToAllProfiles`. Validation: when `AppliesToAllProfiles=true`, `ProfileIds` must be empty; when false, at least one profile must be selected.
+- [ ] List endpoints accept an optional `profileId` filter that returns rows in the junction OR with `AppliesToAllProfiles=true`.
+- [ ] Unit tests cover the validation invariant; integration tests cover create/update/delete flows for both entities under both modes.
+
+## Out of scope
+
+- UI changes (covered in 022 for hotkeys; hotstring UI revisit covered in note on 014).
+- Script generation logic (covered in 026).
+
+## Notes / dependencies
+
+- Depends on **024** (Profile entity must exist).
+- Required by **022, 022b, 026**.
+- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 2).

--- a/.claude/backlog/025-header-templates-per-profile.md
+++ b/.claude/backlog/025-header-templates-per-profile.md
@@ -1,4 +1,4 @@
-# 025 - Header templates per profile
+# 025 - Header & footer templates per profile
 
 ## Metadata
 
@@ -8,25 +8,27 @@
 
 ## Summary
 
-Allow users to define an AHK header template per profile that is prepended to generated `.ahk` scripts.
+Per-profile `HeaderTemplate` and `FooterTemplate` text fields, editable in the Profiles UI. Generated `.ahk` scripts are `{HeaderTemplate} + {generated rules} + {FooterTemplate}`.
 
 ## User story
 
-As a user, I want a header template per profile so that generated scripts include consistent metadata and setup code.
+As a user, I want each profile to carry its own AHK header and footer so I can customize boilerplate (e.g., a Gaming profile with different `SetCapsLockState` than Work).
 
 ## Acceptance criteria
 
-- [ ] Store a header template per profile.
-- [ ] UI provides an editor for the template.
-- [ ] Script generation prepends the header (if configured).
-- [ ] Validation enforces reasonable size limits.
-- [ ] Unit tests for template storage, validation, and size limits.
-- [ ] Integration tests ensure generated scripts include the header when configured.
+- [ ] `HeaderTemplate` (≤8000 chars) and `FooterTemplate` (≤4000 chars) on the `Profile` entity (defined in 024).
+- [ ] New profile defaults: `HeaderTemplate` seeded from `old_project_reference/AHKFlowOldMAUI/AHKFlow.API/Templates/header_template.txt`; `FooterTemplate=""`.
+- [ ] UI provides a textarea editor for both fields on the Profile detail/edit view (large, monospace).
+- [ ] API validates length limits and returns 400 with ProblemDetails on overflow.
+- [ ] Unit tests cover validation/length limits. Integration tests verify round-trip and that `GET /profiles/{id}` returns both fields.
 
 ## Out of scope
 
-- Template versioning.
+- Template versioning / history.
+- Per-user (cross-profile) default that overrides the seed.
 
 ## Notes / dependencies
 
-- Depends on 024.
+- This item is largely absorbed into **024** (templates land with the Profile entity in one PR). Kept as a backlog entry for the explicit "footer template" delta from the original 025 scope (header only).
+- Depends on **024**.
+- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 1, decision D3).

--- a/.claude/backlog/025-header-templates-per-profile.md
+++ b/.claude/backlog/025-header-templates-per-profile.md
@@ -17,7 +17,7 @@ As a user, I want each profile to carry its own AHK header and footer so I can c
 ## Acceptance criteria
 
 - [ ] `HeaderTemplate` (≤8000 chars) and `FooterTemplate` (≤4000 chars) on the `Profile` entity (defined in 024).
-- [ ] New profile defaults: `HeaderTemplate` seeded from `old_project_reference/AHKFlowOldMAUI/AHKFlow.API/Templates/header_template.txt`; `FooterTemplate=""`.
+- [ ] New profile defaults: `HeaderTemplate` seeded with the standard AHK v2 boilerplate defined in the design spec; `FooterTemplate=""`.
 - [ ] UI provides a textarea editor for both fields on the Profile detail/edit view (large, monospace).
 - [ ] API validates length limits and returns 400 with ProblemDetails on overflow.
 - [ ] Unit tests cover validation/length limits. Integration tests verify round-trip and that `GET /profiles/{id}` returns both fields.
@@ -31,4 +31,4 @@ As a user, I want each profile to carry its own AHK header and footer so I can c
 
 - This item is largely absorbed into **024** (templates land with the Profile entity in one PR). Kept as a backlog entry for the explicit "footer template" delta from the original 025 scope (header only).
 - Depends on **024**.
-- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 1, decision D3).
+- Design spec: `docs/superpowers/specs/2026-04-30-ahkflow-alignment-design.md` (Phase 1, decision D3).

--- a/.claude/backlog/026-generate-ahk-per-profile.md
+++ b/.claude/backlog/026-generate-ahk-per-profile.md
@@ -34,4 +34,4 @@ As a user, I want one `.ahk` per profile that I can download and run locally, wi
 ## Notes / dependencies
 
 - Depends on **022b, 024, 024b, 025**.
-- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 4).
+- Design spec: `docs/superpowers/specs/2026-04-30-ahkflow-alignment-design.md` (Phase 4).

--- a/.claude/backlog/026-generate-ahk-per-profile.md
+++ b/.claude/backlog/026-generate-ahk-per-profile.md
@@ -8,25 +8,30 @@
 
 ## Summary
 
-Generate valid AutoHotkey `.ahk` output per profile from stored hotstrings/hotkeys and header template.
+Generate a valid AutoHotkey `.ahk` script per profile. Output = `HeaderTemplate` + generated hotstrings + generated hotkeys + `FooterTemplate`. Includes any row that is in the profile's junction table OR has `AppliesToAllProfiles=true`.
 
 ## User story
 
-As a user, I want an `.ahk` script generated per profile so that I can download and run a single script representing my definitions.
+As a user, I want one `.ahk` per profile that I can download and run locally, with the rules I've defined for that profile (or marked "Any") translated to valid AutoHotkey syntax.
 
 ## Acceptance criteria
 
-- [ ] Generation is profile-scoped.
-- [ ] Output includes hotstrings and hotkeys defined in that profile.
-- [ ] Output prepends the header template if configured (see 025).
-- [ ] Output ordering is deterministic.
-- [ ] Unit tests for generation logic to validate formatting and deterministic ordering.
-- [ ] Integration tests generate scripts from seeded data and assert expected content and ordering.
+- [ ] New `AhkScriptGenerator` service in the Application layer; pure, testable, no DB calls.
+- [ ] Generation is profile-scoped: includes hotkeys/hotstrings where `(HotkeyProfile/HotstringProfile contains profileId) OR AppliesToAllProfiles=true`.
+- [ ] Output structure: `{Profile.HeaderTemplate}\n; --- Hotstrings ---\n{hotstrings}\n; --- Hotkeys ---\n{hotkeys}\n{Profile.FooterTemplate}`.
+- [ ] Hotkey translation: `^!+#` modifier prefix order = Ctrl, Alt, Shift, Win; line is `{modifiers}{Key}::{Action}, {Parameters}` (e.g. `^!a::Send, hello`).
+- [ ] Hotstring translation: `:{options}:{Trigger}::{Replacement}` where `options = "*?"` if `IsTriggerInsideWord`, plus the ending-character option per `IsEndingCharacterRequired` (matches old project's syntax).
+- [ ] Deterministic ordering: hotstrings ordered by `Trigger` ASC, hotkeys ordered by `Description` ASC.
+- [ ] Unit tests on `AhkScriptGenerator` cover: empty profile (just header+footer), each modifier combo, both `HotkeyAction` values, both hotstring option flags, ordering, "Any" inclusion logic.
+- [ ] Integration test: seed a profile + mixed hotkeys/hotstrings (some specific, some Any), generate script, assert exact expected text.
 
 ## Out of scope
 
-- Runtime execution of AutoHotkey.
+- Runtime execution of AutoHotkey (intentionally excluded).
+- Comments referencing source row IDs (could be added later for debugging).
+- Linting / validating that the generated AHK is syntactically correct beyond what our generator emits.
 
 ## Notes / dependencies
 
-- Depends on 013, 021, 025.
+- Depends on **022b, 024, 024b, 025**.
+- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 4).

--- a/.claude/backlog/026-generate-ahk-per-profile.md
+++ b/.claude/backlog/026-generate-ahk-per-profile.md
@@ -20,7 +20,7 @@ As a user, I want one `.ahk` per profile that I can download and run locally, wi
 - [ ] Generation is profile-scoped: includes hotkeys/hotstrings where `(HotkeyProfile/HotstringProfile contains profileId) OR AppliesToAllProfiles=true`.
 - [ ] Output structure: `{Profile.HeaderTemplate}\n; --- Hotstrings ---\n{hotstrings}\n; --- Hotkeys ---\n{hotkeys}\n{Profile.FooterTemplate}`.
 - [ ] Hotkey translation: `^!+#` modifier prefix order = Ctrl, Alt, Shift, Win; line is `{modifiers}{Key}::{Action}, {Parameters}` (e.g. `^!a::Send, hello`).
-- [ ] Hotstring translation: `:{options}:{Trigger}::{Replacement}` where `options` appends `*` when `IsEndingCharacterRequired=false` and appends `?` when `IsTriggerInsideWord=true` (matches the design spec / old project's syntax).
+- [ ] Hotstring translation: `:{options}:{Trigger}::{Replacement}` where `options` appends `*` when `IsEndingCharacterRequired=false` and appends `?` when `IsTriggerInsideWord=true`.
 - [ ] Deterministic ordering: hotstrings ordered by `Trigger` ASC, hotkeys ordered by `Description` ASC.
 - [ ] Unit tests on `AhkScriptGenerator` cover: empty profile (just header+footer), each modifier combo, both `HotkeyAction` values, both hotstring option flags, ordering, "Any" inclusion logic.
 - [ ] Integration test: seed a profile + mixed hotkeys/hotstrings (some specific, some Any), generate script, assert exact expected text.

--- a/.claude/backlog/026-generate-ahk-per-profile.md
+++ b/.claude/backlog/026-generate-ahk-per-profile.md
@@ -20,7 +20,7 @@ As a user, I want one `.ahk` per profile that I can download and run locally, wi
 - [ ] Generation is profile-scoped: includes hotkeys/hotstrings where `(HotkeyProfile/HotstringProfile contains profileId) OR AppliesToAllProfiles=true`.
 - [ ] Output structure: `{Profile.HeaderTemplate}\n; --- Hotstrings ---\n{hotstrings}\n; --- Hotkeys ---\n{hotkeys}\n{Profile.FooterTemplate}`.
 - [ ] Hotkey translation: `^!+#` modifier prefix order = Ctrl, Alt, Shift, Win; line is `{modifiers}{Key}::{Action}, {Parameters}` (e.g. `^!a::Send, hello`).
-- [ ] Hotstring translation: `:{options}:{Trigger}::{Replacement}` where `options = "*?"` if `IsTriggerInsideWord`, plus the ending-character option per `IsEndingCharacterRequired` (matches old project's syntax).
+- [ ] Hotstring translation: `:{options}:{Trigger}::{Replacement}` where `options` appends `*` when `IsEndingCharacterRequired=false` and appends `?` when `IsTriggerInsideWord=true` (matches the design spec / old project's syntax).
 - [ ] Deterministic ordering: hotstrings ordered by `Trigger` ASC, hotkeys ordered by `Description` ASC.
 - [ ] Unit tests on `AhkScriptGenerator` cover: empty profile (just header+footer), each modifier combo, both `HotkeyAction` values, both hotstring option flags, ordering, "Any" inclusion logic.
 - [ ] Integration test: seed a profile + mixed hotkeys/hotstrings (some specific, some Any), generate script, assert exact expected text.

--- a/.claude/backlog/027-download-generated-script-endpoint.md
+++ b/.claude/backlog/027-download-generated-script-endpoint.md
@@ -31,4 +31,4 @@ As a user, I want to download the generated script for a profile so that I can i
 ## Notes / dependencies
 
 - Depends on **026** (script generation).
-- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 5).
+- Design spec: `docs/superpowers/specs/2026-04-30-ahkflow-alignment-design.md` (Phase 5).

--- a/.claude/backlog/027-download-generated-script-endpoint.md
+++ b/.claude/backlog/027-download-generated-script-endpoint.md
@@ -1,31 +1,34 @@
-# 027 - Download generated script endpoint
+# 027 - Download generated script endpoint (per profile)
 
 ## Metadata
 
 - **Epic**: Script generation & download
 - **Type**: Feature
-- **Interfaces**: API
+- **Interfaces**: UI | API
 
 ## Summary
 
-Expose an authenticated endpoint to download the generated `.ahk` script for a given profile.
+Authenticated endpoint that returns the generated `.ahk` for a specific profile, plus a Downloads page in the UI listing profiles with a per-row Download button.
 
 ## User story
 
-As a user, I want to download the generated script so that I can install/use it locally.
+As a user, I want to download the generated script for a profile so that I can install/use it locally.
 
 ## Acceptance criteria
 
-- [ ] Endpoint returns `.ahk` content with appropriate content type and download headers.
-- [ ] Endpoint requires authentication/authorization (see 012).
-- [ ] Endpoint enforces profile-scoped access.
-- [ ] Integration tests verify content-type, content-disposition headers, authentication, and profile-scoped access.
-- [ ] Unit tests for controller/handler logic around response headers and access checks.
+- [ ] `GET /api/v1/downloads/{profileId}` returns `text/plain` (or `application/octet-stream`) with `Content-Disposition: attachment; filename="ahkflow_{profile_name}.ahk"`.
+- [ ] Endpoint is authenticated (per 012) and scoped to the user's own profiles (404 for other users' profileId).
+- [ ] UI: `Pages/Downloads.razor` lists every profile with a per-row Download button that triggers the endpoint.
+- [ ] Integration tests: content-type, content-disposition filename, auth challenge, owner scoping (other-user profileId returns 404).
+- [ ] Unit test on the controller wiring `AhkScriptGenerator` → bytes → response headers.
 
 ## Out of scope
 
-- Serving multiple script variants.
+- Bulk zip download (covered in **027b**).
+- Caching / ETag.
+- Multi-variant scripts (e.g., compressed, signed).
 
 ## Notes / dependencies
 
-- Depends on 026.
+- Depends on **026** (script generation).
+- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 5).

--- a/.claude/backlog/027b-bulk-zip-download.md
+++ b/.claude/backlog/027b-bulk-zip-download.md
@@ -30,4 +30,4 @@ As a user with several profiles, I want to download all my generated scripts in 
 ## Notes / dependencies
 
 - Depends on **026** and **027** (reuses the per-profile generator + endpoint behavior).
-- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 5, decision D5).
+- Design spec: `docs/superpowers/specs/2026-04-30-ahkflow-alignment-design.md` (Phase 5, decision D5).

--- a/.claude/backlog/027b-bulk-zip-download.md
+++ b/.claude/backlog/027b-bulk-zip-download.md
@@ -1,0 +1,33 @@
+# 027b - Bulk download (zip of every profile script)
+
+## Metadata
+
+- **Epic**: Script generation & download
+- **Type**: Feature
+- **Interfaces**: UI | API
+
+## Summary
+
+A single endpoint and UI button that returns a zip containing one `.ahk` per profile owned by the user.
+
+## User story
+
+As a user with several profiles, I want to download all my generated scripts in one zip so I don't have to click each profile individually.
+
+## Acceptance criteria
+
+- [ ] `GET /api/v1/downloads/zip` returns `application/zip` with `Content-Disposition: attachment; filename="ahkflow_scripts.zip"`.
+- [ ] Zip contains one entry per profile, named `ahkflow_{profile_name}.ahk` (sanitized to remove path-unsafe characters).
+- [ ] Endpoint authenticated; only the calling user's profiles are included.
+- [ ] UI: top-of-page button on `Pages/Downloads.razor` labelled "Download all (zip)".
+- [ ] Integration test: seed two profiles, hit the endpoint, assert zip entry count + filenames + content matches per-profile generator output.
+
+## Out of scope
+
+- Selecting a subset of profiles to zip.
+- Streaming for very large profile sets (we'll buffer; revisit if profile count grows).
+
+## Notes / dependencies
+
+- Depends on **026** and **027** (reuses the per-profile generator + endpoint behavior).
+- Design spec: `C:\Users\btase\.claude\plans\start-your-work-on-validated-walrus.md` (Phase 5, decision D5).

--- a/docs/superpowers/plans/2026-04-17-013-hotstrings-api-crud.md
+++ b/docs/superpowers/plans/2026-04-17-013-hotstrings-api-crud.md
@@ -4,7 +4,7 @@
 
 Backlog 013 asks for five REST endpoints (create / update / delete / get-by-id / list-by-profile) for hotstrings, secured, documented via OpenAPI, with unit + integration tests.
 
-The current repo is a greenfield .NET 10 rebuild — only `TestMessage` entity exists; no Hotstring/Profile code. The old MAUI-era AHKFlow at `C:\Dev\segocom-github\AHKFlowApp\old_project_reference\AHKFlowOldMAUI\` is the **semantic reference** for the feature: it has a working Hotstring domain shape, API, migrations, and UI. Port the **domain meaning** from there; do NOT copy its patterns (repository pattern, int Ids, global uniqueness, unprotected endpoints) — those conflict with the new project's AGENTS.md.
+The current repo is a greenfield .NET 10 rebuild — only `TestMessage` entity exists; no Hotstring/Profile code. The domain meaning (field names, AHK behavior flags, validation rules) is derived from the prior AHKFlow implementation. Port the **domain meaning**; do NOT copy its patterns (repository pattern, int Ids, global uniqueness, unprotected endpoints) — those conflict with the new project's AGENTS.md.
 
 **What 013 owns end-to-end** (none of this exists yet in either project in the right shape):
 1. Hotstring domain entity + EF config + migration.
@@ -28,14 +28,7 @@ The current repo is a greenfield .NET 10 rebuild — only `TestMessage` entity e
 | 7 | Dev-only seeder endpoint (improved) | Useful for manual demos and Swagger try-it-out without hand-crafting bodies |
 | 8 | Pagination on list | `page`/`pageSize` query params; `PagedResult<T>` envelope; default 50, max 200 |
 
-## What the old MAUI project tells us (key takeaways)
-
-Key files inspected:
-- `AHKFlow.Shared/Entities/Hotstring.cs` — entity shape
-- `AHKFlow.Shared/Validators/HotstringValidator.cs` — FluentValidation rules
-- `AHKFlow.API/Controllers/HotstringsController.cs` — endpoints
-- `AHKFLow.Data/Migrations/20230408090904_InitialMigration.cs` — SQLite schema
-- `AHKFlow.Service/AHKFlowApiConsumer.cs` — typed HTTP client (future ref for 014)
+## Domain shape reference
 
 ### Domain shape (port as-is for field names + semantics)
 
@@ -65,18 +58,18 @@ public int      ProfileId { get; set; }                         // FK, required
 | No `CreatedAt` / `UpdatedAt` | No audit trail | Add both, stamp via `TimeProvider` |
 | FluentValidation not pipeline-wired (manual) | Validators authored but bypassed | Auto-runs via `ValidationBehavior` pipeline |
 
-### Things old project had that new project is **missing** (and 013 needs some of)
+### Things 013 needs to add or defer
 
-| Missing in new | In old at | 013 action |
-|---|---|---|
-| `<GenerateDocumentationFile>true</GenerateDocumentationFile>` | Old also missing — both need it | **ADD** in `AHKFlowApp.API.csproj` |
-| `Swashbuckle.AspNetCore.Filters` (request/response examples) | `HotstringRequestExample.cs`, `HotstringResponseExample.cs` | **ADD** package + examples — gives 013 richer OpenAPI |
-| AutoHotkey behavior flags on entity | In `Hotstring.cs` | **ADD** `IsEndingCharacterRequired`, `IsTriggerInsideWord` |
-| `Profile` entity | `AHKFlow.Shared/Entities/Profile.cs` | **DEFER** — item 024. Use nullable `ProfileId` for now. |
-| Typed HTTP client (`AHKFlowApiConsumer`) | `AHKFlow.Service/AHKFlowApiConsumer.cs` | **DEFER** — item 014 (Blazor UI CRUD) |
-| MudBlazor hotstrings page | `AHKFlow.Wasm/Pages/Hotstrings.razor` | **DEFER** — item 014 |
-| Search/filter | client-side in Razor | **DEFER** — item 019 |
-| Seed data | `TestDataHelper.GetHotstrings()` (`btw`, `fyi`, `f2f`) | **ADD** — improved dev-only seeder endpoint, richer sample set + flag variations |
+| Item | 013 action |
+|---|---|
+| `<GenerateDocumentationFile>true</GenerateDocumentationFile>` | **ADD** in `AHKFlowApp.API.csproj` |
+| `Swashbuckle.AspNetCore.Filters` (request/response examples) | **ADD** package + examples — richer OpenAPI |
+| AutoHotkey behavior flags on entity | **ADD** `IsEndingCharacterRequired`, `IsTriggerInsideWord` |
+| `Profile` entity | **DEFER** — item 024. Use nullable `ProfileId` for now. |
+| Typed HTTP client | **DEFER** — item 014 (Blazor UI CRUD) |
+| MudBlazor hotstrings page | **DEFER** — item 014 |
+| Search/filter | **DEFER** — item 019 |
+| Seed data | **ADD** — improved dev-only seeder endpoint, richer sample set + flag variations |
 
 Other infra the new project **already has** and the old project lacked: `ICurrentUser` + Entra claim extraction, `ValidationBehavior` pipeline, `Testcontainers` SQL Server fixture, `TestAuthHandler` + `TestUserBuilder`, `TimeProvider` as singleton, Serilog, `ProblemDetails` with traceId, `Ardalis.Result.AspNetCore` package referenced. The new project is strictly ahead on platform; 013 just uses those pieces for the first time.
 

--- a/docs/superpowers/specs/2026-04-09-010-ci-cd-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-09-010-ci-cd-pipeline-design.md
@@ -7,7 +7,7 @@ Backlog item [`010-create-ci-cd-pipeline.md`](../../../.claude/backlog/010-creat
 - Item 009 (Docker) — just landed. Provides `src/Backend/AHKFlowApp.API/Dockerfile` and root `docker-compose.yml`. CI reuses the Dockerfile.
 - Item 003 (scaffold) — landed. Solution layout, `Directory.Build.props`, `global.json`, MinVer.
 
-`.github/workflows/` is currently empty. CLAUDE.md / AGENTS.md reference 4 aspirational workflow files — this spec implements them for real. Old project reference at `old_project_reference/AHKFlow` used zip-publish + SQL password auth + service principal; this spec modernises that pattern.
+`.github/workflows/` is currently empty. CLAUDE.md / AGENTS.md reference 4 aspirational workflow files — this spec implements them for real. The prior AHKFlow implementation used zip-publish + SQL password auth + service principal; this spec modernises that pattern with managed identity and container-based publishing.
 
 ## Goal
 

--- a/docs/superpowers/specs/2026-04-30-ahkflow-alignment-design.md
+++ b/docs/superpowers/specs/2026-04-30-ahkflow-alignment-design.md
@@ -1,0 +1,152 @@
+# Design Spec — AHKFlow alignment redesign
+
+> Replaces the prior 022-only plan (shipped). This is a new, larger redesign.
+
+## Context
+
+The just-shipped Hotkeys UI (backlog 022) uses a free-form `Trigger`/`Action`/`Description` model. The redesign aligns the Hotkeys page with the AHKFlow reference UI, with columns: **Description, Key, CTRL, ALT, SHIFT, Win, Action (enum dropdown), Profile (multi-select / "Any"), Parameters, Actions**.
+
+This is not a UI tweak. It requires reshaping the Hotkey domain, adding many-to-many profile association, wiring a real Profiles UI/API, and building per-profile script generation + download. Backlog items 024–027 already anticipate most of this; they need updates rather than wholesale rewrite.
+
+## Decisions (locked in by user during brainstorm)
+
+| # | Decision |
+|---|---|
+| D1 | **Profile association = many-to-many.** Junction tables `HotkeyProfile` and `HotstringProfile`. |
+| D2 | **"Any" = global flag.** Hotkey/Hotstring entity gets `AppliesToAllProfiles` bool. When true, junction is empty and the row is included in every profile's generated script (current and future). |
+| D3 | **Header + footer templates per profile.** Both stored on `Profile`, editable by the user. Seeded from defaults on profile creation. |
+| D4 | **Hotkey `Action` = extensible enum** (start with `Send`, `Run`; add later without schema break). `Parameters` is a separate string column. |
+| D5 | **Downloads UX = per-profile rows + bulk zip.** Each profile row has its own Download button; one top-level "Download all" zips every profile's `.ahk`. |
+| D6 | **Phase 0 = standalone docs PR.** Backlog rewrite lands by itself before any code phase. |
+| D7 | **Dev-only data preservation.** Migrations may drop columns / tables freely; no copy-forward SQL needed. (Revisit if PROD ever holds real user data.) |
+
+## Target domain model
+
+### Profile (new entity)
+```
+Id (Guid), OwnerOid (Guid), Name (string, ≤100, unique per owner),
+IsDefault (bool, exactly one true per owner),
+HeaderTemplate (string, ≤8000), FooterTemplate (string, ≤4000),
+CreatedAt, UpdatedAt
+```
+Default `HeaderTemplate` is a standard AHK v2 header (e.g. `#Requires AutoHotkey v2.0`, `#SingleInstance Force`, `SetCapsLockState "AlwaysOff"`, etc.). `FooterTemplate` defaults to empty string.
+
+### Hotkey (rebuild — drop `Trigger`/`Action`/`Description` strings)
+```
+Id, OwnerOid,
+Description (string, ≤200, required, primary identifier),
+Key (string, ≤20, required),                 -- single AHK key, e.g. "n", "F5", "Numpad0"
+Ctrl, Alt, Shift, Win (bool flags),
+Action (enum: Send=0, Run=1; extensible),
+Parameters (string, ≤4000),
+AppliesToAllProfiles (bool),
+CreatedAt, UpdatedAt
+```
+Junction: `HotkeyProfile (HotkeyId, ProfileId)` — empty when `AppliesToAllProfiles=true`.
+
+Unique index: `(OwnerOid, Key, Ctrl, Alt, Shift, Win)` — one mapping per modifier-combo per user.
+
+### Hotstring (mostly unchanged — schema already aligns)
+```
+Id, OwnerOid, Trigger, Replacement,
+IsEndingCharacterRequired, IsTriggerInsideWord,
+AppliesToAllProfiles (NEW),
+CreatedAt, UpdatedAt
+```
+Drop existing nullable `ProfileId` column; replace with junction `HotstringProfile (HotstringId, ProfileId)`.
+
+## Decomposition (six phases)
+
+Each phase = one PR. Items map to existing backlog items where possible.
+
+### Phase 0 — Backlog rewrite (no code) ✅
+Update items 022, 024, 025, 026, 027; add items 022b, 024b, 027b. Each item gets its acceptance criteria adjusted to the locked-in decisions.
+
+### Phase 1 — Profile foundation (touches: Domain, Application, Infrastructure, API, UI)
+- New `Profile` entity + EF configuration + migration.
+- Default-profile seeding on first sign-in (interceptor or login handler).
+- API: `ProfilesController` (GET list, GET id, POST, PUT, DELETE) with header/footer fields.
+- UI: `Pages/Profiles.razor` — list + inline edit; expand-row textareas for header/footer (large, monospace).
+- Maps to backlog **024 + 025** (combined; templates land with the entity).
+
+### Phase 2 — Many-to-many profile association (touches: Domain, Infrastructure, API, UI for Hotstrings only at first)
+- Add `AppliesToAllProfiles` to Hotstring; create `HotstringProfile` junction; migration that copies the existing single `ProfileId` into the junction (one row each) and drops the old column.
+- API: Hotstring DTOs gain `Guid[] ProfileIds` + `bool AppliesToAllProfiles`.
+- Hotstrings UI: replace single-profile picker with multi-select + "Any" checkbox row.
+- Existing 014 hotstring tests adapted; new tests for "Any" flag.
+- Maps to backlog **024b**.
+
+### Phase 3 — Hotkey rebuild (touches: Domain, Application, Infrastructure, API, UI)
+- Rebuild `Hotkey` to the target schema. Migration drops `Trigger`/`Action`/`Description` columns and the nullable `ProfileId`; adds `Description` (required), `Key`, `Ctrl/Alt/Shift/Win`, `Action` enum (int), `Parameters`, `AppliesToAllProfiles`. Junction `HotkeyProfile`.
+- API: rebuild DTOs/validators/handlers/controller. Backward-incompatible. Existing 021 + 022 tests are largely thrown out and rewritten.
+- UI: rebuild `Pages/Hotkeys.razor` — Description, Key (single text input), Ctrl/Alt/Shift/Win (MudCheckBox), Action (MudSelect bound to enum), Profile (MudSelect multi-select with "Any" toggle), Parameters (MudTextField), Actions.
+- Maps to **022 (replace)** + **022b**.
+
+### Phase 4 — Script generation
+- New `AhkScriptGenerator` service in Application layer. Per-profile output:
+  ```
+  {profile.HeaderTemplate}
+  ; --- Hotstrings ---
+  ...generated lines using IsEndingCharacterRequired + IsTriggerInsideWord...
+  ; --- Hotkeys ---
+  ...modifiers + key + Action(Send|Run) + Parameters...
+  {profile.FooterTemplate}
+  ```
+- Includes hotkeys/hotstrings where the row is in `{Profile}Profile` junction OR `AppliesToAllProfiles=true`.
+- Deterministic ordering: hotstrings by `Trigger` ASC, hotkeys by `Description` ASC.
+- AHK v2 syntax: `^!+#` modifier prefix order = Ctrl, Alt, Shift, Win; hotstring format `:options:trigger::replacement`; option `*` = no ending character required, `?` = trigger inside word.
+- Pure unit tests on the generator + integration test against seeded data.
+- Maps to **026**.
+
+### Phase 5 — Downloads page + endpoints
+- API: `GET /api/v1/downloads/{profileId}` returns one `.ahk`; `GET /api/v1/downloads/zip` returns a zip of every profile's `.ahk`.
+- UI: `Pages/Downloads.razor` — list profiles with per-row Download button, plus a top-level "Download all (zip)" button.
+- Maps to **027** + **027b**.
+
+## Files (representative, not exhaustive)
+
+- `src/Backend/AHKFlowApp.Domain/Entities/Profile.cs` (new)
+- `src/Backend/AHKFlowApp.Domain/Entities/Hotkey.cs` (rebuild)
+- `src/Backend/AHKFlowApp.Domain/Entities/Hotstring.cs` (add `AppliesToAllProfiles`)
+- `src/Backend/AHKFlowApp.Domain/Entities/HotkeyProfile.cs`, `HotstringProfile.cs` (new junctions)
+- `src/Backend/AHKFlowApp.Domain/Enums/HotkeyAction.cs` (new enum)
+- `src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/{Profile,Hotkey,Hotstring,HotkeyProfile,HotstringProfile}Configuration.cs`
+- `src/Backend/AHKFlowApp.Infrastructure/Migrations/...` (one per phase)
+- `src/Backend/AHKFlowApp.Application/Services/AhkScriptGenerator.cs` (new)
+- `src/Backend/AHKFlowApp.API/Controllers/{Profiles,Downloads}Controller.cs` (new); rebuild `HotkeysController.cs`
+- `src/Frontend/AHKFlowApp.UI.Blazor/Pages/{Profiles,Hotkeys,Hotstrings,Downloads}.razor`
+- `.claude/backlog/{022,022b,024,024b,025,026,027,027b}.md`
+
+## Files NOT touched
+
+- `tests/AHKFlowApp.E2E.Tests` (no E2E in this stream)
+- CI/CD workflows
+- MSAL / auth wiring
+- AppInsights / Serilog config
+- Dockerfile / docker-compose
+
+## Verification (per phase)
+
+1. `dotnet test --configuration Release --no-build` passes.
+2. `dotnet format` clean.
+3. Manual smoke after Phase 3: create two profiles, add a hotkey with "Any" + a hotkey with one specific profile + a hotstring; download both profiles; inspect `.ahk` for correct header, modifier prefixes, hotstring options, footer.
+4. Phase 5 final smoke: bulk zip downloads correct number of files, each named `ahkflow_{profile_name}.ahk`.
+
+## Out of scope (for THIS spec)
+
+- Search/filter UI (backlog 023 for hotkeys; 019 for hotstrings — separate work).
+- CLI changes (017/018/028/029).
+- Profile import/export.
+- Template versioning.
+- Key-capture widget for the Key field — plain text input only (`MudTextField`); user types `n`, `F5`, `Numpad0`. Capture widget can come later.
+- Runtime execution of AHK scripts.
+
+## Decisions log
+
+- Profile assoc model → many-to-many (D1)
+- "Any" semantics → global flag (D2)
+- Templates editable → per-profile, editable (D3)
+- Action field → extensible enum (D4)
+- Download UX → per-profile + zip (D5)
+- Phase 0 packaging → standalone docs PR first (D6)
+- Data preservation → dev-only, destructive migrations OK (D7)


### PR DESCRIPTION
M2M profile assoc + AppliesToAllProfiles flag; Hotkey schema rebuild (Description/Key/modifiers/Action enum/Parameters); per-profile header
+ footer templates; per-profile + bulk zip downloads. Adds 022b/024b/ 027b; reopens 022 with new ACs; supersedes 021.

## Summary

Brief description of changes.

## Checklist

- [ ] Tests pass (`dotnet test`)
- [ ] Build succeeds (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Breaking changes documented (if any)
