### PR TITLE
feat: expand dev seed data to 12 hotstrings + 12 hotkeys + categories

### DIFF
--- a/src/Backend/AHKFlowApp.API/Controllers/DevController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/DevController.cs
@@ -12,6 +12,8 @@ namespace AHKFlowApp.API.Controllers;
 [Route("api/v1/dev")]
 [Authorize]
 [RequiredScope("access_as_user")]
+[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
 public sealed class DevController(IMediator mediator) : ControllerBase
 {
     /// <summary>Seeds a curated set of sample hotstrings for the authenticated user. Development only.</summary>

--- a/src/Backend/AHKFlowApp.API/Controllers/DevController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/DevController.cs
@@ -22,4 +22,32 @@ public sealed class DevController(IMediator mediator) : ControllerBase
         [FromQuery] bool reset = false,
         CancellationToken ct = default) =>
         (await mediator.Send(new SeedHotstringsCommand(reset), ct)).ToProblemActionResult(this);
+
+    /// <summary>Seeds the eight default categories for the authenticated user. Development only.</summary>
+    [HttpPost("categories/seed")]
+    [ProducesResponseType(typeof(IReadOnlyList<CategoryDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<IReadOnlyList<CategoryDto>>> SeedCategories(
+        [FromQuery] bool reset = false,
+        CancellationToken ct = default) =>
+        (await mediator.Send(new SeedCategoriesCommand(reset), ct)).ToProblemActionResult(this);
+
+    /// <summary>Seeds 12 sample hotkeys for the authenticated user. Development only.</summary>
+    [HttpPost("hotkeys/seed")]
+    [ProducesResponseType(typeof(PagedList<HotkeyDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<PagedList<HotkeyDto>>> SeedHotkeys(
+        [FromQuery] bool reset = false,
+        CancellationToken ct = default) =>
+        (await mediator.Send(new SeedHotkeysCommand(reset), ct)).ToProblemActionResult(this);
+
+    /// <summary>Runs the full seed pipeline (categories + hotstrings + hotkeys) in a single transaction. Development only.</summary>
+    [HttpPost("seed-all")]
+    [ProducesResponseType(typeof(SeedAllResultDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<SeedAllResultDto>> SeedAll(
+        [FromQuery] bool reset = false,
+        CancellationToken ct = default) =>
+        (await mediator.Send(new SeedAllCommand(reset), ct)).ToProblemActionResult(this);
 }

--- a/src/Backend/AHKFlowApp.Application/Abstractions/IAppDbContext.cs
+++ b/src/Backend/AHKFlowApp.Application/Abstractions/IAppDbContext.cs
@@ -21,4 +21,6 @@ public interface IAppDbContext
     Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class;
 
     Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default);
+
+    IExecutionStrategy CreateExecutionStrategy();
 }

--- a/src/Backend/AHKFlowApp.Application/Abstractions/IAppDbContext.cs
+++ b/src/Backend/AHKFlowApp.Application/Abstractions/IAppDbContext.cs
@@ -1,5 +1,6 @@
 using AHKFlowApp.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace AHKFlowApp.Application.Abstractions;
 
@@ -18,4 +19,6 @@ public interface IAppDbContext
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 
     Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class;
+
+    Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedAllCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedAllCommand.cs
@@ -2,6 +2,7 @@ using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.DTOs;
 using Ardalis.Result;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace AHKFlowApp.Application.Commands.Dev;
@@ -21,37 +22,45 @@ internal sealed class SeedAllCommandHandler(
         if (!env.IsDevelopment)
             return Result.NotFound();
 
-        // `await using` rolls the transaction back if it is disposed without a
-        // commit — including when a child step throws. Unexpected exceptions are
-        // left to GlobalExceptionMiddleware; the handler never swallows them.
-        await using IDbContextTransaction tx = await db.BeginTransactionAsync(ct);
-
-        Result<IReadOnlyList<CategoryDto>> catResult = await mediator.Send(new SeedCategoriesCommand(request.Reset), ct);
-        if (!catResult.IsSuccess)
+        // The DbContext is configured with EnableRetryOnFailure, so a manual
+        // transaction must run inside an execution strategy — the strategy
+        // re-runs the whole unit on a transient failure.
+        IExecutionStrategy strategy = db.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async token =>
         {
-            await tx.RollbackAsync(ct);
-            return Result.Error("seed-all: categories step failed");
-        }
+            // `await using` rolls the transaction back if it is disposed without
+            // a commit — including when a child step throws. Unexpected
+            // exceptions are left to GlobalExceptionMiddleware; the handler
+            // never swallows them.
+            await using IDbContextTransaction tx = await db.BeginTransactionAsync(token);
 
-        Result<PagedList<HotstringDto>> hsResult = await mediator.Send(new SeedHotstringsCommand(request.Reset), ct);
-        if (!hsResult.IsSuccess)
-        {
-            await tx.RollbackAsync(ct);
-            return Result.Error("seed-all: hotstrings step failed");
-        }
+            Result<IReadOnlyList<CategoryDto>> catResult = await mediator.Send(new SeedCategoriesCommand(request.Reset), token);
+            if (!catResult.IsSuccess)
+            {
+                await tx.RollbackAsync(token);
+                return Result.Error("seed-all: categories step failed");
+            }
 
-        Result<PagedList<HotkeyDto>> hkResult = await mediator.Send(new SeedHotkeysCommand(request.Reset), ct);
-        if (!hkResult.IsSuccess)
-        {
-            await tx.RollbackAsync(ct);
-            return Result.Error("seed-all: hotkeys step failed");
-        }
+            Result<PagedList<HotstringDto>> hsResult = await mediator.Send(new SeedHotstringsCommand(request.Reset), token);
+            if (!hsResult.IsSuccess)
+            {
+                await tx.RollbackAsync(token);
+                return Result.Error("seed-all: hotstrings step failed");
+            }
 
-        await tx.CommitAsync(ct);
+            Result<PagedList<HotkeyDto>> hkResult = await mediator.Send(new SeedHotkeysCommand(request.Reset), token);
+            if (!hkResult.IsSuccess)
+            {
+                await tx.RollbackAsync(token);
+                return Result.Error("seed-all: hotkeys step failed");
+            }
 
-        return Result.Success(new SeedAllResultDto(
-            CategoriesCount: catResult.Value.Count,
-            HotstringsCount: hsResult.Value.TotalCount,
-            HotkeysCount: hkResult.Value.TotalCount));
+            await tx.CommitAsync(token);
+
+            return Result.Success(new SeedAllResultDto(
+                CategoriesCount: catResult.Value.Count,
+                HotstringsCount: hsResult.Value.TotalCount,
+                HotkeysCount: hkResult.Value.TotalCount));
+        }, ct);
     }
 }

--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedAllCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedAllCommand.cs
@@ -38,21 +38,21 @@ internal sealed class SeedAllCommandHandler(
             if (!catResult.IsSuccess)
             {
                 await tx.RollbackAsync(token);
-                return Result.Error("seed-all: categories step failed");
+                return PropagateStepFailure(catResult, "categories");
             }
 
             Result<PagedList<HotstringDto>> hsResult = await mediator.Send(new SeedHotstringsCommand(request.Reset), token);
             if (!hsResult.IsSuccess)
             {
                 await tx.RollbackAsync(token);
-                return Result.Error("seed-all: hotstrings step failed");
+                return PropagateStepFailure(hsResult, "hotstrings");
             }
 
             Result<PagedList<HotkeyDto>> hkResult = await mediator.Send(new SeedHotkeysCommand(request.Reset), token);
             if (!hkResult.IsSuccess)
             {
                 await tx.RollbackAsync(token);
-                return Result.Error("seed-all: hotkeys step failed");
+                return PropagateStepFailure(hkResult, "hotkeys");
             }
 
             await tx.CommitAsync(token);
@@ -62,5 +62,20 @@ internal sealed class SeedAllCommandHandler(
                 HotstringsCount: hsResult.Value.TotalCount,
                 HotkeysCount: hkResult.Value.TotalCount));
         }, ct);
+    }
+
+    private static Result<SeedAllResultDto> PropagateStepFailure<T>(Result<T> result, string stepName)
+    {
+        string detail = result.Errors.FirstOrDefault() ?? $"seed-all: {stepName} step failed";
+
+        return result.Status switch
+        {
+            ResultStatus.Unauthorized => Result.Unauthorized(),
+            ResultStatus.Forbidden => Result.Forbidden(),
+            ResultStatus.NotFound => Result.NotFound(detail),
+            ResultStatus.Conflict => Result.Conflict(detail),
+            ResultStatus.Invalid => Result.Invalid([.. result.ValidationErrors]),
+            _ => Result.Error(detail),
+        };
     }
 }

--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedAllCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedAllCommand.cs
@@ -1,0 +1,57 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.DTOs;
+using Ardalis.Result;
+using MediatR;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace AHKFlowApp.Application.Commands.Dev;
+
+// Dev-only: runs the full seed pipeline (categories, hotstrings, hotkeys) inside
+// a single transaction. Any failure rolls the whole pipeline back.
+public sealed record SeedAllCommand(bool Reset) : IRequest<Result<SeedAllResultDto>>;
+
+internal sealed class SeedAllCommandHandler(
+    IAppDbContext db,
+    IMediator mediator,
+    AppEnvironment env)
+    : IRequestHandler<SeedAllCommand, Result<SeedAllResultDto>>
+{
+    public async Task<Result<SeedAllResultDto>> Handle(SeedAllCommand request, CancellationToken ct)
+    {
+        if (!env.IsDevelopment)
+            return Result.NotFound();
+
+        // `await using` rolls the transaction back if it is disposed without a
+        // commit — including when a child step throws. Unexpected exceptions are
+        // left to GlobalExceptionMiddleware; the handler never swallows them.
+        await using IDbContextTransaction tx = await db.BeginTransactionAsync(ct);
+
+        Result<IReadOnlyList<CategoryDto>> catResult = await mediator.Send(new SeedCategoriesCommand(request.Reset), ct);
+        if (!catResult.IsSuccess)
+        {
+            await tx.RollbackAsync(ct);
+            return Result.Error("seed-all: categories step failed");
+        }
+
+        Result<PagedList<HotstringDto>> hsResult = await mediator.Send(new SeedHotstringsCommand(request.Reset), ct);
+        if (!hsResult.IsSuccess)
+        {
+            await tx.RollbackAsync(ct);
+            return Result.Error("seed-all: hotstrings step failed");
+        }
+
+        Result<PagedList<HotkeyDto>> hkResult = await mediator.Send(new SeedHotkeysCommand(request.Reset), ct);
+        if (!hkResult.IsSuccess)
+        {
+            await tx.RollbackAsync(ct);
+            return Result.Error("seed-all: hotkeys step failed");
+        }
+
+        await tx.CommitAsync(ct);
+
+        return Result.Success(new SeedAllResultDto(
+            CategoriesCount: catResult.Value.Count,
+            HotstringsCount: hsResult.Value.TotalCount,
+            HotkeysCount: hkResult.Value.TotalCount));
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedCategoriesCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedCategoriesCommand.cs
@@ -1,0 +1,88 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Entities;
+using Ardalis.Result;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace AHKFlowApp.Application.Commands.Dev;
+
+// Dev-only: seeds the eight starter categories for the current user.
+// Idempotent on (OwnerOid, Name). Also sets UserPreference.CategoriesSeededAt
+// so a subsequent GET /categories does not lazy-seed again.
+public sealed record SeedCategoriesCommand(bool Reset) : IRequest<Result<IReadOnlyList<CategoryDto>>>;
+
+internal sealed class SeedCategoriesCommandHandler(
+    IAppDbContext db,
+    ICurrentUser currentUser,
+    TimeProvider clock,
+    AppEnvironment env)
+    : IRequestHandler<SeedCategoriesCommand, Result<IReadOnlyList<CategoryDto>>>
+{
+    public static readonly string[] DefaultNames =
+    [
+        "Autocorrect", "Communication", "DateTime", "Email",
+        "Code", "Symbols", "Window Management", "App Launcher",
+    ];
+
+    public async Task<Result<IReadOnlyList<CategoryDto>>> Handle(SeedCategoriesCommand request, CancellationToken ct)
+    {
+        if (!env.IsDevelopment)
+            return Result.NotFound();
+
+        if (currentUser.Oid is not Guid ownerOid)
+            return Result.Unauthorized();
+
+        if (request.Reset)
+        {
+            List<Category> existing = await db.Categories
+                .Where(c => c.OwnerOid == ownerOid)
+                .ToListAsync(ct);
+            db.Categories.RemoveRange(existing);
+        }
+
+        // After RemoveRange the rows still exist in the DB until SaveChanges, so a
+        // per-name query would wrongly report them as present. On reset, treat the
+        // owner's category set as empty and insert the full default list fresh.
+        HashSet<string> existingNames = request.Reset
+            ? new(StringComparer.OrdinalIgnoreCase)
+            : (await db.Categories
+                    .Where(c => c.OwnerOid == ownerOid)
+                    .Select(c => c.Name)
+                    .ToListAsync(ct))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (string name in DefaultNames)
+        {
+            if (!existingNames.Add(name)) continue;
+            db.Categories.Add(Category.Create(ownerOid, name, clock));
+        }
+
+        // Upsert the seed marker so a later GET /categories does not also lazy-seed.
+        UserPreference? pref = await db.UserPreferences
+            .FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
+        if (pref is null)
+        {
+            pref = UserPreference.CreateDefault(ownerOid, clock);
+            db.UserPreferences.Add(pref);
+        }
+        if (request.Reset)
+        {
+            // MarkCategoriesSeeded is a no-op when already set; clear it so reset
+            // refreshes the marker to the current clock tick.
+            db.Entry(pref).Property(p => p.CategoriesSeededAt).CurrentValue = null;
+        }
+        pref.MarkCategoriesSeeded(clock);
+
+        await db.SaveChangesAsync(ct);
+
+        List<CategoryDto> items = await db.Categories
+            .AsNoTracking()
+            .Where(c => c.OwnerOid == ownerOid)
+            .OrderBy(c => c.Name)
+            .Select(c => new CategoryDto(c.Id, c.Name, c.CreatedAt, c.UpdatedAt))
+            .ToListAsync(ct);
+
+        return Result.Success<IReadOnlyList<CategoryDto>>(items);
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotkeysCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotkeysCommand.cs
@@ -1,0 +1,133 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
+using Ardalis.Result;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace AHKFlowApp.Application.Commands.Dev;
+
+// Dev-only: seeds curated sample hotkeys for the current user, each linked to
+// one or more categories. Idempotent on (OwnerOid, Key, Ctrl, Alt, Shift, Win);
+// a non-reset re-run backfills missing category links onto pre-existing rows.
+public sealed record SeedHotkeysCommand(bool Reset) : IRequest<Result<PagedList<HotkeyDto>>>;
+
+internal sealed class SeedHotkeysCommandHandler(
+    IAppDbContext db,
+    ICurrentUser currentUser,
+    TimeProvider clock,
+    AppEnvironment env)
+    : IRequestHandler<SeedHotkeysCommand, Result<PagedList<HotkeyDto>>>
+{
+    private static readonly (
+        string Description,
+        bool Ctrl, bool Alt, bool Shift, bool Win,
+        string Key,
+        HotkeyAction Action,
+        string Parameters,
+        string[] Categories)[] s_samples =
+    [
+        ("Launch Windows Terminal", true,  true,  false, false, "T",     HotkeyAction.Run,  "wt.exe",       ["App Launcher"]),
+        ("Launch Notepad",          true,  true,  false, false, "N",     HotkeyAction.Run,  "notepad.exe",  ["App Launcher"]),
+        ("Launch File Explorer",    true,  true,  false, false, "E",     HotkeyAction.Run,  "explorer.exe", ["App Launcher"]),
+        ("Open default browser",    true,  true,  false, false, "B",     HotkeyAction.Run,  "https://",     ["App Launcher"]),
+        ("Maximize window",         false, true,  false, true,  "Up",    HotkeyAction.Send, "{Up}",         ["Window Management"]),
+        ("Minimize window",         false, true,  false, true,  "Down",  HotkeyAction.Send, "{Down}",       ["Window Management"]),
+        ("Snap window left",        false, true,  false, true,  "Left",  HotkeyAction.Send, "{Left}",       ["Window Management"]),
+        ("Snap window right",       false, true,  false, true,  "Right", HotkeyAction.Send, "{Right}",      ["Window Management"]),
+        ("Paste as plain text",     true,  false, true,  false, "V",     HotkeyAction.Send, "^v",           ["Code"]),
+        ("Insert today's date",     true,  true,  false, false, "D",     HotkeyAction.Send, "{{date:yyyy-MM-dd}}", ["DateTime"]),
+        ("Lock workstation",        true,  true,  false, false, "L",     HotkeyAction.Run,  "rundll32.exe user32.dll,LockWorkStation", ["App Launcher"]),
+        ("Reload AHK script",       true,  true,  false, false, "R",     HotkeyAction.Run,  "Reload",       ["App Launcher"]),
+    ];
+
+    public async Task<Result<PagedList<HotkeyDto>>> Handle(SeedHotkeysCommand request, CancellationToken ct)
+    {
+        if (!env.IsDevelopment)
+            return Result.NotFound();
+
+        if (currentUser.Oid is not Guid ownerOid)
+            return Result.Unauthorized();
+
+        if (request.Reset)
+        {
+            List<Hotkey> existing = await db.Hotkeys
+                .Where(h => h.OwnerOid == ownerOid)
+                .ToListAsync(ct);
+            db.Hotkeys.RemoveRange(existing);
+        }
+
+        Dictionary<string, Guid> catByName = await db.Categories
+            .Where(c => c.OwnerOid == ownerOid)
+            .ToDictionaryAsync(c => c.Name, c => c.Id, ct);
+
+        // On reset the prior hotkeys/junctions still exist in the DB until
+        // SaveChanges (junctions cascade-delete with their hotkeys), so treat the
+        // link set as empty and skip the per-key existence lookup.
+        HashSet<(Guid HotkeyId, Guid CategoryId)> existingLinks = request.Reset
+            ? []
+            : (await db.HotkeyCategories
+                    .Where(hc => hc.Hotkey.OwnerOid == ownerOid)
+                    .Select(hc => new { hc.HotkeyId, hc.CategoryId })
+                    .ToListAsync(ct))
+                .Select(x => (x.HotkeyId, x.CategoryId))
+                .ToHashSet();
+
+        foreach ((string descr, bool ctrl, bool alt, bool shift, bool win, string key, HotkeyAction action, string param, string[] cats) in s_samples)
+        {
+            Hotkey? existing = request.Reset
+                ? null
+                : await db.Hotkeys.FirstOrDefaultAsync(h =>
+                    h.OwnerOid == ownerOid &&
+                    h.Key == key &&
+                    h.Ctrl == ctrl && h.Alt == alt && h.Shift == shift && h.Win == win, ct);
+
+            Guid hotkeyId;
+            if (existing is not null)
+            {
+                hotkeyId = existing.Id;
+            }
+            else
+            {
+                var entity = Hotkey.Create(
+                    ownerOid, descr, key, ctrl, alt, shift, win, action, param,
+                    appliesToAllProfiles: true, clock);
+                db.Hotkeys.Add(entity);
+                hotkeyId = entity.Id;
+            }
+
+            foreach (string cat in cats)
+            {
+                if (!catByName.TryGetValue(cat, out Guid cid)) continue;
+                if (!existingLinks.Add((hotkeyId, cid))) continue;
+                db.HotkeyCategories.Add(HotkeyCategory.Create(hotkeyId, cid));
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+
+        List<HotkeyDto> items = await db.Hotkeys
+            .AsNoTracking()
+            .Where(h => h.OwnerOid == ownerOid)
+            .OrderBy(h => h.Description)
+            .Select(h => new HotkeyDto(
+                h.Id,
+                h.Profiles.Select(p => p.ProfileId).ToArray(),
+                h.AppliesToAllProfiles,
+                h.Description,
+                h.Key,
+                h.Ctrl,
+                h.Alt,
+                h.Shift,
+                h.Win,
+                h.Action,
+                h.Parameters,
+                h.CreatedAt,
+                h.UpdatedAt,
+                h.Categories.Select(hc => hc.CategoryId).ToArray()))
+            .ToListAsync(ct);
+
+        return Result.Success(new PagedList<HotkeyDto>(items, Page: 1, PageSize: items.Count, TotalCount: items.Count));
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotkeysCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotkeysCommand.cs
@@ -58,9 +58,11 @@ internal sealed class SeedHotkeysCommandHandler(
             db.Hotkeys.RemoveRange(existing);
         }
 
-        Dictionary<string, Guid> catByName = await db.Categories
-            .Where(c => c.OwnerOid == ownerOid)
-            .ToDictionaryAsync(c => c.Name, c => c.Id, ct);
+        var catByName = (await db.Categories
+                .Where(c => c.OwnerOid == ownerOid)
+                .Select(c => new { c.Name, c.Id })
+                .ToListAsync(ct))
+            .ToDictionary(c => c.Name, c => c.Id, StringComparer.OrdinalIgnoreCase);
 
         // On reset the prior hotkeys/junctions still exist in the DB until
         // SaveChanges (junctions cascade-delete with their hotkeys), so treat the

--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotstringsCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotstringsCommand.cs
@@ -32,7 +32,7 @@ internal sealed class SeedHotstringsCommandHandler(
         ("fyi",     "for your information", true,  false, ["Communication"]),
         ("/today",  "{{date:yyyy-MM-dd}}",  false, false, ["DateTime"]),
         ("/now",    "{{datetime:HH:mm}}",   false, false, ["DateTime"]),
-        ("@sig",    "Bart Segers\nbart@segocom.nl\nSegocom", false, false, ["Email"]),
+        ("@sig",    "Example User\nuser@example.com\nExample Company", false, false, ["Email"]),
         (";arrow",  "→",               false, false, ["Symbols"]),
         (";check",  "✓",               false, false, ["Symbols"]),
         (";shrug",  "¯\\_(ツ)_/¯", false, false, ["Symbols"]),
@@ -56,9 +56,11 @@ internal sealed class SeedHotstringsCommandHandler(
             db.Hotstrings.RemoveRange(existing);
         }
 
-        Dictionary<string, Guid> categoryByName = await db.Categories
-            .Where(c => c.OwnerOid == ownerOid)
-            .ToDictionaryAsync(c => c.Name, c => c.Id, ct);
+        var categoryByName = (await db.Categories
+                .Where(c => c.OwnerOid == ownerOid)
+                .Select(c => new { c.Name, c.Id })
+                .ToListAsync(ct))
+            .ToDictionary(c => c.Name, c => c.Id, StringComparer.OrdinalIgnoreCase);
 
         // On reset the prior hotstrings/junctions still exist in the DB until
         // SaveChanges (junctions cascade-delete with their hotstrings), so treat

--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotstringsCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotstringsCommand.cs
@@ -1,6 +1,5 @@
 using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.DTOs;
-using AHKFlowApp.Application.Mapping;
 using AHKFlowApp.Domain.Entities;
 using Ardalis.Result;
 using MediatR;
@@ -8,7 +7,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace AHKFlowApp.Application.Commands.Dev;
 
-// Dev-only: seeds curated sample hotstrings for the current user.
+// Dev-only: seeds curated sample hotstrings for the current user, each linked
+// to one or more categories. Idempotent on (OwnerOid, Trigger); a non-reset
+// re-run backfills missing category links onto pre-existing seed rows.
 public sealed record SeedHotstringsCommand(bool Reset) : IRequest<Result<PagedList<HotstringDto>>>;
 
 internal sealed class SeedHotstringsCommandHandler(
@@ -18,11 +19,25 @@ internal sealed class SeedHotstringsCommandHandler(
     AppEnvironment env)
     : IRequestHandler<SeedHotstringsCommand, Result<PagedList<HotstringDto>>>
 {
-    private static readonly (string Trigger, string Replacement, bool Ending, bool InsideWord)[] s_samples =
+    private static readonly (
+        string Trigger,
+        string Replacement,
+        bool Ending,
+        bool InsideWord,
+        string[] Categories)[] s_samples =
     [
-        ("btw", "by the way",           true, true),
-        ("fyi", "for your information", true, true),
-        ("brb", "be right back",        true, true),
+        ("recieve", "receive",              true,  true,  ["Autocorrect"]),
+        ("btw",     "by the way",           true,  false, ["Communication"]),
+        ("brb",     "be right back",        true,  false, ["Communication"]),
+        ("fyi",     "for your information", true,  false, ["Communication"]),
+        ("/today",  "{{date:yyyy-MM-dd}}",  false, false, ["DateTime"]),
+        ("/now",    "{{datetime:HH:mm}}",   false, false, ["DateTime"]),
+        ("@sig",    "Bart Segers\nbart@segocom.nl\nSegocom", false, false, ["Email"]),
+        (";arrow",  "→",               false, false, ["Symbols"]),
+        (";check",  "✓",               false, false, ["Symbols"]),
+        (";shrug",  "¯\\_(ツ)_/¯", false, false, ["Symbols"]),
+        (";e:",     "ë",               false, false, ["Symbols"]),
+        (";todo",   "TODO(name): ",         false, false, ["Code"]),
     ];
 
     public async Task<Result<PagedList<HotstringDto>>> Handle(SeedHotstringsCommand request, CancellationToken ct)
@@ -41,17 +56,49 @@ internal sealed class SeedHotstringsCommandHandler(
             db.Hotstrings.RemoveRange(existing);
         }
 
-        foreach ((string trigger, string replacement, bool ending, bool inside) in s_samples)
+        Dictionary<string, Guid> categoryByName = await db.Categories
+            .Where(c => c.OwnerOid == ownerOid)
+            .ToDictionaryAsync(c => c.Name, c => c.Id, ct);
+
+        // On reset the prior hotstrings/junctions still exist in the DB until
+        // SaveChanges (junctions cascade-delete with their hotstrings), so treat
+        // the link set as empty and skip the per-trigger existence lookup.
+        HashSet<(Guid HotstringId, Guid CategoryId)> existingLinks = request.Reset
+            ? []
+            : (await db.HotstringCategories
+                    .Where(hc => hc.Hotstring.OwnerOid == ownerOid)
+                    .Select(hc => new { hc.HotstringId, hc.CategoryId })
+                    .ToListAsync(ct))
+                .Select(x => (x.HotstringId, x.CategoryId))
+                .ToHashSet();
+
+        foreach ((string trigger, string replacement, bool ending, bool inside, string[] cats) in s_samples)
         {
-            bool exists = await db.Hotstrings.AnyAsync(
-                h => h.OwnerOid == ownerOid && h.Trigger == trigger,
-                ct);
+            Hotstring? existing = request.Reset
+                ? null
+                : await db.Hotstrings.FirstOrDefaultAsync(
+                    h => h.OwnerOid == ownerOid && h.Trigger == trigger, ct);
 
-            if (exists) continue;
+            Guid hotstringId;
+            if (existing is not null)
+            {
+                hotstringId = existing.Id;
+            }
+            else
+            {
+                var entity = Hotstring.Create(
+                    ownerOid, trigger, replacement, description: null, appliesToAllProfiles: true,
+                    isEndingCharacterRequired: ending, isTriggerInsideWord: inside, clock);
+                db.Hotstrings.Add(entity);
+                hotstringId = entity.Id;
+            }
 
-            db.Hotstrings.Add(Hotstring.Create(
-                ownerOid, trigger, replacement, description: null, appliesToAllProfiles: true,
-                isEndingCharacterRequired: ending, isTriggerInsideWord: inside, clock));
+            foreach (string categoryName in cats)
+            {
+                if (!categoryByName.TryGetValue(categoryName, out Guid categoryId)) continue;
+                if (!existingLinks.Add((hotstringId, categoryId))) continue;
+                db.HotstringCategories.Add(HotstringCategory.Create(hotstringId, categoryId));
+            }
         }
 
         await db.SaveChangesAsync(ct);

--- a/src/Backend/AHKFlowApp.Application/DTOs/SeedAllResultDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/SeedAllResultDto.cs
@@ -1,0 +1,6 @@
+namespace AHKFlowApp.Application.DTOs;
+
+public sealed record SeedAllResultDto(
+    int CategoriesCount,
+    int HotstringsCount,
+    int HotkeysCount);

--- a/src/Backend/AHKFlowApp.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Persistence/AppDbContext.cs
@@ -21,6 +21,9 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
     public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
         => Database.BeginTransactionAsync(cancellationToken);
 
+    public IExecutionStrategy CreateExecutionStrategy()
+        => Database.CreateExecutionStrategy();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);

--- a/src/Backend/AHKFlowApp.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Persistence/AppDbContext.cs
@@ -1,6 +1,7 @@
 using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace AHKFlowApp.Infrastructure.Persistence;
 
@@ -16,6 +17,9 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
     public DbSet<Category> Categories => Set<Category>();
     public DbSet<HotstringCategory> HotstringCategories => Set<HotstringCategory>();
     public DbSet<HotkeyCategory> HotkeyCategories => Set<HotkeyCategory>();
+
+    public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+        => Database.BeginTransactionAsync(cancellationToken);
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/tests/AHKFlowApp.API.Tests/Dev/DevSeedEndpointTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Dev/DevSeedEndpointTests.cs
@@ -8,9 +8,39 @@ using Xunit;
 namespace AHKFlowApp.API.Tests.Dev;
 
 [Collection("WebApi")]
-public sealed class SeedAllEndpointTests(SqlContainerFixture sqlFixture) : IDisposable
+public sealed class DevSeedEndpointTests(SqlContainerFixture sqlFixture) : IDisposable
 {
     private readonly CustomWebApplicationFactory _factory = new(sqlFixture);
+
+    [Fact]
+    public async Task SeedCategories_Returns200WithEightCategories()
+    {
+        using HttpClient client = _factory
+            .WithTestAuth(b => b.WithOid(Guid.NewGuid()))
+            .CreateClient();
+
+        HttpResponseMessage resp = await client.PostAsync("/api/v1/dev/categories/seed?reset=true", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        List<CategoryDto>? body = await resp.Content.ReadFromJsonAsync<List<CategoryDto>>();
+        body.Should().NotBeNull();
+        body!.Should().HaveCount(8);
+    }
+
+    [Fact]
+    public async Task SeedHotkeys_Returns200WithTwelveHotkeys()
+    {
+        using HttpClient client = _factory
+            .WithTestAuth(b => b.WithOid(Guid.NewGuid()))
+            .CreateClient();
+
+        HttpResponseMessage resp = await client.PostAsync("/api/v1/dev/hotkeys/seed?reset=true", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        PagedList<HotkeyDto>? body = await resp.Content.ReadFromJsonAsync<PagedList<HotkeyDto>>();
+        body.Should().NotBeNull();
+        body!.Items.Should().HaveCount(12);
+    }
 
     [Fact]
     public async Task SeedAll_ReturnsCountsAnd200_InDevelopment()

--- a/tests/AHKFlowApp.API.Tests/Dev/SeedAllEndpointTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Dev/SeedAllEndpointTests.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using System.Net.Http.Json;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.TestUtilities.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.API.Tests.Dev;
+
+[Collection("WebApi")]
+public sealed class SeedAllEndpointTests(SqlContainerFixture sqlFixture) : IDisposable
+{
+    private readonly CustomWebApplicationFactory _factory = new(sqlFixture);
+
+    [Fact]
+    public async Task SeedAll_ReturnsCountsAnd200_InDevelopment()
+    {
+        using HttpClient client = _factory
+            .WithTestAuth(b => b.WithOid(Guid.NewGuid()))
+            .CreateClient();
+
+        HttpResponseMessage resp = await client.PostAsync("/api/v1/dev/seed-all?reset=true", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        SeedAllResultDto? result = await resp.Content.ReadFromJsonAsync<SeedAllResultDto>();
+        result.Should().NotBeNull();
+        result!.CategoriesCount.Should().Be(8);
+        result.HotstringsCount.Should().Be(12);
+        result.HotkeysCount.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task SeedAll_IsIdempotent_OnRepeatCall()
+    {
+        using HttpClient client = _factory
+            .WithTestAuth(b => b.WithOid(Guid.NewGuid()))
+            .CreateClient();
+
+        await client.PostAsync("/api/v1/dev/seed-all?reset=true", content: null);
+        HttpResponseMessage resp = await client.PostAsync("/api/v1/dev/seed-all?reset=false", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        SeedAllResultDto? result = await resp.Content.ReadFromJsonAsync<SeedAllResultDto>();
+        result.Should().NotBeNull();
+        result!.CategoriesCount.Should().Be(8);
+        result.HotstringsCount.Should().Be(12);
+        result.HotkeysCount.Should().Be(12);
+    }
+
+    public void Dispose() => _factory.Dispose();
+}

--- a/tests/AHKFlowApp.Application.Tests/Dev/DevDbFixture.cs
+++ b/tests/AHKFlowApp.Application.Tests/Dev/DevDbFixture.cs
@@ -1,0 +1,32 @@
+using AHKFlowApp.Infrastructure.Persistence;
+using AHKFlowApp.TestUtilities.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Dev;
+
+public sealed class DevDbFixture : IAsyncLifetime
+{
+    private readonly SqlContainerFixture _sql = new();
+    public string ConnectionString => _sql.ConnectionString;
+
+    public async Task InitializeAsync()
+    {
+        await _sql.InitializeAsync();
+        await using AppDbContext ctx = CreateContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    public Task DisposeAsync() => _sql.DisposeAsync();
+
+    public AppDbContext CreateContext()
+    {
+        DbContextOptions<AppDbContext> options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlServer(ConnectionString)
+            .Options;
+        return new AppDbContext(options);
+    }
+}
+
+[CollectionDefinition("DevDb")]
+public sealed class DevDbCollection : ICollectionFixture<DevDbFixture>;

--- a/tests/AHKFlowApp.Application.Tests/Dev/SeedAllCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Dev/SeedAllCommandHandlerTests.cs
@@ -28,14 +28,14 @@ public sealed class SeedAllCommandHandlerTests(DevDbFixture fx)
         return u;
     }
 
-    private ServiceProvider BuildProvider(IAppDbContext db)
+    private ServiceProvider BuildProvider(IAppDbContext db, ICurrentUser? user = null, AppEnvironment? appEnv = null)
     {
         ServiceCollection services = new();
         services.AddLogging();
         services.AddSingleton(db);
-        services.AddSingleton(User());
+        services.AddSingleton(user ?? User());
         services.AddSingleton<TimeProvider>(_clock);
-        services.AddSingleton(_devEnv);
+        services.AddSingleton(appEnv ?? _devEnv);
         services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<SeedAllCommand>());
         return services.BuildServiceProvider();
     }
@@ -102,18 +102,25 @@ public sealed class SeedAllCommandHandlerTests(DevDbFixture fx)
     public async Task SeedAll_ReturnsNotFound_When_NotInDevelopment()
     {
         await using AppDbContext ctx = fx.CreateContext();
-        ServiceCollection services = new();
-        services.AddLogging();
-        services.AddSingleton<IAppDbContext>(ctx);
-        services.AddSingleton(User());
-        services.AddSingleton<TimeProvider>(_clock);
-        services.AddSingleton(new AppEnvironment(IsDevelopment: false));
-        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<SeedAllCommand>());
-        await using ServiceProvider sp = services.BuildServiceProvider();
+        await using ServiceProvider sp = BuildProvider(ctx, appEnv: new AppEnvironment(IsDevelopment: false));
 
         Result<SeedAllResultDto> result = await sp.GetRequiredService<IMediator>()
             .Send(new SeedAllCommand(Reset: false));
 
         result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task SeedAll_PropagatesUnauthorized_WhenInnerStepReturnsUnauthorized()
+    {
+        await using AppDbContext ctx = fx.CreateContext();
+        ICurrentUser noUser = Substitute.For<ICurrentUser>();
+        noUser.Oid.Returns((Guid?)null);
+        await using ServiceProvider sp = BuildProvider(ctx, user: noUser);
+
+        Result<SeedAllResultDto> result = await sp.GetRequiredService<IMediator>()
+            .Send(new SeedAllCommand(Reset: false));
+
+        result.Status.Should().Be(ResultStatus.Unauthorized);
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/Dev/SeedAllCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Dev/SeedAllCommandHandlerTests.cs
@@ -1,0 +1,119 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.Commands.Dev;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Infrastructure.Persistence;
+using Ardalis.Result;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Dev;
+
+[Collection("DevDb")]
+public sealed class SeedAllCommandHandlerTests(DevDbFixture fx)
+{
+    private readonly Guid _ownerOid = Guid.NewGuid();
+    private readonly FakeTimeProvider _clock = new(DateTimeOffset.Parse("2026-05-19T12:00:00Z"));
+    private readonly AppEnvironment _devEnv = new(IsDevelopment: true);
+
+    private ICurrentUser User()
+    {
+        ICurrentUser u = Substitute.For<ICurrentUser>();
+        u.Oid.Returns(_ownerOid);
+        return u;
+    }
+
+    private ServiceProvider BuildProvider(IAppDbContext db)
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddSingleton(db);
+        services.AddSingleton(User());
+        services.AddSingleton<TimeProvider>(_clock);
+        services.AddSingleton(_devEnv);
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<SeedAllCommand>());
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task SeedAll_Inserts_AllThree_Inside_OneTransaction()
+    {
+        await using AppDbContext ctx = fx.CreateContext();
+        await using ServiceProvider sp = BuildProvider(ctx);
+
+        Result<SeedAllResultDto> result = await sp.GetRequiredService<IMediator>()
+            .Send(new SeedAllCommand(Reset: false));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CategoriesCount.Should().Be(8);
+        result.Value.HotstringsCount.Should().Be(12);
+        result.Value.HotkeysCount.Should().Be(12);
+
+        await using AppDbContext verify = fx.CreateContext();
+        (await verify.HotstringCategories.CountAsync(hc => hc.Hotstring.OwnerOid == _ownerOid)).Should().Be(12);
+        (await verify.HotkeyCategories.CountAsync(hc => hc.Hotkey.OwnerOid == _ownerOid)).Should().Be(12);
+    }
+
+    [Fact]
+    public async Task SeedAll_Reset_ClearsAll_AndReseeds()
+    {
+        await using (AppDbContext ctx1 = fx.CreateContext())
+        await using (ServiceProvider sp1 = BuildProvider(ctx1))
+        {
+            await sp1.GetRequiredService<IMediator>().Send(new SeedAllCommand(Reset: false));
+        }
+
+        await using AppDbContext ctx2 = fx.CreateContext();
+        await using ServiceProvider sp2 = BuildProvider(ctx2);
+
+        Result<SeedAllResultDto> result = await sp2.GetRequiredService<IMediator>()
+            .Send(new SeedAllCommand(Reset: true));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CategoriesCount.Should().Be(8);
+        result.Value.HotstringsCount.Should().Be(12);
+        result.Value.HotkeysCount.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task SeedAll_RollsBack_OnInnerFailure_LeavesNoRows()
+    {
+        await using AppDbContext realCtx = fx.CreateContext();
+        IAppDbContext failingDb = new ThrowOnNthSaveDbContext(realCtx, failOnCall: 2);
+        await using ServiceProvider sp = BuildProvider(failingDb);
+        IMediator mediator = sp.GetRequiredService<IMediator>();
+
+        Func<Task> act = async () => await mediator.Send(new SeedAllCommand(Reset: false));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        await using AppDbContext verify = fx.CreateContext();
+        (await verify.Categories.CountAsync(c => c.OwnerOid == _ownerOid)).Should().Be(0);
+        (await verify.Hotstrings.CountAsync(h => h.OwnerOid == _ownerOid)).Should().Be(0);
+        (await verify.Hotkeys.CountAsync(h => h.OwnerOid == _ownerOid)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SeedAll_ReturnsNotFound_When_NotInDevelopment()
+    {
+        await using AppDbContext ctx = fx.CreateContext();
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddSingleton<IAppDbContext>(ctx);
+        services.AddSingleton(User());
+        services.AddSingleton<TimeProvider>(_clock);
+        services.AddSingleton(new AppEnvironment(IsDevelopment: false));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<SeedAllCommand>());
+        await using ServiceProvider sp = services.BuildServiceProvider();
+
+        Result<SeedAllResultDto> result = await sp.GetRequiredService<IMediator>()
+            .Send(new SeedAllCommand(Reset: false));
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Dev/SeedCategoriesCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Dev/SeedCategoriesCommandHandlerTests.cs
@@ -1,0 +1,109 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.Commands.Dev;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Infrastructure.Persistence;
+using AHKFlowApp.TestUtilities.Builders;
+using Ardalis.Result;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Dev;
+
+[Collection("DevDb")]
+public sealed class SeedCategoriesCommandHandlerTests(DevDbFixture fx)
+{
+    private readonly Guid _ownerOid = Guid.NewGuid();
+    private readonly FakeTimeProvider _clock = new(DateTimeOffset.Parse("2026-05-19T12:00:00Z"));
+    private readonly AppEnvironment _devEnv = new(IsDevelopment: true);
+
+    private ICurrentUser User()
+    {
+        ICurrentUser u = Substitute.For<ICurrentUser>();
+        u.Oid.Returns(_ownerOid);
+        return u;
+    }
+
+    [Fact]
+    public async Task Seed_Inserts_EightDefaultCategories_AndMarksUserPreference()
+    {
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new SeedCategoriesCommandHandler(ctx, User(), _clock, _devEnv);
+
+        Result<IReadOnlyList<CategoryDto>> result = await sut.Handle(new SeedCategoriesCommand(Reset: false), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(8);
+        (await ctx.Categories.CountAsync(c => c.OwnerOid == _ownerOid)).Should().Be(8);
+
+        UserPreference? pref = await ctx.UserPreferences.AsNoTracking().FirstOrDefaultAsync(p => p.OwnerOid == _ownerOid);
+        pref.Should().NotBeNull();
+        pref!.CategoriesSeededAt.Should().Be(_clock.GetUtcNow());
+    }
+
+    [Fact]
+    public async Task Seed_Idempotent_WhenCategoriesAlreadyExist()
+    {
+        await using AppDbContext ctx = fx.CreateContext();
+        ctx.Categories.Add(new CategoryBuilder().WithOwner(_ownerOid).Named("Email").Build());
+        await ctx.SaveChangesAsync();
+
+        var sut = new SeedCategoriesCommandHandler(ctx, User(), _clock, _devEnv);
+
+        await sut.Handle(new SeedCategoriesCommand(Reset: false), default);
+
+        (await ctx.Categories.CountAsync(c => c.OwnerOid == _ownerOid)).Should().Be(8);
+    }
+
+    [Fact]
+    public async Task Reset_ClearsUserCategories_ThenInserts()
+    {
+        await using AppDbContext ctx = fx.CreateContext();
+        ctx.Categories.Add(new CategoryBuilder().WithOwner(_ownerOid).Named("Custom1").Build());
+        ctx.Categories.Add(new CategoryBuilder().WithOwner(_ownerOid).Named("Custom2").Build());
+        var prefBefore = UserPreference.CreateDefault(_ownerOid, _clock);
+        prefBefore.MarkCategoriesSeeded(_clock);
+        ctx.UserPreferences.Add(prefBefore);
+        await ctx.SaveChangesAsync();
+
+        _clock.Advance(TimeSpan.FromMinutes(5));
+        var sut = new SeedCategoriesCommandHandler(ctx, User(), _clock, _devEnv);
+        await sut.Handle(new SeedCategoriesCommand(Reset: true), default);
+
+        List<string> names = await ctx.Categories.Where(c => c.OwnerOid == _ownerOid).Select(c => c.Name).ToListAsync();
+        names.Should().HaveCount(8);
+        names.Should().NotContain(["Custom1", "Custom2"]);
+
+        UserPreference pref = await ctx.UserPreferences.AsNoTracking().FirstAsync(p => p.OwnerOid == _ownerOid);
+        pref.CategoriesSeededAt.Should().Be(_clock.GetUtcNow());
+    }
+
+    [Fact]
+    public async Task Reseed_AfterFullSeed_KeepsEightCategories()
+    {
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new SeedCategoriesCommandHandler(ctx, User(), _clock, _devEnv);
+        await sut.Handle(new SeedCategoriesCommand(Reset: false), default);
+
+        await using AppDbContext ctx2 = fx.CreateContext();
+        var sut2 = new SeedCategoriesCommandHandler(ctx2, User(), _clock, _devEnv);
+        await sut2.Handle(new SeedCategoriesCommand(Reset: true), default);
+
+        (await ctx2.Categories.CountAsync(c => c.OwnerOid == _ownerOid)).Should().Be(8);
+    }
+
+    [Fact]
+    public async Task Returns_NotFound_When_NotInDevelopment()
+    {
+        await using AppDbContext ctx = fx.CreateContext();
+        AppEnvironment prodEnv = new(IsDevelopment: false);
+        var sut = new SeedCategoriesCommandHandler(ctx, User(), _clock, prodEnv);
+
+        Result<IReadOnlyList<CategoryDto>> result = await sut.Handle(new SeedCategoriesCommand(Reset: false), default);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Dev/SeedHotkeysCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Dev/SeedHotkeysCommandHandlerTests.cs
@@ -1,0 +1,174 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.Commands.Dev;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Infrastructure.Persistence;
+using Ardalis.Result;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Dev;
+
+[Collection("DevDb")]
+public sealed class SeedHotkeysCommandHandlerTests(DevDbFixture fx)
+{
+    private const int SampleCount = 12;
+
+    private readonly Guid _ownerOid = Guid.NewGuid();
+    private readonly AppEnvironment _devEnv = new(IsDevelopment: true);
+
+    private ICurrentUser User(Guid? oid = null)
+    {
+        ICurrentUser u = Substitute.For<ICurrentUser>();
+        u.Oid.Returns(oid ?? _ownerOid);
+        return u;
+    }
+
+    private async Task SeedCategoriesAsync()
+    {
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new SeedCategoriesCommandHandler(db, User(), TimeProvider.System, _devEnv);
+        await handler.Handle(new SeedCategoriesCommand(Reset: false), default);
+    }
+
+    private SeedHotkeysCommandHandler Sut(AppDbContext db, ICurrentUser? user = null) =>
+        new(db, user ?? User(), TimeProvider.System, _devEnv);
+
+    [Fact]
+    public async Task Handle_InDevelopment_SeedsTwelveSamples()
+    {
+        await using AppDbContext db = fx.CreateContext();
+
+        Result<PagedList<HotkeyDto>> result = await Sut(db).Handle(new SeedHotkeysCommand(Reset: false), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Items.Should().HaveCount(SampleCount);
+    }
+
+    [Fact]
+    public async Task Handle_NotInDevelopment_ReturnsNotFound()
+    {
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new SeedHotkeysCommandHandler(db, User(), TimeProvider.System, new AppEnvironment(IsDevelopment: false));
+
+        Result<PagedList<HotkeyDto>> result = await handler.Handle(new SeedHotkeysCommand(false), default);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoOid_InDevEnv_ReturnsUnauthorized()
+    {
+        await using AppDbContext db = fx.CreateContext();
+        ICurrentUser noUser = Substitute.For<ICurrentUser>();
+        noUser.Oid.Returns((Guid?)null);
+        var handler = new SeedHotkeysCommandHandler(db, noUser, TimeProvider.System, _devEnv);
+
+        Result<PagedList<HotkeyDto>> result = await handler.Handle(new SeedHotkeysCommand(false), default);
+
+        result.Status.Should().Be(ResultStatus.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Handle_Rerun_DoesNotDuplicateRows()
+    {
+        await using (AppDbContext first = fx.CreateContext())
+            await Sut(first).Handle(new SeedHotkeysCommand(Reset: false), default);
+
+        await using AppDbContext db = fx.CreateContext();
+        Result<PagedList<HotkeyDto>> result = await Sut(db).Handle(new SeedHotkeysCommand(Reset: false), default);
+
+        result.Value.Items.Should().HaveCount(SampleCount);
+    }
+
+    [Fact]
+    public async Task Handle_WithReset_AfterFullSeed_KeepsTwelveSamples()
+    {
+        await SeedCategoriesAsync();
+
+        await using (AppDbContext first = fx.CreateContext())
+            await Sut(first).Handle(new SeedHotkeysCommand(Reset: false), default);
+
+        await using AppDbContext db = fx.CreateContext();
+        Result<PagedList<HotkeyDto>> result = await Sut(db).Handle(new SeedHotkeysCommand(Reset: true), default);
+
+        result.Value.Items.Should().HaveCount(SampleCount);
+        result.Value.Items.Sum(h => h.CategoryIds.Length).Should().Be(SampleCount);
+    }
+
+    [Fact]
+    public async Task Handle_AfterCategoriesSeeded_AttachesCategoryLinks()
+    {
+        await SeedCategoriesAsync();
+
+        Dictionary<string, Guid> catByName;
+        await using (AppDbContext lookup = fx.CreateContext())
+        {
+            catByName = await lookup.Categories
+                .Where(c => c.OwnerOid == _ownerOid)
+                .ToDictionaryAsync(c => c.Name, c => c.Id);
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        Result<PagedList<HotkeyDto>> result = await Sut(db).Handle(new SeedHotkeysCommand(Reset: false), default);
+
+        result.Value.Items.Sum(h => h.CategoryIds.Length).Should().Be(SampleCount);
+        result.Value.Items.Single(h => h.Description == "Launch Notepad").CategoryIds
+            .Should().ContainSingle().Which.Should().Be(catByName["App Launcher"]);
+        result.Value.Items.Single(h => h.Description == "Maximize window").CategoryIds
+            .Should().ContainSingle().Which.Should().Be(catByName["Window Management"]);
+        result.Value.Items.Single(h => h.Description == "Paste as plain text").CategoryIds
+            .Should().ContainSingle().Which.Should().Be(catByName["Code"]);
+        result.Value.Items.Single(h => h.Description == "Insert today's date").CategoryIds
+            .Should().ContainSingle().Which.Should().Be(catByName["DateTime"]);
+    }
+
+    [Fact]
+    public async Task Handle_BeforeCategoriesSeeded_CreatesTwelveWithNoJunctions()
+    {
+        await using AppDbContext db = fx.CreateContext();
+
+        Result<PagedList<HotkeyDto>> result = await Sut(db).Handle(new SeedHotkeysCommand(Reset: false), default);
+
+        result.Value.Items.Should().HaveCount(SampleCount);
+        result.Value.Items.Should().OnlyContain(h => h.CategoryIds.Length == 0);
+
+        await using AppDbContext verify = fx.CreateContext();
+        int junctions = await verify.HotkeyCategories.CountAsync(hc => hc.Hotkey.OwnerOid == _ownerOid);
+        junctions.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_Backfill_AttachesMissingJunctions_OnRerun()
+    {
+        await using (AppDbContext before = fx.CreateContext())
+            await Sut(before).Handle(new SeedHotkeysCommand(Reset: false), default);
+
+        await SeedCategoriesAsync();
+
+        await using AppDbContext db = fx.CreateContext();
+        Result<PagedList<HotkeyDto>> result = await Sut(db).Handle(new SeedHotkeysCommand(Reset: false), default);
+
+        result.Value.Items.Should().HaveCount(SampleCount);
+        result.Value.Items.Sum(h => h.CategoryIds.Length).Should().Be(SampleCount);
+    }
+
+    [Fact]
+    public async Task Handle_Rerun_WithCategories_DoesNotDuplicateJunctions()
+    {
+        await SeedCategoriesAsync();
+
+        await using (AppDbContext first = fx.CreateContext())
+            await Sut(first).Handle(new SeedHotkeysCommand(Reset: false), default);
+
+        await using AppDbContext db = fx.CreateContext();
+        Result<PagedList<HotkeyDto>> result = await Sut(db).Handle(new SeedHotkeysCommand(Reset: false), default);
+
+        result.Value.Items.Should().HaveCount(SampleCount);
+
+        await using AppDbContext verify = fx.CreateContext();
+        int junctions = await verify.HotkeyCategories.CountAsync(hc => hc.Hotkey.OwnerOid == _ownerOid);
+        junctions.Should().Be(SampleCount);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Dev/SeedHotkeysCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Dev/SeedHotkeysCommandHandlerTests.cs
@@ -171,4 +171,30 @@ public sealed class SeedHotkeysCommandHandlerTests(DevDbFixture fx)
         int junctions = await verify.HotkeyCategories.CountAsync(hc => hc.Hotkey.OwnerOid == _ownerOid);
         junctions.Should().Be(SampleCount);
     }
+
+    [Fact]
+    public async Task Handle_WithLowercaseCategories_MatchesSampleCategoryNamesCaseInsensitively()
+    {
+        await SeedCategoriesAsync();
+
+        await using (AppDbContext lowerCase = fx.CreateContext())
+        {
+            List<Domain.Entities.Category> categories = await lowerCase.Categories
+                .Where(c => c.OwnerOid == _ownerOid)
+                .ToListAsync();
+
+            foreach (Domain.Entities.Category category in categories)
+            {
+                category.Update(category.Name.ToLowerInvariant(), TimeProvider.System);
+            }
+
+            await lowerCase.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        Result<PagedList<HotkeyDto>> result = await Sut(db).Handle(new SeedHotkeysCommand(Reset: false), default);
+
+        result.Value.Items.Should().HaveCount(SampleCount);
+        result.Value.Items.Sum(h => h.CategoryIds.Length).Should().Be(SampleCount);
+    }
 }

--- a/tests/AHKFlowApp.Application.Tests/Dev/ThrowOnNthSaveDbContext.cs
+++ b/tests/AHKFlowApp.Application.Tests/Dev/ThrowOnNthSaveDbContext.cs
@@ -36,4 +36,7 @@ internal sealed class ThrowOnNthSaveDbContext(AppDbContext inner, int failOnCall
 
     public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
         => inner.BeginTransactionAsync(cancellationToken);
+
+    public IExecutionStrategy CreateExecutionStrategy()
+        => inner.CreateExecutionStrategy();
 }

--- a/tests/AHKFlowApp.Application.Tests/Dev/ThrowOnNthSaveDbContext.cs
+++ b/tests/AHKFlowApp.Application.Tests/Dev/ThrowOnNthSaveDbContext.cs
@@ -1,0 +1,39 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace AHKFlowApp.Application.Tests.Dev;
+
+// Test decorator: forwards every IAppDbContext member to a real AppDbContext but
+// throws on the Nth SaveChangesAsync call. Used to verify SeedAll rollback.
+internal sealed class ThrowOnNthSaveDbContext(AppDbContext inner, int failOnCall) : IAppDbContext
+{
+    private int _saveCount;
+
+    public DbSet<Hotstring> Hotstrings => inner.Hotstrings;
+    public DbSet<HotstringProfile> HotstringProfiles => inner.HotstringProfiles;
+    public DbSet<Hotkey> Hotkeys => inner.Hotkeys;
+    public DbSet<HotkeyProfile> HotkeyProfiles => inner.HotkeyProfiles;
+    public DbSet<Profile> Profiles => inner.Profiles;
+    public DbSet<UserPreference> UserPreferences => inner.UserPreferences;
+    public DbSet<Category> Categories => inner.Categories;
+    public DbSet<HotstringCategory> HotstringCategories => inner.HotstringCategories;
+    public DbSet<HotkeyCategory> HotkeyCategories => inner.HotkeyCategories;
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        _saveCount++;
+        if (_saveCount == failOnCall)
+            throw new InvalidOperationException("forced failure");
+        return inner.SaveChangesAsync(cancellationToken);
+    }
+
+    public EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class
+        => inner.Entry(entity);
+
+    public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+        => inner.BeginTransactionAsync(cancellationToken);
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/SeedHotstringsCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/SeedHotstringsCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using AHKFlowApp.Application;
+using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.Commands.Dev;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Domain.Entities;
@@ -13,10 +14,19 @@ namespace AHKFlowApp.Application.Tests.Hotstrings;
 [Collection("HotstringDb")]
 public sealed class SeedHotstringsCommandHandlerTests(HotstringDbFixture fx)
 {
+    private const int SampleCount = 12;
+
     private static AppEnvironment DevEnv(bool isDev) => new(isDev);
 
+    private async Task SeedCategoriesAsync(Guid owner)
+    {
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new SeedCategoriesCommandHandler(db, CurrentUserHelper.For(owner), TimeProvider.System, DevEnv(true));
+        await handler.Handle(new SeedCategoriesCommand(Reset: false), default);
+    }
+
     [Fact]
-    public async Task Handle_InDevelopment_SeedsSamples()
+    public async Task Handle_InDevelopment_SeedsTwelveSamples()
     {
         var owner = Guid.NewGuid();
         await using AppDbContext db = fx.CreateContext();
@@ -25,7 +35,7 @@ public sealed class SeedHotstringsCommandHandlerTests(HotstringDbFixture fx)
         Result<PagedList<HotstringDto>> result = await handler.Handle(new SeedHotstringsCommand(Reset: false), default);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Items.Count.Should().BeGreaterThanOrEqualTo(3);
+        result.Value.Items.Should().HaveCount(SampleCount);
     }
 
     [Fact]
@@ -67,6 +77,7 @@ public sealed class SeedHotstringsCommandHandlerTests(HotstringDbFixture fx)
         Result<PagedList<HotstringDto>> result = await handler.Handle(new SeedHotstringsCommand(Reset: false), default);
 
         result.IsSuccess.Should().BeTrue();
+        result.Value.Items.Should().HaveCount(SampleCount);
         result.Value.Items.Should().Contain(h => h.Trigger == "btw" && h.Replacement == "existing");
         result.Value.Items.Should().Contain(h => h.Trigger == "fyi");
         result.Value.Items.Should().Contain(h => h.Trigger == "brb");
@@ -89,8 +100,120 @@ public sealed class SeedHotstringsCommandHandlerTests(HotstringDbFixture fx)
         Result<PagedList<HotstringDto>> result = await handler.Handle(new SeedHotstringsCommand(Reset: true), default);
 
         result.IsSuccess.Should().BeTrue();
+        result.Value.Items.Should().HaveCount(SampleCount);
         await using AppDbContext verify = fx.CreateContext();
         bool hasPreexisting = await verify.Hotstrings.AnyAsync(h => h.OwnerOid == owner && h.Trigger == "preexisting");
         hasPreexisting.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WithReset_AfterFullSeed_KeepsTwelveSamples()
+    {
+        var owner = Guid.NewGuid();
+        await SeedCategoriesAsync(owner);
+
+        await using (AppDbContext first = fx.CreateContext())
+        {
+            var h1 = new SeedHotstringsCommandHandler(first, CurrentUserHelper.For(owner), TimeProvider.System, DevEnv(true));
+            await h1.Handle(new SeedHotstringsCommand(Reset: false), default);
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new SeedHotstringsCommandHandler(db, CurrentUserHelper.For(owner), TimeProvider.System, DevEnv(true));
+        Result<PagedList<HotstringDto>> result = await handler.Handle(new SeedHotstringsCommand(Reset: true), default);
+
+        result.Value.Items.Should().HaveCount(SampleCount);
+        result.Value.Items.Sum(h => h.CategoryIds.Length).Should().Be(SampleCount);
+    }
+
+    [Fact]
+    public async Task Handle_AfterCategoriesSeeded_AttachesCategoryLinks()
+    {
+        var owner = Guid.NewGuid();
+        await SeedCategoriesAsync(owner);
+
+        Dictionary<string, Guid> catByName;
+        await using (AppDbContext lookup = fx.CreateContext())
+        {
+            catByName = await lookup.Categories
+                .Where(c => c.OwnerOid == owner)
+                .ToDictionaryAsync(c => c.Name, c => c.Id);
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new SeedHotstringsCommandHandler(db, CurrentUserHelper.For(owner), TimeProvider.System, DevEnv(true));
+
+        Result<PagedList<HotstringDto>> result = await handler.Handle(new SeedHotstringsCommand(Reset: false), default);
+
+        result.Value.Items.Sum(h => h.CategoryIds.Length).Should().Be(SampleCount);
+        result.Value.Items.Single(h => h.Trigger == "recieve").CategoryIds
+            .Should().ContainSingle().Which.Should().Be(catByName["Autocorrect"]);
+        result.Value.Items.Single(h => h.Trigger == "btw").CategoryIds
+            .Should().ContainSingle().Which.Should().Be(catByName["Communication"]);
+        result.Value.Items.Single(h => h.Trigger == ";arrow").CategoryIds
+            .Should().ContainSingle().Which.Should().Be(catByName["Symbols"]);
+        result.Value.Items.Single(h => h.Trigger == ";todo").CategoryIds
+            .Should().ContainSingle().Which.Should().Be(catByName["Code"]);
+    }
+
+    [Fact]
+    public async Task Handle_BeforeCategoriesSeeded_CreatesTwelveWithNoJunctions()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new SeedHotstringsCommandHandler(db, CurrentUserHelper.For(owner), TimeProvider.System, DevEnv(true));
+
+        Result<PagedList<HotstringDto>> result = await handler.Handle(new SeedHotstringsCommand(Reset: false), default);
+
+        result.Value.Items.Should().HaveCount(SampleCount);
+        result.Value.Items.Should().OnlyContain(h => h.CategoryIds.Length == 0);
+
+        await using AppDbContext verify = fx.CreateContext();
+        int junctions = await verify.HotstringCategories.CountAsync(hc => hc.Hotstring.OwnerOid == owner);
+        junctions.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_Backfill_AttachesMissingJunctions_OnRerun()
+    {
+        var owner = Guid.NewGuid();
+
+        await using (AppDbContext before = fx.CreateContext())
+        {
+            var h1 = new SeedHotstringsCommandHandler(before, CurrentUserHelper.For(owner), TimeProvider.System, DevEnv(true));
+            await h1.Handle(new SeedHotstringsCommand(Reset: false), default);
+        }
+
+        await SeedCategoriesAsync(owner);
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new SeedHotstringsCommandHandler(db, CurrentUserHelper.For(owner), TimeProvider.System, DevEnv(true));
+        Result<PagedList<HotstringDto>> result = await handler.Handle(new SeedHotstringsCommand(Reset: false), default);
+
+        result.Value.Items.Should().HaveCount(SampleCount);
+        result.Value.Items.Sum(h => h.CategoryIds.Length).Should().Be(SampleCount);
+    }
+
+    [Fact]
+    public async Task Handle_Rerun_WithCategories_DoesNotDuplicateJunctions()
+    {
+        var owner = Guid.NewGuid();
+        await SeedCategoriesAsync(owner);
+
+        await using (AppDbContext first = fx.CreateContext())
+        {
+            var h1 = new SeedHotstringsCommandHandler(first, CurrentUserHelper.For(owner), TimeProvider.System, DevEnv(true));
+            await h1.Handle(new SeedHotstringsCommand(Reset: false), default);
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new SeedHotstringsCommandHandler(db, CurrentUserHelper.For(owner), TimeProvider.System, DevEnv(true));
+        Result<PagedList<HotstringDto>> result = await handler.Handle(new SeedHotstringsCommand(Reset: false), default);
+
+        result.Value.Items.Should().HaveCount(SampleCount);
+
+        await using AppDbContext verify = fx.CreateContext();
+        int junctions = await verify.HotstringCategories.CountAsync(hc => hc.Hotstring.OwnerOid == owner);
+        junctions.Should().Be(SampleCount);
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/SeedHotstringsCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/SeedHotstringsCommandHandlerTests.cs
@@ -216,4 +216,32 @@ public sealed class SeedHotstringsCommandHandlerTests(HotstringDbFixture fx)
         int junctions = await verify.HotstringCategories.CountAsync(hc => hc.Hotstring.OwnerOid == owner);
         junctions.Should().Be(SampleCount);
     }
+
+    [Fact]
+    public async Task Handle_WithLowercaseCategories_MatchesSampleCategoryNamesCaseInsensitively()
+    {
+        var owner = Guid.NewGuid();
+        await SeedCategoriesAsync(owner);
+
+        await using (AppDbContext lowerCase = fx.CreateContext())
+        {
+            List<Category> categories = await lowerCase.Categories
+                .Where(c => c.OwnerOid == owner)
+                .ToListAsync();
+
+            foreach (Category category in categories)
+            {
+                category.Update(category.Name.ToLowerInvariant(), TimeProvider.System);
+            }
+
+            await lowerCase.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        var handler = new SeedHotstringsCommandHandler(db, CurrentUserHelper.For(owner), TimeProvider.System, DevEnv(true));
+        Result<PagedList<HotstringDto>> result = await handler.Handle(new SeedHotstringsCommand(Reset: false), default);
+
+        result.Value.Items.Should().HaveCount(SampleCount);
+        result.Value.Items.Sum(h => h.CategoryIds.Length).Should().Be(SampleCount);
+    }
 }


### PR DESCRIPTION
## Summary

Implements the Seed Expansion plan (`docs/superpowers/plans/2026-05-19-seed-expansion.md`). Expands dev-only seed data from 3 hotstrings to a full set, all tagged to the eight default categories.

- **`SeedCategoriesCommand`** — seeds the 8 default categories, idempotent on `(OwnerOid, Name)`, upserts `UserPreference.CategoriesSeededAt` so a later `GET /categories` does not lazy-seed again.
- **`SeedHotstringsCommand`** — expanded to 12 samples, each linked to a category; non-reset re-run backfills missing junctions onto pre-existing rows.
- **`SeedHotkeysCommand`** — new; 12 samples with category links, same backfill behavior.
- **`SeedAllCommand`** — orchestrates categories → hotstrings → hotkeys inside a single transaction; any failure rolls the whole pipeline back.
- **`DevController`** — new routes: `categories/seed`, `hotkeys/seed`, `seed-all` (all dev-only, 404 outside Development).

## Plan corrections

Three issues in the plan were found and fixed during implementation:

1. **Reset idempotency** — the plan's reset path does `RemoveRange` then checks `AnyAsync`/`FirstOrDefault`, which still see the not-yet-deleted DB rows, so default-named rows would be deleted and never reinserted. Reset now skips the existence check and inserts fresh.
2. **`EnableRetryOnFailure` + manual transaction** — a bare `BeginTransaction` throws in the real host. `SeedAll` now wraps the transaction in an execution strategy (`IAppDbContext.CreateExecutionStrategy()`). Caught by an integration test.
3. **`.Select(x => x.ToDto())`** — EF Core cannot translate method calls in projections; replaced with inline projections.

## Test plan

- [x] `dotnet build` (Release) — 0 warnings, 0 errors
- [x] Full test suite — 817 tests, 0 failures
- [x] Handler tests: SeedCategories, SeedHotstrings, SeedHotkeys (idempotency, reset, backfill, dev gate)
- [x] `SeedAllCommand` rollback verified via `ThrowOnNthSaveDbContext` decorator
- [x] HTTP integration tests for all three new routes
- [x] `dotnet format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)