### PR TITLE
[codex] Document release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Each Azure environment (TEST/PROD) has isolated resources:
 
 See `docs/deployment/getting-started.md` for provisioning instructions.
 
+### Releases
+
+Versioning and GitHub Release creation use MinVer tags. See [docs/development/versioning.md](docs/development/versioning.md) for the release process, including CLI package publishing.
+
 ```bash
 dotnet restore AHKFlowApp.slnx
 dotnet build AHKFlowApp.slnx --configuration Release --no-restore

--- a/docs/development/versioning.md
+++ b/docs/development/versioning.md
@@ -4,7 +4,7 @@ AHKFlowApp uses [MinVer](https://github.com/adamralph/minver) for automated sema
 
 ## Quick Start
 
-### Create a Release
+### Create a Release Tag
 
 1. **Tag the commit:**
    ```bash
@@ -18,6 +18,92 @@ AHKFlowApp uses [MinVer](https://github.com/adamralph/minver) for automated sema
    ```
 
 That's it! MinVer automatically calculates and injects the version.
+
+## GitHub Release Process
+
+Use this process after the release commit has been merged to `main`.
+
+### 1. Choose the version
+
+Use SemVer and the repository tag prefix `v`:
+
+- `v1.0.1` for a bug fix.
+- `v1.1.0` for a backward-compatible feature release.
+- `v2.0.0` for a breaking release.
+
+For a first public or early CLI release, prefer a conservative version such as `v0.1.0` unless the product is ready for `v1.0.0`.
+
+### 2. Create and push the tag
+
+```powershell
+git switch main
+git pull --ff-only origin main
+
+$tag = "v0.1.0"
+
+git tag -a $tag -m "Release $tag"
+git push origin $tag
+```
+
+Pushing a `v*` tag triggers the release workflows that listen for version tags.
+
+### 3. CLI release prerequisites
+
+The `Release CLI` workflow packages `ahkflow-win-x64.zip` and creates or updates a GitHub Release. Before pushing the tag, confirm these production values are configured in GitHub:
+
+- Repository secret: `AZURE_API_BASE_URL_PROD`
+- Repository variable: `AZURE_AD_CLIENT_ID_PROD`
+- Repository variable: `AZURE_AD_TENANT_ID_PROD`
+
+The workflow injects these values into the packaged `appsettings.json`. Do not commit production values to source control.
+
+### 4. Watch the workflow
+
+```powershell
+gh run list --workflow "Release CLI" --limit 5
+gh run watch
+```
+
+When the workflow completes, open the release:
+
+```powershell
+gh release view $tag --web
+```
+
+The release should include `ahkflow-win-x64.zip`.
+
+### 5. Manual release workflow rerun
+
+If the tag already exists and you need to rebuild or re-upload the CLI asset, run the workflow manually with the same tag:
+
+```powershell
+gh workflow run "Release CLI" -f tag=$tag
+gh run watch
+```
+
+The workflow validates that the tag exists and starts with `v`.
+
+### 6. Smoke test the published CLI
+
+After the GitHub Release asset is published:
+
+1. Download `ahkflow-win-x64.zip` from the release.
+2. Extract it on Windows.
+3. Run:
+
+   ```powershell
+   .\ahkflow.exe --help
+   .\ahkflow.exe login
+   .\ahkflow.exe hotstring list
+   .\ahkflow.exe logout
+   ```
+
+Expected results:
+
+- `--help` exits successfully and lists the CLI commands.
+- `login` completes device-code sign-in against production Entra configuration.
+- `hotstring list` reaches the production API without local `AHKFLOW_` environment variables.
+- `logout` clears local sign-in state.
 
 ## How It Works
 


### PR DESCRIPTION
## Summary
- Document the MinVer-based GitHub Release process.
- Add CLI release workflow prerequisites and manual rerun steps.
- Link the release docs from the README.

## Test Plan
- git diff --check -- README.md docs/development/versioning.md
- pre-push hook ran build, tests, and coverage verification successfully