### PR TITLE
fix(cli): wire MinVer and enforce release-asset immutability

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -213,7 +213,25 @@ jobs:
               }
           }
           else {
-              gh release upload $env:RELEASE_TAG $zipPath --clobber
+              $assetName = Split-Path $zipPath -Leaf
+
+              # Reaching this branch means the outer `gh release view` succeeded,
+              # so the release definitely exists. A failure to enumerate its
+              # assets here is therefore an auth/API/transient error, not a
+              # signal that the release is empty. Treat any non-zero exit as
+              # fatal — silently falling through would risk overwriting an
+              # already-published asset via the unconditional `gh release upload`
+              # below, breaking the immutability promise this step exists to keep.
+              $existingAssets = gh release view $env:RELEASE_TAG --json assets --jq ".assets[].name"
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Could not enumerate assets for tag $($env:RELEASE_TAG) (gh release view exit code $LASTEXITCODE). Refusing to upload without knowing the current asset state."
+              }
+
+              if ($existingAssets -split "`n" -contains $assetName) {
+                  throw "Release asset '$assetName' is already published for tag $($env:RELEASE_TAG). Treating release assets as immutable. To ship a new build, cut a new tag."
+              }
+
+              gh release upload $env:RELEASE_TAG $zipPath
               if ($LASTEXITCODE -ne 0) {
                   throw "gh release upload failed with exit code $LASTEXITCODE."
               }

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -169,10 +169,11 @@ jobs:
               throw "ahkflow.exe --help failed with exit code $LASTEXITCODE."
           }
 
-          # Strip any pre-release/build suffix from the tag so the comparison
-          # is symmetric with $actualVersion (which only carries the SemVer
-          # core MAJOR.MINOR.PATCH after the regex below).
-          $expectedVersion = ($env:RELEASE_TAG.TrimStart("v") -replace '[+-].*$', '')
+          # Drop only the +build metadata from the tag. Pre-release components
+          # (e.g. -rc.1) MUST be preserved so the gate compares full SemVer
+          # identity, not just MAJOR.MINOR.PATCH; otherwise a v0.1.3-rc.1 tag
+          # would accept a binary reporting 0.1.3-beta.9.
+          $expectedVersion = ($env:RELEASE_TAG.TrimStart("v") -replace '\+.*$', '')
 
           # Capture stdout only. The CLI configures Serilog to write to stderr,
           # so any future startup banner on stderr must not be allowed to push
@@ -184,10 +185,10 @@ jobs:
 
           $versionText = ($versionOutput -join "`n")
 
-          # Match the first SemVer token in the output, with optional +build
-          # or -prerelease tail. Robust to extra lines and to System.CommandLine
-          # changing its surrounding wording.
-          if ($versionText -notmatch '\b(\d+\.\d+\.\d+)(?:[+-][^\s]*)?\b') {
+          # Capture MAJOR.MINOR.PATCH plus optional -prerelease (group 1),
+          # discarding any trailing +build metadata. The full SemVer identity
+          # is what we compare against the tag.
+          if ($versionText -notmatch '\b(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)(?:\+[0-9A-Za-z.-]+)?') {
               throw "Could not find a SemVer token in --version output. Raw output: '$versionText'"
           }
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -169,7 +169,10 @@ jobs:
               throw "ahkflow.exe --help failed with exit code $LASTEXITCODE."
           }
 
-          $expectedVersion = $env:RELEASE_TAG.TrimStart("v")
+          # Strip any pre-release/build suffix from the tag so the comparison
+          # is symmetric with $actualVersion (which only carries the SemVer
+          # core MAJOR.MINOR.PATCH after the regex below).
+          $expectedVersion = ($env:RELEASE_TAG.TrimStart("v") -replace '[+-].*$', '')
 
           # Capture stdout only. The CLI configures Serilog to write to stderr,
           # so any future startup banner on stderr must not be allowed to push

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -168,6 +168,30 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
               throw "ahkflow.exe --help failed with exit code $LASTEXITCODE."
           }
+
+          $expectedVersion = $env:RELEASE_TAG.TrimStart("v")
+
+          # Capture stdout only. The CLI configures Serilog to write to stderr,
+          # so any future startup banner on stderr must not be allowed to push
+          # the version line past our parser (which is why we do NOT use 2>&1).
+          $versionOutput = & (Join-Path $extractPath "ahkflow.exe") --version
+          if ($LASTEXITCODE -ne 0) {
+              throw "ahkflow.exe --version failed with exit code $LASTEXITCODE."
+          }
+
+          $versionText = ($versionOutput -join "`n")
+
+          # Match the first SemVer token in the output, with optional +build
+          # or -prerelease tail. Robust to extra lines and to System.CommandLine
+          # changing its surrounding wording.
+          if ($versionText -notmatch '\b(\d+\.\d+\.\d+)(?:[+-][^\s]*)?\b') {
+              throw "Could not find a SemVer token in --version output. Raw output: '$versionText'"
+          }
+
+          $actualVersion = $Matches[1]
+          if ($actualVersion -ne $expectedVersion) {
+              throw "Version mismatch. Tag: $expectedVersion. Binary reports: $actualVersion. Expected the binary's InformationalVersion to match the tag (sans 'v')."
+          }
       - uses: actions/upload-artifact@v4
         with:
           name: ahkflow-win-x64

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -194,7 +194,7 @@ jobs:
 
           $actualVersion = $Matches[1]
           if ($actualVersion -ne $expectedVersion) {
-              throw "Version mismatch. Tag: $expectedVersion. Binary reports: $actualVersion. Expected the binary's InformationalVersion to match the tag (sans 'v')."
+              throw "Version mismatch. Tag (sans leading 'v' and +build metadata): $expectedVersion. Binary reports (sans +build metadata): $actualVersion. Expected the binary's InformationalVersion to match the tag on MAJOR.MINOR.PATCH[-prerelease]."
           }
       - uses: actions/upload-artifact@v4
         with:

--- a/docs/cli/winget-submission.md
+++ b/docs/cli/winget-submission.md
@@ -159,6 +159,8 @@ wingetcreate new-version --urls $zipUrl AHKFlow.CLI
 
 `wingetcreate` clones your fork, generates manifests at `manifests/a/AHKFlow/CLI/0.1.2/` reusing metadata from the prior version, and recomputes the SHA256. Re-run steps 3–7 above.
 
+The `release-cli.yml` workflow asserts that the binary's reported version matches the tag before uploading, and refuses to overwrite an existing release asset for the same tag. So the SHA256 you compute against the published asset is stable for the lifetime of the tag — re-running the workflow on the same tag will fail rather than mutate the asset.
+
 **Versioning rule:** `PackageVersion` always equals the git tag with the `v` stripped (`v1.2.3` → `1.2.3`).
 
 ## Moderator feedback loop

--- a/docs/superpowers/plans/2026-05-18-cli-binary-version-fix.md
+++ b/docs/superpowers/plans/2026-05-18-cli-binary-version-fix.md
@@ -86,21 +86,39 @@ dotnet build src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj --configuration Rele
 
 Expected: build succeeds, no new warnings. MinVer prints a line like `MinVer: Calculated version 0.1.3-alpha.0.NN+<sha>` to the build log because HEAD is past `v0.1.2` on the feature branch (untagged → height-suffixed pre-release).
 
-- [ ] **Step 3: Smoke-check the produced `--version` output**
+- [ ] **Step 3: Smoke-check the produced `--version` output and assert the shape**
 
 Run:
 
 ```powershell
-dotnet run --project src/Tools/AHKFlowApp.CLI --configuration Release --no-build -- --version
+$versionLine = (dotnet run --project src/Tools/AHKFlowApp.CLI --configuration Release --no-build -- --version | Select-Object -First 1).Trim()
+Write-Host "Reported version: $versionLine"
+
+# On this feature branch the latest reachable version tag is v0.1.2 and HEAD is
+# past it (untagged), so MinVer should produce a tag-derived height-suffixed
+# pre-release of the form `0.1.X-alpha.N.M+<sha>`. Any other shape (1.0.0,
+# 0.0.0, a bare X.Y.Z with no MinVer suffix on an untagged commit, etc.)
+# indicates MinVer is not wired correctly.
+if ($versionLine -notmatch '^0\.1\.\d+-alpha\.\d+\.\d+(\+[0-9a-f]+)?$') {
+    throw "Unexpected --version shape: '$versionLine'. Expected a MinVer height-suffixed pre-release like 0.1.3-alpha.0.5+<sha>. MinVer is likely not applied."
+}
+
+Write-Host "MinVer shape OK."
 ```
 
-Expected output (the exact suffix varies — what matters is the prefix is **not** `1.0.0`):
+Expected: `MinVer shape OK.` and a printed line such as `0.1.3-alpha.0.5+1440c88`.
 
-```
-0.1.3-alpha.0.NN+<commit-sha>
-```
+Why this specific shape:
+- `0.1.\d+` — patch must derive from the `v0.1.2` tag (MinVer's default increment rule), proving the tag is being read.
+- `-alpha\.\d+\.\d+` — MinVer's untagged-commit height suffix; its presence proves we are not silently shipping the SDK default (which would be `1.0.0` with no pre-release tail) or a manually-overridden static version.
+- `(\+[0-9a-f]+)?` — optional `+sha` build metadata from the SDK's `SourceRevisionId`; we tolerate its absence so the assertion doesn't fail on rare configurations where it's stripped.
 
-If the output still starts with `1.0.0`, MinVer is not actually being applied — most commonly because `<PrivateAssets>all</PrivateAssets>` was omitted (which sometimes blocks the targets), or because the build is using a cached `obj/` from before the edit. Run `dotnet clean src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj` and rebuild. Do not proceed to Step 4 until the version line is non-`1.0.0`.
+If the regex fails, the most common causes are:
+- `<PrivateAssets>all</PrivateAssets>` omitted, blocking MinVer's targets.
+- Stale `obj/` cache from before the csproj edit — run `dotnet clean src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj` and rebuild.
+- Shallow clone with no tag history — run `git fetch --tags` to confirm `v0.1.2` is locally present.
+
+Do not proceed to Step 4 until the assertion passes.
 
 - [ ] **Step 4: Confirm the CLI test suite still passes**
 
@@ -273,7 +291,18 @@ Change only the `else { ... }` branch. The `if` branch (release does not yet exi
 ```yaml
           else {
               $assetName = Split-Path $zipPath -Leaf
-              $existingAssets = gh release view $env:RELEASE_TAG --json assets --jq ".assets[].name" 2>$null
+
+              # Reaching this branch means the outer `gh release view` succeeded,
+              # so the release definitely exists. A failure to enumerate its
+              # assets here is therefore an auth/API/transient error, not a
+              # signal that the release is empty. Treat any non-zero exit as
+              # fatal — silently falling through would risk overwriting an
+              # already-published asset via the unconditional `gh release upload`
+              # below, breaking the immutability promise this step exists to keep.
+              $existingAssets = gh release view $env:RELEASE_TAG --json assets --jq ".assets[].name"
+              if ($LASTEXITCODE -ne 0) {
+                  throw "Could not enumerate assets for tag $($env:RELEASE_TAG) (gh release view exit code $LASTEXITCODE). Refusing to upload without knowing the current asset state."
+              }
 
               if ($existingAssets -split "`n" -contains $assetName) {
                   throw "Release asset '$assetName' is already published for tag $($env:RELEASE_TAG). Treating release assets as immutable. To ship a new build, cut a new tag."
@@ -288,32 +317,62 @@ Change only the `else { ... }` branch. The `if` branch (release does not yet exi
 
 Key changes from the current code:
 - `--clobber` is gone.
-- A list of existing asset names is fetched via `gh release view --json assets --jq ".assets[].name"`.
-- If our asset name (`ahkflow-win-x64.zip`) is already in that list, the step throws — winget consumers rely on the SHA256 being stable for the lifetime of the tag.
-- If the asset is not yet present (e.g., a release was created manually with notes but no binary, or a previous workflow upload step failed before completing), the upload proceeds normally.
+- A list of existing asset names is fetched via `gh release view --json assets --jq ".assets[].name"`. **No `2>$null`** — any failure on this call must surface, because in this branch the release is known to exist.
+- A non-zero exit on the inner `gh release view` hard-fails the workflow rather than falling through to upload (which would risk overwriting via the absence of `-contains` matches against an empty `$existingAssets`).
+- If our asset name (`ahkflow-win-x64.zip`) is already in the list, the step throws — winget consumers rely on the SHA256 being stable for the lifetime of the tag.
+- If the asset is not yet present (e.g., a previous workflow run created the release entry but the upload itself never completed — say it crashed between `gh release create --notes` and the asset push), the upload proceeds normally. This is the only legitimate path that reaches the upload line.
 
 - [ ] **Step 3: Re-check the YAML parses**
 
 Repeat Step 3 from Task 2 — `ConvertFrom-Yaml` (or `python -c "import yaml; ..."`) on the file. Expected: `YAML parses OK.`
 
-- [ ] **Step 4: Dry-run the asset-existence check against a real release**
+- [ ] **Step 4: Dry-run the asset-existence check against the two production-path scenarios**
 
-This step only validates the `gh` invocation shape — it does **not** mutate anything. In a `pwsh` session with `gh` authenticated:
+This step only validates the `gh` invocation shape — it does **not** mutate anything. The else branch in the workflow is only ever reached when the release for the current tag already exists, so we dry-run the two cases that match that precondition. (The "release does not exist at all" case routes to the `if` branch in the workflow and is not exercised here.)
 
-```powershell
-$tag = "v0.1.2"
-gh release view $tag --json assets --jq ".assets[].name"
-```
+In a `pwsh` session with `gh` authenticated:
 
-Expected: a single line `ahkflow-win-x64.zip` is printed (the v0.1.2 release we already published). Confirms the JSON path and jq filter both work.
-
-Then verify the negative case against a fictitious tag:
+**Case A — asset already present (workflow would throw the immutability error):**
 
 ```powershell
-gh release view "v0.0.0-does-not-exist" --json assets --jq ".assets[].name" 2>$null
+$assetName = "ahkflow-win-x64.zip"
+$existingAssets = gh release view "v0.1.2" --json assets --jq ".assets[].name"
+if ($LASTEXITCODE -ne 0) { throw "gh release view failed (exit $LASTEXITCODE)" }
+
+Write-Host "Assets on v0.1.2:`n$existingAssets"
+
+if ($existingAssets -split "`n" -contains $assetName) {
+    Write-Host "DRYRUN-EXPECTED: would throw immutability error for v0.1.2."
+} else {
+    throw "DRYRUN UNEXPECTED: v0.1.2 has no '$assetName' asset. Investigate before continuing."
+}
 ```
 
-Expected: empty output, non-zero exit. In the workflow, `2>$null` suppresses the error message; the `-contains` comparison against an empty `$existingAssets` returns false; control falls through to the upload. That's the intended behaviour for a fresh tag.
+Expected:
+```
+Assets on v0.1.2:
+ahkflow-win-x64.zip
+DRYRUN-EXPECTED: would throw immutability error for v0.1.2.
+```
+
+**Case B — release exists but the asset slot is empty (workflow would proceed to upload):**
+
+There is no naturally-occurring empty-asset release we can poke without mutating state, so simulate by overriding `$existingAssets`:
+
+```powershell
+$assetName = "ahkflow-win-x64.zip"
+$existingAssets = ""  # simulated empty asset list — what we would see on a partially-created release
+
+if ($existingAssets -split "`n" -contains $assetName) {
+    throw "DRYRUN UNEXPECTED: empty list should not contain '$assetName'."
+} else {
+    Write-Host "DRYRUN-EXPECTED: would proceed to upload."
+}
+```
+
+Expected: `DRYRUN-EXPECTED: would proceed to upload.`
+
+These two confirm both production paths behave correctly. Note that neither case relies on `2>$null` — the production code is now sensitive to inner-view failures, and these dry-runs are checking the post-view branching logic.
 
 - [ ] **Step 5: Commit**
 
@@ -392,14 +451,42 @@ tag. This matches the new release-cli.yml behaviour."
 
 **Files:** none (git/GitHub-only)
 
-- [ ] **Step 1: Verify the branch state**
+- [ ] **Step 1: Verify the branch state by intent, not by pinned SHAs**
 
 ```powershell
-git status
-git log feature/cli-binary-version-fix --oneline -10
+# Working tree must be clean apart from build-cache noise.
+$dirty = git status --porcelain | Where-Object { $_ -notmatch '\.lscache$' }
+if ($dirty) {
+    throw "Working tree has unexpected changes:`n$($dirty -join "`n")"
+}
+
+# Confirm that exactly the expected commits sit on top of origin/main:
+#   - 4 implementation commits (Tasks 1-4)
+#   - 2 spec commits authored during brainstorming
+# Total: 6 commits ahead of origin/main.
+$aheadCount = (git rev-list --count origin/main..HEAD)
+if ([int]$aheadCount -ne 6) {
+    throw "Expected 6 commits ahead of origin/main (4 impl + 2 spec). Got $aheadCount. Run `git log origin/main..HEAD --oneline` and reconcile."
+}
+
+# Verify the four implementation commit subjects appear, regardless of order/SHA.
+$subjects = git log origin/main..HEAD --format="%s"
+$requiredSubjects = @(
+    "feat(cli): wire MinVer so --version reflects the git tag",
+    "ci(release): assert ahkflow --version matches the release tag",
+    "ci(release): refuse to overwrite an existing release asset",
+    "docs(cli): document release-asset immutability in winget runbook"
+)
+
+$missing = @($requiredSubjects | Where-Object { $_ -notin ($subjects -split "`n") })
+if ($missing.Count -gt 0) {
+    throw "Expected commits missing from branch:`n$($missing -join "`n")"
+}
+
+Write-Host "Branch state OK: 6 commits ahead, all four implementation commits present."
 ```
 
-Expected: clean working tree (apart from the `.lscache` untracked noise present at session start), and the branch shows — top to bottom — Task 4 commit, Task 3 commit, Task 2 commit, Task 1 commit, the two spec commits (`c208a07`, `1440c88`), then `6a4f85f` (origin/main HEAD).
+Expected: `Branch state OK: 6 commits ahead, all four implementation commits present.` This validates intent (four named implementation commits sit atop two spec commits, atop `origin/main`) without pinning to transient SHA values that change if commits are reworded or rebased.
 
 - [ ] **Step 2: Confirm build and tests one more time before pushing**
 
@@ -477,8 +564,9 @@ Posting a GitHub comment leaves no local repo state. The PR for this branch (Tas
 
 - [ ] All four implementation tasks committed on `feature/cli-binary-version-fix`.
 - [ ] Local `dotnet build` + `dotnet test` pass after Task 1.
-- [ ] Local `ahkflow --version` smoke (Task 1 Step 3) shows a non-`1.0.0` prefix.
+- [ ] Local `ahkflow --version` matches the tag-derived MinVer shape `^0\.1\.\d+-alpha\.\d+\.\d+(\+[0-9a-f]+)?$` (Task 1 Step 3). "Anything other than `1.0.0`" is not sufficient — the assertion is that MinVer is reading the `v0.1.2` tag and incrementing the patch with a height suffix.
 - [ ] YAML parse check passes after Tasks 2 and 3.
+- [ ] Task 3 dry-run shows the immutability case throwing on `v0.1.2`'s already-present asset (Case A) and the simulated-empty case proceeding (Case B).
 - [ ] PR opened (Task 5) and CI green.
 - [ ] Validator reply posted on PR #374595 (Task 6).
 

--- a/docs/superpowers/plans/2026-05-18-cli-binary-version-fix.md
+++ b/docs/superpowers/plans/2026-05-18-cli-binary-version-fix.md
@@ -1,0 +1,485 @@
+# CLI binary version self-reporting fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ahkflow --version` print the git tag (e.g. `0.1.3+<sha>`) instead of the SDK fallback (`1.0.0+<sha>`), and prevent winget-breaking release-asset mutation by hardening the release workflow.
+
+**Architecture:** Add `MinVer` to the CLI csproj so the assembly's `InformationalVersion` flows from the git tag. Extend `release-cli.yml` with a stdout-only, regex-based version-vs-tag assertion and an upload step that refuses to overwrite an existing asset. Update the winget runbook to document the new guarantee.
+
+**Tech Stack:** .NET 10 SDK, MinVer 7.0.0, System.CommandLine 3.0 (preview), GitHub Actions, PowerShell (`pwsh`), `gh` CLI.
+
+**Spec:** `docs/superpowers/specs/2026-05-18-cli-binary-version-fix-design.md`
+
+**Branch:** `feature/cli-binary-version-fix` (already created; spec is committed there)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj` | Modify | Add MinVer `<PackageReference>` so the build-time assembly version reflects the git tag. |
+| `.github/workflows/release-cli.yml` | Modify (verify step) | Assert `ahkflow.exe --version` prefix matches the release tag; fail the workflow otherwise. |
+| `.github/workflows/release-cli.yml` | Modify (publish step) | Refuse to overwrite an already-published release asset for the same tag. |
+| `docs/cli/winget-submission.md` | Modify | Document the new immutability guarantee in the "Subsequent releases" section. |
+
+No new files. No test files (the change is purely build-tooling; verification happens via CI on a tagged commit and via a local sanity build).
+
+**Out of plan scope:** Posting the validator reply on PR #374595 (the maintainer pastes it manually — see Task 6). Tagging and shipping v0.1.3 (a separate release event after merge).
+
+---
+
+## Task 1: Add MinVer to the CLI csproj
+
+**Files:**
+- Modify: `src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj`
+
+- [ ] **Step 1: Add the MinVer PackageReference**
+
+Open `src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj`. The current `<ItemGroup>` for package references (lines 13–22) looks like:
+
+```xml
+<ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Identity.Client" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
+    <PackageReference Include="Serilog.Extensions.Hosting" />
+    <PackageReference Include="Serilog.Settings.Configuration" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="System.CommandLine" />
+</ItemGroup>
+```
+
+Insert the `MinVer` reference in alphabetical position (between `Microsoft.Identity.Client.Extensions.Msal` and `Serilog.Extensions.Hosting`). The result should be:
+
+```xml
+<ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Identity.Client" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
+    <PackageReference Include="MinVer">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Serilog.Extensions.Hosting" />
+    <PackageReference Include="Serilog.Settings.Configuration" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="System.CommandLine" />
+</ItemGroup>
+```
+
+Notes:
+- No `Version=` attribute. Central Package Management (`Directory.Packages.props`) already pins `MinVer 7.0.0`.
+- `Directory.Build.props` already sets `<MinVerTagPrefix>v</MinVerTagPrefix>` solution-wide, so the `v0.1.2`/`v0.1.3` tags are recognised.
+- The `IncludeAssets` / `PrivateAssets` shape mirrors what `AHKFlowApp.API.csproj:17-20` and `AHKFlowApp.UI.Blazor.csproj` already use, so MinVer's build-only assets do not flow transitively to consumers.
+
+- [ ] **Step 2: Restore and build the CLI to make sure nothing breaks**
+
+Run from the repository root:
+
+```powershell
+dotnet restore src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj
+dotnet build src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj --configuration Release --no-restore
+```
+
+Expected: build succeeds, no new warnings. MinVer prints a line like `MinVer: Calculated version 0.1.3-alpha.0.NN+<sha>` to the build log because HEAD is past `v0.1.2` on the feature branch (untagged → height-suffixed pre-release).
+
+- [ ] **Step 3: Smoke-check the produced `--version` output**
+
+Run:
+
+```powershell
+dotnet run --project src/Tools/AHKFlowApp.CLI --configuration Release --no-build -- --version
+```
+
+Expected output (the exact suffix varies — what matters is the prefix is **not** `1.0.0`):
+
+```
+0.1.3-alpha.0.NN+<commit-sha>
+```
+
+If the output still starts with `1.0.0`, MinVer is not actually being applied — most commonly because `<PrivateAssets>all</PrivateAssets>` was omitted (which sometimes blocks the targets), or because the build is using a cached `obj/` from before the edit. Run `dotnet clean src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj` and rebuild. Do not proceed to Step 4 until the version line is non-`1.0.0`.
+
+- [ ] **Step 4: Confirm the CLI test suite still passes**
+
+Run:
+
+```powershell
+dotnet test tests/AHKFlowApp.CLI.Tests --configuration Release --verbosity normal
+```
+
+Expected: all CLI tests pass. (None assert on version strings, so MinVer should not break anything. If a test does fail with a version-related diff, the test is asserting on assembly metadata it shouldn't — investigate and fix the test before continuing.)
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj
+git commit -m "feat(cli): wire MinVer so --version reflects the git tag
+
+The CLI csproj was the only publishable project missing the MinVer
+package reference, so AssemblyInformationalVersion fell back to the
+SDK default of 1.0.0+sha. With MinVer in place, a tagged build now
+produces e.g. 0.1.3+sha and the binary self-report aligns with the
+winget manifest's PackageVersion."
+```
+
+---
+
+## Task 2: Add the version-vs-tag assertion to `release-cli.yml`
+
+**Files:**
+- Modify: `.github/workflows/release-cli.yml` (the `Verify package` step, immediately after the existing `--help` check at lines 167–170)
+
+- [ ] **Step 1: Locate the insertion point**
+
+Open `.github/workflows/release-cli.yml`. The end of the `Verify package` step currently looks like (lines 167–170):
+
+```yaml
+          & (Join-Path $extractPath "ahkflow.exe") --help
+          if ($LASTEXITCODE -ne 0) {
+              throw "ahkflow.exe --help failed with exit code $LASTEXITCODE."
+          }
+```
+
+Immediately after that closing `}` and before the next `- uses: actions/upload-artifact@v4` line, the new block goes in.
+
+- [ ] **Step 2: Add the version assertion block**
+
+Append the following lines so the `Verify package` step's `run: |` body ends with both the existing `--help` block and the new `--version` block:
+
+```yaml
+          $expectedVersion = $env:RELEASE_TAG.TrimStart("v")
+
+          # Capture stdout only. The CLI configures Serilog to write to stderr,
+          # so any future startup banner on stderr must not be allowed to push
+          # the version line past our parser (which is why we do NOT use 2>&1).
+          $versionOutput = & (Join-Path $extractPath "ahkflow.exe") --version
+          if ($LASTEXITCODE -ne 0) {
+              throw "ahkflow.exe --version failed with exit code $LASTEXITCODE."
+          }
+
+          $versionText = ($versionOutput -join "`n")
+
+          # Match the first SemVer token in the output, with optional +build
+          # or -prerelease tail. Robust to extra lines and to System.CommandLine
+          # changing its surrounding wording.
+          if ($versionText -notmatch '\b(\d+\.\d+\.\d+)(?:[+-][^\s]*)?\b') {
+              throw "Could not find a SemVer token in --version output. Raw output: '$versionText'"
+          }
+
+          $actualVersion = $Matches[1]
+          if ($actualVersion -ne $expectedVersion) {
+              throw "Version mismatch. Tag: $expectedVersion. Binary reports: $actualVersion. Expected the binary's InformationalVersion to match the tag (sans 'v')."
+          }
+```
+
+Mind the indentation: the lines must sit at the same column as the existing `& (Join-Path $extractPath "ahkflow.exe") --help` line (10 spaces of leading whitespace under `run: |`).
+
+- [ ] **Step 3: Syntax-check the YAML**
+
+Run a YAML parse check to catch indentation slips:
+
+```powershell
+$content = Get-Content .github/workflows/release-cli.yml -Raw
+try {
+    $content | ConvertFrom-Yaml | Out-Null
+    Write-Host "YAML parses OK."
+} catch {
+    Write-Host "YAML parse failed: $_"
+}
+```
+
+If `ConvertFrom-Yaml` is not available (Windows PowerShell without `powershell-yaml`), fall back to:
+
+```powershell
+python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release-cli.yml','r',encoding='utf-8').read()); print('YAML parses OK.')"
+```
+
+Expected: `YAML parses OK.` Any other output means the indentation drifted — re-open the file and align with the surrounding step.
+
+- [ ] **Step 4: Dry-run the PowerShell logic against a known-good string**
+
+In a `pwsh` session at the repo root, paste:
+
+```powershell
+$expectedVersion = "0.1.3"
+$versionText = "0.1.3+abcdef1234"
+if ($versionText -notmatch '\b(\d+\.\d+\.\d+)(?:[+-][^\s]*)?\b') {
+    throw "Regex did not match"
+}
+$actualVersion = $Matches[1]
+if ($actualVersion -ne $expectedVersion) { throw "mismatch: $actualVersion vs $expectedVersion" }
+Write-Host "OK: $actualVersion"
+```
+
+Expected: `OK: 0.1.3`. Then repeat with a deliberately broken string to confirm the gate fails loudly:
+
+```powershell
+$expectedVersion = "0.1.3"
+$versionText = "1.0.0+abcdef1234"
+if ($versionText -notmatch '\b(\d+\.\d+\.\d+)(?:[+-][^\s]*)?\b') { throw "Regex did not match" }
+$actualVersion = $Matches[1]
+if ($actualVersion -ne $expectedVersion) { throw "mismatch: $actualVersion vs $expectedVersion" }
+```
+
+Expected: throws `mismatch: 1.0.0 vs 0.1.3`.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add .github/workflows/release-cli.yml
+git commit -m "ci(release): assert ahkflow --version matches the release tag
+
+Extend the Verify package step in release-cli.yml with a stdout-only,
+regex-based check that the binary's reported SemVer matches RELEASE_TAG
+(minus the leading v). Hard-fails the workflow before the asset is
+uploaded, so a regression in MinVer wiring can never ship to winget
+silently again."
+```
+
+---
+
+## Task 3: Enforce release-asset immutability in `release-cli.yml`
+
+**Files:**
+- Modify: `.github/workflows/release-cli.yml` (the `Publish GitHub Release asset` step's `else` branch, lines 191–196)
+
+- [ ] **Step 1: Locate the existing upload branch**
+
+The current `Publish GitHub Release asset` step ends with (lines 184–196):
+
+```yaml
+          gh release view $env:RELEASE_TAG 2>$null
+          if ($LASTEXITCODE -ne 0) {
+              gh release create $env:RELEASE_TAG $zipPath --verify-tag --title $env:RELEASE_TAG --notes "AHKFlow CLI Windows x64 release."
+              if ($LASTEXITCODE -ne 0) {
+                  throw "gh release create failed with exit code $LASTEXITCODE."
+              }
+          }
+          else {
+              gh release upload $env:RELEASE_TAG $zipPath --clobber
+              if ($LASTEXITCODE -ne 0) {
+                  throw "gh release upload failed with exit code $LASTEXITCODE."
+              }
+          }
+```
+
+- [ ] **Step 2: Replace the `else` branch with an immutability check**
+
+Change only the `else { ... }` branch. The `if` branch (release does not yet exist → create + upload in one shot) stays untouched. The new `else` branch:
+
+```yaml
+          else {
+              $assetName = Split-Path $zipPath -Leaf
+              $existingAssets = gh release view $env:RELEASE_TAG --json assets --jq ".assets[].name" 2>$null
+
+              if ($existingAssets -split "`n" -contains $assetName) {
+                  throw "Release asset '$assetName' is already published for tag $($env:RELEASE_TAG). Treating release assets as immutable. To ship a new build, cut a new tag."
+              }
+
+              gh release upload $env:RELEASE_TAG $zipPath
+              if ($LASTEXITCODE -ne 0) {
+                  throw "gh release upload failed with exit code $LASTEXITCODE."
+              }
+          }
+```
+
+Key changes from the current code:
+- `--clobber` is gone.
+- A list of existing asset names is fetched via `gh release view --json assets --jq ".assets[].name"`.
+- If our asset name (`ahkflow-win-x64.zip`) is already in that list, the step throws — winget consumers rely on the SHA256 being stable for the lifetime of the tag.
+- If the asset is not yet present (e.g., a release was created manually with notes but no binary, or a previous workflow upload step failed before completing), the upload proceeds normally.
+
+- [ ] **Step 3: Re-check the YAML parses**
+
+Repeat Step 3 from Task 2 — `ConvertFrom-Yaml` (or `python -c "import yaml; ..."`) on the file. Expected: `YAML parses OK.`
+
+- [ ] **Step 4: Dry-run the asset-existence check against a real release**
+
+This step only validates the `gh` invocation shape — it does **not** mutate anything. In a `pwsh` session with `gh` authenticated:
+
+```powershell
+$tag = "v0.1.2"
+gh release view $tag --json assets --jq ".assets[].name"
+```
+
+Expected: a single line `ahkflow-win-x64.zip` is printed (the v0.1.2 release we already published). Confirms the JSON path and jq filter both work.
+
+Then verify the negative case against a fictitious tag:
+
+```powershell
+gh release view "v0.0.0-does-not-exist" --json assets --jq ".assets[].name" 2>$null
+```
+
+Expected: empty output, non-zero exit. In the workflow, `2>$null` suppresses the error message; the `-contains` comparison against an empty `$existingAssets` returns false; control falls through to the upload. That's the intended behaviour for a fresh tag.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add .github/workflows/release-cli.yml
+git commit -m "ci(release): refuse to overwrite an existing release asset
+
+The previous --clobber semantics broke the immutability promise that
+docs/cli/winget-submission.md (line 29) makes to downstream winget
+consumers: a re-run of the workflow on an existing tag would silently
+mutate the asset's SHA256 and invalidate any winget manifest already
+submitted or merged. Replace --clobber with an explicit existence
+check that hard-fails the workflow. Recovery from a partial-upload
+state remains possible via 'gh release delete-asset' + re-run."
+```
+
+---
+
+## Task 4: Document the new guarantee in the winget runbook
+
+**Files:**
+- Modify: `docs/cli/winget-submission.md` (between lines 160 and 162)
+
+- [ ] **Step 1: Insert the new paragraph**
+
+Open `docs/cli/winget-submission.md`. The relevant region is currently (lines 158–162):
+
+```markdown
+wingetcreate new-version --urls $zipUrl AHKFlow.CLI
+```
+
+`wingetcreate` clones your fork, generates manifests at `manifests/a/AHKFlow/CLI/0.1.2/` reusing metadata from the prior version, and recomputes the SHA256. Re-run steps 3–7 above.
+
+**Versioning rule:** `PackageVersion` always equals the git tag with the `v` stripped (`v1.2.3` → `1.2.3`).
+```
+
+Insert a new paragraph between the `wingetcreate clones your fork…` paragraph (line 160) and the `**Versioning rule:**` line (line 162). After the change the region reads:
+
+```markdown
+wingetcreate new-version --urls $zipUrl AHKFlow.CLI
+```
+
+`wingetcreate` clones your fork, generates manifests at `manifests/a/AHKFlow/CLI/0.1.2/` reusing metadata from the prior version, and recomputes the SHA256. Re-run steps 3–7 above.
+
+The `release-cli.yml` workflow asserts that the binary's reported version matches the tag before uploading, and refuses to overwrite an existing release asset for the same tag. So the SHA256 you compute against the published asset is stable for the lifetime of the tag — re-running the workflow on the same tag will fail rather than mutate the asset.
+
+**Versioning rule:** `PackageVersion` always equals the git tag with the `v` stripped (`v1.2.3` → `1.2.3`).
+```
+
+- [ ] **Step 2: Lint the markdown**
+
+Run a quick sanity check — the file should still render cleanly:
+
+```powershell
+$lines = Get-Content docs/cli/winget-submission.md
+"Lines: $($lines.Length); Headings: $((Select-String -Path docs/cli/winget-submission.md -Pattern '^#+ ').Count)"
+```
+
+Expected: line count grew by ~2 (the new paragraph + blank line), heading count unchanged. If the heading count changed, an accidental `#` got into the new paragraph — fix.
+
+- [ ] **Step 3: Commit**
+
+```powershell
+git add docs/cli/winget-submission.md
+git commit -m "docs(cli): document release-asset immutability in winget runbook
+
+The Subsequent releases section now states that the workflow refuses
+to overwrite an existing asset for the same tag, so the SHA256
+computed against the published zip is stable for the lifetime of the
+tag. This matches the new release-cli.yml behaviour."
+```
+
+---
+
+## Task 5: Push the branch and open the PR
+
+**Files:** none (git/GitHub-only)
+
+- [ ] **Step 1: Verify the branch state**
+
+```powershell
+git status
+git log feature/cli-binary-version-fix --oneline -10
+```
+
+Expected: clean working tree (apart from the `.lscache` untracked noise present at session start), and the branch shows — top to bottom — Task 4 commit, Task 3 commit, Task 2 commit, Task 1 commit, the two spec commits (`c208a07`, `1440c88`), then `6a4f85f` (origin/main HEAD).
+
+- [ ] **Step 2: Confirm build and tests one more time before pushing**
+
+```powershell
+dotnet build --configuration Release --no-restore
+dotnet test --configuration Release --no-build --verbosity normal
+```
+
+Expected: build succeeds, all tests pass. If either fails, fix the cause and amend the relevant task's commit (do **not** add a noise "fix typo" commit on top — keep the four implementation commits clean).
+
+- [ ] **Step 3: Push the branch**
+
+```powershell
+git push -u origin feature/cli-binary-version-fix
+```
+
+Expected: branch tracks `origin/feature/cli-binary-version-fix`.
+
+- [ ] **Step 4: Open the PR**
+
+```powershell
+gh pr create --base main --head feature/cli-binary-version-fix `
+    --title "fix(cli): wire MinVer and enforce release-asset immutability" `
+    --body @"
+## Summary
+- Wires MinVer into ``AHKFlowApp.CLI.csproj`` so ``ahkflow --version`` reflects the git tag instead of the SDK fallback ``1.0.0+sha``. Addresses winget-pkgs PR #374595 validator finding.
+- Adds a stdout-only, regex-based version-vs-tag assertion to the ``Verify package`` step in ``release-cli.yml`` so a future regression cannot ship to winget silently.
+- Drops ``--clobber`` from the ``Publish GitHub Release asset`` step and replaces it with an explicit asset-existence check that hard-fails on re-run. Closes the gap where re-running the workflow on an existing tag would mutate a SHA256 already merged into winget.
+- Updates ``docs/cli/winget-submission.md`` to document the new immutability guarantee.
+
+## Spec
+``docs/superpowers/specs/2026-05-18-cli-binary-version-fix-design.md``
+
+## Test plan
+- [ ] CI: build + test pass on the PR.
+- [ ] After merge, tag ``v0.1.3`` and trigger the release workflow. The ``Verify package`` step asserts the binary reports ``0.1.3`` before upload; the ``Publish`` step uploads on first run.
+- [ ] Re-run the release workflow on the same tag (``workflow_dispatch`` with ``v0.1.3``). Confirm it fails at the upload step with the immutability error.
+- [ ] Submit a fresh winget PR for v0.1.3 per ``docs/cli/winget-submission.md``. Validator's ``ahkflow --version`` smoke check should report ``0.1.3+<sha>``.
+"@
+```
+
+Expected: `gh` prints the PR URL. Capture it for the next step.
+
+---
+
+## Task 6: Post the validator reply on winget-pkgs PR #374595
+
+**Files:** none (out-of-tree, posted manually in the browser)
+
+This task is **not automated** — the maintainer pastes the reply by hand because the PR lives in a third-party repository and we want a human to read the validator's latest state before responding.
+
+- [ ] **Step 1: Confirm no new comments landed since the reply was drafted**
+
+Open `https://github.com/microsoft/winget-pkgs/pull/374595` in a browser and skim recent activity. If the validator posted anything after `comment-4480496773` that changes the picture (e.g., they auto-closed, requested something else), pause and reassess.
+
+- [ ] **Step 2: Paste the reply**
+
+Use the exact text from the spec's "Part A — validator reply" section (`docs/superpowers/specs/2026-05-18-cli-binary-version-fix-design.md`). For convenience, the verbatim text:
+
+> Thanks for catching this, @stephengillie.
+>
+> The `1.0.0+<sha>` shown by `ahkflow --version` is a build-tooling artifact — our CLI project is missing the MinVer wiring that the rest of our solution uses, so the assembly's `InformationalVersion` falls back to the SDK default of `1.0.0` plus the source-revision commit SHA. The manifest's `PackageVersion: 0.1.2` is the authoritative version, and ARP / `winget list` reflect it correctly (`DisplayVersion: 0.1.2` as you showed).
+>
+> A `DisplayVersion` field in the manifest would just restate `PackageVersion`, so I'd prefer to fix it at the source: add MinVer to the CLI project so the binary self-reports the tag. That ships in **v0.1.3** as a follow-up submission; the underlying bits in this v0.1.2 PR are otherwise correct and install/upgrade behaviors aren't affected by the cosmetic mismatch.
+>
+> Happy to defer the merge if you'd rather see the corrected binary first — let me know.
+
+- [ ] **Step 3: No commit needed**
+
+Posting a GitHub comment leaves no local repo state. The PR for this branch (Task 5) is the only thing CI cares about.
+
+---
+
+## Definition of done
+
+- [ ] All four implementation tasks committed on `feature/cli-binary-version-fix`.
+- [ ] Local `dotnet build` + `dotnet test` pass after Task 1.
+- [ ] Local `ahkflow --version` smoke (Task 1 Step 3) shows a non-`1.0.0` prefix.
+- [ ] YAML parse check passes after Tasks 2 and 3.
+- [ ] PR opened (Task 5) and CI green.
+- [ ] Validator reply posted on PR #374595 (Task 6).
+
+The next deliverable after this PR merges is cutting tag `v0.1.3` and running the release workflow — out of scope for this plan, but the spec's Verification section is the script to follow.

--- a/docs/superpowers/specs/2026-05-18-cli-binary-version-fix-design.md
+++ b/docs/superpowers/specs/2026-05-18-cli-binary-version-fix-design.md
@@ -38,10 +38,11 @@ The winget `PackageVersion` is entered manually via `wingetcreate` from the git 
 
 - Re-uploading the v0.1.2 release asset (violates the immutability rule in `docs/cli/winget-submission.md`).
 - Closing or withdrawing PR #374595.
-- Any change to `wingetcreate` flow or the winget submission runbook beyond a one-line clarification.
+- Any `wingetcreate` flow changes; the runbook addition is the only documentation change.
 - Adding a `DisplayVersion` field to the manifest — it would just restate `PackageVersion`; the source-of-truth fix is in the binary.
 - Source Link / `Microsoft.SourceLink.GitHub` integration. The SDK's `SourceRevisionId` already produces the `+sha` suffix we want.
 - Touching API or Blazor projects — they already have MinVer wired.
+- Adding an immutability check on the API / Blazor release pipelines. The winget contract is CLI-specific; if the other pipelines grow a similar promise we'll extend then, not pre-emptively.
 
 ## Approach
 
@@ -61,7 +62,7 @@ A single comment on PR #374595, posted manually by the maintainer (not via `gh p
 
 ### Part B — code & CI changes for v0.1.3
 
-Three files change. Net additions ≈ 15 lines.
+Four touches. Net additions ≈ 30 lines across three files.
 
 **B1. `src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj`**
 
@@ -82,42 +83,85 @@ Append to the existing PowerShell block in the `package` job's verify step, afte
 
 ```powershell
 $expectedVersion = $env:RELEASE_TAG.TrimStart("v")
-$versionOutput = & (Join-Path $extractPath "ahkflow.exe") --version 2>&1
+
+# Capture stdout only — the CLI's Serilog logger writes to stderr, and any
+# future startup warning on stderr would push the version line past
+# `Select-Object -First 1` if we merged streams with 2>&1.
+$versionOutput = & (Join-Path $extractPath "ahkflow.exe") --version
 if ($LASTEXITCODE -ne 0) {
     throw "ahkflow.exe --version failed with exit code $LASTEXITCODE."
 }
 
-$actualVersion = ($versionOutput | Select-Object -First 1).Trim().Split("+")[0]
+$versionText = ($versionOutput -join "`n")
+
+# Match the first SemVer token in the output, with optional `+build` or
+# `-prerelease` suffix. Robust to extra banner/diagnostic lines and to
+# `System.CommandLine` changing its surrounding wording.
+if ($versionText -notmatch '\b(\d+\.\d+\.\d+)(?:[+-][^\s]*)?\b') {
+    throw "Could not find a SemVer token in --version output. Raw output: '$versionText'"
+}
+
+$actualVersion = $Matches[1]
 if ($actualVersion -ne $expectedVersion) {
     throw "Version mismatch. Tag: $expectedVersion. Binary reports: $actualVersion. Expected the binary's InformationalVersion to match the tag (sans 'v')."
 }
 ```
 
 Rationale:
-- Splits on `+` so the SDK's source-revision-id (everything after `+`) does not break the comparison; the prefix is what must match.
+- Reads stdout only. The CLI configures Serilog to write to stderr (`Program.cs`), so merging streams with `2>&1` would let a future warning shift the version line.
+- Regex extracts the SemVer core (`MAJOR.MINOR.PATCH`) anywhere in the output, ignoring any `+sha` suffix or `-prerelease` tail. The prefix is what must match.
 - Trims `v` from the tag to mirror the manifest's `PackageVersion` convention.
 - Hard-fails the workflow — same severity as the existing `appsettings.json` checks in the same step.
 - Runs against the extracted zip, not the raw publish directory, so the verified bytes are what users receive.
 
-**B3. `docs/cli/winget-submission.md` — one-line runbook addition**
+**B3. `.github/workflows/release-cli.yml` — enforce asset immutability on upload**
+
+The current upload logic uses `gh release upload --clobber`, which will silently overwrite an existing asset for the same tag. That contradicts the immutability promise the winget runbook depends on (`docs/cli/winget-submission.md` line 29: "Treat the GitHub Release asset as immutable once submitted — re-uploading the zip changes the SHA256 and breaks installs."). A re-run of the release workflow on an existing tag would change the SHA256 of an already-merged or already-submitted winget manifest.
+
+Replace the existing "Publish GitHub Release asset" step's `else` branch:
+
+```powershell
+# OLD: gh release upload $env:RELEASE_TAG $zipPath --clobber
+```
+
+with an explicit existence check that fails the workflow if the asset is already published for this tag:
+
+```powershell
+$assetName = Split-Path $zipPath -Leaf
+$existingAssets = gh release view $env:RELEASE_TAG --json assets --jq ".assets[].name" 2>$null
+
+if ($existingAssets -split "`n" -contains $assetName) {
+    throw "Release asset '$assetName' is already published for tag $($env:RELEASE_TAG). Treating release assets as immutable. To ship a new build, cut a new tag."
+}
+
+gh release upload $env:RELEASE_TAG $zipPath
+if ($LASTEXITCODE -ne 0) {
+    throw "gh release upload failed with exit code $LASTEXITCODE."
+}
+```
+
+The `gh release create` branch (release doesn't exist yet) is unchanged. Manual recovery (force-overwrite) remains possible by deleting the asset via the GitHub UI or `gh release delete-asset` — but it's no longer the default code path.
+
+**B4. `docs/cli/winget-submission.md` — runbook addition**
 
 In the "Subsequent releases (v0.1.2 and later)" section, insert between the paragraph that follows the `wingetcreate new-version` snippet ("`wingetcreate` clones your fork…") and the "**Versioning rule:**" line:
 
-> The `release-cli.yml` workflow asserts that the binary's reported version matches the tag before publishing the release asset, so by the time you reach this step the SHA256 is pinned to a correctly-versioned binary.
+> The `release-cli.yml` workflow asserts that the binary's reported version matches the tag before uploading, and refuses to overwrite an existing release asset for the same tag. So the SHA256 you compute against the published asset is stable for the lifetime of the tag — re-running the workflow on the same tag will fail rather than mutate the asset.
 
 ## Verification
 
 Once Part B lands and `v0.1.3` is tagged + the workflow runs:
 
-1. The `Verify package` step asserts `ahkflow.exe --version` starts with `0.1.3` — otherwise the workflow fails before publishing.
-2. After the workflow publishes the release asset, run locally:
+1. The `Verify package` step asserts `ahkflow.exe --version` reports `0.1.3` — otherwise the workflow fails before uploading.
+2. The `Publish GitHub Release asset` step uploads the zip on the first run. On a second run for the same tag (re-triggered via `workflow_dispatch`), it fails with the immutability error — confirm by re-running once.
+3. After the workflow publishes the release asset, run locally:
    ```powershell
    $tag = "v0.1.3"
    Invoke-WebRequest "https://github.com/<owner>/AHKFlowApp/releases/download/$tag/ahkflow-win-x64.zip" -OutFile ahkflow.zip
    Expand-Archive ahkflow.zip -DestinationPath .\ahkflow-extract
    .\ahkflow-extract\ahkflow.exe --version  # expect: 0.1.3+<sha>
    ```
-3. Submit the v0.1.3 winget PR per the runbook. The validator's manual `ahkflow --version` check should now report `0.1.3+<sha>`.
+4. Submit the v0.1.3 winget PR per the runbook. The validator's manual `ahkflow --version` check should now report `0.1.3+<sha>`.
 
 ## Risks & mitigations
 
@@ -125,8 +169,10 @@ Once Part B lands and `v0.1.3` is tagged + the workflow runs:
 |---|---|
 | MinVer requires deep git history. | `release-cli.yml`'s checkout already uses `fetch-depth: 0`. Confirmed before design. |
 | Local `dotnet run` after merge shows e.g. `0.1.3-alpha.0.1+<sha>` on untagged commits. | Expected MinVer behavior. Fine for development; the gate only runs in the release workflow. |
-| `System.CommandLine` could change how `--version` parses `AssemblyInformationalVersion` in a future major. | The gate splits on `+` defensively. If the format ever changes more substantively, the gate will fail loudly, which is what we want. |
+| `System.CommandLine` could change how `--version` parses `AssemblyInformationalVersion` in a future major. | The gate regex-matches the first SemVer token anywhere in stdout, ignoring surrounding wording and any `+build` / `-prerelease` tail. If the format ever changes so radically that no SemVer token is present, the gate fails loudly — which is what we want. |
 | Validator declines to merge v0.1.2 and demands a corrected binary first. | The reply explicitly offers the defer-and-resubmit path. If they take it, we cut v0.1.3, withdraw v0.1.2, submit fresh. Outcome difference is one merge cycle. |
+| The new immutability check blocks a legitimate retry — e.g., the workflow was re-run after a transient upload failure that did partially complete. | Operator deletes the half-uploaded asset (`gh release delete-asset`) and re-runs. Documented behavior — the gate refusing to silently mutate state is the point. |
+| Stdout-only capture misses the version if `System.CommandLine` ever decides to print it to stderr. | Gate fails with "Could not find a SemVer token" rather than passing a false negative. Loud failure beats silent drift. |
 
 ## Unresolved questions
 

--- a/docs/superpowers/specs/2026-05-18-cli-binary-version-fix-design.md
+++ b/docs/superpowers/specs/2026-05-18-cli-binary-version-fix-design.md
@@ -1,0 +1,136 @@
+# CLI binary version self-reporting — design
+
+**Status:** Approved (brainstorming, 2026-05-18)
+**Related:** backlog [031](../../.claude/backlog/031-cli-winget-distribution.md), spec [2026-05-14-031-cli-winget-distribution-design.md](2026-05-14-031-cli-winget-distribution-design.md)
+**Trigger:** [winget-pkgs PR #374595, comment 4480496773](https://github.com/microsoft/winget-pkgs/pull/374595#issuecomment-4480496773)
+
+## Problem
+
+The v0.1.2 winget submission ships a binary whose self-reported version diverges from the manifest's `PackageVersion`:
+
+| Source | Value |
+|---|---|
+| `ahkflow --version` | `1.0.0+d25b6c93acb8e774c3021c1667809a5aeae6fe7d` |
+| winget manifest `PackageVersion` | `0.1.2` |
+| ARP `DisplayVersion` (from manifest) | `0.1.2` |
+
+The Microsoft validator flagged this on PR #374595 and asked whether the manifest should carry an explicit `DisplayVersion`. The mismatch is cosmetic — install/upgrade behavior is unaffected, and `winget list` / ARP show the correct version — but it looks unprofessional and undermines `--version` as a debugging aid.
+
+## Root cause
+
+`AHKFlowApp.CLI.csproj` is the only publishable project in the solution missing a `MinVer` `<PackageReference>`. `Directory.Packages.props` pins `MinVer 7.0.0` and `Directory.Build.props` sets `<MinVerTagPrefix>v</MinVerTagPrefix>`, but those are inert without the package reference. As a result:
+
+- `AssemblyVersion` falls back to the SDK default `1.0.0.0`.
+- `AssemblyInformationalVersion` falls back to `1.0.0+<source-revision-id>` — the `+sha` is appended by the .NET SDK property `IncludeSourceRevisionInInformationalVersion` (default `true`).
+- `System.CommandLine`'s built-in `--version` handler reads `AssemblyInformationalVersion`, so users see `1.0.0+<sha>`.
+
+The winget `PackageVersion` is entered manually via `wingetcreate` from the git tag with the leading `v` stripped — an independent code path, hence the divergence.
+
+`AHKFlowApp.API.csproj` and `AHKFlowApp.UI.Blazor.csproj` already reference MinVer with the correct `IncludeAssets` envelope and produce tag-accurate versions; only the CLI is broken.
+
+## Outcome
+
+1. **v0.1.2 winget PR:** a clear validator reply lands so the existing PR proceeds to merge without re-uploading the release asset.
+2. **v0.1.3:** the CLI binary self-reports the tag (e.g. `0.1.3+<sha>`), matching the manifest's `PackageVersion`.
+3. **Going forward:** a CI gate in `release-cli.yml` hard-fails any release whose binary version doesn't match the tag, so this regression cannot ship silently again.
+
+## Out of scope
+
+- Re-uploading the v0.1.2 release asset (violates the immutability rule in `docs/cli/winget-submission.md`).
+- Closing or withdrawing PR #374595.
+- Any change to `wingetcreate` flow or the winget submission runbook beyond a one-line clarification.
+- Adding a `DisplayVersion` field to the manifest — it would just restate `PackageVersion`; the source-of-truth fix is in the binary.
+- Source Link / `Microsoft.SourceLink.GitHub` integration. The SDK's `SourceRevisionId` already produces the `+sha` suffix we want.
+- Touching API or Blazor projects — they already have MinVer wired.
+
+## Approach
+
+Two deliverables, ordered:
+
+### Part A — validator reply (now)
+
+A single comment on PR #374595, posted manually by the maintainer (not via `gh pr comment`). Reply text:
+
+> Thanks for catching this, @stephengillie.
+>
+> The `1.0.0+<sha>` shown by `ahkflow --version` is a build-tooling artifact — our CLI project is missing the MinVer wiring that the rest of our solution uses, so the assembly's `InformationalVersion` falls back to the SDK default of `1.0.0` plus the source-revision commit SHA. The manifest's `PackageVersion: 0.1.2` is the authoritative version, and ARP / `winget list` reflect it correctly (`DisplayVersion: 0.1.2` as you showed).
+>
+> A `DisplayVersion` field in the manifest would just restate `PackageVersion`, so I'd prefer to fix it at the source: add MinVer to the CLI project so the binary self-reports the tag. That ships in **v0.1.3** as a follow-up submission; the underlying bits in this v0.1.2 PR are otherwise correct and install/upgrade behaviors aren't affected by the cosmetic mismatch.
+>
+> Happy to defer the merge if you'd rather see the corrected binary first — let me know.
+
+### Part B — code & CI changes for v0.1.3
+
+Three files change. Net additions ≈ 15 lines.
+
+**B1. `src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj`**
+
+Add MinVer to the existing `<ItemGroup>` of package references, mirroring `AHKFlowApp.API.csproj`:
+
+```xml
+<PackageReference Include="MinVer">
+  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+  <PrivateAssets>all</PrivateAssets>
+</PackageReference>
+```
+
+No version attribute (Central Package Management). No other csproj changes.
+
+**B2. `.github/workflows/release-cli.yml` — extend the "Verify package" step**
+
+Append to the existing PowerShell block in the `package` job's verify step, after the current `ahkflow.exe --help` invocation:
+
+```powershell
+$expectedVersion = $env:RELEASE_TAG.TrimStart("v")
+$versionOutput = & (Join-Path $extractPath "ahkflow.exe") --version 2>&1
+if ($LASTEXITCODE -ne 0) {
+    throw "ahkflow.exe --version failed with exit code $LASTEXITCODE."
+}
+
+$actualVersion = ($versionOutput | Select-Object -First 1).Trim().Split("+")[0]
+if ($actualVersion -ne $expectedVersion) {
+    throw "Version mismatch. Tag: $expectedVersion. Binary reports: $actualVersion. Expected the binary's InformationalVersion to match the tag (sans 'v')."
+}
+```
+
+Rationale:
+- Splits on `+` so the SDK's source-revision-id (everything after `+`) does not break the comparison; the prefix is what must match.
+- Trims `v` from the tag to mirror the manifest's `PackageVersion` convention.
+- Hard-fails the workflow — same severity as the existing `appsettings.json` checks in the same step.
+- Runs against the extracted zip, not the raw publish directory, so the verified bytes are what users receive.
+
+**B3. `docs/cli/winget-submission.md` — one-line runbook addition**
+
+In the "Subsequent releases (v0.1.2 and later)" section, insert between the paragraph that follows the `wingetcreate new-version` snippet ("`wingetcreate` clones your fork…") and the "**Versioning rule:**" line:
+
+> The `release-cli.yml` workflow asserts that the binary's reported version matches the tag before publishing the release asset, so by the time you reach this step the SHA256 is pinned to a correctly-versioned binary.
+
+## Verification
+
+Once Part B lands and `v0.1.3` is tagged + the workflow runs:
+
+1. The `Verify package` step asserts `ahkflow.exe --version` starts with `0.1.3` — otherwise the workflow fails before publishing.
+2. After the workflow publishes the release asset, run locally:
+   ```powershell
+   $tag = "v0.1.3"
+   Invoke-WebRequest "https://github.com/<owner>/AHKFlowApp/releases/download/$tag/ahkflow-win-x64.zip" -OutFile ahkflow.zip
+   Expand-Archive ahkflow.zip -DestinationPath .\ahkflow-extract
+   .\ahkflow-extract\ahkflow.exe --version  # expect: 0.1.3+<sha>
+   ```
+3. Submit the v0.1.3 winget PR per the runbook. The validator's manual `ahkflow --version` check should now report `0.1.3+<sha>`.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| MinVer requires deep git history. | `release-cli.yml`'s checkout already uses `fetch-depth: 0`. Confirmed before design. |
+| Local `dotnet run` after merge shows e.g. `0.1.3-alpha.0.1+<sha>` on untagged commits. | Expected MinVer behavior. Fine for development; the gate only runs in the release workflow. |
+| `System.CommandLine` could change how `--version` parses `AssemblyInformationalVersion` in a future major. | The gate splits on `+` defensively. If the format ever changes more substantively, the gate will fail loudly, which is what we want. |
+| Validator declines to merge v0.1.2 and demands a corrected binary first. | The reply explicitly offers the defer-and-resubmit path. If they take it, we cut v0.1.3, withdraw v0.1.2, submit fresh. Outcome difference is one merge cycle. |
+
+## Unresolved questions
+
+None at design time. Open during implementation:
+
+- Backlog item — assign 032? Defer.
+- Patch-level (0.1.3) vs minor bump (0.2.0)? Patch — purely cosmetic fix, no behavior change.

--- a/docs/superpowers/specs/2026-05-18-cli-binary-version-fix-design.md
+++ b/docs/superpowers/specs/2026-05-18-cli-binary-version-fix-design.md
@@ -1,7 +1,7 @@
 # CLI binary version self-reporting — design
 
 **Status:** Approved (brainstorming, 2026-05-18)
-**Related:** backlog [031](../../.claude/backlog/031-cli-winget-distribution.md), spec [2026-05-14-031-cli-winget-distribution-design.md](2026-05-14-031-cli-winget-distribution-design.md)
+**Related:** backlog [031](../../../.claude/backlog/031-cli-winget-distribution.md), spec [2026-05-14-031-cli-winget-distribution-design.md](2026-05-14-031-cli-winget-distribution-design.md)
 **Trigger:** [winget-pkgs PR #374595, comment 4480496773](https://github.com/microsoft/winget-pkgs/pull/374595#issuecomment-4480496773)
 
 ## Problem

--- a/src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj
+++ b/src/Tools/AHKFlowApp.CLI/AHKFlowApp.CLI.csproj
@@ -15,6 +15,10 @@
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
+    <PackageReference Include="MinVer">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Serilog.Extensions.Hosting" />
     <PackageReference Include="Serilog.Settings.Configuration" />
     <PackageReference Include="Serilog.Sinks.Console" />


### PR DESCRIPTION
## Summary
- Wires MinVer into `AHKFlowApp.CLI.csproj` so `ahkflow --version` reflects the git tag instead of the SDK fallback `1.0.0+sha`. Addresses winget-pkgs PR #374595 validator finding.
- Adds a stdout-only, regex-based version-vs-tag assertion to the `Verify package` step in `release-cli.yml` so a future regression cannot ship to winget silently. Gate compares full SemVer identity (incl. pre-release), discarding only `+build` metadata.
- Drops `--clobber` from the `Publish GitHub Release asset` step and replaces it with an explicit asset-existence check that hard-fails on re-run. Closes the gap where re-running the workflow on an existing tag would mutate a SHA256 already merged into winget.
- Updates `docs/cli/winget-submission.md` to document the new immutability guarantee.

## Spec
`docs/superpowers/specs/2026-05-18-cli-binary-version-fix-design.md`

## Test plan
- [ ] CI: build + test pass on the PR.
- [ ] After merge, tag `v0.1.3` and trigger the release workflow. The `Verify package` step asserts the binary reports `0.1.3` before upload; the `Publish` step uploads on first run.
- [ ] Re-run the release workflow on the same tag. Confirm it fails at the upload step with the immutability error.
- [ ] Submit a fresh winget PR for v0.1.3 per `docs/cli/winget-submission.md`. Validator's `ahkflow --version` smoke check should report `0.1.3+<sha>`.
