### PR TITLE
chore: gitignore C# Dev Kit lscache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,6 +410,9 @@ FodyWeavers.xsd
 # Local History for Visual Studio Code
 .history/
 
+# C# Dev Kit language service caches (regenerated automatically — https://aka.ms/lscache)
+*.csproj.lscache
+
 # Built Visual Studio Code Extensions
 *.vsix
 


### PR DESCRIPTION
## Summary
The C# Dev Kit VS Code extension writes `*.csproj.lscache` files next to each project for design-time evaluation perf. They are local-only and regenerate automatically (see https://aka.ms/lscache). Ignoring them removes 14 untracked files from `git status` for anyone using C# Dev Kit on this repo.

## Test plan
- [ ] `git status` shows no `*.csproj.lscache` entries after merge.
- [ ] `git check-ignore -v src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj.lscache` matches the new rule.
- [ ] Existing tracked files are unaffected (the rule is narrow: `*.csproj.lscache`, not `*.lscache` or `*cache*`).