### PR TITLE
feat: lazy-seed hotstrings and hotkeys on first GET in dev

### DIFF
--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotkeysCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotkeysCommand.cs
@@ -107,6 +107,22 @@ internal sealed class SeedHotkeysCommandHandler(
             }
         }
 
+        // Upsert the seed marker so a later GET /hotkeys does not also lazy-seed.
+        UserPreference? pref = await db.UserPreferences
+            .FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
+        if (pref is null)
+        {
+            pref = UserPreference.CreateDefault(ownerOid, clock);
+            db.UserPreferences.Add(pref);
+        }
+        if (request.Reset)
+        {
+            // MarkHotkeysSeeded is a no-op when already set; clear it so reset
+            // refreshes the marker to the current clock tick.
+            db.Entry(pref).Property(p => p.HotkeysSeededAt).CurrentValue = null;
+        }
+        pref.MarkHotkeysSeeded(clock);
+
         await db.SaveChangesAsync(ct);
 
         List<HotkeyDto> items = await db.Hotkeys

--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotstringsCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotstringsCommand.cs
@@ -103,6 +103,22 @@ internal sealed class SeedHotstringsCommandHandler(
             }
         }
 
+        // Upsert the seed marker so a later GET /hotstrings does not also lazy-seed.
+        UserPreference? pref = await db.UserPreferences
+            .FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
+        if (pref is null)
+        {
+            pref = UserPreference.CreateDefault(ownerOid, clock);
+            db.UserPreferences.Add(pref);
+        }
+        if (request.Reset)
+        {
+            // MarkHotstringsSeeded is a no-op when already set; clear it so reset
+            // refreshes the marker to the current clock tick.
+            db.Entry(pref).Property(p => p.HotstringsSeededAt).CurrentValue = null;
+        }
+        pref.MarkHotstringsSeeded(clock);
+
         await db.SaveChangesAsync(ct);
 
         List<HotstringDto> items = await db.Hotstrings

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
@@ -1,5 +1,7 @@
 using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.Common;
 using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Constants;
 using AHKFlowApp.Domain.Entities;
 using AHKFlowApp.Domain.Enums;
 using Ardalis.Result;
@@ -53,13 +55,36 @@ public sealed class ListHotkeysQueryValidator : AbstractValidator<ListHotkeysQue
 
 internal sealed class ListHotkeysQueryHandler(
     IAppDbContext db,
-    ICurrentUser currentUser)
+    ICurrentUser currentUser,
+    AppEnvironment env,
+    TimeProvider clock)
     : IRequestHandler<ListHotkeysQuery, Result<PagedList<HotkeyDto>>>
 {
+    // Mirrors SeedHotkeysCommand.s_samples — update both if seed set changes.
+    private static readonly (
+        string Description, bool Ctrl, bool Alt, bool Shift, bool Win,
+        string Key, HotkeyAction Action, string Parameters, string[] Categories)[] s_lazySeed =
+    [
+        ("Launch Windows Terminal", true,  true,  false, false, "T",     HotkeyAction.Run,  "wt.exe",       ["App Launcher"]),
+        ("Launch Notepad",          true,  true,  false, false, "N",     HotkeyAction.Run,  "notepad.exe",  ["App Launcher"]),
+        ("Launch File Explorer",    true,  true,  false, false, "E",     HotkeyAction.Run,  "explorer.exe", ["App Launcher"]),
+        ("Open default browser",    true,  true,  false, false, "B",     HotkeyAction.Run,  "https://",     ["App Launcher"]),
+        ("Maximize window",         false, true,  false, true,  "Up",    HotkeyAction.Send, "{Up}",         ["Window Management"]),
+        ("Minimize window",         false, true,  false, true,  "Down",  HotkeyAction.Send, "{Down}",       ["Window Management"]),
+        ("Snap window left",        false, true,  false, true,  "Left",  HotkeyAction.Send, "{Left}",       ["Window Management"]),
+        ("Snap window right",       false, true,  false, true,  "Right", HotkeyAction.Send, "{Right}",      ["Window Management"]),
+        ("Paste as plain text",     true,  false, true,  false, "V",     HotkeyAction.Send, "^v",           ["Code"]),
+        ("Insert today's date",     true,  true,  false, false, "D",     HotkeyAction.Send, "{{date:yyyy-MM-dd}}", ["DateTime"]),
+        ("Lock workstation",        true,  true,  false, false, "L",     HotkeyAction.Run,  "rundll32.exe user32.dll,LockWorkStation", ["App Launcher"]),
+        ("Reload AHK script",       true,  true,  false, false, "R",     HotkeyAction.Run,  "Reload",       ["App Launcher"]),
+    ];
+
     public async Task<Result<PagedList<HotkeyDto>>> Handle(ListHotkeysQuery request, CancellationToken ct)
     {
         if (currentUser.Oid is not Guid ownerOid)
             return Result.Unauthorized();
+
+        await EnsureHotkeysSeededAsync(ownerOid, ct);
 
         IQueryable<Hotkey> query = db.Hotkeys
             .AsNoTracking()
@@ -149,6 +174,83 @@ internal sealed class ListHotkeysQueryHandler(
             .ToListAsync(ct);
 
         return Result.Success(new PagedList<HotkeyDto>(items, request.Page, request.PageSize, total));
+    }
+
+    private async Task EnsureHotkeysSeededAsync(Guid ownerOid, CancellationToken ct)
+    {
+        if (!env.IsDevelopment) return;
+
+        UserPreference? pref = await db.UserPreferences
+            .FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
+
+        if (pref?.HotkeysSeededAt is not null) return;
+
+        // Ensure categories exist; seed them inline if this is the user's first request
+        bool seedingCategories = pref?.CategoriesSeededAt is null;
+        Dictionary<string, Guid> catByName;
+
+        if (seedingCategories)
+        {
+            catByName = [];
+            foreach (string name in DefaultCategories.Names)
+            {
+                var cat = Category.Create(ownerOid, name, clock);
+                db.Categories.Add(cat);
+                catByName[name] = cat.Id;
+            }
+        }
+        else
+        {
+            catByName = (await db.Categories
+                    .Where(c => c.OwnerOid == ownerOid)
+                    .Select(c => new { c.Name, c.Id })
+                    .ToListAsync(ct))
+                .ToDictionary(c => c.Name, c => c.Id, StringComparer.OrdinalIgnoreCase);
+        }
+
+        foreach ((string descr, bool ctrl, bool alt, bool shift, bool win, string key,
+                  HotkeyAction action, string param, string[] cats) in s_lazySeed)
+        {
+            var hk = Hotkey.Create(ownerOid, descr, key, ctrl, alt, shift, win,
+                action, param, appliesToAllProfiles: true, clock);
+            db.Hotkeys.Add(hk);
+            foreach (string catName in cats)
+            {
+                if (catByName.TryGetValue(catName, out Guid catId))
+                    db.HotkeyCategories.Add(HotkeyCategory.Create(hk.Id, catId));
+            }
+        }
+
+        if (pref is null)
+        {
+            pref = UserPreference.CreateDefault(ownerOid, clock);
+            if (seedingCategories) pref.MarkCategoriesSeeded(clock);
+            pref.MarkHotkeysSeeded(clock);
+            db.UserPreferences.Add(pref);
+        }
+        else
+        {
+            if (seedingCategories) pref.MarkCategoriesSeeded(clock);
+            pref.MarkHotkeysSeeded(clock);
+        }
+
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex) when (ex.IsDuplicateKeyViolation())
+        {
+            // Concurrent first-call race — detach all pending entities so the
+            // read query below works cleanly against whatever was committed first.
+            foreach (Hotkey hk in db.Hotkeys.Local.ToList())
+                db.Entry(hk).State = EntityState.Detached;
+            foreach (HotkeyCategory hc in db.HotkeyCategories.Local.ToList())
+                db.Entry(hc).State = EntityState.Detached;
+            foreach (Category cat in db.Categories.Local.ToList())
+                db.Entry(cat).State = EntityState.Detached;
+            if (pref is not null)
+                db.Entry(pref).State = EntityState.Detached;
+        }
     }
 
     private static IOrderedQueryable<Hotkey> ApplySorting(

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
@@ -240,8 +240,9 @@ internal sealed class ListHotkeysQueryHandler(
         }
         catch (DbUpdateException ex) when (ex.IsDuplicateKeyViolation())
         {
-            // Concurrent first-call race — detach all pending entities so the
-            // read query below works cleanly against whatever was committed first.
+            // Concurrent first-call race or pre-existing data after migration (null
+            // markers but hotkeys already present) — detach pending entities and
+            // persist markers in a follow-up save so future GETs skip the seed path.
             foreach (Hotkey hk in db.Hotkeys.Local.ToList())
                 db.Entry(hk).State = EntityState.Detached;
             foreach (HotkeyCategory hc in db.HotkeyCategories.Local.ToList())
@@ -250,6 +251,17 @@ internal sealed class ListHotkeysQueryHandler(
                 db.Entry(cat).State = EntityState.Detached;
             if (pref is not null)
                 db.Entry(pref).State = EntityState.Detached;
+
+            // Reload pref (may have been inserted by the concurrent winner) and set markers.
+            pref = await db.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
+            if (pref is null)
+            {
+                pref = UserPreference.CreateDefault(ownerOid, clock);
+                db.UserPreferences.Add(pref);
+            }
+            if (seedingCategories) pref.MarkCategoriesSeeded(clock);
+            pref.MarkHotkeysSeeded(clock);
+            await db.SaveChangesAsync(ct);
         }
     }
 

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
@@ -224,8 +224,9 @@ internal sealed class ListHotstringsQueryHandler(
         }
         catch (DbUpdateException ex) when (ex.IsDuplicateKeyViolation())
         {
-            // Concurrent first-call race — detach all pending entities so the
-            // read query below works cleanly against whatever was committed first.
+            // Concurrent first-call race or pre-existing data after migration (null
+            // markers but hotstrings already present) — detach pending entities and
+            // persist markers in a follow-up save so future GETs skip the seed path.
             foreach (Hotstring hs in db.Hotstrings.Local.ToList())
                 db.Entry(hs).State = EntityState.Detached;
             foreach (HotstringCategory hc in db.HotstringCategories.Local.ToList())
@@ -234,6 +235,17 @@ internal sealed class ListHotstringsQueryHandler(
                 db.Entry(cat).State = EntityState.Detached;
             if (pref is not null)
                 db.Entry(pref).State = EntityState.Detached;
+
+            // Reload pref (may have been inserted by the concurrent winner) and set markers.
+            pref = await db.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
+            if (pref is null)
+            {
+                pref = UserPreference.CreateDefault(ownerOid, clock);
+                db.UserPreferences.Add(pref);
+            }
+            if (seedingCategories) pref.MarkCategoriesSeeded(clock);
+            pref.MarkHotstringsSeeded(clock);
+            await db.SaveChangesAsync(ct);
         }
     }
 

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
@@ -1,5 +1,7 @@
 using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.Common;
 using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Constants;
 using AHKFlowApp.Domain.Entities;
 using Ardalis.Result;
 using FluentValidation;
@@ -52,13 +54,34 @@ public sealed class ListHotstringsQueryValidator : AbstractValidator<ListHotstri
 
 internal sealed class ListHotstringsQueryHandler(
     IAppDbContext db,
-    ICurrentUser currentUser)
+    ICurrentUser currentUser,
+    AppEnvironment env,
+    TimeProvider clock)
     : IRequestHandler<ListHotstringsQuery, Result<PagedList<HotstringDto>>>
 {
+    // Mirrors SeedHotstringsCommand.s_samples — update both if seed set changes.
+    private static readonly (string Trigger, string Replacement, bool Ending, bool InsideWord, string[] Categories)[] s_lazySeed =
+    [
+        ("recieve", "receive",              true,  true,  ["Autocorrect"]),
+        ("btw",     "by the way",           true,  false, ["Communication"]),
+        ("brb",     "be right back",        true,  false, ["Communication"]),
+        ("fyi",     "for your information", true,  false, ["Communication"]),
+        ("/today",  "{{date:yyyy-MM-dd}}",  false, false, ["DateTime"]),
+        ("/now",    "{{datetime:HH:mm}}",   false, false, ["DateTime"]),
+        ("@sig",    "Example User\nuser@example.com\nExample Company", false, false, ["Email"]),
+        (";arrow",  "→",               false, false, ["Symbols"]),
+        (";check",  "✓",               false, false, ["Symbols"]),
+        (";shrug",  "¯\\_(ツ)_/¯", false, false, ["Symbols"]),
+        (";e:",     "ë",               false, false, ["Symbols"]),
+        (";todo",   "TODO(name): ",         false, false, ["Code"]),
+    ];
+
     public async Task<Result<PagedList<HotstringDto>>> Handle(ListHotstringsQuery request, CancellationToken ct)
     {
         if (currentUser.Oid is not Guid ownerOid)
             return Result.Unauthorized();
+
+        await EnsureHotstringsSeededAsync(ownerOid, ct);
 
         IQueryable<Hotstring> query = db.Hotstrings
             .AsNoTracking()
@@ -136,6 +159,82 @@ internal sealed class ListHotstringsQueryHandler(
             .ToListAsync(ct);
 
         return Result.Success(new PagedList<HotstringDto>(items, request.Page, request.PageSize, total));
+    }
+
+    private async Task EnsureHotstringsSeededAsync(Guid ownerOid, CancellationToken ct)
+    {
+        if (!env.IsDevelopment) return;
+
+        UserPreference? pref = await db.UserPreferences
+            .FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
+
+        if (pref?.HotstringsSeededAt is not null) return;
+
+        // Ensure categories exist; seed them inline if this is the user's first request
+        bool seedingCategories = pref?.CategoriesSeededAt is null;
+        Dictionary<string, Guid> catByName;
+
+        if (seedingCategories)
+        {
+            catByName = [];
+            foreach (string name in DefaultCategories.Names)
+            {
+                var cat = Category.Create(ownerOid, name, clock);
+                db.Categories.Add(cat);
+                catByName[name] = cat.Id;
+            }
+        }
+        else
+        {
+            catByName = (await db.Categories
+                    .Where(c => c.OwnerOid == ownerOid)
+                    .Select(c => new { c.Name, c.Id })
+                    .ToListAsync(ct))
+                .ToDictionary(c => c.Name, c => c.Id, StringComparer.OrdinalIgnoreCase);
+        }
+
+        foreach ((string trigger, string replacement, bool ending, bool inside, string[] cats) in s_lazySeed)
+        {
+            var hs = Hotstring.Create(ownerOid, trigger, replacement, null,
+                appliesToAllProfiles: true, ending, inside, clock);
+            db.Hotstrings.Add(hs);
+            foreach (string catName in cats)
+            {
+                if (catByName.TryGetValue(catName, out Guid catId))
+                    db.HotstringCategories.Add(HotstringCategory.Create(hs.Id, catId));
+            }
+        }
+
+        if (pref is null)
+        {
+            pref = UserPreference.CreateDefault(ownerOid, clock);
+            if (seedingCategories) pref.MarkCategoriesSeeded(clock);
+            pref.MarkHotstringsSeeded(clock);
+            db.UserPreferences.Add(pref);
+        }
+        else
+        {
+            if (seedingCategories) pref.MarkCategoriesSeeded(clock);
+            pref.MarkHotstringsSeeded(clock);
+        }
+
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex) when (ex.IsDuplicateKeyViolation())
+        {
+            // Concurrent first-call race — detach all pending entities so the
+            // read query below works cleanly against whatever was committed first.
+            foreach (Hotstring hs in db.Hotstrings.Local.ToList())
+                db.Entry(hs).State = EntityState.Detached;
+            foreach (HotstringCategory hc in db.HotstringCategories.Local.ToList())
+                db.Entry(hc).State = EntityState.Detached;
+            foreach (Category cat in db.Categories.Local.ToList())
+                db.Entry(cat).State = EntityState.Detached;
+            if (pref is not null)
+                db.Entry(pref).State = EntityState.Detached;
+        }
     }
 
     private static IOrderedQueryable<Hotstring> ApplySorting(

--- a/src/Backend/AHKFlowApp.Domain/Entities/UserPreference.cs
+++ b/src/Backend/AHKFlowApp.Domain/Entities/UserPreference.cs
@@ -9,6 +9,8 @@ public sealed class UserPreference
     public bool DarkMode { get; private set; }
     public DateTimeOffset UpdatedAt { get; private set; }
     public DateTimeOffset? CategoriesSeededAt { get; private set; }
+    public DateTimeOffset? HotstringsSeededAt { get; private set; }
+    public DateTimeOffset? HotkeysSeededAt { get; private set; }
 
     public static UserPreference CreateDefault(Guid ownerOid, TimeProvider clock) => new()
     {
@@ -30,6 +32,22 @@ public sealed class UserPreference
         if (CategoriesSeededAt is not null) return; // idempotent
         DateTimeOffset now = clock.GetUtcNow();
         CategoriesSeededAt = now;
+        UpdatedAt = now;
+    }
+
+    public void MarkHotstringsSeeded(TimeProvider clock)
+    {
+        if (HotstringsSeededAt is not null) return; // idempotent
+        DateTimeOffset now = clock.GetUtcNow();
+        HotstringsSeededAt = now;
+        UpdatedAt = now;
+    }
+
+    public void MarkHotkeysSeeded(TimeProvider clock)
+    {
+        if (HotkeysSeededAt is not null) return; // idempotent
+        DateTimeOffset now = clock.GetUtcNow();
+        HotkeysSeededAt = now;
         UpdatedAt = now;
     }
 }

--- a/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260523153120_AddLazySeedMarkers.Designer.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260523153120_AddLazySeedMarkers.Designer.cs
@@ -4,6 +4,7 @@ using AHKFlowApp.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AHKFlowApp.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260523153120_AddLazySeedMarkers")]
+    partial class AddLazySeedMarkers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260523153120_AddLazySeedMarkers.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260523153120_AddLazySeedMarkers.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AHKFlowApp.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddLazySeedMarkers : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "HotkeysSeededAt",
+            table: "UserPreferences",
+            type: "datetimeoffset",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "HotstringsSeededAt",
+            table: "UserPreferences",
+            type: "datetimeoffset",
+            nullable: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "HotkeysSeededAt",
+            table: "UserPreferences");
+
+        migrationBuilder.DropColumn(
+            name: "HotstringsSeededAt",
+            table: "UserPreferences");
+    }
+}

--- a/tests/AHKFlowApp.API.Tests/Hotkeys/HotkeysEndpointsTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Hotkeys/HotkeysEndpointsTests.cs
@@ -236,7 +236,7 @@ public sealed class HotkeysEndpointsTests(SqlContainerFixture sqlFixture) : IDis
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         PagedList<HotkeyDto>? body = await response.Content.ReadFromJsonAsync<PagedList<HotkeyDto>>();
-        body!.TotalCount.Should().Be(5);
+        body!.TotalCount.Should().Be(17);  // 5 created + 12 lazy-seeded in dev
         body.Items.Should().HaveCount(2);
         body.Page.Should().Be(2);
     }
@@ -331,14 +331,14 @@ public sealed class HotkeysEndpointsTests(SqlContainerFixture sqlFixture) : IDis
         using HttpClient client = CreateAuthed(owner);
 
         await client.PostAsJsonAsync("/api/v1/hotkeys",
-            new CreateHotkeyDto("Open browser", "f3", Ctrl: true, AppliesToAllProfiles: true));
+            new CreateHotkeyDto("MyCustom browser", "f3", Ctrl: true, AppliesToAllProfiles: true));
         await client.PostAsJsonAsync("/api/v1/hotkeys",
-            new CreateHotkeyDto("Open notepad", "f1", Ctrl: true, AppliesToAllProfiles: true));
+            new CreateHotkeyDto("MyCustom notepad", "f1", Ctrl: true, AppliesToAllProfiles: true));
         await client.PostAsJsonAsync("/api/v1/hotkeys",
             new CreateHotkeyDto("Lock workstation", "f2", Ctrl: true, AppliesToAllProfiles: true));
 
         HttpResponseMessage response = await client.GetAsync(
-            "/api/v1/hotkeys?descriptionFilter=Open&sortField=key&sortDescending=false");
+            "/api/v1/hotkeys?descriptionFilter=MyCustom&sortField=key&sortDescending=false");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         PagedList<HotkeyDto>? body = await response.Content.ReadFromJsonAsync<PagedList<HotkeyDto>>();

--- a/tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs
@@ -236,7 +236,7 @@ public sealed class HotstringsEndpointsTests(SqlContainerFixture sqlFixture) : I
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         PagedList<HotstringDto>? pagedBody = await response.Content.ReadFromJsonAsync<PagedList<HotstringDto>>();
-        pagedBody!.TotalCount.Should().Be(5);
+        pagedBody!.TotalCount.Should().Be(17);  // 5 created + 12 lazy-seeded in dev
         pagedBody.Items.Should().HaveCount(2);
         pagedBody.Page.Should().Be(2);
     }
@@ -257,14 +257,14 @@ public sealed class HotstringsEndpointsTests(SqlContainerFixture sqlFixture) : I
         var owner = Guid.NewGuid();
         using HttpClient client = CreateAuthed(owner);
 
-        await client.PostAsJsonAsync("/api/v1/hotstrings", new CreateHotstringDto("btw", "by the way"));
-        await client.PostAsJsonAsync("/api/v1/hotstrings", new CreateHotstringDto("fyi", "for your info"));
+        await client.PostAsJsonAsync("/api/v1/hotstrings", new CreateHotstringDto("mytest1", "custom test 1"));
+        await client.PostAsJsonAsync("/api/v1/hotstrings", new CreateHotstringDto("mytest2", "custom test 2"));
 
-        HttpResponseMessage response = await client.GetAsync("/api/v1/hotstrings?search=btw");
+        HttpResponseMessage response = await client.GetAsync("/api/v1/hotstrings?search=mytest1");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         PagedList<HotstringDto>? pagedBody = await response.Content.ReadFromJsonAsync<PagedList<HotstringDto>>();
-        pagedBody!.Items.Should().ContainSingle().Which.Trigger.Should().Be("btw");
+        pagedBody!.Items.Should().ContainSingle().Which.Trigger.Should().Be("mytest1");
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Dev/SeedHotkeysCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Dev/SeedHotkeysCommandHandlerTests.cs
@@ -47,6 +47,21 @@ public sealed class SeedHotkeysCommandHandlerTests(DevDbFixture fx)
     }
 
     [Fact]
+    public async Task Handle_InDevelopment_SetsHotkeysSeededAtMarker()
+    {
+        await using (AppDbContext db = fx.CreateContext())
+        {
+            await Sut(db).Handle(new SeedHotkeysCommand(Reset: false), default);
+        }
+
+        await using AppDbContext verify = fx.CreateContext();
+        Domain.Entities.UserPreference? pref = await verify.UserPreferences
+            .FirstOrDefaultAsync(p => p.OwnerOid == _ownerOid);
+        pref.Should().NotBeNull();
+        pref!.HotkeysSeededAt.Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task Handle_NotInDevelopment_ReturnsNotFound()
     {
         await using AppDbContext db = fx.CreateContext();

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysFilterByCategoryTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysFilterByCategoryTests.cs
@@ -39,7 +39,7 @@ public sealed class ListHotkeysFilterByCategoryTests(HotkeyDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotkeysQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotkeysQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AHKFlowApp.Application.AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotkeyDto>> result = await handler.Handle(
             new ListHotkeysQuery(CategoryIds: [cat1.Id, cat2.Id]), default);
@@ -67,7 +67,7 @@ public sealed class ListHotkeysFilterByCategoryTests(HotkeyDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotkeysQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotkeysQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AHKFlowApp.Application.AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotkeyDto>> result = await handler.Handle(
             new ListHotkeysQuery(CategoryIds: null), default);

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysLazySeedTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysLazySeedTests.cs
@@ -90,6 +90,33 @@ public sealed class ListHotkeysLazySeedTests(HotkeyDbFixture fx)
     }
 
     [Fact]
+    public async Task Handle_AfterSeedHotkeysCommand_DoesNotReattemptSeed()
+    {
+        var owner = Guid.NewGuid();
+
+        // Step 1: run the dev seed command (mirrors POST /api/v1/dev/hotkeys/seed)
+        await using (AppDbContext seedCtx = fx.CreateContext())
+        {
+            var seedHandler = new AHKFlowApp.Application.Commands.Dev.SeedHotkeysCommandHandler(
+                seedCtx, CurrentUserHelper.For(owner), TimeProvider.System, s_dev);
+            await seedHandler.Handle(new AHKFlowApp.Application.Commands.Dev.SeedHotkeysCommand(Reset: false), CancellationToken.None);
+        }
+
+        // Step 2: lazy list — must not re-attempt seed (marker should already be set)
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotkeysQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+        Result<PagedList<HotkeyDto>> result = await sut.Handle(new ListHotkeysQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(12);
+
+        // Marker persisted (the bug: lazy-seed would have detached pref on duplicate-key)
+        await using AppDbContext verify = fx.CreateContext();
+        UserPreference? pref = await verify.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == owner);
+        pref!.HotkeysSeededAt.Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task Handle_FirstCallInDev_LinksHotkeysToCategories()
     {
         var owner = Guid.NewGuid();

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysLazySeedTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysLazySeedTests.cs
@@ -131,4 +131,37 @@ public sealed class ListHotkeysLazySeedTests(HotkeyDbFixture fx)
             .CountAsync();
         linkedCount.Should().BeGreaterThan(0);
     }
+
+    [Fact]
+    public async Task Handle_WhenHotkeysExistWithNullMarker_SetsMarkerWithoutDuplicating()
+    {
+        // Simulate a post-migration dev DB: hotkeys already present but marker is null
+        var owner = Guid.NewGuid();
+        await using (AppDbContext seedCtx = fx.CreateContext())
+        {
+            // Insert a key combo that overlaps with the lazy-seed sample set (Ctrl+Alt+N)
+            seedCtx.Hotkeys.Add(Hotkey.Create(owner, "Launch Notepad", "N",
+                ctrl: true, alt: true, shift: false, win: false,
+                AHKFlowApp.Domain.Enums.HotkeyAction.Run, "notepad.exe",
+                appliesToAllProfiles: true, TimeProvider.System));
+            await seedCtx.SaveChangesAsync();
+        }
+
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotkeysQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+        Result<PagedList<HotkeyDto>> result = await sut.Handle(new ListHotkeysQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+
+        await using AppDbContext verify = fx.CreateContext();
+
+        // Marker must be persisted so the next GET does not retry
+        UserPreference? pref = await verify.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == owner);
+        pref!.HotkeysSeededAt.Should().NotBeNull();
+
+        // No duplicate rows — Ctrl+Alt+N still exists exactly once
+        int ctrlAltNCount = await verify.Hotkeys
+            .CountAsync(h => h.OwnerOid == owner && h.Key == "N" && h.Ctrl && h.Alt && !h.Shift && !h.Win);
+        ctrlAltNCount.Should().Be(1);
+    }
 }

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysLazySeedTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysLazySeedTests.cs
@@ -1,0 +1,107 @@
+using AHKFlowApp.Application;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Queries.Hotkeys;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Infrastructure.Persistence;
+using Ardalis.Result;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Hotkeys;
+
+[Collection("HotkeyDb")]
+public sealed class ListHotkeysLazySeedTests(HotkeyDbFixture fx)
+{
+    private readonly FakeTimeProvider _clock = new(DateTimeOffset.Parse("2026-05-23T10:00:00Z"));
+    private static readonly AppEnvironment s_dev = new(IsDevelopment: true);
+    private static readonly AppEnvironment s_prod = new(IsDevelopment: false);
+
+    [Fact]
+    public async Task Handle_FirstCallInDev_Seeds12Hotkeys()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotkeysQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+
+        Result<PagedList<HotkeyDto>> result = await sut.Handle(new ListHotkeysQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task Handle_FirstCallInDev_SetsHotkeysSeededAtMarker()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotkeysQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+
+        await sut.Handle(new ListHotkeysQuery(), CancellationToken.None);
+
+        await using AppDbContext ctx2 = fx.CreateContext();
+        UserPreference? pref = await ctx2.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == owner);
+        pref.Should().NotBeNull();
+        pref!.HotkeysSeededAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Handle_SecondCallInDev_DoesNotDuplicateHotkeys()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotkeysQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+        await sut.Handle(new ListHotkeysQuery(), CancellationToken.None);
+
+        await using AppDbContext ctx2 = fx.CreateContext();
+        var sut2 = new ListHotkeysQueryHandler(ctx2, CurrentUserHelper.For(owner), s_dev, _clock);
+        Result<PagedList<HotkeyDto>> result = await sut2.Handle(new ListHotkeysQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task Handle_FirstCallInProd_DoesNotSeed()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotkeysQueryHandler(ctx, CurrentUserHelper.For(owner), s_prod, _clock);
+
+        Result<PagedList<HotkeyDto>> result = await sut.Handle(new ListHotkeysQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_FirstCallInDev_AlsoSeedsCategories_WhenNoneExist()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotkeysQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+
+        await sut.Handle(new ListHotkeysQuery(), CancellationToken.None);
+
+        await using AppDbContext ctx2 = fx.CreateContext();
+        int categoryCount = await ctx2.Categories.CountAsync(c => c.OwnerOid == owner);
+        categoryCount.Should().Be(8);
+    }
+
+    [Fact]
+    public async Task Handle_FirstCallInDev_LinksHotkeysToCategories()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotkeysQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+
+        await sut.Handle(new ListHotkeysQuery(), CancellationToken.None);
+
+        await using AppDbContext ctx2 = fx.CreateContext();
+        int linkedCount = await ctx2.HotkeyCategories
+            .Where(hc => hc.Hotkey.OwnerOid == owner)
+            .CountAsync();
+        linkedCount.Should().BeGreaterThan(0);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysQueryHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysQueryHandlerTests.cs
@@ -1,3 +1,4 @@
+using AHKFlowApp.Application;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Application.Queries.Hotkeys;
 using AHKFlowApp.Domain.Entities;
@@ -26,7 +27,7 @@ public sealed class ListHotkeysQueryHandlerTests(HotkeyDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotkeyDto>> result = await handler.Handle(new ListHotkeysQuery(), default);
 
@@ -61,7 +62,7 @@ public sealed class ListHotkeysQueryHandlerTests(HotkeyDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotkeyDto>> result = await handler.Handle(
             new ListHotkeysQuery(ProfileId: profileId), default);
@@ -89,7 +90,7 @@ public sealed class ListHotkeysQueryHandlerTests(HotkeyDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotkeyDto>> page2 = await handler.Handle(
             new ListHotkeysQuery(Page: 2, PageSize: 2), default);
@@ -104,7 +105,7 @@ public sealed class ListHotkeysQueryHandlerTests(HotkeyDbFixture fx)
     public async Task Handle_WhenNoOid_ReturnsUnauthorized()
     {
         await using AppDbContext db = fx.CreateContext();
-        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(null));
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(null), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotkeyDto>> result = await handler.Handle(new ListHotkeysQuery(), default);
 
@@ -124,7 +125,7 @@ public sealed class ListHotkeysQueryHandlerTests(HotkeyDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotkeyDto>> result = await handler.Handle(
             new ListHotkeysQuery(Search: "f1"), default);
@@ -145,7 +146,7 @@ public sealed class ListHotkeysQueryHandlerTests(HotkeyDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotkeyDto>> result = await handler.Handle(
             new ListHotkeysQuery(Search: "browser"), default);
@@ -166,7 +167,7 @@ public sealed class ListHotkeysQueryHandlerTests(HotkeyDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotkeyDto>> result = await handler.Handle(
             new ListHotkeysQuery(Search: "notepad"), default);
@@ -188,7 +189,7 @@ public sealed class ListHotkeysQueryHandlerTests(HotkeyDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotkeyDto>> result = await handler.Handle(
             new ListHotkeysQuery(DescriptionFilter: "Open"), default);
@@ -211,7 +212,7 @@ public sealed class ListHotkeysQueryHandlerTests(HotkeyDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotkeyDto>> result = await handler.Handle(
             new ListHotkeysQuery(Ctrl: true), default);
@@ -235,7 +236,7 @@ public sealed class ListHotkeysQueryHandlerTests(HotkeyDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner));
+        var handler = new ListHotkeysQueryHandler(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotkeyDto>> result = await handler.Handle(
             new ListHotkeysQuery(SortField: "key", SortDescending: false), default);

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsFilterByCategoryTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsFilterByCategoryTests.cs
@@ -38,7 +38,7 @@ public sealed class ListHotstringsFilterByCategoryTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AHKFlowApp.Application.AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(
             new ListHotstringsQuery(CategoryIds: [cat1.Id, cat2.Id]), default);
@@ -66,7 +66,7 @@ public sealed class ListHotstringsFilterByCategoryTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AHKFlowApp.Application.AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(
             new ListHotstringsQuery(CategoryIds: null), default);

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsLazySeedTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsLazySeedTests.cs
@@ -120,6 +120,33 @@ public sealed class ListHotstringsLazySeedTests(HotstringDbFixture fx)
     }
 
     [Fact]
+    public async Task Handle_AfterSeedHotstringsCommand_DoesNotReattemptSeed()
+    {
+        var owner = Guid.NewGuid();
+
+        // Step 1: run the dev seed command (mirrors POST /api/v1/dev/hotstrings/seed)
+        await using (AppDbContext seedCtx = fx.CreateContext())
+        {
+            var seedHandler = new AHKFlowApp.Application.Commands.Dev.SeedHotstringsCommandHandler(
+                seedCtx, CurrentUserHelper.For(owner), TimeProvider.System, s_dev);
+            await seedHandler.Handle(new AHKFlowApp.Application.Commands.Dev.SeedHotstringsCommand(Reset: false), CancellationToken.None);
+        }
+
+        // Step 2: lazy list — must not re-attempt seed (marker should already be set)
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotstringsQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+        Result<PagedList<HotstringDto>> result = await sut.Handle(new ListHotstringsQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(12);
+
+        // Marker persisted (the bug: lazy-seed would have detached pref on duplicate-key)
+        await using AppDbContext verify = fx.CreateContext();
+        UserPreference? pref = await verify.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == owner);
+        pref!.HotstringsSeededAt.Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task Handle_FirstCallInDev_UsesExistingCategories_WhenAlreadySeeded()
     {
         var owner = Guid.NewGuid();

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsLazySeedTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsLazySeedTests.cs
@@ -1,0 +1,148 @@
+using AHKFlowApp.Application;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Queries.Hotstrings;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Infrastructure.Persistence;
+using Ardalis.Result;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Hotstrings;
+
+[Collection("HotstringDb")]
+public sealed class ListHotstringsLazySeedTests(HotstringDbFixture fx)
+{
+    private readonly FakeTimeProvider _clock = new(DateTimeOffset.Parse("2026-05-23T10:00:00Z"));
+    private static readonly AppEnvironment s_dev = new(IsDevelopment: true);
+    private static readonly AppEnvironment s_prod = new(IsDevelopment: false);
+
+    [Fact]
+    public async Task Handle_FirstCallInDev_Seeds12Hotstrings()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotstringsQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+
+        Result<PagedList<HotstringDto>> result = await sut.Handle(new ListHotstringsQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task Handle_FirstCallInDev_SetsHotstringsSeededAtMarker()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotstringsQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+
+        await sut.Handle(new ListHotstringsQuery(), CancellationToken.None);
+
+        await using AppDbContext ctx2 = fx.CreateContext();
+        UserPreference? pref = await ctx2.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == owner);
+        pref.Should().NotBeNull();
+        pref!.HotstringsSeededAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Handle_SecondCallInDev_DoesNotDuplicateHotstrings()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotstringsQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+        await sut.Handle(new ListHotstringsQuery(), CancellationToken.None);
+
+        await using AppDbContext ctx2 = fx.CreateContext();
+        var sut2 = new ListHotstringsQueryHandler(ctx2, CurrentUserHelper.For(owner), s_dev, _clock);
+        Result<PagedList<HotstringDto>> result = await sut2.Handle(new ListHotstringsQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task Handle_FirstCallInProd_DoesNotSeed()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotstringsQueryHandler(ctx, CurrentUserHelper.For(owner), s_prod, _clock);
+
+        Result<PagedList<HotstringDto>> result = await sut.Handle(new ListHotstringsQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_FirstCallInDev_AlsoSeedsCategories_WhenNoneExist()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotstringsQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+
+        await sut.Handle(new ListHotstringsQuery(), CancellationToken.None);
+
+        await using AppDbContext ctx2 = fx.CreateContext();
+        int categoryCount = await ctx2.Categories.CountAsync(c => c.OwnerOid == owner);
+        categoryCount.Should().Be(8);
+    }
+
+    [Fact]
+    public async Task Handle_FirstCallInDev_SetsCategoriesSeededMarker_WhenNoneExist()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotstringsQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+
+        await sut.Handle(new ListHotstringsQuery(), CancellationToken.None);
+
+        await using AppDbContext ctx2 = fx.CreateContext();
+        UserPreference? pref = await ctx2.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == owner);
+        pref!.CategoriesSeededAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Handle_FirstCallInDev_LinksHotstringsToCategories()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotstringsQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+
+        await sut.Handle(new ListHotstringsQuery(), CancellationToken.None);
+
+        await using AppDbContext ctx2 = fx.CreateContext();
+        int linkedCount = await ctx2.HotstringCategories
+            .Where(hc => hc.Hotstring.OwnerOid == owner)
+            .CountAsync();
+        linkedCount.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Handle_FirstCallInDev_UsesExistingCategories_WhenAlreadySeeded()
+    {
+        var owner = Guid.NewGuid();
+
+        // Pre-seed categories via the categories handler pattern
+        await using (AppDbContext seedCtx = fx.CreateContext())
+        {
+            seedCtx.Categories.Add(Category.Create(owner, "Communication", TimeProvider.System));
+            await seedCtx.SaveChangesAsync();
+            var pref = UserPreference.CreateDefault(owner, TimeProvider.System);
+            pref.MarkCategoriesSeeded(TimeProvider.System);
+            seedCtx.UserPreferences.Add(pref);
+            await seedCtx.SaveChangesAsync();
+        }
+
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotstringsQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+        await sut.Handle(new ListHotstringsQuery(), CancellationToken.None);
+
+        // Should not have created duplicate categories
+        await using AppDbContext ctx2 = fx.CreateContext();
+        int communicationCount = await ctx2.Categories
+            .CountAsync(c => c.OwnerOid == owner && c.Name == "Communication");
+        communicationCount.Should().Be(1);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsLazySeedTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsLazySeedTests.cs
@@ -172,4 +172,33 @@ public sealed class ListHotstringsLazySeedTests(HotstringDbFixture fx)
             .CountAsync(c => c.OwnerOid == owner && c.Name == "Communication");
         communicationCount.Should().Be(1);
     }
+
+    [Fact]
+    public async Task Handle_WhenHotstringsExistWithNullMarker_SetsMarkerWithoutDuplicating()
+    {
+        // Simulate a post-migration dev DB: hotstrings already present but marker is null
+        var owner = Guid.NewGuid();
+        await using (AppDbContext seedCtx = fx.CreateContext())
+        {
+            // Insert a trigger that overlaps with the lazy-seed sample set
+            seedCtx.Hotstrings.Add(Hotstring.Create(owner, "btw", "pre-existing", null, true, true, true, TimeProvider.System));
+            await seedCtx.SaveChangesAsync();
+        }
+
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotstringsQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+        Result<PagedList<HotstringDto>> result = await sut.Handle(new ListHotstringsQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+
+        await using AppDbContext verify = fx.CreateContext();
+
+        // Marker must be persisted so the next GET does not retry
+        UserPreference? pref = await verify.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == owner);
+        pref!.HotstringsSeededAt.Should().NotBeNull();
+
+        // No duplicate rows — "btw" still exists exactly once
+        int btwCount = await verify.Hotstrings.CountAsync(h => h.OwnerOid == owner && h.Trigger == "btw");
+        btwCount.Should().Be(1);
+    }
 }

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsQueryHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsQueryHandlerTests.cs
@@ -1,3 +1,4 @@
+using AHKFlowApp.Application;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Application.Queries.Hotstrings;
 using AHKFlowApp.Domain.Entities;
@@ -25,7 +26,7 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(new ListHotstringsQuery(), default);
 
@@ -55,7 +56,7 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(
             new ListHotstringsQuery(ProfileId: profileId), default);
@@ -82,7 +83,7 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> page2 = await handler.Handle(
             new ListHotstringsQuery(Page: 2, PageSize: 2), default);
@@ -97,7 +98,7 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
     public async Task Handle_WhenNoOid_ReturnsUnauthorized()
     {
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(null));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(null), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(new ListHotstringsQuery(), default);
 
@@ -117,7 +118,7 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(
             new ListHotstringsQuery(Search: "btw"), default);
@@ -138,7 +139,7 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(
             new ListHotstringsQuery(Search: "needle"), default);
@@ -159,7 +160,7 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(
             new ListHotstringsQuery(Search: "german"), default);
@@ -180,7 +181,7 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(
             new ListHotstringsQuery(Search: "foo"), default);
@@ -202,7 +203,7 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(
             new ListHotstringsQuery(Search: "way", TriggerFilter: "btw"), default);
@@ -224,7 +225,7 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(
             new ListHotstringsQuery(IsEndingCharacterRequired: true, IsTriggerInsideWord: false), default);
@@ -246,7 +247,7 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(
             new ListHotstringsQuery(SortField: "trigger", SortDescending: false), default);
@@ -268,7 +269,7 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(
             new ListHotstringsQuery(DescriptionFilter: "greeting"), default);
@@ -290,7 +291,7 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
         }
 
         await using AppDbContext db = fx.CreateContext();
-        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner));
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
 
         Result<PagedList<HotstringDto>> result = await handler.Handle(
             new ListHotstringsQuery(SortField: "description", SortDescending: false), default);

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/SeedHotstringsCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/SeedHotstringsCommandHandlerTests.cs
@@ -39,6 +39,22 @@ public sealed class SeedHotstringsCommandHandlerTests(HotstringDbFixture fx)
     }
 
     [Fact]
+    public async Task Handle_InDevelopment_SetsHotstringsSeededAtMarker()
+    {
+        var owner = Guid.NewGuid();
+        await using (AppDbContext db = fx.CreateContext())
+        {
+            var handler = new SeedHotstringsCommandHandler(db, CurrentUserHelper.For(owner), TimeProvider.System, DevEnv(true));
+            await handler.Handle(new SeedHotstringsCommand(Reset: false), default);
+        }
+
+        await using AppDbContext verify = fx.CreateContext();
+        UserPreference? pref = await verify.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == owner);
+        pref.Should().NotBeNull();
+        pref!.HotstringsSeededAt.Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task Handle_NotInDevelopment_ReturnsNotFound()
     {
         await using AppDbContext db = fx.CreateContext();


### PR DESCRIPTION
## Summary

Implements lazy-seeding for hotstrings and hotkeys: on first authenticated GET /hotstrings or /hotkeys in Development environment, auto-seeds 12 hotstrings / 12 hotkeys with correct category links. Seeds 8 default categories if not yet present.

Uses HotstringsSeededAt and HotkeysSeededAt markers on UserPreference to stay idempotent — seeding only happens once per user per environment.

## Changes

**Domain:** Added nullable HotstringsSeededAt and HotkeysSeededAt columns to UserPreference.

**Application:** ListHotstringsQueryHandler and ListHotkeysQueryHandler now accept AppEnvironment and TimeProvider, check seeding markers, and lazy-seed on first call.

**Commands:** SeedHotstringsCommand and SeedHotkeysCommand now set seeding markers, preventing infinite re-seeding loops.

**Infrastructure:** Migration adds the two marker columns.

**Tests:** Comprehensive coverage of lazy-seed behavior including regression tests for seed-command-then-lazy-list compatibility. API integration tests adjusted for dev environment lazy-seeding.

Fixes #0 (seed expansion design in spec).