### PR TITLE
refactor: drop no-op ignoreCase param from list queries

### DIFF
--- a/src/Backend/AHKFlowApp.API/Controllers/HotkeysController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/HotkeysController.cs
@@ -25,11 +25,10 @@ public sealed class HotkeysController(IMediator mediator) : ControllerBase
     public async Task<ActionResult<PagedList<HotkeyDto>>> List(
         [FromQuery] Guid? profileId,
         [FromQuery] string? search = null,
-        [FromQuery] bool ignoreCase = true,
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 50,
         CancellationToken ct = default) =>
-        (await mediator.Send(new ListHotkeysQuery(profileId, search, ignoreCase, page, pageSize), ct)).ToProblemActionResult(this);
+        (await mediator.Send(new ListHotkeysQuery(profileId, search, page, pageSize), ct)).ToProblemActionResult(this);
 
     /// <summary>Get a hotkey by id.</summary>
     [HttpGet("{id:guid}", Name = "GetHotkey")]

--- a/src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs
@@ -25,11 +25,10 @@ public sealed class HotstringsController(IMediator mediator) : ControllerBase
     public async Task<ActionResult<PagedList<HotstringDto>>> List(
         [FromQuery] Guid? profileId,
         [FromQuery] string? search = null,
-        [FromQuery] bool ignoreCase = true,
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 50,
         CancellationToken ct = default) =>
-        (await mediator.Send(new ListHotstringsQuery(profileId, search, ignoreCase, page, pageSize), ct)).ToProblemActionResult(this);
+        (await mediator.Send(new ListHotstringsQuery(profileId, search, page, pageSize), ct)).ToProblemActionResult(this);
 
     /// <summary>Get a hotstring by id.</summary>
     [HttpGet("{id:guid}", Name = "GetHotstring")]

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
@@ -11,7 +11,6 @@ namespace AHKFlowApp.Application.Queries.Hotkeys;
 public sealed record ListHotkeysQuery(
     Guid? ProfileId = null,
     string? Search = null,
-    bool IgnoreCase = true,
     int Page = 1,
     int PageSize = 50) : IRequest<Result<PagedList<HotkeyDto>>>;
 

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
@@ -11,7 +11,6 @@ namespace AHKFlowApp.Application.Queries.Hotstrings;
 public sealed record ListHotstringsQuery(
     Guid? ProfileId = null,
     string? Search = null,
-    bool IgnoreCase = true,
     int Page = 1,
     int PageSize = 50) : IRequest<Result<PagedList<HotstringDto>>>;
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
@@ -208,7 +208,6 @@
             page: state.Page + 1,
             pageSize: state.PageSize,
             search: string.IsNullOrWhiteSpace(_search) ? null : _search,
-            ignoreCase: true,
             ct: ct);
 
         _loading = false;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -186,7 +186,6 @@
             page: state.Page + 1,
             pageSize: state.PageSize,
             search: string.IsNullOrWhiteSpace(_search) ? null : _search,
-            ignoreCase: true,
             ct: ct);
 
         _loading = false;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/HotkeysApiClient.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/HotkeysApiClient.cs
@@ -7,12 +7,11 @@ public sealed class HotkeysApiClient(HttpClient httpClient) : ApiClientBase(http
 {
     private const string BasePath = "api/v1/hotkeys";
 
-    public Task<ApiResult<PagedList<HotkeyDto>>> ListAsync(Guid? profileId, int page, int pageSize, string? search = null, bool ignoreCase = true, CancellationToken ct = default)
+    public Task<ApiResult<PagedList<HotkeyDto>>> ListAsync(Guid? profileId, int page, int pageSize, string? search = null, CancellationToken ct = default)
     {
         string query = $"?page={page}&pageSize={pageSize}";
         if (profileId is { } pid) query += $"&profileId={pid}";
         if (!string.IsNullOrWhiteSpace(search)) query += $"&search={Uri.EscapeDataString(search)}";
-        if (!ignoreCase) query += "&ignoreCase=false";
         return SendAsync<PagedList<HotkeyDto>>(HttpMethod.Get, BasePath + query, content: null, ct);
     }
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/HotstringsApiClient.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/HotstringsApiClient.cs
@@ -7,12 +7,11 @@ public sealed class HotstringsApiClient(HttpClient httpClient) : ApiClientBase(h
 {
     private const string BasePath = "api/v1/hotstrings";
 
-    public Task<ApiResult<PagedList<HotstringDto>>> ListAsync(Guid? profileId, int page, int pageSize, string? search = null, bool ignoreCase = true, CancellationToken ct = default)
+    public Task<ApiResult<PagedList<HotstringDto>>> ListAsync(Guid? profileId, int page, int pageSize, string? search = null, CancellationToken ct = default)
     {
         string query = $"?page={page}&pageSize={pageSize}";
         if (profileId is { } pid) query += $"&profileId={pid}";
         if (!string.IsNullOrWhiteSpace(search)) query += $"&search={Uri.EscapeDataString(search)}";
-        if (!ignoreCase) query += "&ignoreCase=false";
         return SendAsync<PagedList<HotstringDto>>(HttpMethod.Get, BasePath + query, content: null, ct);
     }
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/IHotkeysApiClient.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/IHotkeysApiClient.cs
@@ -4,7 +4,7 @@ namespace AHKFlowApp.UI.Blazor.Services;
 
 public interface IHotkeysApiClient
 {
-    Task<ApiResult<PagedList<HotkeyDto>>> ListAsync(Guid? profileId, int page, int pageSize, string? search = null, bool ignoreCase = true, CancellationToken ct = default);
+    Task<ApiResult<PagedList<HotkeyDto>>> ListAsync(Guid? profileId, int page, int pageSize, string? search = null, CancellationToken ct = default);
     Task<ApiResult<HotkeyDto>> GetAsync(Guid id, CancellationToken ct = default);
     Task<ApiResult<HotkeyDto>> CreateAsync(CreateHotkeyDto input, CancellationToken ct = default);
     Task<ApiResult<HotkeyDto>> UpdateAsync(Guid id, UpdateHotkeyDto input, CancellationToken ct = default);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/IHotstringsApiClient.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/IHotstringsApiClient.cs
@@ -4,7 +4,7 @@ namespace AHKFlowApp.UI.Blazor.Services;
 
 public interface IHotstringsApiClient
 {
-    Task<ApiResult<PagedList<HotstringDto>>> ListAsync(Guid? profileId, int page, int pageSize, string? search = null, bool ignoreCase = true, CancellationToken ct = default);
+    Task<ApiResult<PagedList<HotstringDto>>> ListAsync(Guid? profileId, int page, int pageSize, string? search = null, CancellationToken ct = default);
     Task<ApiResult<HotstringDto>> GetAsync(Guid id, CancellationToken ct = default);
     Task<ApiResult<HotstringDto>> CreateAsync(CreateHotstringDto input, CancellationToken ct = default);
     Task<ApiResult<HotstringDto>> UpdateAsync(Guid id, UpdateHotstringDto input, CancellationToken ct = default);

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
@@ -56,11 +56,11 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
         new(items, 1, 50, items.Length, 1, false, false);
 
     private void StubList(PagedList<HotkeyDto> page) =>
-        _api.ListAsync(Arg.Any<Guid?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+        _api.ListAsync(Arg.Any<Guid?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult<PagedList<HotkeyDto>>.Ok(page));
 
     private void StubListFailure(ApiResultStatus status, ApiProblemDetails? problem = null) =>
-        _api.ListAsync(Arg.Any<Guid?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+        _api.ListAsync(Arg.Any<Guid?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult<PagedList<HotkeyDto>>.Failure(status, problem));
 
     [Fact]

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -52,11 +52,11 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         new(items, 1, 50, items.Length, 1, false, false);
 
     private void StubList(PagedList<HotstringDto> page) =>
-        _api.ListAsync(Arg.Any<Guid?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+        _api.ListAsync(Arg.Any<Guid?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult<PagedList<HotstringDto>>.Ok(page));
 
     private void StubListFailure(ApiResultStatus status, ApiProblemDetails? problem = null) =>
-        _api.ListAsync(Arg.Any<Guid?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+        _api.ListAsync(Arg.Any<Guid?>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult<PagedList<HotstringDto>>.Failure(status, problem));
 
     [Fact]


### PR DESCRIPTION
SQL Server CI collation makes it redundant — remove from queries, controllers, frontend clients, pages, and bUnit test stubs.

## Summary

Brief description of changes.

## Checklist

- [ ] Tests pass (`dotnet test`)
- [ ] Build succeeds (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Breaking changes documented (if any)
