### PR TITLE
fix(test): wait for edit mode before querying replacement-input

### DIFF
--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -217,6 +217,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         IRenderedComponent<Hotstrings> cut = RenderPage();
         cut.WaitForAssertion(() => cut.Find("button.start-edit"));
         cut.Find("button.start-edit").Click();
+        cut.WaitForAssertion(() => cut.Find("input[data-test=\"replacement-input\"]"));
         cut.Find("input[data-test=\"replacement-input\"]").Input("by the way!");
         cut.Find("button.commit-edit").Click();
 


### PR DESCRIPTION
## Summary
- `Page_EditExistingRow_CallsUpdate` clicked `start-edit` then immediately queried `input[data-test="replacement-input"]` before Blazor re-rendered the row in edit mode. Intermittent `ElementNotFoundException` — surfaced in the `release-cli.yml` test run for v0.1.3.
- Fix: add `WaitForAssertion(() => cut.Find("input[data-test=\"replacement-input\"]"))` between the click and the input interaction.

## Test plan
- [ ] CI: build + test pass.
- [ ] After merge, re-run the `release-cli.yml` workflow on the `v0.1.3` tag.