### PR TITLE
fix(coverage): pin Add-Content encoding to UTF-8

### DIFF
--- a/scripts/run-coverage.ps1
+++ b/scripts/run-coverage.ps1
@@ -58,7 +58,7 @@ try {
         $summaryFooter = & python $thresholdScriptPath --github-summary-footer
         if ($LASTEXITCODE -ne 0) { throw "Failed to generate the coverage summary footer." }
 
-        Add-Content -Path $summaryGithubPath -Value $summaryFooter
+        Add-Content -Path $summaryGithubPath -Value $summaryFooter -Encoding utf8
     }
 
     if (-not $SkipThresholdCheck) {


### PR DESCRIPTION
Follow-up to #105.

## Why
`run-coverage.ps1` appends the threshold footer to `CoverageReport/SummaryGithub.md` via `Add-Content` without a pinned encoding. Windows PowerShell 5.1 defaults to ANSI (system codepage); pwsh 7+ defaults to UTF-8 without BOM. CI runs on Linux pwsh (UTF-8). Locally on Windows PowerShell 5.1 the same file would be written as ANSI — invisible today since the footer is pure ASCII after the recent `>=` rewrite, but a latent risk if any non-ASCII character (em dash, percent sign variants, etc.) ever lands in the footer.

## Change
`Add-Content ... -Encoding utf8`. PS 5.1-compatible, matches CI output, removes the only place where local vs CI summaries could diverge silently.

## Test
- Generated footer locally: file content unchanged, just guaranteed UTF-8 on disk.
- No CI behavior change (CI never ran the local script).