### PR TITLE
ci: skip build/test on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,37 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # MinVer needs full history for version derivation
+      - name: Detect non-docs changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+              - '!.claude/**'
+      - name: Skip notice (docs-only PR)
+        if: steps.filter.outputs.code == 'false'
+        run: echo "Docs-only changes detected — skipping build, test, and coverage." >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/setup-dotnet@v4
+        if: steps.filter.outputs.code == 'true'
         with:
           global-json-file: global.json
           cache: true
           cache-dependency-path: '**/*.csproj'
-      - run: dotnet restore
-      - run: dotnet build --configuration Release --no-restore
+      - if: steps.filter.outputs.code == 'true'
+        run: dotnet restore
+      - if: steps.filter.outputs.code == 'true'
+        run: dotnet build --configuration Release --no-restore
       - name: CLI --help smoke test
+        if: steps.filter.outputs.code == 'true'
         run: dotnet run --project src/Tools/AHKFlowApp.CLI --no-build --configuration Release -- --help
       - name: CLI hotstring --help smoke test
+        if: steps.filter.outputs.code == 'true'
         run: dotnet run --project src/Tools/AHKFlowApp.CLI --no-build --configuration Release -- hotstring --help
       - name: Test with coverage
+        if: steps.filter.outputs.code == 'true'
         run: >
           dotnet test --configuration Release --no-build --verbosity normal
           --logger "trx;LogFileName=test-results.trx"
@@ -37,33 +56,33 @@ jobs:
           --results-directory TestResults
           --settings coverlet.runsettings
       - name: Merge coverage reports
-        if: always()
+        if: always() && steps.filter.outputs.code == 'true'
         uses: danielpalme/ReportGenerator-GitHub-Action@5.3.0
         with:
           reports: 'TestResults/**/coverage.cobertura.xml'
           targetdir: 'CoverageReport'
           reporttypes: 'MarkdownSummaryGithub;JsonSummary;HtmlInline_AzurePipelines;Cobertura'
       - name: Append coverage guidance to summary
-        if: always()
+        if: always() && steps.filter.outputs.code == 'true'
         run: |
           mkdir -p CoverageReport
           python scripts/check-coverage-thresholds.py --github-summary-footer >> CoverageReport/SummaryGithub.md
       - name: Append coverage summary to job summary
-        if: always()
+        if: always() && steps.filter.outputs.code == 'true'
         run: cat CoverageReport/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"
       - name: Publish test results
-        if: always()
+        if: always() && steps.filter.outputs.code == 'true'
         uses: EnricoMi/publish-unit-test-result-action/linux@v2
         with:
           files: 'TestResults/**/*.trx'
       - name: Sticky coverage comment
-        if: always() && github.event_name == 'pull_request'
+        if: always() && steps.filter.outputs.code == 'true' && github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: coverage
           path: CoverageReport/SummaryGithub.md
       - name: Upload coverage artifacts
-        if: always()
+        if: always() && steps.filter.outputs.code == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
@@ -72,9 +91,10 @@ jobs:
             TestResults/**/*.trx
           retention-days: 14
       - name: Enforce per-assembly coverage thresholds
-        if: always()
+        if: always() && steps.filter.outputs.code == 'true'
         run: python scripts/check-coverage-thresholds.py
-      - run: dotnet format --verify-no-changes
+      - if: steps.filter.outputs.code == 'true'
+        run: dotnet format --verify-no-changes
 
   bicep-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0  # MinVer needs full history for version derivation
       - name: Detect non-docs changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4.0.1
         with:
           predicate-quantifier: 'every'
           filters: |


### PR DESCRIPTION
## Summary
- Gate heavy steps in `build-test` on `dorny/paths-filter@v3` — when a PR touches only `**/*.md`, `docs/**`, or `.claude/**`, build/test/coverage are skipped.
- Job still runs and reports `success`, so the required status check on `main` is satisfied (paths-ignore would have stranded docs-only PRs).
- Example pain point: #123 ran the full pipeline on a markdown-only change.

## How it works
1. New `Detect non-docs changes` step uses `predicate-quantifier: every` + negation filters. Output `code=true` iff at least one changed file is *not* docs-only.
2. Every subsequent step is wrapped with `if: steps.filter.outputs.code == 'true'`.
3. Docs-only runs emit a one-line job summary noting the skip.

## Test plan
- [ ] Open this PR — `build-test` should run fully (non-docs change to `.github/workflows/ci.yml`).
- [ ] Verify a follow-up docs-only PR (or rebase #123 onto this) reports `build-test: success` with the "Docs-only changes detected" summary and no dotnet steps executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)