### PR TITLE
docs(030): close backlog 030 — AC5 smoke-tested via v0.1.1

### DIFF
--- a/.claude/backlog/030-cli-native-windows-distribution.md
+++ b/.claude/backlog/030-cli-native-windows-distribution.md
@@ -21,20 +21,17 @@ As a Windows user, I want to install the AHKFlow CLI and immediately run `ahkflo
 - [x] The published artifact contains an executable users can run as `ahkflow.exe`.
 - [x] The published CLI includes production `ApiBaseUrl`, `ClientId`, and `TenantId` configuration so users do not need environment variables for normal use.
 - [x] The zip includes minimal install instructions for adding the extracted folder to `PATH`.
-- [ ] `ahkflow login`, `ahkflow hotstring list`, and `ahkflow logout` work from the extracted zip against production services.
+- [x] `ahkflow login`, `ahkflow hotstring list`, and `ahkflow logout` work from the extracted zip against production services.
 - [x] Release documentation explains the supported install path and how to uninstall or remove the local token cache.
 - [x] A follow-up installer path is documented, either Winget or an MSI/MSIX installer, with the chosen direction recorded.
 
-## Status
+---
 
-**Implementation completed:** 2026-05-11
-**Production acceptance:** Pending manual smoke test from the published GitHub Release asset
+**Completed:** 2026-05-13 (v0.1.1 zip smoke-tested against prod: login, hotstring list, logout all passed without `AHKFLOW_` overrides; v0.1.0 had insufficient cold-start timeouts, fixed in v0.1.1)
 
 Release channel: GitHub Releases with `ahkflow-win-x64.zip`.
 
 Follow-up installer direction: Winget, after the zip release asset is stable.
-
-Criteria 1-4 and 6-7 are implemented. Criterion 5 remains open until the released zip is smoke-tested against production without `AHKFLOW_` overrides.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

- Ticks AC 5 in backlog 030: `ahkflow login`, `ahkflow hotstring list`, and `ahkflow logout` all passed against production from the extracted v0.1.1 zip without `AHKFLOW_` env overrides
- v0.1.0 failed due to insufficient cold-start timeouts (Polly 10s/attempt, 30s total); v0.1.1 ships the retry + UX fixes and passes
- Updates status block to **Completed:** 2026-05-13

## Test plan

- [x] Smoke test run manually from `ahkflow-win-x64.zip` (v0.1.1) against prod — login (device-code), hotstring list (returned rows after 2 cold-start retries), logout (signed out), post-logout list (correctly blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)