### PR TITLE
OpenAPI polish

### DIFF
--- a/src/Backend/AHKFlowApp.API/Controllers/HealthController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/HealthController.cs
@@ -17,6 +17,7 @@ public sealed class HealthController(
     IConfiguration configuration,
     ILogger<HealthController> logger) : ControllerBase
 {
+    /// <summary>Aggregates registered health checks. Returns 200 for Healthy or Degraded, 503 for Unhealthy.</summary>
     [HttpGet]
     [ProducesResponseType(typeof(HealthResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(HealthResponse), StatusCodes.Status503ServiceUnavailable)]

--- a/src/Backend/AHKFlowApp.API/Controllers/VersionController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/VersionController.cs
@@ -10,6 +10,7 @@ namespace AHKFlowApp.API.Controllers;
 [AllowAnonymous]
 public sealed class VersionController(IVersionService versionService) : ControllerBase
 {
+    /// <summary>Returns the deployed API version (MinVer / informational version).</summary>
     [HttpGet]
     [ProducesResponseType(typeof(VersionResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<VersionResponse>> GetVersionAsync(CancellationToken cancellationToken)

--- a/src/Backend/AHKFlowApp.API/Controllers/WhoAmIController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/WhoAmIController.cs
@@ -9,11 +9,20 @@ namespace AHKFlowApp.API.Controllers;
 [Route("api/v1/[controller]")]
 [Authorize]
 [RequiredScope("access_as_user")]
+[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
 public sealed class WhoAmIController(ICurrentUser currentUser) : ControllerBase
 {
+    /// <summary>Returns identity claims for the authenticated caller.</summary>
     [HttpGet]
-    public IActionResult Get() =>
+    [ProducesResponseType(typeof(WhoAmIResponse), StatusCodes.Status200OK)]
+    public ActionResult<WhoAmIResponse> Get() =>
         Ok(new WhoAmIResponse(currentUser.Oid, currentUser.Email, currentUser.Name, currentUser.IsAuthenticated));
 }
 
+/// <summary>Identity details for the authenticated caller.</summary>
+/// <param name="Oid">Entra object id (stable per-user GUID), or null when unauthenticated.</param>
+/// <param name="Email">Caller email / preferred username, when present in the token.</param>
+/// <param name="Name">Caller display name, when present in the token.</param>
+/// <param name="IsAuthenticated">True when the request carried a valid token.</param>
 public sealed record WhoAmIResponse(Guid? Oid, string? Email, string? Name, bool IsAuthenticated);

--- a/src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs
+++ b/src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs
@@ -48,9 +48,12 @@ internal static class ApiExtensions
                 }
             });
 
-            string xmlPath = Path.Combine(AppContext.BaseDirectory, "AHKFlowApp.API.xml");
-            if (File.Exists(xmlPath))
-                options.IncludeXmlComments(xmlPath, includeControllerXmlComments: true);
+            foreach (string assemblyName in new[] { "AHKFlowApp.API", "AHKFlowApp.Application" })
+            {
+                string xmlPath = Path.Combine(AppContext.BaseDirectory, $"{assemblyName}.xml");
+                if (File.Exists(xmlPath))
+                    options.IncludeXmlComments(xmlPath, includeControllerXmlComments: true);
+            }
 
             options.ExampleFilters();
         });

--- a/src/Backend/AHKFlowApp.Application/AHKFlowApp.Application.csproj
+++ b/src/Backend/AHKFlowApp.Application/AHKFlowApp.Application.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- We document only the public DTO contract surface. Suppress CS1591 on
+         everything else so the build doesn't drown in noise for handlers/validators/etc. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AHKFlowApp.Domain\AHKFlowApp.Domain.csproj" />

--- a/src/Backend/AHKFlowApp.Application/DTOs/BulkDeleteRequestDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/BulkDeleteRequestDto.cs
@@ -1,3 +1,5 @@
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>Payload for deleting multiple entities by id.</summary>
+/// <param name="Ids">Entity ids requested for deletion.</param>
 public sealed record BulkDeleteRequestDto(Guid[] Ids);

--- a/src/Backend/AHKFlowApp.Application/DTOs/BulkDeleteResultDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/BulkDeleteResultDto.cs
@@ -1,5 +1,8 @@
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>Result summary for a bulk-delete request.</summary>
+/// <param name="DeletedCount">Number of entities deleted.</param>
+/// <param name="MissingIds">Requested ids that were not found.</param>
 public sealed record BulkDeleteResultDto(
     int DeletedCount,
     IReadOnlyList<Guid> MissingIds);

--- a/src/Backend/AHKFlowApp.Application/DTOs/CategoryDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/CategoryDto.cs
@@ -1,5 +1,10 @@
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>A user-defined category for grouping hotstrings and hotkeys.</summary>
+/// <param name="Id">Server-generated identifier.</param>
+/// <param name="Name">User-chosen category name.</param>
+/// <param name="CreatedAt">UTC creation timestamp.</param>
+/// <param name="UpdatedAt">UTC last-update timestamp.</param>
 public sealed record CategoryDto(
     Guid Id,
     string Name,

--- a/src/Backend/AHKFlowApp.Application/DTOs/CreateCategoryDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/CreateCategoryDto.cs
@@ -1,3 +1,5 @@
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>Payload to create a new category.</summary>
+/// <param name="Name">Category name. Must be unique per user.</param>
 public sealed record CreateCategoryDto(string Name);

--- a/src/Backend/AHKFlowApp.Application/DTOs/DashboardStatsDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/DashboardStatsDto.cs
@@ -1,22 +1,41 @@
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>Aggregated stats for the home dashboard.</summary>
+/// <param name="Hotstrings">Hotstring totals plus recent-creation buckets.</param>
+/// <param name="Hotkeys">Hotkey totals plus recent-creation buckets.</param>
+/// <param name="Profiles">Profile counts, including total, active, and default.</param>
+/// <param name="RecentActivity">Recently created or updated entities, newest first.</param>
 public sealed record DashboardStatsDto(
     EntityStatsDto Hotstrings,
     EntityStatsDto Hotkeys,
     ProfileStatsDto Profiles,
     IReadOnlyList<RecentActivityItemDto> RecentActivity);
 
+/// <summary>Counts for an entity kind shown on the dashboard.</summary>
+/// <param name="Total">Total number of entities owned by the user.</param>
+/// <param name="CreatedThisWeek">Number created in the past 7 days.</param>
+/// <param name="DailyBuckets">Per-day creation counts for the past 7 days, oldest first.</param>
 public sealed record EntityStatsDto(
     int Total,
     int CreatedThisWeek,
     IReadOnlyList<int> DailyBuckets);
 
+/// <summary>Profile-specific counts for the dashboard.</summary>
+/// <param name="Total">Total profiles owned by the user.</param>
+/// <param name="Active">Profiles containing at least one hotstring or hotkey.</param>
+/// <param name="Default">Always 0 or 1; number of default profiles.</param>
+/// <param name="DailyBuckets">Per-day creation counts for the past 7 days, oldest first.</param>
 public sealed record ProfileStatsDto(
     int Total,
     int Active,
     int Default,
     IReadOnlyList<int> DailyBuckets);
 
+/// <summary>A single line in the recent-activity stream.</summary>
+/// <param name="Kind">Entity kind, such as <c>Hotstring</c>, <c>Hotkey</c>, or <c>Profile</c>.</param>
+/// <param name="Action">Action verb, such as <c>Created</c> or <c>Updated</c>.</param>
+/// <param name="Label">Human-readable label, such as a trigger, description, or profile name.</param>
+/// <param name="OccurredAt">UTC timestamp when the action happened.</param>
 public sealed record RecentActivityItemDto(
     string Kind,
     string Action,

--- a/src/Backend/AHKFlowApp.Application/DTOs/HotkeyDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/HotkeyDto.cs
@@ -2,6 +2,21 @@ using AHKFlowApp.Domain.Enums;
 
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>A keyboard hotkey binding owned by the current user.</summary>
+/// <param name="Id">Server-generated identifier.</param>
+/// <param name="ProfileIds">Profiles the hotkey is attached to.</param>
+/// <param name="AppliesToAllProfiles">When true, the hotkey is included in every profile the user owns.</param>
+/// <param name="Description">Human-readable label.</param>
+/// <param name="Key">The main key, such as <c>F1</c> or <c>a</c>.</param>
+/// <param name="Ctrl">Ctrl modifier required.</param>
+/// <param name="Alt">Alt modifier required.</param>
+/// <param name="Shift">Shift modifier required.</param>
+/// <param name="Win">Windows modifier required.</param>
+/// <param name="Action">Action kind performed when the hotkey fires.</param>
+/// <param name="Parameters">Action-specific parameter payload, such as text to send or a command to run.</param>
+/// <param name="CreatedAt">UTC creation timestamp.</param>
+/// <param name="UpdatedAt">UTC last-update timestamp.</param>
+/// <param name="CategoryIds">Categories assigned to this hotkey.</param>
 public sealed record HotkeyDto(
     Guid Id,
     Guid[] ProfileIds,
@@ -18,6 +33,18 @@ public sealed record HotkeyDto(
     DateTimeOffset UpdatedAt,
     Guid[] CategoryIds);
 
+/// <summary>Payload to create a new hotkey.</summary>
+/// <param name="Description">Human-readable label.</param>
+/// <param name="Key">Main key.</param>
+/// <param name="Ctrl">Ctrl modifier required.</param>
+/// <param name="Alt">Alt modifier required.</param>
+/// <param name="Shift">Shift modifier required.</param>
+/// <param name="Win">Windows modifier required.</param>
+/// <param name="Action">Action kind performed when the hotkey fires.</param>
+/// <param name="Parameters">Action-specific payload.</param>
+/// <param name="ProfileIds">Profiles to attach the new hotkey to.</param>
+/// <param name="AppliesToAllProfiles">When true, the hotkey applies to every profile.</param>
+/// <param name="CategoryIds">Categories to assign to the new hotkey.</param>
 public sealed record CreateHotkeyDto(
     string Description,
     string Key,
@@ -31,6 +58,18 @@ public sealed record CreateHotkeyDto(
     bool AppliesToAllProfiles = false,
     Guid[]? CategoryIds = null);
 
+/// <summary>Payload to replace the editable fields of an existing hotkey.</summary>
+/// <param name="Description">Human-readable label.</param>
+/// <param name="Key">Main key.</param>
+/// <param name="Ctrl">Ctrl modifier required.</param>
+/// <param name="Alt">Alt modifier required.</param>
+/// <param name="Shift">Shift modifier required.</param>
+/// <param name="Win">Windows modifier required.</param>
+/// <param name="Action">Action kind performed when the hotkey fires.</param>
+/// <param name="Parameters">Action-specific payload.</param>
+/// <param name="ProfileIds">Replacement profile-attachment set.</param>
+/// <param name="AppliesToAllProfiles">When true, the hotkey applies to every profile.</param>
+/// <param name="CategoryIds">Replacement category assignment set.</param>
 public sealed record UpdateHotkeyDto(
     string Description,
     string Key,

--- a/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
@@ -1,5 +1,17 @@
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>A hotstring (text trigger plus replacement) owned by the current user.</summary>
+/// <param name="Id">Server-generated identifier.</param>
+/// <param name="ProfileIds">Profiles the hotstring is attached to. Empty when <paramref name="AppliesToAllProfiles"/> is true.</param>
+/// <param name="AppliesToAllProfiles">When true, the hotstring is included in every profile the user owns.</param>
+/// <param name="Trigger">Abbreviation that activates the replacement, such as <c>btw</c>.</param>
+/// <param name="Replacement">Text that replaces the trigger, such as <c>by the way</c>.</param>
+/// <param name="Description">Optional human-readable note for the hotstring.</param>
+/// <param name="IsEndingCharacterRequired">When true, AutoHotkey requires a trailing whitespace or punctuation character to fire.</param>
+/// <param name="IsTriggerInsideWord">When true, the trigger matches even inside a larger word.</param>
+/// <param name="CreatedAt">UTC creation timestamp.</param>
+/// <param name="UpdatedAt">UTC last-update timestamp.</param>
+/// <param name="CategoryIds">Categories assigned to this hotstring.</param>
 public sealed record HotstringDto(
     Guid Id,
     Guid[] ProfileIds,
@@ -13,6 +25,15 @@ public sealed record HotstringDto(
     DateTimeOffset UpdatedAt,
     Guid[] CategoryIds);
 
+/// <summary>Payload to create a new hotstring.</summary>
+/// <param name="Trigger">Abbreviation that activates the replacement.</param>
+/// <param name="Replacement">Text inserted in place of the trigger.</param>
+/// <param name="ProfileIds">Profiles to attach the new hotstring to. Ignored when <paramref name="AppliesToAllProfiles"/> is true.</param>
+/// <param name="AppliesToAllProfiles">When true, the hotstring applies to every profile and <paramref name="ProfileIds"/> is ignored.</param>
+/// <param name="IsEndingCharacterRequired">Controls AutoHotkey's <c>*</c> option.</param>
+/// <param name="IsTriggerInsideWord">Controls AutoHotkey's <c>?</c> option.</param>
+/// <param name="Description">Optional human-readable note for the hotstring.</param>
+/// <param name="CategoryIds">Categories to assign to the new hotstring.</param>
 public sealed record CreateHotstringDto(
     string Trigger,
     string Replacement,
@@ -23,6 +44,15 @@ public sealed record CreateHotstringDto(
     string? Description = null,
     Guid[]? CategoryIds = null);
 
+/// <summary>Payload to replace the editable fields of an existing hotstring.</summary>
+/// <param name="Trigger">Abbreviation that activates the replacement.</param>
+/// <param name="Replacement">Text inserted in place of the trigger.</param>
+/// <param name="ProfileIds">Replacement profile-attachment set. Ignored when <paramref name="AppliesToAllProfiles"/> is true.</param>
+/// <param name="AppliesToAllProfiles">When true, the hotstring applies to every profile.</param>
+/// <param name="IsEndingCharacterRequired">Controls AutoHotkey's <c>*</c> option.</param>
+/// <param name="IsTriggerInsideWord">Controls AutoHotkey's <c>?</c> option.</param>
+/// <param name="Description">Optional human-readable note for the hotstring.</param>
+/// <param name="CategoryIds">Replacement category assignment set.</param>
 public sealed record UpdateHotstringDto(
     string Trigger,
     string Replacement,

--- a/src/Backend/AHKFlowApp.Application/DTOs/PagedList.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/PagedList.cs
@@ -1,12 +1,23 @@
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>Paginated wrapper for a list response.</summary>
+/// <typeparam name="T">Element type.</typeparam>
+/// <param name="Items">Page contents.</param>
+/// <param name="Page">1-based page number returned.</param>
+/// <param name="PageSize">Maximum number of items per page.</param>
+/// <param name="TotalCount">Total matching items across all pages.</param>
 public sealed record PagedList<T>(
     IReadOnlyList<T> Items,
     int Page,
     int PageSize,
     int TotalCount)
 {
+    /// <summary>Total number of pages, calculated as <c>ceil(TotalCount / PageSize)</c>.</summary>
     public int TotalPages => PageSize == 0 ? 0 : (int)Math.Ceiling(TotalCount / (double)PageSize);
+
+    /// <summary>True when a next page exists.</summary>
     public bool HasNextPage => Page < TotalPages;
+
+    /// <summary>True when a previous page exists.</summary>
     public bool HasPreviousPage => Page > 1;
 }

--- a/src/Backend/AHKFlowApp.Application/DTOs/ProfileDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/ProfileDto.cs
@@ -1,5 +1,13 @@
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>A named grouping of hotstrings and hotkeys.</summary>
+/// <param name="Id">Server-generated identifier.</param>
+/// <param name="Name">User-chosen profile name.</param>
+/// <param name="IsDefault">True for the user's single default profile.</param>
+/// <param name="HeaderTemplate">Liquid-style header injected at the top of the generated <c>.ahk</c> script.</param>
+/// <param name="FooterTemplate">Liquid-style footer appended to the generated <c>.ahk</c> script.</param>
+/// <param name="CreatedAt">UTC creation timestamp.</param>
+/// <param name="UpdatedAt">UTC last-update timestamp.</param>
 public sealed record ProfileDto(
     Guid Id,
     string Name,
@@ -9,12 +17,22 @@ public sealed record ProfileDto(
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt);
 
+/// <summary>Payload to create a new profile.</summary>
+/// <param name="Name">Profile name. Must be unique per user.</param>
+/// <param name="HeaderTemplate">Optional header template; falls back to the application default.</param>
+/// <param name="FooterTemplate">Optional footer template; falls back to the application default.</param>
+/// <param name="IsDefault">When true, marks this profile as the user's default and clears the flag on any other.</param>
 public sealed record CreateProfileDto(
     string Name,
     string? HeaderTemplate = null,
     string? FooterTemplate = null,
     bool IsDefault = false);
 
+/// <summary>Payload to replace the editable fields of an existing profile.</summary>
+/// <param name="Name">Profile name. Must be unique per user.</param>
+/// <param name="HeaderTemplate">Header template content.</param>
+/// <param name="FooterTemplate">Footer template content.</param>
+/// <param name="IsDefault">When true, marks this profile as the user's default.</param>
 public sealed record UpdateProfileDto(
     string Name,
     string HeaderTemplate,

--- a/src/Backend/AHKFlowApp.Application/DTOs/ProfileScript.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/ProfileScript.cs
@@ -1,3 +1,6 @@
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>A rendered AutoHotkey script for a profile.</summary>
+/// <param name="FileName">Suggested filename for download, such as <c>Work.ahk</c>.</param>
+/// <param name="Content">Full script body.</param>
 public sealed record ProfileScript(string FileName, string Content);

--- a/src/Backend/AHKFlowApp.Application/DTOs/ProfileScriptPreviewDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/ProfileScriptPreviewDto.cs
@@ -1,5 +1,10 @@
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>Preview of a generated AutoHotkey script without downloading it.</summary>
+/// <param name="Script">Rendered script body.</param>
+/// <param name="HotstringCount">Number of hotstrings included in the script.</param>
+/// <param name="HotkeyCount">Number of hotkeys included in the script.</param>
+/// <param name="GeneratedAt">UTC timestamp when the preview was generated.</param>
 public sealed record ProfileScriptPreviewDto(
     string Script,
     int HotstringCount,

--- a/src/Backend/AHKFlowApp.Application/DTOs/SeedAllResultDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/SeedAllResultDto.cs
@@ -1,5 +1,9 @@
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>Counts returned after seeding demo data for development.</summary>
+/// <param name="CategoriesCount">Number of categories created or already present.</param>
+/// <param name="HotstringsCount">Number of hotstrings created or already present.</param>
+/// <param name="HotkeysCount">Number of hotkeys created or already present.</param>
 public sealed record SeedAllResultDto(
     int CategoriesCount,
     int HotstringsCount,

--- a/src/Backend/AHKFlowApp.Application/DTOs/UpdateCategoryDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/UpdateCategoryDto.cs
@@ -1,3 +1,5 @@
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>Payload to rename an existing category.</summary>
+/// <param name="Name">Replacement category name. Must be unique per user.</param>
 public sealed record UpdateCategoryDto(string Name);

--- a/src/Backend/AHKFlowApp.Application/DTOs/UserPreferenceDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/UserPreferenceDto.cs
@@ -1,5 +1,11 @@
 namespace AHKFlowApp.Application.DTOs;
 
+/// <summary>UI preferences for the current user.</summary>
+/// <param name="RowsPerPage">Preferred page size in paginated tables.</param>
+/// <param name="DarkMode">True when the dark theme is active.</param>
 public sealed record UserPreferenceDto(int RowsPerPage, bool DarkMode);
 
+/// <summary>Payload to update UI preferences.</summary>
+/// <param name="RowsPerPage">Preferred page size in paginated tables.</param>
+/// <param name="DarkMode">True when the dark theme is active.</param>
 public sealed record UpdateUserPreferenceDto(int RowsPerPage, bool DarkMode);

--- a/tests/AHKFlowApp.API.Tests/OpenApi/ApplicationDtoXmlDocCoverageTests.cs
+++ b/tests/AHKFlowApp.API.Tests/OpenApi/ApplicationDtoXmlDocCoverageTests.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using System.Xml.Linq;
+using AHKFlowApp.Application.DTOs;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.API.Tests.OpenApi;
+
+public sealed class ApplicationDtoXmlDocCoverageTests
+{
+    [Fact]
+    public void PublicApplicationDtoTypesAndProperties_HaveXmlSummaries()
+    {
+        Assembly applicationAssembly = typeof(HotstringDto).Assembly;
+        string xmlPath = Path.ChangeExtension(applicationAssembly.Location, ".xml");
+        var xmlDocument = XDocument.Load(xmlPath);
+        var documentedMembers = xmlDocument
+            .Descendants("member")
+            .Where(member => HasNonEmptySummary(member))
+            .Select(member => member.Attribute("name")?.Value)
+            .Where(name => name is not null)
+            .ToHashSet();
+
+        var missingDocs = applicationAssembly.GetTypes()
+            .Where(type => type is { IsPublic: true, Namespace: "AHKFlowApp.Application.DTOs" })
+            .SelectMany(type => RequiredMemberNames(type))
+            .Where(memberName => !documentedMembers.Contains(memberName))
+            .ToList();
+
+        missingDocs.Should().BeEmpty(
+            "public Application DTO contracts are exposed through OpenAPI schemas and must stay documented");
+    }
+
+    private static IEnumerable<string> RequiredMemberNames(Type type)
+    {
+        yield return $"T:{GetXmlTypeName(type)}";
+
+        foreach (PropertyInfo property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+        {
+            if (property.GetIndexParameters().Length == 0)
+                yield return $"P:{GetXmlTypeName(type)}.{property.Name}";
+        }
+    }
+
+    private static string GetXmlTypeName(Type type)
+    {
+        string fullName = type.FullName ?? throw new InvalidOperationException($"Type {type} has no full name.");
+        return fullName.Replace('+', '.');
+    }
+
+    private static bool HasNonEmptySummary(XElement member)
+    {
+        string? summary = member.Element("summary")?.Value;
+        return !string.IsNullOrWhiteSpace(summary);
+    }
+}

--- a/tests/AHKFlowApp.API.Tests/OpenApi/ProducesResponseTypeCoverageTests.cs
+++ b/tests/AHKFlowApp.API.Tests/OpenApi/ProducesResponseTypeCoverageTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using AHKFlowApp.API.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Xunit;
+
+namespace AHKFlowApp.API.Tests.OpenApi;
+
+public sealed class ProducesResponseTypeCoverageTests
+{
+    [Fact]
+    public void EveryControllerAction_DeclaresExplicit2xxProducesResponseType()
+    {
+        Assembly apiAssembly = typeof(HotstringsController).Assembly;
+
+        var offenders = apiAssembly.GetTypes()
+            .Where(t => typeof(ControllerBase).IsAssignableFrom(t) && !t.IsAbstract)
+            .SelectMany(t => t
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(m => m.GetCustomAttributes<HttpMethodAttribute>().Any())
+                .Select(m => new { Controller = t.Name, Action = m }))
+            .Where(x => !x.Action.GetCustomAttributes<ProducesResponseTypeAttribute>()
+                .Any(attr => attr.StatusCode is >= 200 and <= 299))
+            .Select(x => $"{x.Controller}.{x.Action.Name}")
+            .ToList();
+
+        offenders.Should().BeEmpty(
+            "every controller action must carry an explicit method-level [ProducesResponseType] " +
+            "with a 2xx status code; Swashbuckle's inferred 200 is not a substitute");
+    }
+}

--- a/tests/AHKFlowApp.API.Tests/OpenApi/SwaggerDocTests.cs
+++ b/tests/AHKFlowApp.API.Tests/OpenApi/SwaggerDocTests.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+using AHKFlowApp.TestUtilities.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.API.Tests.OpenApi;
+
+[Collection("WebApi")]
+public sealed class SwaggerDocTests(SqlContainerFixture sqlFixture) : IDisposable
+{
+    private readonly CustomWebApplicationFactory _factory = new(sqlFixture);
+
+    [Fact]
+    public async Task SwaggerJson_HotstringDtoSchema_SurfacesPropertyDescriptions()
+    {
+        // Confirms AHKFlowApp.Application.xml is wired into Swagger.
+        // If the wiring breaks, schema property descriptions disappear.
+
+        // Arrange
+        using HttpClient client = _factory.CreateClient();
+
+        // Act
+        await using Stream stream = await client.GetStreamAsync("/swagger/v1/swagger.json");
+        using JsonDocument doc = await JsonDocument.ParseAsync(stream);
+
+        // Assert
+        JsonElement properties = doc.RootElement
+            .GetProperty("components")
+            .GetProperty("schemas")
+            .GetProperty("HotstringDto")
+            .GetProperty("properties");
+
+        bool anyDescribed = properties.EnumerateObject()
+            .Any(p => p.Value.TryGetProperty("description", out JsonElement description)
+                      && !string.IsNullOrWhiteSpace(description.GetString()));
+
+        anyDescribed.Should().BeTrue(
+            "HotstringDto property descriptions must be surfaced from AHKFlowApp.Application.xml");
+    }
+
+    public void Dispose() => _factory.Dispose();
+}


### PR DESCRIPTION
## Summary
- Annotate previously bare API endpoints for Swagger response metadata and operation summaries.
- Emit Application XML docs and include them in Swagger so DTO schema descriptions surface.
- Add OpenAPI regression gates for explicit 2xx ProducesResponseType metadata and public Application DTO XML docs.

## Validation
- dotnet build --no-restore
- dotnet test tests/AHKFlowApp.API.Tests --filter "FullyQualifiedName~OpenApi" --no-build --verbosity normal
- Earlier full verification after final code changes: dotnet test --no-build --verbosity normal
