### PR TITLE
Mobile-friendly hotstrings + hotkeys pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -449,6 +449,7 @@ src/Backend/**/appsettings.Production.json
 .worktrees/
 .claude/worktrees/
 .playwright-cli/
+.superpowers/
 
 # Code coverage reports
 coverage-report/

--- a/docs/superpowers/plans/2026-05-24-mobile-hotstrings-hotkeys.md
+++ b/docs/superpowers/plans/2026-05-24-mobile-hotstrings-hotkeys.md
@@ -913,13 +913,13 @@ Expected: FAIL — `.desktop-branch` / `.mobile-branch` / `add-hotstring-fab` no
 In `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor`, after line 11 (`<MudText Typo="Typo.h4" ...>Hotstrings</MudText>`), wrap the existing `<MudPaper Class="pa-4">...</MudPaper>` (lines 13-175) in:
 
 ```razor
-<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
+<MudHidden Breakpoint="Breakpoint.SmAndDown">
     <div class="desktop-branch">
         <!-- existing MudPaper + MudDataGrid block unchanged -->
     </div>
 </MudHidden>
 
-<MudHidden Breakpoint="Breakpoint.SmAndDown">
+<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
     <div class="mobile-branch">
         <MudPaper Class="pa-2" Style="position:relative;min-height:80vh;">
             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
@@ -1513,7 +1513,7 @@ For each viewport (375×812 phone, 768×1024 tablet portrait, 1280×800 desktop)
 Add to `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md` after the existing conventions list:
 
 ```markdown
-- For list pages that need mobile support: render both branches gated by `<MudHidden Breakpoint="Breakpoint.SmAndDown">`. Desktop branch uses `MudDataGrid` with inline editing; mobile branch uses a compact list component + full-screen `MudDialog` for edit/create + `MudFab` for add. See `Components/Hotstrings/` and `Components/Hotkeys/` for examples.
+- For list pages that need mobile support: render both branches gated by `<MudHidden Breakpoint="Breakpoint.SmAndDown">`; use the non-inverted branch for desktop `MudDataGrid` markup and the inverted branch for the mobile list. Mobile uses a compact list component + full-screen `MudDialog` for edit/create + `MudFab` for add. See `Components/Hotstrings/` and `Components/Hotkeys/` for examples.
 ```
 
 - [ ] **Step 2: Commit the note**

--- a/docs/superpowers/plans/2026-05-24-mobile-hotstrings-hotkeys.md
+++ b/docs/superpowers/plans/2026-05-24-mobile-hotstrings-hotkeys.md
@@ -4,7 +4,7 @@
 
 **Goal:** Ship a mobile-friendly view for `/hotstrings` and `/hotkeys` that triggers under 960px width, using a compact 2-column list with expandable rows + a full-screen `MudDialog` for create/edit + a FAB for add + a select-mode toggle for bulk delete. Desktop (md+) keeps the existing `MudDataGrid` inline-edit experience unchanged.
 
-**Architecture:** Each page renders two branches gated by `MudHidden Breakpoint="Breakpoint.SmAndDown"`. Existing data-loading logic (`LoadServerData`) is split into a thin grid callback + a reusable `LoadAsync` method that the mobile branch also calls. Two new components per page: a full-screen edit/create dialog (`*EditDialog.razor`) and a mobile list component (`*MobileList.razor`). No backend or API client changes.
+**Architecture:** Each page renders two plain branch containers, `.desktop-branch` and `.mobile-branch`, with visibility gated by the page's scoped `.razor.css` at `959.95px`. Existing data-loading logic (`LoadServerData`) is split into a thin grid callback + a reusable `LoadAsync` method that the mobile branch also calls. Two new components per page: a full-screen edit/create dialog (`*EditDialog.razor`) and a mobile list component (`*MobileList.razor`). No backend or API client changes.
 
 **Tech Stack:** Blazor WebAssembly (.NET 10), MudBlazor 9.3.0, FluentValidation via existing edit models, xUnit + bUnit + FluentAssertions + NSubstitute for unit tests, Playwright + WebApplicationFactory (`StackFixture`) for E2E.
 
@@ -886,25 +886,23 @@ Append to `HotstringsPageTests.cs`:
 
 ```csharp
 [Fact]
-public void Page_RendersBothDesktopAndMobileBranches()
+public void Page_RendersCssGatedDesktopAndMobileBranches()
 {
     StubList(Page());
 
     IRenderedComponent<Hotstrings> cut = RenderPage();
-    cut.WaitForAssertion(() => cut.Find("button.add-hotstring"));
 
-    // Desktop branch wrapper
-    cut.FindAll(".desktop-branch").Should().NotBeEmpty();
-    // Mobile branch wrapper
-    cut.FindAll(".mobile-branch").Should().NotBeEmpty();
-    // FAB only in mobile branch
-    cut.FindAll("button.add-hotstring-fab").Should().NotBeEmpty();
+    cut.WaitForAssertion(() =>
+    {
+        cut.Find(".desktop-branch button.add-hotstring").Should().NotBeNull();
+        cut.Find(".mobile-branch button.add-hotstring-fab").Should().NotBeNull();
+    });
 }
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotstringsPageTests.Page_RendersBothDesktopAndMobileBranches" --no-restore`
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotstringsPageTests.Page_RendersCssGatedDesktopAndMobileBranches" --no-restore`
 
 Expected: FAIL — `.desktop-branch` / `.mobile-branch` / `add-hotstring-fab` not found.
 
@@ -913,20 +911,17 @@ Expected: FAIL — `.desktop-branch` / `.mobile-branch` / `add-hotstring-fab` no
 In `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor`, after line 11 (`<MudText Typo="Typo.h4" ...>Hotstrings</MudText>`), wrap the existing `<MudPaper Class="pa-4">...</MudPaper>` (lines 13-175) in:
 
 ```razor
-<MudHidden Breakpoint="Breakpoint.SmAndDown">
-    <div class="desktop-branch">
-        <!-- existing MudPaper + MudDataGrid block unchanged -->
-    </div>
-</MudHidden>
+<div class="desktop-branch">
+    <!-- existing MudPaper + MudDataGrid block unchanged -->
+</div>
 
-<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
-    <div class="mobile-branch">
-        <MudPaper Class="pa-2" Style="position:relative;min-height:80vh;">
-            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
-                <MudIconButton Class="reload-hotstrings" Icon="@Icons.Material.Filled.Refresh"
-                               OnClick="ReloadAsync" Disabled="@(!_isAuthenticated || _loading)" />
-                <MudSpacer />
-            </MudStack>
+<div class="mobile-branch">
+    <MudPaper Class="pa-2" Style="position:relative;min-height:80vh;">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
+            <MudIconButton Class="reload-hotstrings" Icon="@Icons.Material.Filled.Refresh"
+                           OnClick="ReloadAsync" Disabled="@(!_isAuthenticated || _loading)" />
+            <MudSpacer />
+        </MudStack>
 
             <MudTextField T="string" @bind-Value="_search" @bind-Value:after="OnSearchChangedAsync"
                           DebounceInterval="300"
@@ -969,9 +964,8 @@ In `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor`, after line 11 (`<
                     StartIcon="@Icons.Material.Filled.Add"
                     Style="position:fixed;right:16px;bottom:16px;z-index:100;"
                     OnClick="OpenCreateDialogAsync" />
-        </MudPaper>
-    </div>
-</MudHidden>
+    </MudPaper>
+</div>
 ```
 
 Add to `@code { ... }` block (after existing fields):
@@ -1405,7 +1399,7 @@ git commit -m "feat: hotkey mobile list (collapsed + expand + select + bulk dele
 - Modify: `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor`
 - Modify: `tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs`
 
-Apply the same MudHidden split + mobile branch + new helper methods (`LoadMobileAsync`, `OpenCreateDialogAsync`, `OpenEditDialogAsync`, `MobileBulkDeleteAsync`, `ReloadAllAsync`) to `Hotkeys.razor`. Substitutions:
+Apply the same CSS-gated branch split + mobile branch + new helper methods (`LoadMobileAsync`, `OpenCreateDialogAsync`, `OpenEditDialogAsync`, `MobileBulkDeleteAsync`, `ReloadAllAsync`) to `Hotkeys.razor`. Substitutions:
 
 - `HotstringMobileList` → `HotkeyMobileList`
 - `HotstringEditDialog` → `HotkeyEditDialog`
@@ -1415,7 +1409,7 @@ Apply the same MudHidden split + mobile branch + new helper methods (`LoadMobile
 - `HotkeyEditModel.FromDto(new HotkeyDto(...))` — construct the DTO from `item` fields. Look at existing `MapItem` in `Hotkeys.razor:393` for the shape.
 
 - [ ] **Step 1: Add the failing test** — mirror Task 5 Step 1's test in `HotkeysPageTests.cs`. Selector: `button.add-hotkey-fab`.
-- [ ] **Step 2: Run — expect FAIL.** `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotkeysPageTests.Page_RendersBothDesktopAndMobileBranches" --no-restore`
+- [ ] **Step 2: Run — expect FAIL.** `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotkeysPageTests.Page_RendersCssGatedDesktopAndMobileBranches" --no-restore`
 - [ ] **Step 3: Modify `Hotkeys.razor`** with the same split treatment.
 - [ ] **Step 4: Run all UI tests + build.** `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --no-restore && dotnet build --no-restore`
 - [ ] **Step 5: Commit.**
@@ -1513,7 +1507,7 @@ For each viewport (375×812 phone, 768×1024 tablet portrait, 1280×800 desktop)
 Add to `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md` after the existing conventions list:
 
 ```markdown
-- For list pages that need mobile support: render both branches gated by `<MudHidden Breakpoint="Breakpoint.SmAndDown">`; use the non-inverted branch for desktop `MudDataGrid` markup and the inverted branch for the mobile list. Mobile uses a compact list component + full-screen `MudDialog` for edit/create + `MudFab` for add. See `Components/Hotstrings/` and `Components/Hotkeys/` for examples.
+- For list pages that need mobile support: render both branches as plain `.desktop-branch` and `.mobile-branch` containers, then gate visibility in the page's scoped `.razor.css` at `959.95px`. Desktop uses `MudDataGrid`; mobile uses a compact list component, full-screen `MudDialog`, and `MudFab`. See `Components/Hotstrings/` and `Components/Hotkeys/` for examples.
 ```
 
 - [ ] **Step 2: Commit the note**

--- a/docs/superpowers/plans/2026-05-24-mobile-hotstrings-hotkeys.md
+++ b/docs/superpowers/plans/2026-05-24-mobile-hotstrings-hotkeys.md
@@ -1,0 +1,1587 @@
+# Mobile-friendly Hotstrings + Hotkeys — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a mobile-friendly view for `/hotstrings` and `/hotkeys` that triggers under 960px width, using a compact 2-column list with expandable rows + a full-screen `MudDialog` for create/edit + a FAB for add + a select-mode toggle for bulk delete. Desktop (md+) keeps the existing `MudDataGrid` inline-edit experience unchanged.
+
+**Architecture:** Each page renders two branches gated by `MudHidden Breakpoint="Breakpoint.SmAndDown"`. Existing data-loading logic (`LoadServerData`) is split into a thin grid callback + a reusable `LoadAsync` method that the mobile branch also calls. Two new components per page: a full-screen edit/create dialog (`*EditDialog.razor`) and a mobile list component (`*MobileList.razor`). No backend or API client changes.
+
+**Tech Stack:** Blazor WebAssembly (.NET 10), MudBlazor 9.3.0, FluentValidation via existing edit models, xUnit + bUnit + FluentAssertions + NSubstitute for unit tests, Playwright + WebApplicationFactory (`StackFixture`) for E2E.
+
+**Source spec:** `docs/superpowers/specs/2026-05-24-mobile-hotstrings-hotkeys-design.md`
+
+**Branch:** `feature/032-mobile-hotstrings-hotkeys` (already created).
+
+---
+
+## Defaults for spec's deferred questions
+
+The implementer picks these defaults and flags them in the PR. The reviewer can push back per item.
+
+| Question | Default |
+|---|---|
+| Pager UI | `MudPagination` |
+| Page size on mobile | 10 (same as desktop default) |
+| Hotkeys primary-line truncation | Description ellipsizes first; modifier+key stays intact |
+| FAB scroll behavior | Always visible |
+| Select-mode action bar | Sticky bottom |
+
+---
+
+## File map
+
+**Create:**
+- `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor`
+- `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor`
+- `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor`
+- `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor`
+- `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs`
+- `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs`
+- `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs`
+- `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyMobileListTests.cs`
+- `tests/AHKFlowApp.E2E.Tests/HotstringsMobileFlowTests.cs`
+- `tests/AHKFlowApp.E2E.Tests/HotkeysMobileFlowTests.cs`
+
+**Modify:**
+- `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor` — split into desktop + mobile branches; extract `LoadAsync`; add dialog-opening helpers.
+- `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor` — same treatment.
+- `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md` — add note about the breakpoint pattern.
+
+**Reuse unchanged:** `Validation/HotstringEditModel.cs`, `Validation/HotkeyEditModel.cs`, `Services/IHotstringsApiClient`, `Services/IHotkeysApiClient`, `Services/IProfilesApiClient`, `Services/ICategoriesApiClient`, all DTOs.
+
+---
+
+## Task 1: HotstringEditDialog — render in create mode
+
+**Files:**
+- Create: `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor`
+- Create: `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs`:
+
+```csharp
+using AHKFlowApp.UI.Blazor.Components.Hotstrings;
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Services;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using NSubstitute;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Components.Hotstrings;
+
+public sealed class HotstringEditDialogTests : BunitContext
+{
+    private readonly IHotstringsApiClient _api = Substitute.For<IHotstringsApiClient>();
+
+    public HotstringEditDialogTests()
+    {
+        Services.AddSingleton(_api);
+        Services.AddSingleton(Substitute.For<ISnackbar>());
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [Fact]
+    public void CreateMode_RendersEmptyFields()
+    {
+        Render<MudDialogProvider>();
+
+        IDialogReference reference = default!;
+        InvokeAsync(async () =>
+        {
+            IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+            reference = await dialogService.ShowAsync<HotstringEditDialog>("New",
+                new DialogParameters
+                {
+                    [nameof(HotstringEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                    [nameof(HotstringEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+                },
+                new DialogOptions { FullScreen = true, CloseButton = false });
+        }).GetAwaiter().GetResult();
+
+        WaitForAssertion(() => Find("input[data-test=\"trigger-input\"]").GetAttribute("value").Should().Be(""));
+        Find("input[data-test=\"replacement-input\"]").GetAttribute("value").Should().Be("");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotstringEditDialogTests" --no-restore`
+
+Expected: FAIL — `HotstringEditDialog` type does not exist.
+
+- [ ] **Step 3: Create the dialog component**
+
+Create `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor`:
+
+```razor
+@using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Services
+@using AHKFlowApp.UI.Blazor.Validation
+@using MudBlazor
+
+<MudDialog Class="hotstring-edit-dialog">
+    <TitleContent>
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="flex-grow-1">
+            <MudIconButton Class="cancel-edit" Icon="@Icons.Material.Filled.ArrowBack" OnClick="Cancel" />
+            <MudText Typo="Typo.h6">@(Item.Id is null ? "New hotstring" : "Edit hotstring")</MudText>
+            <MudButton Class="commit-edit" Color="Color.Primary" Variant="Variant.Filled" OnClick="SaveAsync">Save</MudButton>
+        </MudStack>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3" Class="pa-2">
+            <MudTextField T="string" Label="Trigger" @bind-Value="Item.Trigger"
+                          Required="true" RequiredError="Trigger is required" MaxLength="50"
+                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "trigger-input" })" />
+            <MudTextField T="string" Label="Replacement" @bind-Value="Item.Replacement"
+                          Lines="3" Required="true" RequiredError="Replacement is required" MaxLength="4000"
+                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "replacement-input" })" />
+            <MudTextField T="string" Label="Description" @bind-Value="Item.Description"
+                          MaxLength="200"
+                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "description-input" })" />
+
+            <MudCheckBox T="bool" @bind-Value="Item.AppliesToAllProfiles" Label="Apply to all profiles"
+                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "applies-to-all-checkbox" })" />
+            @if (!Item.AppliesToAllProfiles)
+            {
+                <MudSelect T="Guid" MultiSelection="true" Label="Profiles"
+                           SelectedValues="Item.ProfileIds"
+                           SelectedValuesChanged="ids => Item.ProfileIds = [.. ids]"
+                           ToStringFunc="@(id => Profiles.FirstOrDefault(p => p.Id == id)?.Name ?? id.ToString())"
+                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "profile-select" })">
+                    @foreach (ProfileDto p in Profiles)
+                    {
+                        <MudSelectItem T="Guid" Value="@p.Id">@p.Name</MudSelectItem>
+                    }
+                </MudSelect>
+            }
+
+            <MudCheckBox T="bool" @bind-Value="Item.IsEndingCharacterRequired" Label="Ending character required" />
+            <MudCheckBox T="bool" @bind-Value="Item.IsTriggerInsideWord" Label="Trigger inside word" />
+
+            <MudSelect T="Guid" MultiSelection="true" Label="Categories"
+                       SelectedValues="Item.CategoryIds"
+                       SelectedValuesChanged="ids => Item.CategoryIds = [.. ids]"
+                       ToStringFunc="@(id => Categories.FirstOrDefault(c => c.Id == id)?.Name ?? id.ToString())"
+                       UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "category-select" })">
+                @foreach (CategoryDto c in Categories)
+                {
+                    <MudSelectItem T="Guid" Value="@c.Id">@c.Name</MudSelectItem>
+                }
+            </MudSelect>
+
+            @if (_error is not null)
+            {
+                <MudAlert Severity="Severity.Error">@_error</MudAlert>
+            }
+        </MudStack>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance Dialog { get; set; } = default!;
+    [Inject] private IHotstringsApiClient Api { get; set; } = default!;
+
+    [Parameter] public HotstringEditModel Item { get; set; } = new();
+    [Parameter] public IReadOnlyList<ProfileDto> Profiles { get; set; } = [];
+    [Parameter] public IReadOnlyList<CategoryDto> Categories { get; set; } = [];
+
+    private string? _error;
+
+    private void Cancel() => Dialog.Cancel();
+
+    private async Task SaveAsync()
+    {
+        _error = null;
+        if (string.IsNullOrWhiteSpace(Item.Trigger) || string.IsNullOrWhiteSpace(Item.Replacement))
+        {
+            _error = "Trigger and Replacement are required.";
+            return;
+        }
+
+        ApiResult<HotstringDto> result = Item.Id is null
+            ? await Api.CreateAsync(Item.ToCreateDto(), CancellationToken.None)
+            : await Api.UpdateAsync(Item.Id.Value, Item.ToUpdateDto(), CancellationToken.None);
+
+        if (!result.IsSuccess)
+        {
+            _error = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+            return;
+        }
+
+        Dialog.Close(DialogResult.Ok(result.Value));
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotstringEditDialogTests" --no-restore`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+git commit -m "feat: hotstring edit dialog (create mode)"
+```
+
+---
+
+## Task 2: HotstringEditDialog — edit mode + save calls API
+
+**Files:**
+- Modify: `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to the test class:
+
+```csharp
+[Fact]
+public void EditMode_PrefillsFieldsFromItem()
+{
+    HotstringEditModel item = new()
+    {
+        Id = Guid.NewGuid(),
+        Trigger = "btw",
+        Replacement = "by the way",
+        Description = "polite filler",
+    };
+
+    Render<MudDialogProvider>();
+    InvokeAsync(async () =>
+    {
+        IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+        await dialogService.ShowAsync<HotstringEditDialog>("Edit",
+            new DialogParameters
+            {
+                [nameof(HotstringEditDialog.Item)] = item,
+                [nameof(HotstringEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                [nameof(HotstringEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+            },
+            new DialogOptions { FullScreen = true, CloseButton = false });
+    }).GetAwaiter().GetResult();
+
+    WaitForAssertion(() => Find("input[data-test=\"trigger-input\"]").GetAttribute("value").Should().Be("btw"));
+    Find("input[data-test=\"replacement-input\"]").TextContent.Should().Contain("by the way");
+}
+
+[Fact]
+public async Task SaveInCreateMode_CallsCreateAsync()
+{
+    HotstringDto created = new(Guid.NewGuid(), [], true, "btw", "by the way", null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+    _api.CreateAsync(Arg.Any<CreateHotstringDto>(), Arg.Any<CancellationToken>())
+        .Returns(ApiResult<HotstringDto>.Ok(created));
+
+    Render<MudDialogProvider>();
+    await InvokeAsync(async () =>
+    {
+        IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+        await dialogService.ShowAsync<HotstringEditDialog>("New",
+            new DialogParameters
+            {
+                [nameof(HotstringEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                [nameof(HotstringEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+            },
+            new DialogOptions { FullScreen = true, CloseButton = false });
+    });
+
+    WaitForAssertion(() => Find("input[data-test=\"trigger-input\"]"));
+    Find("input[data-test=\"trigger-input\"]").Input("btw");
+    Find("input[data-test=\"replacement-input\"]").Input("by the way");
+    Find("button.commit-edit").Click();
+
+    WaitForAssertion(() => _api.Received(1).CreateAsync(
+        Arg.Is<CreateHotstringDto>(d => d.Trigger == "btw" && d.Replacement == "by the way"),
+        Arg.Any<CancellationToken>()));
+}
+
+[Fact]
+public async Task SaveInEditMode_CallsUpdateAsync()
+{
+    HotstringEditModel item = new()
+    {
+        Id = Guid.NewGuid(),
+        Trigger = "btw",
+        Replacement = "by the way",
+    };
+    _api.UpdateAsync(item.Id!.Value, Arg.Any<UpdateHotstringDto>(), Arg.Any<CancellationToken>())
+        .Returns(ApiResult<HotstringDto>.Ok(
+            new HotstringDto(item.Id.Value, [], true, "btw", "by the way!", null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)));
+
+    Render<MudDialogProvider>();
+    await InvokeAsync(async () =>
+    {
+        IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+        await dialogService.ShowAsync<HotstringEditDialog>("Edit",
+            new DialogParameters
+            {
+                [nameof(HotstringEditDialog.Item)] = item,
+                [nameof(HotstringEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                [nameof(HotstringEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+            },
+            new DialogOptions { FullScreen = true, CloseButton = false });
+    });
+
+    WaitForAssertion(() => Find("input[data-test=\"replacement-input\"]"));
+    Find("input[data-test=\"replacement-input\"]").Input("by the way!");
+    Find("button.commit-edit").Click();
+
+    WaitForAssertion(() => _api.Received(1).UpdateAsync(
+        item.Id.Value,
+        Arg.Is<UpdateHotstringDto>(d => d.Replacement == "by the way!"),
+        Arg.Any<CancellationToken>()));
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotstringEditDialogTests" --no-restore`
+
+Expected: PASS (no code changes needed — Task 1 already supports both modes via `Item.Id`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+git commit -m "test: hotstring edit dialog covers create + edit"
+```
+
+---
+
+## Task 3: HotstringMobileList — collapsed list + Edit/Delete events
+
+**Files:**
+- Create: `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor`
+- Create: `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using AHKFlowApp.UI.Blazor.Components.Hotstrings;
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Validation;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Components.Hotstrings;
+
+public sealed class HotstringMobileListTests : BunitContext
+{
+    public HotstringMobileListTests()
+    {
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    private static HotstringEditModel Item(string trigger = "btw", string replacement = "by the way") =>
+        new() { Id = Guid.NewGuid(), Trigger = trigger, Replacement = replacement };
+
+    [Fact]
+    public void Renders_TriggerAndReplacement_PerRow()
+    {
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [Item("btw", "by the way"), Item("addr", "123 Main St")])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        cut.Markup.Should().Contain("btw");
+        cut.Markup.Should().Contain("by the way");
+        cut.Markup.Should().Contain("addr");
+    }
+
+    [Fact]
+    public async Task EditButton_RaisesOnEdit()
+    {
+        HotstringEditModel item = Item();
+        HotstringEditModel? edited = null;
+
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [item])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[])
+            .Add(c => c.OnEdit, EventCallback.Factory.Create<HotstringEditModel>(this, m => edited = m)));
+
+        // Expand the row first
+        await cut.InvokeAsync(() => cut.Find("tr.mobile-row").Click());
+        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
+        await cut.InvokeAsync(() => cut.Find("button.start-edit").Click());
+
+        edited.Should().Be(item);
+    }
+
+    [Fact]
+    public async Task DeleteButton_RaisesOnDelete()
+    {
+        HotstringEditModel item = Item();
+        HotstringEditModel? deleted = null;
+
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [item])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[])
+            .Add(c => c.OnDelete, EventCallback.Factory.Create<HotstringEditModel>(this, m => deleted = m)));
+
+        await cut.InvokeAsync(() => cut.Find("tr.mobile-row").Click());
+        cut.WaitForAssertion(() => cut.Find("button.delete"));
+        await cut.InvokeAsync(() => cut.Find("button.delete").Click());
+
+        deleted.Should().Be(item);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotstringMobileListTests" --no-restore`
+
+Expected: FAIL — `HotstringMobileList` does not exist.
+
+- [ ] **Step 3: Create the component**
+
+Create `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor`:
+
+```razor
+@using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Validation
+@using MudBlazor
+
+<MudStack Spacing="0">
+    @if (Items.Count == 0)
+    {
+        <MudText Class="pa-4 text-center" Typo="Typo.body2">No hotstrings yet.</MudText>
+    }
+
+    <table class="mobile-list">
+        <thead>
+            <tr class="mobile-header">
+                <th>Trigger</th>
+                <th>Replacement</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (HotstringEditModel item in Items)
+            {
+                bool expanded = _expandedId == item.Id;
+                <tr class="mobile-row" @onclick="() => ToggleExpand(item)">
+                    <td class="trigger-cell"><code>@item.Trigger</code></td>
+                    <td class="replacement-cell">@item.Replacement</td>
+                    <td class="chevron-cell">@(expanded ? "▾" : "▸")</td>
+                </tr>
+                @if (expanded)
+                {
+                    <tr class="mobile-row-expanded">
+                        <td colspan="3">
+                            <MudStack Spacing="1" Class="pa-3">
+                                @if (!string.IsNullOrWhiteSpace(item.Description))
+                                {
+                                    <MudText Typo="Typo.body2"><strong>Description:</strong> @item.Description</MudText>
+                                }
+                                <MudText Typo="Typo.body2"><strong>Profiles:</strong>
+                                    @if (item.AppliesToAllProfiles)
+                                    {
+                                        <MudChip T="string" Size="Size.Small" Color="Color.Info">Any</MudChip>
+                                    }
+                                    else
+                                    {
+                                        @foreach (Guid pid in item.ProfileIds)
+                                        {
+                                            string name = Profiles.FirstOrDefault(p => p.Id == pid)?.Name ?? pid.ToString()[..8];
+                                            <MudChip T="string" Size="Size.Small">@name</MudChip>
+                                        }
+                                    }
+                                </MudText>
+                                <MudText Typo="Typo.body2"><strong>Categories:</strong>
+                                    @foreach (Guid cid in item.CategoryIds)
+                                    {
+                                        string name = Categories.FirstOrDefault(c => c.Id == cid)?.Name ?? cid.ToString()[..8];
+                                        <MudChip T="string" Size="Size.Small">@name</MudChip>
+                                    }
+                                </MudText>
+                                <MudText Typo="Typo.body2">
+                                    <strong>End-char:</strong> @(item.IsEndingCharacterRequired ? "✓" : "✗") &nbsp;
+                                    <strong>In-word:</strong> @(item.IsTriggerInsideWord ? "✓" : "✗")
+                                </MudText>
+                                <MudStack Row="true" Spacing="2" Class="mt-2">
+                                    <MudButton Class="start-edit" Variant="Variant.Filled" Color="Color.Primary"
+                                               StartIcon="@Icons.Material.Filled.Edit"
+                                               OnClick="@(async () => await OnEdit.InvokeAsync(item))">Edit</MudButton>
+                                    <MudButton Class="delete" Variant="Variant.Filled" Color="Color.Error"
+                                               StartIcon="@Icons.Material.Filled.Delete"
+                                               OnClick="@(async () => await OnDelete.InvokeAsync(item))">Delete</MudButton>
+                                </MudStack>
+                            </MudStack>
+                        </td>
+                    </tr>
+                }
+            }
+        </tbody>
+    </table>
+</MudStack>
+
+@code {
+    [Parameter] public IReadOnlyList<HotstringEditModel> Items { get; set; } = [];
+    [Parameter] public IReadOnlyList<ProfileDto> Profiles { get; set; } = [];
+    [Parameter] public IReadOnlyList<CategoryDto> Categories { get; set; } = [];
+    [Parameter] public EventCallback<HotstringEditModel> OnEdit { get; set; }
+    [Parameter] public EventCallback<HotstringEditModel> OnDelete { get; set; }
+
+    private Guid? _expandedId;
+
+    private void ToggleExpand(HotstringEditModel item)
+    {
+        _expandedId = _expandedId == item.Id ? null : item.Id;
+    }
+}
+```
+
+Add minimal styles. Create `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor.css`:
+
+```css
+.mobile-list {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+
+.mobile-list .mobile-header {
+    background: var(--mud-palette-background-grey);
+}
+
+.mobile-list .mobile-header th {
+    text-align: left;
+    padding: 6px 12px;
+    font-weight: 500;
+    font-size: 0.75rem;
+    color: var(--mud-palette-text-secondary);
+}
+
+.mobile-list .mobile-row {
+    border-top: 1px solid var(--mud-palette-divider);
+    cursor: pointer;
+}
+
+.mobile-list .mobile-row td {
+    padding: 10px 12px;
+    vertical-align: middle;
+}
+
+.mobile-list .trigger-cell {
+    width: 30%;
+    white-space: nowrap;
+}
+
+.mobile-list .replacement-cell {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 0;
+}
+
+.mobile-list .chevron-cell {
+    width: 24px;
+    text-align: right;
+    color: var(--mud-palette-text-secondary);
+}
+
+.mobile-list .mobile-row-expanded {
+    background: var(--mud-palette-background-grey);
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotstringMobileListTests" --no-restore`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor.css tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
+git commit -m "feat: hotstring mobile list (collapsed + expand + edit/delete)"
+```
+
+---
+
+## Task 4: HotstringMobileList — select mode + bulk delete
+
+**Files:**
+- Modify: `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor`
+- Modify: `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `HotstringMobileListTests.cs`:
+
+```csharp
+[Fact]
+public async Task SelectModeToggle_RevealsCheckboxes()
+{
+    IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+        .Add(c => c.Items, [Item()])
+        .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+        .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+    cut.FindAll("input.row-checkbox").Should().BeEmpty();
+
+    await cut.InvokeAsync(() => cut.Find("button.toggle-select-mode").Click());
+
+    cut.WaitForAssertion(() => cut.FindAll("input.row-checkbox").Should().NotBeEmpty());
+}
+
+[Fact]
+public async Task BulkDelete_RaisesOnBulkDelete_WithSelectedIds()
+{
+    HotstringEditModel a = Item("a", "x");
+    HotstringEditModel b = Item("b", "y");
+    IReadOnlyList<Guid>? deletedIds = null;
+
+    IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+        .Add(c => c.Items, [a, b])
+        .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+        .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[])
+        .Add(c => c.OnBulkDelete, EventCallback.Factory.Create<IReadOnlyList<Guid>>(this, ids => deletedIds = ids)));
+
+    await cut.InvokeAsync(() => cut.Find("button.toggle-select-mode").Click());
+
+    cut.WaitForAssertion(() => cut.FindAll("input.row-checkbox").Count.Should().Be(2));
+    cut.FindAll("input.row-checkbox")[0].Change(true);
+    cut.FindAll("input.row-checkbox")[1].Change(true);
+
+    await cut.InvokeAsync(() => cut.Find("button.bulk-delete-hotstrings").Click());
+
+    deletedIds.Should().BeEquivalentTo(new[] { a.Id!.Value, b.Id!.Value });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotstringMobileListTests" --no-restore`
+
+Expected: FAIL — `button.toggle-select-mode` and `button.bulk-delete-hotstrings` not found.
+
+- [ ] **Step 3: Add select-mode to the component**
+
+Replace `HotstringMobileList.razor` content with:
+
+```razor
+@using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Validation
+@using MudBlazor
+
+<MudStack Spacing="0">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Class="pa-2">
+        <MudIconButton Class="toggle-select-mode"
+                       Icon="@(_selectMode ? Icons.Material.Filled.Close : Icons.Material.Filled.CheckBox)"
+                       OnClick="ToggleSelectMode" />
+        <MudText Typo="Typo.subtitle2">@(_selectMode ? $"{_selectedIds.Count} selected" : "")</MudText>
+    </MudStack>
+
+    @if (Items.Count == 0)
+    {
+        <MudText Class="pa-4 text-center" Typo="Typo.body2">No hotstrings yet.</MudText>
+    }
+
+    <table class="mobile-list">
+        <thead>
+            <tr class="mobile-header">
+                @if (_selectMode)
+                {
+                    <th style="width:36px"></th>
+                }
+                <th>Trigger</th>
+                <th>Replacement</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (HotstringEditModel item in Items)
+            {
+                bool expanded = !_selectMode && _expandedId == item.Id;
+                <tr class="mobile-row" @onclick="() => OnRowClick(item)">
+                    @if (_selectMode)
+                    {
+                        <td class="checkbox-cell" @onclick:stopPropagation="true">
+                            <input type="checkbox" class="row-checkbox"
+                                   checked="@(_selectedIds.Contains(item.Id!.Value))"
+                                   @onchange="e => OnRowCheckboxChanged(item, (bool)e.Value!)" />
+                        </td>
+                    }
+                    <td class="trigger-cell"><code>@item.Trigger</code></td>
+                    <td class="replacement-cell">@item.Replacement</td>
+                    <td class="chevron-cell">@(expanded ? "▾" : "▸")</td>
+                </tr>
+                @if (expanded)
+                {
+                    <tr class="mobile-row-expanded">
+                        <td colspan="3">
+                            <MudStack Spacing="1" Class="pa-3">
+                                @if (!string.IsNullOrWhiteSpace(item.Description))
+                                {
+                                    <MudText Typo="Typo.body2"><strong>Description:</strong> @item.Description</MudText>
+                                }
+                                <MudText Typo="Typo.body2"><strong>Profiles:</strong>
+                                    @if (item.AppliesToAllProfiles)
+                                    {
+                                        <MudChip T="string" Size="Size.Small" Color="Color.Info">Any</MudChip>
+                                    }
+                                    else
+                                    {
+                                        @foreach (Guid pid in item.ProfileIds)
+                                        {
+                                            string name = Profiles.FirstOrDefault(p => p.Id == pid)?.Name ?? pid.ToString()[..8];
+                                            <MudChip T="string" Size="Size.Small">@name</MudChip>
+                                        }
+                                    }
+                                </MudText>
+                                <MudText Typo="Typo.body2"><strong>Categories:</strong>
+                                    @foreach (Guid cid in item.CategoryIds)
+                                    {
+                                        string name = Categories.FirstOrDefault(c => c.Id == cid)?.Name ?? cid.ToString()[..8];
+                                        <MudChip T="string" Size="Size.Small">@name</MudChip>
+                                    }
+                                </MudText>
+                                <MudText Typo="Typo.body2">
+                                    <strong>End-char:</strong> @(item.IsEndingCharacterRequired ? "✓" : "✗") &nbsp;
+                                    <strong>In-word:</strong> @(item.IsTriggerInsideWord ? "✓" : "✗")
+                                </MudText>
+                                <MudStack Row="true" Spacing="2" Class="mt-2">
+                                    <MudButton Class="start-edit" Variant="Variant.Filled" Color="Color.Primary"
+                                               StartIcon="@Icons.Material.Filled.Edit"
+                                               OnClick="@(async () => await OnEdit.InvokeAsync(item))">Edit</MudButton>
+                                    <MudButton Class="delete" Variant="Variant.Filled" Color="Color.Error"
+                                               StartIcon="@Icons.Material.Filled.Delete"
+                                               OnClick="@(async () => await OnDelete.InvokeAsync(item))">Delete</MudButton>
+                                </MudStack>
+                            </MudStack>
+                        </td>
+                    </tr>
+                }
+            }
+        </tbody>
+    </table>
+
+    @if (_selectMode && _selectedIds.Count > 0)
+    {
+        <div class="select-action-bar">
+            <MudButton Variant="Variant.Text" OnClick="ToggleSelectMode">Cancel</MudButton>
+            <MudButton Class="bulk-delete-hotstrings" Variant="Variant.Filled" Color="Color.Error"
+                       StartIcon="@Icons.Material.Filled.DeleteSweep"
+                       OnClick="RaiseBulkDelete">Delete @_selectedIds.Count</MudButton>
+        </div>
+    }
+</MudStack>
+
+@code {
+    [Parameter] public IReadOnlyList<HotstringEditModel> Items { get; set; } = [];
+    [Parameter] public IReadOnlyList<ProfileDto> Profiles { get; set; } = [];
+    [Parameter] public IReadOnlyList<CategoryDto> Categories { get; set; } = [];
+    [Parameter] public EventCallback<HotstringEditModel> OnEdit { get; set; }
+    [Parameter] public EventCallback<HotstringEditModel> OnDelete { get; set; }
+    [Parameter] public EventCallback<IReadOnlyList<Guid>> OnBulkDelete { get; set; }
+
+    private Guid? _expandedId;
+    private bool _selectMode;
+    private readonly HashSet<Guid> _selectedIds = [];
+
+    private void OnRowClick(HotstringEditModel item)
+    {
+        if (_selectMode)
+        {
+            if (item.Id is { } id) ToggleSelected(id);
+        }
+        else
+        {
+            _expandedId = _expandedId == item.Id ? null : item.Id;
+        }
+    }
+
+    private void OnRowCheckboxChanged(HotstringEditModel item, bool isChecked)
+    {
+        if (item.Id is not { } id) return;
+        if (isChecked) _selectedIds.Add(id);
+        else _selectedIds.Remove(id);
+    }
+
+    private void ToggleSelected(Guid id)
+    {
+        if (!_selectedIds.Add(id)) _selectedIds.Remove(id);
+    }
+
+    private void ToggleSelectMode()
+    {
+        _selectMode = !_selectMode;
+        _selectedIds.Clear();
+        _expandedId = null;
+    }
+
+    private async Task RaiseBulkDelete()
+    {
+        IReadOnlyList<Guid> ids = [.. _selectedIds];
+        await OnBulkDelete.InvokeAsync(ids);
+        _selectMode = false;
+        _selectedIds.Clear();
+    }
+}
+```
+
+Append to `HotstringMobileList.razor.css`:
+
+```css
+.mobile-list .checkbox-cell {
+    width: 36px;
+    text-align: center;
+}
+
+.select-action-bar {
+    position: sticky;
+    bottom: 0;
+    background: var(--mud-palette-surface);
+    border-top: 1px solid var(--mud-palette-divider);
+    padding: 8px 12px;
+    display: flex;
+    justify-content: space-between;
+    z-index: 10;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotstringMobileListTests" --no-restore`
+
+Expected: PASS for all four tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor.css tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
+git commit -m "feat: select mode + bulk delete on hotstring mobile list"
+```
+
+---
+
+## Task 5: Integrate mobile branch into Hotstrings.razor
+
+**Files:**
+- Modify: `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor`
+- Modify: `tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `HotstringsPageTests.cs`:
+
+```csharp
+[Fact]
+public void Page_RendersBothDesktopAndMobileBranches()
+{
+    StubList(Page());
+
+    IRenderedComponent<Hotstrings> cut = RenderPage();
+    cut.WaitForAssertion(() => cut.Find("button.add-hotstring"));
+
+    // Desktop branch wrapper
+    cut.FindAll(".desktop-branch").Should().NotBeEmpty();
+    // Mobile branch wrapper
+    cut.FindAll(".mobile-branch").Should().NotBeEmpty();
+    // FAB only in mobile branch
+    cut.FindAll("button.add-hotstring-fab").Should().NotBeEmpty();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotstringsPageTests.Page_RendersBothDesktopAndMobileBranches" --no-restore`
+
+Expected: FAIL — `.desktop-branch` / `.mobile-branch` / `add-hotstring-fab` not found.
+
+- [ ] **Step 3: Wrap existing markup + add mobile branch**
+
+In `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor`, after line 11 (`<MudText Typo="Typo.h4" ...>Hotstrings</MudText>`), wrap the existing `<MudPaper Class="pa-4">...</MudPaper>` (lines 13-175) in:
+
+```razor
+<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
+    <div class="desktop-branch">
+        <!-- existing MudPaper + MudDataGrid block unchanged -->
+    </div>
+</MudHidden>
+
+<MudHidden Breakpoint="Breakpoint.SmAndDown">
+    <div class="mobile-branch">
+        <MudPaper Class="pa-2" Style="position:relative;min-height:80vh;">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
+                <MudIconButton Class="reload-hotstrings" Icon="@Icons.Material.Filled.Refresh"
+                               OnClick="ReloadAsync" Disabled="@(!_isAuthenticated || _loading)" />
+                <MudSpacer />
+            </MudStack>
+
+            <MudTextField T="string" @bind-Value="_search" @bind-Value:after="OnSearchChangedAsync"
+                          DebounceInterval="300"
+                          Placeholder="Search hotstrings"
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Filled.Search"
+                          Class="search-hotstrings mb-2"
+                          FullWidth="true" Immediate="true" />
+
+            @if (_categories.Count > 0)
+            {
+                <div class="chip-strip mb-2" style="overflow-x:auto;white-space:nowrap;">
+                    <MudChipSet T="Guid" SelectionMode="SelectionMode.MultiSelection"
+                                SelectedValues="_selectedCategoryIds"
+                                SelectedValuesChanged="OnCategoryFilterChangedAsync">
+                        @foreach (CategoryDto c in _categories)
+                        {
+                            <MudChip T="Guid" Value="@c.Id" Variant="Variant.Outlined">@c.Name</MudChip>
+                        }
+                    </MudChipSet>
+                </div>
+            }
+
+            @if (_loadError is not null)
+            {
+                <MudAlert Severity="Severity.Error" Class="mb-3">@_loadError</MudAlert>
+            }
+
+            <HotstringMobileList Items="_mobileItems"
+                                 Profiles="_profiles"
+                                 Categories="_categories"
+                                 OnEdit="OpenEditDialogAsync"
+                                 OnDelete="DeleteAsync"
+                                 OnBulkDelete="MobileBulkDeleteAsync" />
+
+            <MudPagination Class="mt-2" Count="_mobileTotalPages" Selected="_mobilePage"
+                           SelectedChanged="OnMobilePageChangedAsync" />
+
+            <MudFab Class="add-hotstring-fab" Color="Color.Primary"
+                    StartIcon="@Icons.Material.Filled.Add"
+                    Style="position:fixed;right:16px;bottom:16px;z-index:100;"
+                    OnClick="OpenCreateDialogAsync" />
+        </MudPaper>
+    </div>
+</MudHidden>
+```
+
+Add to `@code { ... }` block (after existing fields):
+
+```csharp
+private IReadOnlyList<HotstringEditModel> _mobileItems = [];
+private int _mobilePage = 1;
+private int _mobilePageSize = 10;
+private int _mobileTotalPages;
+```
+
+Extract a shared loader. After `LoadServerData` add:
+
+```csharp
+private async Task LoadMobileAsync()
+{
+    _loading = true;
+    _loadError = null;
+
+    ApiResult<PagedList<HotstringDto>> result = await Api.ListAsync(
+        new HotstringListRequest(
+            Page: _mobilePage,
+            PageSize: _mobilePageSize,
+            Search: string.IsNullOrWhiteSpace(_search) ? null : _search,
+            CategoryIds: _selectedCategoryIds.Count > 0 ? _selectedCategoryIds : null),
+        _cts.Token);
+
+    _loading = false;
+
+    if (!result.IsSuccess)
+    {
+        _loadError = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+        _mobileItems = [];
+        _mobileTotalPages = 0;
+        return;
+    }
+
+    _mobileItems = [.. result.Value!.Items.Select(HotstringEditModel.FromDto)];
+    _mobileTotalPages = (int)Math.Ceiling((double)result.Value.TotalCount / _mobilePageSize);
+}
+
+private async Task OnMobilePageChangedAsync(int page)
+{
+    _mobilePage = page;
+    await LoadMobileAsync();
+}
+
+private async Task OpenCreateDialogAsync()
+{
+    DialogParameters parameters = new()
+    {
+        [nameof(HotstringEditDialog.Item)] = new HotstringEditModel(),
+        [nameof(HotstringEditDialog.Profiles)] = _profiles,
+        [nameof(HotstringEditDialog.Categories)] = _categories,
+    };
+
+    IDialogReference dialog = await DialogService.ShowAsync<HotstringEditDialog>(
+        "New hotstring", parameters,
+        new DialogOptions { FullScreen = true, CloseButton = false });
+
+    DialogResult? result = await dialog.Result;
+    if (result?.Canceled == false)
+    {
+        Snackbar.Add("Hotstring created.", Severity.Success);
+        await ReloadAllAsync();
+    }
+}
+
+private async Task OpenEditDialogAsync(HotstringEditModel item)
+{
+    DialogParameters parameters = new()
+    {
+        [nameof(HotstringEditDialog.Item)] = HotstringEditModel.FromDto(new HotstringDto(
+            item.Id!.Value, [.. item.ProfileIds], item.AppliesToAllProfiles,
+            item.Trigger, item.Replacement, item.Description,
+            item.IsEndingCharacterRequired, item.IsTriggerInsideWord,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)),
+        [nameof(HotstringEditDialog.Profiles)] = _profiles,
+        [nameof(HotstringEditDialog.Categories)] = _categories,
+    };
+
+    IDialogReference dialog = await DialogService.ShowAsync<HotstringEditDialog>(
+        "Edit hotstring", parameters,
+        new DialogOptions { FullScreen = true, CloseButton = false });
+
+    DialogResult? result = await dialog.Result;
+    if (result?.Canceled == false)
+    {
+        Snackbar.Add("Hotstring updated.", Severity.Success);
+        await ReloadAllAsync();
+    }
+}
+
+private async Task MobileBulkDeleteAsync(IReadOnlyList<Guid> ids)
+{
+    if (ids.Count == 0) return;
+
+    bool? confirm = await DialogService.ShowMessageBoxAsync(
+        title: "Delete hotstrings?",
+        message: $"Delete {ids.Count} hotstring(s)? This cannot be undone.",
+        yesText: "Delete", cancelText: "Cancel");
+    if (confirm != true) return;
+
+    ApiResult<BulkDeleteResultDto> result = await Api.BulkDeleteAsync(ids, _cts.Token);
+    if (result.IsSuccess)
+    {
+        Snackbar.Add($"Deleted {result.Value!.DeletedCount} hotstring(s).", Severity.Success);
+        await ReloadAllAsync();
+    }
+    else
+    {
+        Snackbar.Add(ApiErrorMessageFactory.Build(result.Status, result.Problem), Severity.Error);
+    }
+}
+
+private async Task ReloadAllAsync()
+{
+    if (_grid is not null) await _grid.ReloadServerData();
+    await LoadMobileAsync();
+}
+```
+
+Wire `OnInitializedAsync` to also call `LoadMobileAsync()`. After the existing `if (_isAuthenticated)` block:
+
+```csharp
+        if (_isAuthenticated)
+            await LoadMobileAsync();
+```
+
+Update `OnSearchChangedAsync`, `OnCategoryFilterChangedAsync`, and `ReloadAsync` to also reload mobile data — wrap their bodies:
+
+```csharp
+    private async Task ReloadAsync()
+    {
+        if (_grid is not null) await _grid.ReloadServerData();
+        await LoadMobileAsync();
+    }
+
+    private async Task OnSearchChangedAsync()
+    {
+        if (_grid is not null) await _grid.ReloadServerData();
+        _mobilePage = 1;
+        await LoadMobileAsync();
+    }
+
+    private async Task OnCategoryFilterChangedAsync(IReadOnlyCollection<Guid> ids)
+    {
+        _selectedCategoryIds = [.. ids];
+        if (_grid is not null) await _grid.ReloadServerData();
+        _mobilePage = 1;
+        await LoadMobileAsync();
+    }
+```
+
+Update single-row `DeleteAsync` to call `ReloadAllAsync()` instead of `_grid.ReloadServerData()`.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --no-restore`
+
+Expected: PASS for all existing tests + the new branches test.
+
+- [ ] **Step 5: Build the whole solution**
+
+Run: `dotnet build --no-restore`
+
+Expected: Build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+git commit -m "feat: integrate mobile branch into hotstrings page"
+```
+
+---
+
+## Task 6: E2E test for mobile hotstrings flow
+
+**Files:**
+- Create: `tests/AHKFlowApp.E2E.Tests/HotstringsMobileFlowTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using AHKFlowApp.E2E.Tests.Fixtures;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace AHKFlowApp.E2E.Tests;
+
+public sealed class HotstringsMobileFlowTests(StackFixture fixture) : IClassFixture<StackFixture>
+{
+    private static readonly BrowserNewContextOptions PhoneViewport = new()
+    {
+        ViewportSize = new ViewportSize { Width = 375, Height = 812 },
+    };
+
+    [Fact]
+    public async Task CreateEditDelete_OnPhoneViewport_UsesFabAndFullScreenDialog()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotstrings");
+        await page.WaitForSelectorAsync("button.add-hotstring-fab");
+
+        // Add via FAB
+        await page.ClickAsync("button.add-hotstring-fab");
+        await page.WaitForSelectorAsync(".hotstring-edit-dialog");
+        await page.FillAsync(".hotstring-edit-dialog input[data-test=\"trigger-input\"]", "mob");
+        await page.FillAsync(".hotstring-edit-dialog textarea[data-test=\"replacement-input\"]", "mobile by the way");
+        await page.ClickAsync(".hotstring-edit-dialog button.commit-edit");
+
+        await page.WaitForSelectorAsync("text=Hotstring created.");
+        await page.WaitForSelectorAsync(".mobile-row:has-text(\"mob\")");
+
+        // Expand row, click edit, change, save
+        await page.ClickAsync(".mobile-row:has-text(\"mob\")");
+        await page.WaitForSelectorAsync(".mobile-row-expanded button.start-edit");
+        await page.ClickAsync(".mobile-row-expanded button.start-edit");
+        await page.WaitForSelectorAsync(".hotstring-edit-dialog");
+        await page.FillAsync(".hotstring-edit-dialog textarea[data-test=\"replacement-input\"]", "edited!");
+        await page.ClickAsync(".hotstring-edit-dialog button.commit-edit");
+
+        await page.WaitForSelectorAsync("text=Hotstring updated.");
+        await page.WaitForSelectorAsync(".mobile-row:has-text(\"edited!\")");
+
+        // Delete via expanded row
+        await page.ClickAsync(".mobile-row:has-text(\"mob\")");
+        await page.WaitForSelectorAsync(".mobile-row-expanded button.delete");
+        await page.ClickAsync(".mobile-row-expanded button.delete");
+        await page.WaitForSelectorAsync("[role=\"dialog\"]");
+        await page.GetByRole(AriaRole.Button, new() { Name = "Delete" }).Last.ClickAsync();
+
+        await page.WaitForSelectorAsync("text=Hotstring deleted.");
+    }
+
+    [Fact]
+    public async Task BulkDelete_OnPhoneViewport_UsesSelectMode()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotstrings");
+
+        // Create two rows via FAB
+        foreach (string trig in new[] { "bk1", "bk2" })
+        {
+            await page.ClickAsync("button.add-hotstring-fab");
+            await page.WaitForSelectorAsync(".hotstring-edit-dialog");
+            await page.FillAsync(".hotstring-edit-dialog input[data-test=\"trigger-input\"]", trig);
+            await page.FillAsync(".hotstring-edit-dialog textarea[data-test=\"replacement-input\"]", "x");
+            await page.ClickAsync(".hotstring-edit-dialog button.commit-edit");
+            await page.WaitForSelectorAsync($".mobile-row:has-text(\"{trig}\")");
+        }
+
+        // Enter select mode + select both
+        await page.ClickAsync("button.toggle-select-mode");
+        await page.WaitForSelectorAsync("input.row-checkbox");
+        ILocator boxes = page.Locator("input.row-checkbox");
+        int count = await boxes.CountAsync();
+        for (int i = 0; i < count; i++)
+            await boxes.Nth(i).CheckAsync();
+
+        await page.ClickAsync("button.bulk-delete-hotstrings");
+        await page.WaitForSelectorAsync("[role=\"dialog\"]");
+        await page.GetByRole(AriaRole.Button, new() { Name = "Delete" }).Last.ClickAsync();
+
+        await page.WaitForSelectorAsync("text=Deleted 2 hotstring");
+    }
+}
+```
+
+- [ ] **Step 2: Publish Blazor for the SpaHost fixture**
+
+Run: `dotnet publish src/Frontend/AHKFlowApp.UI.Blazor -c Release --no-restore`
+
+Expected: Publish succeeds. `StackFixture` requires the published wwwroot at `bin/Release/net10.0/publish/wwwroot`.
+
+- [ ] **Step 3: Run the new E2E test**
+
+Run: `dotnet test tests/AHKFlowApp.E2E.Tests --filter "HotstringsMobileFlowTests" --no-restore`
+
+Expected: PASS for both tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/AHKFlowApp.E2E.Tests/HotstringsMobileFlowTests.cs
+git commit -m "test: e2e mobile hotstrings flow (fab + dialog + select mode)"
+```
+
+---
+
+## Task 7: HotkeyEditDialog — mirror Task 1+2 for hotkeys
+
+**Files:**
+- Create: `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor`
+- Create: `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs`
+
+Same shape as the hotstring dialog with these field differences:
+
+| Hotstring dialog field | Hotkey dialog field |
+|---|---|
+| Trigger (text) | Key (text, max 20) + modifier checkboxes Ctrl/Alt/Shift/Win |
+| Replacement (multiline text) | Parameters (multiline text, max 4000) |
+| Description | Description (required, max 200) |
+| IsEndingCharacterRequired | Action (`MudSelect<HotkeyAction>` with `Send` / `Run`) |
+| IsTriggerInsideWord | (none) |
+| Profiles, Categories | Profiles, Categories — identical |
+
+API methods to call: `IHotkeysApiClient.CreateAsync(CreateHotkeyDto)` / `UpdateAsync(Guid, UpdateHotkeyDto)`. Reuse `HotkeyEditModel.ToCreateDto()` / `ToUpdateDto()`.
+
+`data-test` attributes (match existing `Hotkeys.razor`): `description-input`, `key-input`, `ctrl-checkbox`, `alt-checkbox`, `shift-checkbox`, `win-checkbox`, `action-select`, `parameters-input`, `applies-to-all-checkbox`, `profile-select`, `category-select`.
+
+CSS class on `<MudDialog>`: `hotkey-edit-dialog`.
+
+Required fields validated inside `SaveAsync`: Description and Key.
+
+- [ ] **Step 1: Write the failing tests** — mirror Task 1 Step 1 and Task 2 Step 1, substituting Hotkey types and field names. The three tests: `CreateMode_RendersEmptyFields`, `SaveInCreateMode_CallsCreateAsync`, `SaveInEditMode_CallsUpdateAsync`. Replace `IHotstringsApiClient` with `IHotkeysApiClient`. `data-test="key-input"` in place of `trigger-input`.
+
+- [ ] **Step 2: Run tests — expect failures**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotkeyEditDialogTests" --no-restore`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Create the dialog** — adapt Task 1 Step 3's razor file with the field substitutions above. Key fields block:
+
+```razor
+<MudTextField T="string" Label="Description" @bind-Value="Item.Description"
+              Required="true" RequiredError="Description is required" MaxLength="200"
+              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "description-input" })" />
+<MudTextField T="string" Label="Key" @bind-Value="Item.Key"
+              Required="true" RequiredError="Key is required" MaxLength="20"
+              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "key-input" })" />
+<MudStack Row="true" Spacing="2">
+    <MudCheckBox T="bool" @bind-Value="Item.Ctrl" Label="Ctrl"
+                 UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "ctrl-checkbox" })" />
+    <MudCheckBox T="bool" @bind-Value="Item.Alt" Label="Alt"
+                 UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "alt-checkbox" })" />
+    <MudCheckBox T="bool" @bind-Value="Item.Shift" Label="Shift"
+                 UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "shift-checkbox" })" />
+    <MudCheckBox T="bool" @bind-Value="Item.Win" Label="Win"
+                 UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "win-checkbox" })" />
+</MudStack>
+<MudSelect T="HotkeyAction" @bind-Value="Item.Action" Label="Action"
+           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "action-select" })">
+    <MudSelectItem T="HotkeyAction" Value="HotkeyAction.Send">Send</MudSelectItem>
+    <MudSelectItem T="HotkeyAction" Value="HotkeyAction.Run">Run</MudSelectItem>
+</MudSelect>
+<MudTextField T="string" Label="Parameters" @bind-Value="Item.Parameters"
+              Lines="3" MaxLength="4000"
+              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "parameters-input" })" />
+```
+
+Use the same Profiles, Categories, error alert, and Save/Cancel header from Task 1.
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotkeyEditDialogTests" --no-restore`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
+git commit -m "feat: hotkey edit dialog (create + edit)"
+```
+
+---
+
+## Task 8: HotkeyMobileList — mirror Tasks 3 + 4 for hotkeys
+
+**Files:**
+- Create: `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor`
+- Create: `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor.css`
+- Create: `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyMobileListTests.cs`
+
+Identical shape to `HotstringMobileList`, with these row-display differences:
+
+**Primary line:**
+- Trigger cell: format combo as `{Mods}+{Key}` where mods is `Ctrl/Alt/Shift/Win` joined by `+`. Example: `Ctrl+Shift+K`. Helper:
+
+```csharp
+private static string FormatCombo(HotkeyEditModel item)
+{
+    List<string> parts = [];
+    if (item.Ctrl) parts.Add("Ctrl");
+    if (item.Alt) parts.Add("Alt");
+    if (item.Shift) parts.Add("Shift");
+    if (item.Win) parts.Add("Win");
+    parts.Add(item.Key);
+    return string.Join("+", parts);
+}
+```
+
+- Replacement cell: show `item.Description` (ellipsizes first if line wraps — default for the deferred question).
+
+**Expanded row extra fields:**
+- Action: `@item.Action`
+- Parameters: `@item.Parameters` (if non-empty)
+- Profiles, Categories — same as hotstring.
+
+**CSS class on bulk-delete button:** `bulk-delete-hotkeys` (matches existing convention).
+
+**Tests** — mirror Task 3 + 4 tests, substituting:
+- `HotstringEditModel` → `HotkeyEditModel`
+- Item factory: `new() { Id = Guid.NewGuid(), Description = "Open palette", Key = "K", Ctrl = true, Shift = true }`
+- Assert primary line shows `Ctrl+Shift+K`
+- Selector for bulk delete: `button.bulk-delete-hotkeys`
+
+- [ ] **Step 1: Write failing tests** — mirror `HotstringMobileListTests` with substitutions above.
+- [ ] **Step 2: Run — expect FAIL.** `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotkeyMobileListTests" --no-restore`
+- [ ] **Step 3: Create the component + css.** Adapt `HotstringMobileList.razor` with the FormatCombo helper for the trigger cell and the extra field rendering.
+- [ ] **Step 4: Run — expect PASS.** `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotkeyMobileListTests" --no-restore`
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor.css tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyMobileListTests.cs
+git commit -m "feat: hotkey mobile list (collapsed + expand + select + bulk delete)"
+```
+
+---
+
+## Task 9: Integrate mobile branch into Hotkeys.razor (mirror Task 5)
+
+**Files:**
+- Modify: `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor`
+- Modify: `tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs`
+
+Apply the same MudHidden split + mobile branch + new helper methods (`LoadMobileAsync`, `OpenCreateDialogAsync`, `OpenEditDialogAsync`, `MobileBulkDeleteAsync`, `ReloadAllAsync`) to `Hotkeys.razor`. Substitutions:
+
+- `HotstringMobileList` → `HotkeyMobileList`
+- `HotstringEditDialog` → `HotkeyEditDialog`
+- `add-hotstring-fab` → `add-hotkey-fab`
+- `IHotstringsApiClient` (`Api`) returns `HotkeyDto`; `HotkeyListRequest` constructor uses different fields — only pass `Page`, `PageSize`, `Search`, `CategoryIds`.
+- Title strings: "New hotkey" / "Edit hotkey".
+- `HotkeyEditModel.FromDto(new HotkeyDto(...))` — construct the DTO from `item` fields. Look at existing `MapItem` in `Hotkeys.razor:393` for the shape.
+
+- [ ] **Step 1: Add the failing test** — mirror Task 5 Step 1's test in `HotkeysPageTests.cs`. Selector: `button.add-hotkey-fab`.
+- [ ] **Step 2: Run — expect FAIL.** `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "HotkeysPageTests.Page_RendersBothDesktopAndMobileBranches" --no-restore`
+- [ ] **Step 3: Modify `Hotkeys.razor`** with the same split treatment.
+- [ ] **Step 4: Run all UI tests + build.** `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --no-restore && dotnet build --no-restore`
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
+git commit -m "feat: integrate mobile branch into hotkeys page"
+```
+
+---
+
+## Task 10: E2E test for mobile hotkeys flow (mirror Task 6)
+
+**Files:**
+- Create: `tests/AHKFlowApp.E2E.Tests/HotkeysMobileFlowTests.cs`
+
+Mirror `HotstringsMobileFlowTests`. Substitutions:
+
+- Route: `/hotkeys`
+- FAB selector: `button.add-hotkey-fab`
+- Dialog selector: `.hotkey-edit-dialog`
+- Bulk delete selector: `button.bulk-delete-hotkeys`
+- Field selectors: `description-input`, `key-input`, modifier checkboxes, `action-select`, `parameters-input`
+- Sample data: description "Open palette", key "K", Ctrl=true, Shift=true
+- Success snackbar: "Hotkey created." / "Hotkey updated." / "Hotkey deleted." / "Deleted 2 hotkey"
+- Row text assertion: `.mobile-row:has-text(\"Ctrl+Shift+K\")` for the formatted combo
+
+Two tests: `CreateEditDelete_OnPhoneViewport_UsesFabAndFullScreenDialog`, `BulkDelete_OnPhoneViewport_UsesSelectMode`.
+
+- [ ] **Step 1: Write the tests.**
+- [ ] **Step 2: Publish frontend** (already done in Task 6 — re-run if Blazor source changed since):
+
+Run: `dotnet publish src/Frontend/AHKFlowApp.UI.Blazor -c Release --no-restore`
+
+- [ ] **Step 3: Run E2E.** `dotnet test tests/AHKFlowApp.E2E.Tests --filter "HotkeysMobileFlowTests" --no-restore`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add tests/AHKFlowApp.E2E.Tests/HotkeysMobileFlowTests.cs
+git commit -m "test: e2e mobile hotkeys flow"
+```
+
+---
+
+## Task 11: Manual headed-browser verification
+
+Drive both pages in headed Playwright at three viewports to confirm UX. Use the `playwright-cli` skill from a fresh Claude Code session, or run by hand.
+
+- [ ] **Step 1: Start API**
+
+Open a terminal, run:
+
+```bash
+dotnet run --project src/Backend/AHKFlowApp.API --launch-profile "Docker SQL (Recommended)"
+```
+
+Expected: API listening on `http://localhost:5600`.
+
+- [ ] **Step 2: Start Blazor frontend**
+
+Open a second terminal, run:
+
+```bash
+dotnet run --project src/Frontend/AHKFlowApp.UI.Blazor
+```
+
+Expected: Frontend on `http://localhost:5601`.
+
+- [ ] **Step 3: Invoke playwright-cli with three viewports**
+
+Via the `playwright-cli` skill, drive these scenarios in **headed** mode (so the user sees the browser):
+
+For each viewport (375×812 phone, 768×1024 tablet portrait, 1280×800 desktop):
+
+1. Navigate to `http://localhost:5601/hotstrings`.
+2. Verify **no horizontal scrollbar** on the page or table.
+3. At 375 and 768 — confirm FAB visible bottom-right, category chip strip scrolls horizontally only within the strip.
+4. At 1280 — confirm the desktop inline-edit grid renders, no FAB, original toolbar buttons present.
+5. Repeat for `/hotkeys`.
+
+- [ ] **Step 4: If anything looks wrong**, fix on a follow-up commit. Otherwise no commit needed.
+
+---
+
+## Task 12: Update frontend CLAUDE.md + open PR
+
+**Files:**
+- Modify: `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md`
+
+- [ ] **Step 1: Append a conventions note**
+
+Add to `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md` after the existing conventions list:
+
+```markdown
+- For list pages that need mobile support: render both branches gated by `<MudHidden Breakpoint="Breakpoint.SmAndDown">`. Desktop branch uses `MudDataGrid` with inline editing; mobile branch uses a compact list component + full-screen `MudDialog` for edit/create + `MudFab` for add. See `Components/Hotstrings/` and `Components/Hotkeys/` for examples.
+```
+
+- [ ] **Step 2: Commit the note**
+
+```bash
+git add src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
+git commit -m "docs: note mobile branch convention for list pages"
+```
+
+- [ ] **Step 3: Run full check**
+
+Run: `dotnet format && dotnet build --no-restore && dotnet test --no-restore`
+
+Expected: all green.
+
+- [ ] **Step 4: Push branch + open PR**
+
+```bash
+git push -u origin feature/032-mobile-hotstrings-hotkeys
+gh pr create --title "Mobile-friendly hotstrings + hotkeys pages" --body "$(cat <<'EOF'
+## Summary
+- Mobile pattern (<960px): compact 2-col list, expandable rows, full-screen edit dialog, FAB, select-mode bulk delete
+- Desktop (md+): inline-edit `MudDataGrid` unchanged
+- Same pattern applied to Hotstrings + Hotkeys; Categories/Profiles deferred to a follow-up
+
+Spec: `docs/superpowers/specs/2026-05-24-mobile-hotstrings-hotkeys-design.md`
+Plan: `docs/superpowers/plans/2026-05-24-mobile-hotstrings-hotkeys.md`
+
+## Deferred-question defaults (please confirm in review)
+- Pager: `MudPagination`, page size 10 on mobile
+- Hotkeys primary-line truncation: description ellipsizes first
+- FAB: always visible (no scroll-hide)
+- Select-mode action bar: sticky bottom
+
+## Test plan
+- [ ] CI green (`dotnet build`, `dotnet test`, `dotnet format --verify-no-changes`)
+- [ ] Manual headed Playwright at 375×812, 768×1024, 1280×800 — verified no horizontal scroll, FAB reachable, desktop grid unchanged
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Return the PR URL.
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+- ✅ Breakpoint cutoff <960px → Tasks 5 + 9 (`Breakpoint.SmAndDown`)
+- ✅ Compact 2-col list + expand → Tasks 3 + 8
+- ✅ Full-screen MudDialog → Tasks 1 + 7
+- ✅ Select-mode bulk delete → Tasks 4 + 8
+- ✅ FAB → Tasks 5 + 9
+- ✅ Horizontally scrollable chip strip → Task 5's mobile branch + Task 9
+- ✅ Tablet (sm) wider rows → no breakpoint-specific code needed (single-column layout naturally widens)
+- ✅ Hotstrings + Hotkeys only → Tasks cover both, nothing about Categories/Profiles
+- ✅ Inline per page first (no shared abstraction) → two separate components per type
+- ✅ Verify via headed playwright → Task 11
+- ✅ Bunit + E2E tests → Tasks 1-4 + 6 (hotstrings); 7-8 + 10 (hotkeys)
+
+**Type consistency check:** Method names and selectors are consistent throughout (e.g. `add-hotstring-fab` vs `add-hotkey-fab`, `commit-edit`/`cancel-edit`/`start-edit`/`delete` matching existing desktop conventions, dialog css classes `hotstring-edit-dialog` / `hotkey-edit-dialog` referenced in E2E selectors).
+
+**Placeholder scan:** All `[ ]` steps contain either complete code, exact commands, or explicit substitution instructions for mirrored tasks.
+
+---
+
+## Execution
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-24-mobile-hotstrings-hotkeys.md`. Pick an execution mode in the parent session.

--- a/docs/superpowers/specs/2026-05-24-mobile-hotstrings-hotkeys-design.md
+++ b/docs/superpowers/specs/2026-05-24-mobile-hotstrings-hotkeys-design.md
@@ -1,0 +1,141 @@
+# Mobile-friendly Hotstrings + Hotkeys pages
+
+## Context
+
+The Hotstrings and Hotkeys pages use `MudDataGrid` with inline cell editing across all viewports. This is productive on desktop but cramped on phones/tablets — 8-10 columns force horizontal scroll, inline `MudTextField` inputs are fiddly on touch, and the toolbar wraps awkwardly. Users on mobile and tablet form factors need a layout that uses available width fully and avoids horizontal scrollbars.
+
+Goal: ship a mobile-pattern view for both pages while leaving the desktop experience unchanged. User-configurable density/font preferences are a future backlog item, not part of this work.
+
+## Decisions
+
+| Topic | Decision |
+|---|---|
+| Breakpoint cutoff | `<960px` (xs+sm) → mobile pattern. `md+` keeps current grid. |
+| Mobile read view | Compact 2-col list (trigger / replacement), tap row → inline expand all fields + Edit/Delete buttons. |
+| Edit/Create UI | Full-screen `MudDialog`. |
+| Bulk delete | "Select" toggle in top app bar → checkboxes appear + sticky bottom action bar. |
+| Add | `MudFab` bottom-right, opens the same full-screen create dialog. |
+| Category filter | Horizontally scrollable chip strip below search. |
+| Tablet (sm) | Same single-column, wider rows (more chars before ellipsis). |
+| Scope | Hotstrings + Hotkeys only. Categories/Profiles deferred. |
+| Reuse | Inline per page first; extract a shared component only if duplication is real. |
+
+## Architecture
+
+Each page renders **two view branches** gated by breakpoint using `MudHidden`:
+
+- `<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">` — wraps existing `MudDataGrid` markup. Unchanged behavior.
+- `<MudHidden Breakpoint="Breakpoint.SmAndDown">` — wraps new mobile view.
+
+Both branches share the same backing state in the page codebehind: `_items`, search text, selected category ids, paging state, snackbar/error handling, and the `LoadServerData` callback. Only rendering differs.
+
+`MudHidden` duplicates DOM but is the cheapest correct approach with no JS interop or extra render cycle. The desktop branch's `MudDataGrid` won't render rows when display is `none`; data is still fetched once and shared.
+
+## Critical files
+
+**Modify (Hotstrings):**
+- `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor` — split into desktop branch (existing grid) + mobile branch (new markup).
+- `src/Frontend/AHKFlowApp.UI.Blazor/Validation/HotstringEditModel.cs` — reused as-is for the dialog.
+
+**Create (Hotstrings):**
+- `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor` — full-screen MudDialog for create/edit. Takes `Guid? id` and `HotstringDto?`.
+- `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor` — compact list + expand row + FAB + select-mode bar.
+
+**Modify (Hotkeys):**
+- `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor` — same split treatment.
+
+**Create (Hotkeys):**
+- `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor`
+- `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor`
+
+**Reuse (existing patterns, no changes needed):**
+- `Services/IHotstringsApiClient` and `IHotkeysApiClient` — Create/Update/Delete/BulkDelete already there.
+- `IDialogService.ShowAsync<T>` — already wired in `MainLayout.razor`.
+- `IDialogService.ShowMessageBoxAsync` — keep for single-row delete confirmation.
+- `Validation/HotstringEditModel` and `HotkeyEditModel` — already map between DTO ↔ form model.
+- `Preferences` service — used today for dark mode; **don't** extend in this PR (density/font lives in a separate backlog item).
+
+## Mobile view layout
+
+Order, top to bottom:
+
+1. **Top app bar row** — page title + icon buttons: Reload, Select (toggles `_selectMode`), overflow menu.
+2. **Search** — debounced `MudTextField` (reuse existing 300ms debounce logic from desktop branch).
+3. **Category chip strip** — wrap a `MudChipSet` in `<div style="overflow-x:auto;white-space:nowrap">`. Filter chips swipe horizontally if numerous.
+4. **List header** — small two-column header row (`Trigger`, `Replacement`).
+5. **Compact rows** — for each item, a row with `<code>trigger</code>` left, ellipsized replacement right, chevron. Click toggles `_expandedId`. Expanded row shows: full replacement, description, profile chips, category chips, flags (✓/✗), `[Edit]` `[Delete]` buttons.
+6. **Pager** — `MudPagination` below the list (driven by the same server paging state as desktop).
+7. **FAB** — `MudFab Color="Primary" StartIcon="Icons.Material.Filled.Add"` positioned `fixed; bottom: 16px; right: 16px`.
+8. **Select-mode bar (conditional)** — when `_selectMode` is true: rows show a leading `MudCheckBox`; a sticky bottom bar shows `[Cancel] Delete N`.
+
+For Hotkeys, the primary line is `<code>{modifiers}+{Key}</code> · Description` (e.g. `Ctrl+Shift+K · Open palette`). Expanded row shows Action, Parameters, profiles, categories.
+
+## Edit/Create dialog
+
+`HotstringEditDialog` (and `HotkeyEditDialog`):
+- Opened with `IDialogService.ShowAsync<HotstringEditDialog>("Edit hotstring", parameters, new DialogOptions { FullScreen = true, CloseButton = false })`.
+- Sticky `MudDialogTitle` row: `[← Cancel] Title [Save]`.
+- Body: `MudForm` with `HotstringEditModel` instance; reuse `EditFormValidator` already in use.
+- Profiles + Categories use `MudSelect` with `MultiSelection=true` (or `MudAutocomplete` if the list is long — match what desktop branch uses today).
+- Save: calls `_api.CreateAsync(...)` or `UpdateAsync(...)`, returns the new/updated DTO via `MudDialog.Close(DialogResult.Ok(dto))`.
+- Caller refreshes via `_grid.ReloadServerData()` (desktop) or by re-invoking `LoadServerData` (mobile branch keeps its own state).
+
+Same component used for Create (no `id`) and Edit (`id` supplied). Same dialog opens whether the user tapped a row's Edit button or the FAB.
+
+## Error handling
+
+No new pathways. Reuse:
+- `Ardalis.Result` → `ProblemDetails` mapping in API.
+- `IHotstringsApiClient` typed error returns.
+- `ISnackbar.Add(...)` for transient errors.
+- Field-level errors (e.g. duplicate trigger conflict) surfaced via `MudForm` validation messages on the relevant input.
+
+## Testing
+
+**New E2E tests (Playwright via existing `StackFixture`):**
+
+- `tests/AHKFlowApp.E2E.Tests/Hotstrings/HotstringsMobileFlowTests.cs`
+- `tests/AHKFlowApp.E2E.Tests/Hotkeys/HotkeysMobileFlowTests.cs` (also fills today's gap — no hotkeys E2E exists)
+
+Each browser context created with `ViewportSize = new ViewportSize(375, 812)` (phone) and a second test with `(768, 1024)` (tablet portrait). Coverage:
+- Add via FAB → full-screen dialog → fill → save → row appears.
+- Tap row → expand → tap Edit → modify → save → updated value visible.
+- Single delete via expanded row → confirm dialog → row gone.
+- Select mode → check 2 rows → Delete N → both gone.
+- Duplicate trigger → conflict error visible inline.
+
+**New bUnit component tests:**
+
+- `tests/AHKFlowApp.UI.Blazor.Tests/Components/HotstringMobileListTests.cs` — render, expand toggle, select-mode toggle reveals checkboxes, FAB click raises event.
+- `tests/AHKFlowApp.UI.Blazor.Tests/Components/HotstringEditDialogTests.cs` — render with no id (create) and with id (edit), validation surfaces errors, save invokes API.
+- Same pair for Hotkeys.
+
+Existing `HotstringsCrudFlowTests` remains untouched — it runs at the default desktop viewport and covers the inline-edit grid.
+
+## Verification
+
+1. Build + test: `dotnet build` then `dotnet test`.
+2. Run locally: `dotnet run --project src/Backend/AHKFlowApp.API --launch-profile "Docker SQL (Recommended)"` (5600) and `dotnet run --project src/Frontend/AHKFlowApp.UI.Blazor` (5601).
+3. **Manual headed-Playwright drive** via the `playwright-cli` skill, with `--headed`:
+   - 375×812 viewport — verify no horizontal scrollbars, FAB reachable, expand/edit/delete flows.
+   - 768×1024 viewport — verify same pattern, wider rows.
+   - 1280×800 viewport — verify desktop grid unchanged.
+4. Run new E2E tests headless: `dotnet test tests/AHKFlowApp.E2E.Tests --filter "Mobile"`.
+5. Format + commit: `dotnet format`, commit on feature branch, open PR.
+
+## Out of scope
+
+- User-configurable font / font size / density preferences (separate backlog).
+- Mobile pattern for Categories and Profiles pages (separate backlog).
+- Bottom-sheet dialog variant (full-screen dialog covers this).
+- Infinite scroll (paged behavior is kept).
+- Backend changes — none required.
+
+## Deferred to implementation (defaults if not raised)
+
+These were left open during brainstorm; implementer picks the default and flags in PR for review:
+
+1. **Pager UI** — default to `MudPagination`, page size 10 on mobile (same as desktop).
+2. **Hotkeys primary-line truncation** — description ellipsizes first; modifier+key stays intact.
+3. **FAB scroll behavior** — always visible.
+4. **Select-mode action bar** — sticky bottom (matches mockup).

--- a/docs/superpowers/specs/2026-05-24-mobile-hotstrings-hotkeys-design.md
+++ b/docs/superpowers/specs/2026-05-24-mobile-hotstrings-hotkeys-design.md
@@ -22,14 +22,14 @@ Goal: ship a mobile-pattern view for both pages while leaving the desktop experi
 
 ## Architecture
 
-Each page renders **two view branches** gated by breakpoint using `MudHidden`:
+Each page renders **two view branches** and gates visibility with page-scoped CSS:
 
-- `<MudHidden Breakpoint="Breakpoint.SmAndDown">` — wraps existing `MudDataGrid` markup. Unchanged behavior.
-- `<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">` — wraps new mobile view.
+- `<div class="desktop-branch">` — wraps existing `MudDataGrid` markup. Unchanged behavior.
+- `<div class="mobile-branch">` — wraps new mobile view.
 
 Both branches share the same backing state in the page codebehind: `_items`, search text, selected category ids, paging state, snackbar/error handling, and the `LoadServerData` callback. Only rendering differs.
 
-`MudHidden` duplicates DOM but is the cheapest correct approach with no JS interop or extra render cycle. The desktop branch's `MudDataGrid` won't render rows when display is `none`; data is still fetched once and shared.
+Scoped `.razor.css` files hide `.desktop-branch` under `960px` and hide `.mobile-branch` at `960px+`. Do not combine this with `MudHidden`; double gating can hide the `MudDataGrid` on mid-sized viewports.
 
 ## Critical files
 

--- a/docs/superpowers/specs/2026-05-24-mobile-hotstrings-hotkeys-design.md
+++ b/docs/superpowers/specs/2026-05-24-mobile-hotstrings-hotkeys-design.md
@@ -24,8 +24,8 @@ Goal: ship a mobile-pattern view for both pages while leaving the desktop experi
 
 Each page renders **two view branches** gated by breakpoint using `MudHidden`:
 
-- `<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">` — wraps existing `MudDataGrid` markup. Unchanged behavior.
-- `<MudHidden Breakpoint="Breakpoint.SmAndDown">` — wraps new mobile view.
+- `<MudHidden Breakpoint="Breakpoint.SmAndDown">` — wraps existing `MudDataGrid` markup. Unchanged behavior.
+- `<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">` — wraps new mobile view.
 
 Both branches share the same backing state in the page codebehind: `_items`, search text, selected category ids, paging state, snackbar/error handling, and the `LoadServerData` callback. Only rendering differs.
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
@@ -14,7 +14,7 @@ Blazor WebAssembly PWA frontend for AHKFlowApp.
 - Bulk-select + delete toolbar for multi-row deletion. Examples: hotstrings, hotkeys pages.
 - `IDialogService.ShowMessageBox(...)` for delete confirmations
 - No `StateHasChanged()` after standard event handlers — Blazor re-renders automatically
-- For list pages that need mobile support: render both branches gated by `<MudHidden Breakpoint="Breakpoint.SmAndDown">`; use the non-inverted branch for desktop `MudDataGrid` markup and the inverted branch for the mobile list. Mobile uses a compact list component + full-screen `MudDialog` for edit/create + `MudFab` for add. See `Components/Hotstrings/` and `Components/Hotkeys/` for examples.
+- For list pages that need mobile support: render both branches as plain `.desktop-branch` and `.mobile-branch` containers, then gate visibility in the page's scoped `.razor.css` at `959.95px`. Desktop uses `MudDataGrid`; mobile uses a compact list component, full-screen `MudDialog`, and `MudFab`. See `Components/Hotstrings/` and `Components/Hotkeys/` for examples.
 
 ## Local Setup
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
@@ -14,7 +14,7 @@ Blazor WebAssembly PWA frontend for AHKFlowApp.
 - Bulk-select + delete toolbar for multi-row deletion. Examples: hotstrings, hotkeys pages.
 - `IDialogService.ShowMessageBox(...)` for delete confirmations
 - No `StateHasChanged()` after standard event handlers — Blazor re-renders automatically
-- For list pages that need mobile support: render both branches gated by CSS `@media` query (breakpoint 960px). Desktop branch uses `MudDataGrid` with inline editing inside `<div class="desktop-branch">`; mobile branch uses a compact list component + full-screen `MudDialog` for edit/create + `MudFab` for add inside `<div class="mobile-branch">`. Visibility is controlled by a co-located `.razor.css` file (not `MudHidden` — bUnit doesn't apply CSS). See `Components/Hotstrings/` and `Components/Hotkeys/` for examples.
+- For list pages that need mobile support: render both branches gated by `<MudHidden Breakpoint="Breakpoint.SmAndDown">`; use the non-inverted branch for desktop `MudDataGrid` markup and the inverted branch for the mobile list. Mobile uses a compact list component + full-screen `MudDialog` for edit/create + `MudFab` for add. See `Components/Hotstrings/` and `Components/Hotkeys/` for examples.
 
 ## Local Setup
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
@@ -14,6 +14,7 @@ Blazor WebAssembly PWA frontend for AHKFlowApp.
 - Bulk-select + delete toolbar for multi-row deletion. Examples: hotstrings, hotkeys pages.
 - `IDialogService.ShowMessageBox(...)` for delete confirmations
 - No `StateHasChanged()` after standard event handlers — Blazor re-renders automatically
+- For list pages that need mobile support: render both branches gated by CSS `@media` query (breakpoint 960px). Desktop branch uses `MudDataGrid` with inline editing inside `<div class="desktop-branch">`; mobile branch uses a compact list component + full-screen `MudDialog` for edit/create + `MudFab` for add inside `<div class="mobile-branch">`. Visibility is controlled by a co-located `.razor.css` file (not `MudHidden` — bUnit doesn't apply CSS). See `Components/Hotstrings/` and `Components/Hotkeys/` for examples.
 
 ## Local Setup
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
@@ -96,7 +96,9 @@
 
     private async Task SaveAsync()
     {
-        if (_saving) return;
+        if (_saving)
+            return;
+
         _saving = true;
         _error = null;
         _keyError = null;
@@ -123,7 +125,10 @@
 
             Dialog.Close(DialogResult.Ok(result.Value));
         }
-        finally { _saving = false; }
+        finally
+        {
+            _saving = false;
+        }
     }
 
     public void Dispose() { _cts.Cancel(); _cts.Dispose(); }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
@@ -14,12 +14,14 @@
         </MudStack>
     </TitleContent>
     <DialogContent>
+        <MudForm @ref="_form">
         <MudStack Spacing="3" Class="pa-2">
             <MudTextField T="string" Label="Description" @bind-Value="Item.Description"
                           Required="true" RequiredError="Description is required" MaxLength="200"
                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "description-input" })" />
             <MudTextField T="string" Label="Key" @bind-Value="Item.Key"
                           Required="true" RequiredError="Key is required" MaxLength="20"
+                          Error="@(_keyError is not null)" ErrorText="@_keyError"
                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "key-input" })" />
             <MudStack Row="true" Spacing="2">
                 <MudCheckBox T="bool" @bind-Value="Item.Ctrl" Label="Ctrl"
@@ -72,6 +74,7 @@
                 <MudAlert Severity="Severity.Error">@_error</MudAlert>
             }
         </MudStack>
+        </MudForm>
     </DialogContent>
 </MudDialog>
 
@@ -84,7 +87,9 @@
     [Parameter] public IReadOnlyList<CategoryDto> Categories { get; set; } = [];
 
     private string? _error;
+    private string? _keyError;
     private bool _saving;
+    private MudForm _form = default!;
     private readonly CancellationTokenSource _cts = new();
 
     private void Cancel() => Dialog.Cancel();
@@ -94,13 +99,12 @@
         if (_saving) return;
         _saving = true;
         _error = null;
+        _keyError = null;
         try
         {
-            if (string.IsNullOrWhiteSpace(Item.Description) || string.IsNullOrWhiteSpace(Item.Key))
-            {
-                _error = "Description and Key are required.";
+            await _form.ValidateAsync();
+            if (!_form.IsValid)
                 return;
-            }
 
             ApiResult<HotkeyDto> result = Item.Id is null
                 ? await Api.CreateAsync(Item.ToCreateDto(), _cts.Token)
@@ -108,7 +112,12 @@
 
             if (!result.IsSuccess)
             {
-                _error = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+                string message = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+                if (result.Status == ApiResultStatus.Conflict)
+                    _keyError = message;
+                else
+                    _error = message;
+
                 return;
             }
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
@@ -1,0 +1,121 @@
+@using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Services
+@using AHKFlowApp.UI.Blazor.Validation
+@using MudBlazor
+@implements IDisposable
+
+<MudDialog Class="hotkey-edit-dialog">
+    <TitleContent>
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="flex-grow-1">
+            <MudIconButton Class="cancel-edit" Icon="@Icons.Material.Filled.ArrowBack" OnClick="Cancel" />
+            <MudText Typo="Typo.h6">@(Item.Id is null ? "New hotkey" : "Edit hotkey")</MudText>
+            <MudButton Class="commit-edit" Color="Color.Primary" Variant="Variant.Filled"
+                       OnClick="SaveAsync" Disabled="@_saving">Save</MudButton>
+        </MudStack>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3" Class="pa-2">
+            <MudTextField T="string" Label="Description" @bind-Value="Item.Description"
+                          Required="true" RequiredError="Description is required" MaxLength="200"
+                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "description-input" })" />
+            <MudTextField T="string" Label="Key" @bind-Value="Item.Key"
+                          Required="true" RequiredError="Key is required" MaxLength="20"
+                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "key-input" })" />
+            <MudStack Row="true" Spacing="2">
+                <MudCheckBox T="bool" @bind-Value="Item.Ctrl" Label="Ctrl"
+                             UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "ctrl-checkbox" })" />
+                <MudCheckBox T="bool" @bind-Value="Item.Alt" Label="Alt"
+                             UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "alt-checkbox" })" />
+                <MudCheckBox T="bool" @bind-Value="Item.Shift" Label="Shift"
+                             UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "shift-checkbox" })" />
+                <MudCheckBox T="bool" @bind-Value="Item.Win" Label="Win"
+                             UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "win-checkbox" })" />
+            </MudStack>
+            <MudSelect T="HotkeyAction" @bind-Value="Item.Action" Label="Action"
+                       UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "action-select" })">
+                <MudSelectItem T="HotkeyAction" Value="HotkeyAction.Send">Send</MudSelectItem>
+                <MudSelectItem T="HotkeyAction" Value="HotkeyAction.Run">Run</MudSelectItem>
+            </MudSelect>
+            <MudTextField T="string" Label="Parameters" @bind-Value="Item.Parameters"
+                          Lines="3" MaxLength="4000"
+                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "parameters-input" })" />
+
+            <MudCheckBox T="bool" @bind-Value="Item.AppliesToAllProfiles" Label="Apply to all profiles"
+                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "applies-to-all-checkbox" })" />
+            @if (!Item.AppliesToAllProfiles)
+            {
+                <MudSelect T="Guid" MultiSelection="true" Label="Profiles"
+                           SelectedValues="Item.ProfileIds"
+                           SelectedValuesChanged="ids => Item.ProfileIds = [.. ids]"
+                           ToStringFunc="@(id => Profiles.FirstOrDefault(p => p.Id == id)?.Name ?? id.ToString())"
+                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "profile-select" })">
+                    @foreach (ProfileDto p in Profiles)
+                    {
+                        <MudSelectItem T="Guid" Value="@p.Id">@p.Name</MudSelectItem>
+                    }
+                </MudSelect>
+            }
+
+            <MudSelect T="Guid" MultiSelection="true" Label="Categories"
+                       SelectedValues="Item.CategoryIds"
+                       SelectedValuesChanged="ids => Item.CategoryIds = [.. ids]"
+                       ToStringFunc="@(id => Categories.FirstOrDefault(c => c.Id == id)?.Name ?? id.ToString())"
+                       UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "category-select" })">
+                @foreach (CategoryDto c in Categories)
+                {
+                    <MudSelectItem T="Guid" Value="@c.Id">@c.Name</MudSelectItem>
+                }
+            </MudSelect>
+
+            @if (_error is not null)
+            {
+                <MudAlert Severity="Severity.Error">@_error</MudAlert>
+            }
+        </MudStack>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance Dialog { get; set; } = default!;
+    [Inject] private IHotkeysApiClient Api { get; set; } = default!;
+
+    [Parameter] public HotkeyEditModel Item { get; set; } = new();
+    [Parameter] public IReadOnlyList<ProfileDto> Profiles { get; set; } = [];
+    [Parameter] public IReadOnlyList<CategoryDto> Categories { get; set; } = [];
+
+    private string? _error;
+    private bool _saving;
+    private readonly CancellationTokenSource _cts = new();
+
+    private void Cancel() => Dialog.Cancel();
+
+    private async Task SaveAsync()
+    {
+        if (_saving) return;
+        _saving = true;
+        _error = null;
+        try
+        {
+            if (string.IsNullOrWhiteSpace(Item.Description) || string.IsNullOrWhiteSpace(Item.Key))
+            {
+                _error = "Description and Key are required.";
+                return;
+            }
+
+            ApiResult<HotkeyDto> result = Item.Id is null
+                ? await Api.CreateAsync(Item.ToCreateDto(), _cts.Token)
+                : await Api.UpdateAsync(Item.Id.Value, Item.ToUpdateDto(), _cts.Token);
+
+            if (!result.IsSuccess)
+            {
+                _error = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+                return;
+            }
+
+            Dialog.Close(DialogResult.Ok(result.Value));
+        }
+        finally { _saving = false; }
+    }
+
+    public void Dispose() { _cts.Cancel(); _cts.Dispose(); }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor
@@ -1,0 +1,166 @@
+@using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Validation
+@using MudBlazor
+
+<MudStack Spacing="0">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Class="pa-2">
+        <MudIconButton Class="toggle-select-mode"
+                       Icon="@(_selectMode ? Icons.Material.Filled.Close : Icons.Material.Filled.CheckBox)"
+                       OnClick="ToggleSelectMode" />
+        <MudText Typo="Typo.subtitle2">@(_selectMode ? $"{_selectedIds.Count} selected" : "")</MudText>
+    </MudStack>
+
+    @if (Items.Count == 0)
+    {
+        <MudText Class="pa-4 text-center" Typo="Typo.body2">No hotkeys yet.</MudText>
+    }
+
+    <table class="mobile-list">
+        <thead>
+            <tr class="mobile-header">
+                @if (_selectMode)
+                {
+                    <th style="width:36px"></th>
+                }
+                <th>Combo</th>
+                <th>Description</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (HotkeyEditModel item in Items)
+            {
+                bool expanded = !_selectMode && _expandedId == item.Id;
+                <tr class="mobile-row" @onclick="() => OnRowClick(item)">
+                    @if (_selectMode)
+                    {
+                        <td class="checkbox-cell" @onclick:stopPropagation="true">
+                            <input type="checkbox" class="row-checkbox"
+                                   checked="@(_selectedIds.Contains(item.Id!.Value))"
+                                   @onchange="e => OnRowCheckboxChanged(item, (bool)e.Value!)" />
+                        </td>
+                    }
+                    <td class="trigger-cell"><code>@FormatCombo(item)</code></td>
+                    <td class="replacement-cell">@item.Description</td>
+                    <td class="chevron-cell">@(expanded ? "▾" : "▸")</td>
+                </tr>
+                @if (expanded)
+                {
+                    <tr class="mobile-row-expanded">
+                        <td colspan="3">
+                            <MudStack Spacing="1" Class="pa-3">
+                                <MudText Typo="Typo.body2"><strong>Action:</strong> @item.Action</MudText>
+                                @if (!string.IsNullOrWhiteSpace(item.Parameters))
+                                {
+                                    <MudText Typo="Typo.body2"><strong>Parameters:</strong> @item.Parameters</MudText>
+                                }
+                                <MudText Typo="Typo.body2"><strong>Profiles:</strong>
+                                    @if (item.AppliesToAllProfiles)
+                                    {
+                                        <MudChip T="string" Size="Size.Small" Color="Color.Info">Any</MudChip>
+                                    }
+                                    else
+                                    {
+                                        @foreach (Guid pid in item.ProfileIds)
+                                        {
+                                            string name = Profiles.FirstOrDefault(p => p.Id == pid)?.Name ?? pid.ToString()[..8];
+                                            <MudChip T="string" Size="Size.Small">@name</MudChip>
+                                        }
+                                    }
+                                </MudText>
+                                <MudText Typo="Typo.body2"><strong>Categories:</strong>
+                                    @foreach (Guid cid in item.CategoryIds)
+                                    {
+                                        string name = Categories.FirstOrDefault(c => c.Id == cid)?.Name ?? cid.ToString()[..8];
+                                        <MudChip T="string" Size="Size.Small">@name</MudChip>
+                                    }
+                                </MudText>
+                                <MudStack Row="true" Spacing="2" Class="mt-2">
+                                    <MudButton Class="start-edit" Variant="Variant.Filled" Color="Color.Primary"
+                                               StartIcon="@Icons.Material.Filled.Edit"
+                                               OnClick="@(async () => await OnEdit.InvokeAsync(item))">Edit</MudButton>
+                                    <MudButton Class="delete" Variant="Variant.Filled" Color="Color.Error"
+                                               StartIcon="@Icons.Material.Filled.Delete"
+                                               OnClick="@(async () => await OnDelete.InvokeAsync(item))">Delete</MudButton>
+                                </MudStack>
+                            </MudStack>
+                        </td>
+                    </tr>
+                }
+            }
+        </tbody>
+    </table>
+
+    @if (_selectMode && _selectedIds.Count > 0)
+    {
+        <div class="select-action-bar">
+            <MudButton Variant="Variant.Text" OnClick="ToggleSelectMode">Cancel</MudButton>
+            <MudButton Class="bulk-delete-hotkeys" Variant="Variant.Filled" Color="Color.Error"
+                       StartIcon="@Icons.Material.Filled.DeleteSweep"
+                       OnClick="RaiseBulkDelete">Delete @_selectedIds.Count</MudButton>
+        </div>
+    }
+</MudStack>
+
+@code {
+    [Parameter] public IReadOnlyList<HotkeyEditModel> Items { get; set; } = [];
+    [Parameter] public IReadOnlyList<ProfileDto> Profiles { get; set; } = [];
+    [Parameter] public IReadOnlyList<CategoryDto> Categories { get; set; } = [];
+    [Parameter] public EventCallback<HotkeyEditModel> OnEdit { get; set; }
+    [Parameter] public EventCallback<HotkeyEditModel> OnDelete { get; set; }
+    [Parameter] public EventCallback<IReadOnlyList<Guid>> OnBulkDelete { get; set; }
+
+    private Guid? _expandedId;
+    private bool _selectMode;
+    private readonly HashSet<Guid> _selectedIds = [];
+
+    private void OnRowClick(HotkeyEditModel item)
+    {
+        if (_selectMode)
+        {
+            if (item.Id is { } id) ToggleSelected(id);
+        }
+        else
+        {
+            _expandedId = _expandedId == item.Id ? null : item.Id;
+        }
+    }
+
+    private void OnRowCheckboxChanged(HotkeyEditModel item, bool isChecked)
+    {
+        if (item.Id is not { } id) return;
+        if (isChecked) _selectedIds.Add(id);
+        else _selectedIds.Remove(id);
+    }
+
+    private void ToggleSelected(Guid id)
+    {
+        if (!_selectedIds.Add(id)) _selectedIds.Remove(id);
+    }
+
+    private void ToggleSelectMode()
+    {
+        _selectMode = !_selectMode;
+        _selectedIds.Clear();
+        _expandedId = null;
+    }
+
+    private async Task RaiseBulkDelete()
+    {
+        IReadOnlyList<Guid> ids = [.. _selectedIds];
+        await OnBulkDelete.InvokeAsync(ids);
+        _selectMode = false;
+        _selectedIds.Clear();
+    }
+
+    private static string FormatCombo(HotkeyEditModel item)
+    {
+        List<string> parts = [];
+        if (item.Ctrl) parts.Add("Ctrl");
+        if (item.Alt) parts.Add("Alt");
+        if (item.Shift) parts.Add("Shift");
+        if (item.Win) parts.Add("Win");
+        parts.Add(item.Key);
+        return string.Join("+", parts);
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor
@@ -14,82 +14,84 @@
     {
         <MudText Class="pa-4 text-center" Typo="Typo.body2">No hotkeys yet.</MudText>
     }
-
-    <table class="mobile-list">
-        <thead>
-            <tr class="mobile-header">
-                @if (_selectMode)
-                {
-                    <th style="width:36px"></th>
-                }
-                <th>Combo</th>
-                <th>Description</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (HotkeyEditModel item in Items)
-            {
-                bool expanded = !_selectMode && _expandedId == item.Id;
-                <tr class="mobile-row" @onclick="() => OnRowClick(item)">
+    else
+    {
+        <table class="mobile-list">
+            <thead>
+                <tr class="mobile-header">
                     @if (_selectMode)
                     {
-                        <td class="checkbox-cell" @onclick:stopPropagation="true">
-                            <input type="checkbox" class="row-checkbox"
-                                   checked="@(_selectedIds.Contains(item.Id!.Value))"
-                                   @onchange="e => OnRowCheckboxChanged(item, (bool)e.Value!)" />
-                        </td>
+                        <th class="checkbox-column"></th>
                     }
-                    <td class="trigger-cell"><code>@FormatCombo(item)</code></td>
-                    <td class="replacement-cell">@item.Description</td>
-                    <td class="chevron-cell">@(expanded ? "▾" : "▸")</td>
+                    <th>Combo</th>
+                    <th>Description</th>
+                    <th></th>
                 </tr>
-                @if (expanded)
+            </thead>
+            <tbody>
+                @foreach (HotkeyEditModel item in Items)
                 {
-                    <tr class="mobile-row-expanded">
-                        <td colspan="3">
-                            <MudStack Spacing="1" Class="pa-3">
-                                <MudText Typo="Typo.body2"><strong>Action:</strong> @item.Action</MudText>
-                                @if (!string.IsNullOrWhiteSpace(item.Parameters))
-                                {
-                                    <MudText Typo="Typo.body2"><strong>Parameters:</strong> @item.Parameters</MudText>
-                                }
-                                <MudText Typo="Typo.body2"><strong>Profiles:</strong>
-                                    @if (item.AppliesToAllProfiles)
+                    bool expanded = item.Id is { } id && !_selectMode && _expandedId == id;
+                    <tr class="mobile-row" @onclick="() => OnRowClick(item)">
+                        @if (_selectMode)
+                        {
+                            <td class="checkbox-cell" @onclick:stopPropagation="true">
+                                <input type="checkbox" class="row-checkbox"
+                                       checked="@(item.Id is { } checkboxId && _selectedIds.Contains(checkboxId))"
+                                       @onchange="e => OnRowCheckboxChanged(item, IsChecked(e))" />
+                            </td>
+                        }
+                        <td class="trigger-cell"><code>@FormatCombo(item)</code></td>
+                        <td class="replacement-cell">@item.Description</td>
+                        <td class="chevron-cell">@(expanded ? "▾" : "▸")</td>
+                    </tr>
+                    @if (expanded)
+                    {
+                        <tr class="mobile-row-expanded">
+                            <td colspan="3">
+                                <MudStack Spacing="1" Class="pa-3">
+                                    <MudText Typo="Typo.body2"><strong>Action:</strong> @item.Action</MudText>
+                                    @if (!string.IsNullOrWhiteSpace(item.Parameters))
                                     {
-                                        <MudChip T="string" Size="Size.Small" Color="Color.Info">Any</MudChip>
+                                        <MudText Typo="Typo.body2"><strong>Parameters:</strong> @item.Parameters</MudText>
                                     }
-                                    else
-                                    {
-                                        @foreach (Guid pid in item.ProfileIds)
+                                    <MudText Typo="Typo.body2"><strong>Profiles:</strong>
+                                        @if (item.AppliesToAllProfiles)
                                         {
-                                            string name = Profiles.FirstOrDefault(p => p.Id == pid)?.Name ?? pid.ToString()[..8];
+                                            <MudChip T="string" Size="Size.Small" Color="Color.Info">Any</MudChip>
+                                        }
+                                        else
+                                        {
+                                            @foreach (Guid pid in item.ProfileIds)
+                                            {
+                                                string name = Profiles.FirstOrDefault(p => p.Id == pid)?.Name ?? pid.ToString()[..8];
+                                                <MudChip T="string" Size="Size.Small">@name</MudChip>
+                                            }
+                                        }
+                                    </MudText>
+                                    <MudText Typo="Typo.body2"><strong>Categories:</strong>
+                                        @foreach (Guid cid in item.CategoryIds)
+                                        {
+                                            string name = Categories.FirstOrDefault(c => c.Id == cid)?.Name ?? cid.ToString()[..8];
                                             <MudChip T="string" Size="Size.Small">@name</MudChip>
                                         }
-                                    }
-                                </MudText>
-                                <MudText Typo="Typo.body2"><strong>Categories:</strong>
-                                    @foreach (Guid cid in item.CategoryIds)
-                                    {
-                                        string name = Categories.FirstOrDefault(c => c.Id == cid)?.Name ?? cid.ToString()[..8];
-                                        <MudChip T="string" Size="Size.Small">@name</MudChip>
-                                    }
-                                </MudText>
-                                <MudStack Row="true" Spacing="2" Class="mt-2">
-                                    <MudButton Class="start-edit" Variant="Variant.Filled" Color="Color.Primary"
-                                               StartIcon="@Icons.Material.Filled.Edit"
-                                               OnClick="@(async () => await OnEdit.InvokeAsync(item))">Edit</MudButton>
-                                    <MudButton Class="delete" Variant="Variant.Filled" Color="Color.Error"
-                                               StartIcon="@Icons.Material.Filled.Delete"
-                                               OnClick="@(async () => await OnDelete.InvokeAsync(item))">Delete</MudButton>
+                                    </MudText>
+                                    <MudStack Row="true" Spacing="2" Class="mt-2">
+                                        <MudButton Class="start-edit" Variant="Variant.Filled" Color="Color.Primary"
+                                                   StartIcon="@Icons.Material.Filled.Edit"
+                                                   OnClick="@(async () => await OnEdit.InvokeAsync(item))">Edit</MudButton>
+                                        <MudButton Class="delete" Variant="Variant.Filled" Color="Color.Error"
+                                                   StartIcon="@Icons.Material.Filled.Delete"
+                                                   OnClick="@(async () => await OnDelete.InvokeAsync(item))">Delete</MudButton>
+                                    </MudStack>
                                 </MudStack>
-                            </MudStack>
-                        </td>
-                    </tr>
+                            </td>
+                        </tr>
+                    }
                 }
-            }
-        </tbody>
-    </table>
+            </tbody>
+        </table>
+    }
 
     @if (_selectMode && _selectedIds.Count > 0)
     {
@@ -120,9 +122,9 @@
         {
             if (item.Id is { } id) ToggleSelected(id);
         }
-        else
+        else if (item.Id is { } id)
         {
-            _expandedId = _expandedId == item.Id ? null : item.Id;
+            _expandedId = _expandedId == id ? null : id;
         }
     }
 
@@ -137,6 +139,14 @@
     {
         if (!_selectedIds.Add(id)) _selectedIds.Remove(id);
     }
+
+    private static bool IsChecked(ChangeEventArgs e) =>
+        e.Value switch
+        {
+            bool value => value,
+            string value when bool.TryParse(value, out bool parsed) => parsed,
+            _ => false,
+        };
 
     private void ToggleSelectMode()
     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor.css
@@ -1,0 +1,69 @@
+.mobile-list {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+
+.mobile-list .mobile-header {
+    background: var(--mud-palette-background-grey);
+}
+
+.mobile-list .mobile-header th {
+    text-align: left;
+    padding: 6px 12px;
+    font-weight: 500;
+    font-size: 0.75rem;
+    color: var(--mud-palette-text-secondary);
+}
+
+.mobile-list .mobile-row {
+    border-top: 1px solid var(--mud-palette-divider);
+    cursor: pointer;
+}
+
+.mobile-list .mobile-row td {
+    padding: 10px 12px;
+    vertical-align: middle;
+}
+
+.mobile-list .trigger-cell {
+    width: 30%;
+    white-space: nowrap;
+}
+
+.mobile-list .replacement-cell {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 0;
+}
+
+.mobile-list .chevron-cell {
+    width: 24px;
+    text-align: right;
+    color: var(--mud-palette-text-secondary);
+}
+
+.mobile-list .mobile-row-expanded {
+    background: var(--mud-palette-background-grey);
+}
+
+.mobile-list {
+    table-layout: fixed;
+}
+
+.mobile-list .checkbox-cell {
+    width: 36px;
+    text-align: center;
+}
+
+.select-action-bar {
+    position: sticky;
+    bottom: 0;
+    background: var(--mud-palette-surface);
+    border-top: 1px solid var(--mud-palette-divider);
+    padding: 8px 12px;
+    display: flex;
+    justify-content: space-between;
+    z-index: 10;
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor.css
@@ -16,6 +16,10 @@
     color: var(--mud-palette-text-secondary);
 }
 
+.mobile-list .checkbox-column {
+    width: 36px;
+}
+
 .mobile-list .mobile-row {
     border-top: 1px solid var(--mud-palette-divider);
     cursor: pointer;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -2,13 +2,14 @@
 @using AHKFlowApp.UI.Blazor.Services
 @using AHKFlowApp.UI.Blazor.Validation
 @using MudBlazor
+@implements IDisposable
 
 <MudDialog Class="hotstring-edit-dialog">
     <TitleContent>
         <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="flex-grow-1">
             <MudIconButton Class="cancel-edit" Icon="@Icons.Material.Filled.ArrowBack" OnClick="Cancel" />
             <MudText Typo="Typo.h6">@(Item.Id is null ? "New hotstring" : "Edit hotstring")</MudText>
-            <MudButton Class="commit-edit" Color="Color.Primary" Variant="Variant.Filled" OnClick="SaveAsync">Save</MudButton>
+            <MudButton Class="commit-edit" Color="Color.Primary" Variant="Variant.Filled" OnClick="SaveAsync" Disabled="@_saving">Save</MudButton>
         </MudStack>
     </TitleContent>
     <DialogContent>
@@ -70,28 +71,45 @@
     [Parameter] public IReadOnlyList<CategoryDto> Categories { get; set; } = [];
 
     private string? _error;
+    private bool _saving;
+    private readonly CancellationTokenSource _cts = new();
 
     private void Cancel() => Dialog.Cancel();
 
     private async Task SaveAsync()
     {
-        _error = null;
-        if (string.IsNullOrWhiteSpace(Item.Trigger) || string.IsNullOrWhiteSpace(Item.Replacement))
+        if (_saving) return;
+        _saving = true;
+        try
         {
-            _error = "Trigger and Replacement are required.";
-            return;
+            _error = null;
+            if (string.IsNullOrWhiteSpace(Item.Trigger) || string.IsNullOrWhiteSpace(Item.Replacement))
+            {
+                _error = "Trigger and Replacement are required.";
+                return;
+            }
+
+            ApiResult<HotstringDto> result = Item.Id is null
+                ? await Api.CreateAsync(Item.ToCreateDto(), _cts.Token)
+                : await Api.UpdateAsync(Item.Id.Value, Item.ToUpdateDto(), _cts.Token);
+
+            if (!result.IsSuccess)
+            {
+                _error = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+                return;
+            }
+
+            Dialog.Close(DialogResult.Ok(result.Value));
         }
-
-        ApiResult<HotstringDto> result = Item.Id is null
-            ? await Api.CreateAsync(Item.ToCreateDto(), CancellationToken.None)
-            : await Api.UpdateAsync(Item.Id.Value, Item.ToUpdateDto(), CancellationToken.None);
-
-        if (!result.IsSuccess)
+        finally
         {
-            _error = ApiErrorMessageFactory.Build(result.Status, result.Problem);
-            return;
+            _saving = false;
         }
+    }
 
-        Dialog.Close(DialogResult.Ok(result.Value));
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
     }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -83,7 +83,9 @@
 
     private async Task SaveAsync()
     {
-        if (_saving) return;
+        if (_saving)
+            return;
+
         _saving = true;
         try
         {
@@ -117,9 +119,5 @@
         }
     }
 
-    public void Dispose()
-    {
-        _cts.Cancel();
-        _cts.Dispose();
-    }
+    public void Dispose() { _cts.Cancel(); _cts.Dispose(); }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -1,0 +1,97 @@
+@using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Services
+@using AHKFlowApp.UI.Blazor.Validation
+@using MudBlazor
+
+<MudDialog Class="hotstring-edit-dialog">
+    <TitleContent>
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="flex-grow-1">
+            <MudIconButton Class="cancel-edit" Icon="@Icons.Material.Filled.ArrowBack" OnClick="Cancel" />
+            <MudText Typo="Typo.h6">@(Item.Id is null ? "New hotstring" : "Edit hotstring")</MudText>
+            <MudButton Class="commit-edit" Color="Color.Primary" Variant="Variant.Filled" OnClick="SaveAsync">Save</MudButton>
+        </MudStack>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3" Class="pa-2">
+            <MudTextField T="string" Label="Trigger" @bind-Value="Item.Trigger"
+                          Required="true" RequiredError="Trigger is required" MaxLength="50"
+                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "trigger-input" })" />
+            <MudTextField T="string" Label="Replacement" @bind-Value="Item.Replacement"
+                          Lines="3" Required="true" RequiredError="Replacement is required" MaxLength="4000"
+                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "replacement-input" })" />
+            <MudTextField T="string" Label="Description" @bind-Value="Item.Description"
+                          MaxLength="200"
+                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "description-input" })" />
+
+            <MudCheckBox T="bool" @bind-Value="Item.AppliesToAllProfiles" Label="Apply to all profiles"
+                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "applies-to-all-checkbox" })" />
+            @if (!Item.AppliesToAllProfiles)
+            {
+                <MudSelect T="Guid" MultiSelection="true" Label="Profiles"
+                           SelectedValues="Item.ProfileIds"
+                           SelectedValuesChanged="ids => Item.ProfileIds = [.. ids]"
+                           ToStringFunc="@(id => Profiles.FirstOrDefault(p => p.Id == id)?.Name ?? id.ToString())"
+                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "profile-select" })">
+                    @foreach (ProfileDto p in Profiles)
+                    {
+                        <MudSelectItem T="Guid" Value="@p.Id">@p.Name</MudSelectItem>
+                    }
+                </MudSelect>
+            }
+
+            <MudCheckBox T="bool" @bind-Value="Item.IsEndingCharacterRequired" Label="Ending character required" />
+            <MudCheckBox T="bool" @bind-Value="Item.IsTriggerInsideWord" Label="Trigger inside word" />
+
+            <MudSelect T="Guid" MultiSelection="true" Label="Categories"
+                       SelectedValues="Item.CategoryIds"
+                       SelectedValuesChanged="ids => Item.CategoryIds = [.. ids]"
+                       ToStringFunc="@(id => Categories.FirstOrDefault(c => c.Id == id)?.Name ?? id.ToString())"
+                       UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "category-select" })">
+                @foreach (CategoryDto c in Categories)
+                {
+                    <MudSelectItem T="Guid" Value="@c.Id">@c.Name</MudSelectItem>
+                }
+            </MudSelect>
+
+            @if (_error is not null)
+            {
+                <MudAlert Severity="Severity.Error">@_error</MudAlert>
+            }
+        </MudStack>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance Dialog { get; set; } = default!;
+    [Inject] private IHotstringsApiClient Api { get; set; } = default!;
+
+    [Parameter] public HotstringEditModel Item { get; set; } = new();
+    [Parameter] public IReadOnlyList<ProfileDto> Profiles { get; set; } = [];
+    [Parameter] public IReadOnlyList<CategoryDto> Categories { get; set; } = [];
+
+    private string? _error;
+
+    private void Cancel() => Dialog.Cancel();
+
+    private async Task SaveAsync()
+    {
+        _error = null;
+        if (string.IsNullOrWhiteSpace(Item.Trigger) || string.IsNullOrWhiteSpace(Item.Replacement))
+        {
+            _error = "Trigger and Replacement are required.";
+            return;
+        }
+
+        ApiResult<HotstringDto> result = Item.Id is null
+            ? await Api.CreateAsync(Item.ToCreateDto(), CancellationToken.None)
+            : await Api.UpdateAsync(Item.Id.Value, Item.ToUpdateDto(), CancellationToken.None);
+
+        if (!result.IsSuccess)
+        {
+            _error = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+            return;
+        }
+
+        Dialog.Close(DialogResult.Ok(result.Value));
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -13,9 +13,11 @@
         </MudStack>
     </TitleContent>
     <DialogContent>
+        <MudForm @ref="_form">
         <MudStack Spacing="3" Class="pa-2">
             <MudTextField T="string" Label="Trigger" @bind-Value="Item.Trigger"
                           Required="true" RequiredError="Trigger is required" MaxLength="50"
+                          Error="@(_triggerError is not null)" ErrorText="@_triggerError"
                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "trigger-input" })" />
             <MudTextField T="string" Label="Replacement" @bind-Value="Item.Replacement"
                           Lines="3" Required="true" RequiredError="Replacement is required" MaxLength="4000"
@@ -59,6 +61,7 @@
                 <MudAlert Severity="Severity.Error">@_error</MudAlert>
             }
         </MudStack>
+        </MudForm>
     </DialogContent>
 </MudDialog>
 
@@ -71,7 +74,9 @@
     [Parameter] public IReadOnlyList<CategoryDto> Categories { get; set; } = [];
 
     private string? _error;
+    private string? _triggerError;
     private bool _saving;
+    private MudForm _form = default!;
     private readonly CancellationTokenSource _cts = new();
 
     private void Cancel() => Dialog.Cancel();
@@ -83,11 +88,11 @@
         try
         {
             _error = null;
-            if (string.IsNullOrWhiteSpace(Item.Trigger) || string.IsNullOrWhiteSpace(Item.Replacement))
-            {
-                _error = "Trigger and Replacement are required.";
+            _triggerError = null;
+
+            await _form.ValidateAsync();
+            if (!_form.IsValid)
                 return;
-            }
 
             ApiResult<HotstringDto> result = Item.Id is null
                 ? await Api.CreateAsync(Item.ToCreateDto(), _cts.Token)
@@ -95,7 +100,12 @@
 
             if (!result.IsSuccess)
             {
-                _error = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+                string message = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+                if (result.Status == ApiResultStatus.Conflict)
+                    _triggerError = message;
+                else
+                    _error = message;
+
                 return;
             }
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
@@ -1,0 +1,92 @@
+@using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Validation
+@using MudBlazor
+
+<MudStack Spacing="0">
+    @if (Items.Count == 0)
+    {
+        <MudText Class="pa-4 text-center" Typo="Typo.body2">No hotstrings yet.</MudText>
+    }
+
+    <table class="mobile-list">
+        <thead>
+            <tr class="mobile-header">
+                <th>Trigger</th>
+                <th>Replacement</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (HotstringEditModel item in Items)
+            {
+                bool expanded = _expandedId == item.Id;
+                <tr class="mobile-row" @onclick="() => ToggleExpand(item)">
+                    <td class="trigger-cell"><code>@item.Trigger</code></td>
+                    <td class="replacement-cell">@item.Replacement</td>
+                    <td class="chevron-cell">@(expanded ? "▾" : "▸")</td>
+                </tr>
+                @if (expanded)
+                {
+                    <tr class="mobile-row-expanded">
+                        <td colspan="3">
+                            <MudStack Spacing="1" Class="pa-3">
+                                @if (!string.IsNullOrWhiteSpace(item.Description))
+                                {
+                                    <MudText Typo="Typo.body2"><strong>Description:</strong> @item.Description</MudText>
+                                }
+                                <MudText Typo="Typo.body2"><strong>Profiles:</strong>
+                                    @if (item.AppliesToAllProfiles)
+                                    {
+                                        <MudChip T="string" Size="Size.Small" Color="Color.Info">Any</MudChip>
+                                    }
+                                    else
+                                    {
+                                        @foreach (Guid pid in item.ProfileIds)
+                                        {
+                                            string name = Profiles.FirstOrDefault(p => p.Id == pid)?.Name ?? pid.ToString()[..8];
+                                            <MudChip T="string" Size="Size.Small">@name</MudChip>
+                                        }
+                                    }
+                                </MudText>
+                                <MudText Typo="Typo.body2"><strong>Categories:</strong>
+                                    @foreach (Guid cid in item.CategoryIds)
+                                    {
+                                        string name = Categories.FirstOrDefault(c => c.Id == cid)?.Name ?? cid.ToString()[..8];
+                                        <MudChip T="string" Size="Size.Small">@name</MudChip>
+                                    }
+                                </MudText>
+                                <MudText Typo="Typo.body2">
+                                    <strong>End-char:</strong> @(item.IsEndingCharacterRequired ? "✓" : "✗") &nbsp;
+                                    <strong>In-word:</strong> @(item.IsTriggerInsideWord ? "✓" : "✗")
+                                </MudText>
+                                <MudStack Row="true" Spacing="2" Class="mt-2">
+                                    <MudButton Class="start-edit" Variant="Variant.Filled" Color="Color.Primary"
+                                               StartIcon="@Icons.Material.Filled.Edit"
+                                               OnClick="@(async () => await OnEdit.InvokeAsync(item))">Edit</MudButton>
+                                    <MudButton Class="delete" Variant="Variant.Filled" Color="Color.Error"
+                                               StartIcon="@Icons.Material.Filled.Delete"
+                                               OnClick="@(async () => await OnDelete.InvokeAsync(item))">Delete</MudButton>
+                                </MudStack>
+                            </MudStack>
+                        </td>
+                    </tr>
+                }
+            }
+        </tbody>
+    </table>
+</MudStack>
+
+@code {
+    [Parameter] public IReadOnlyList<HotstringEditModel> Items { get; set; } = [];
+    [Parameter] public IReadOnlyList<ProfileDto> Profiles { get; set; } = [];
+    [Parameter] public IReadOnlyList<CategoryDto> Categories { get; set; } = [];
+    [Parameter] public EventCallback<HotstringEditModel> OnEdit { get; set; }
+    [Parameter] public EventCallback<HotstringEditModel> OnDelete { get; set; }
+
+    private Guid? _expandedId;
+
+    private void ToggleExpand(HotstringEditModel item)
+    {
+        _expandedId = _expandedId == item.Id ? null : item.Id;
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
@@ -3,6 +3,13 @@
 @using MudBlazor
 
 <MudStack Spacing="0">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Class="pa-2">
+        <MudIconButton Class="toggle-select-mode"
+                       Icon="@(_selectMode ? Icons.Material.Filled.Close : Icons.Material.Filled.CheckBox)"
+                       OnClick="ToggleSelectMode" />
+        <MudText Typo="Typo.subtitle2">@(_selectMode ? $"{_selectedIds.Count} selected" : "")</MudText>
+    </MudStack>
+
     @if (Items.Count == 0)
     {
         <MudText Class="pa-4 text-center" Typo="Typo.body2">No hotstrings yet.</MudText>
@@ -11,6 +18,10 @@
     <table class="mobile-list">
         <thead>
             <tr class="mobile-header">
+                @if (_selectMode)
+                {
+                    <th style="width:36px"></th>
+                }
                 <th>Trigger</th>
                 <th>Replacement</th>
                 <th></th>
@@ -19,8 +30,16 @@
         <tbody>
             @foreach (HotstringEditModel item in Items)
             {
-                bool expanded = _expandedId == item.Id;
-                <tr class="mobile-row" @onclick="() => ToggleExpand(item)">
+                bool expanded = !_selectMode && _expandedId == item.Id;
+                <tr class="mobile-row" @onclick="() => OnRowClick(item)">
+                    @if (_selectMode)
+                    {
+                        <td class="checkbox-cell" @onclick:stopPropagation="true">
+                            <input type="checkbox" class="row-checkbox"
+                                   checked="@(_selectedIds.Contains(item.Id!.Value))"
+                                   @onchange="e => OnRowCheckboxChanged(item, (bool)e.Value!)" />
+                        </td>
+                    }
                     <td class="trigger-cell"><code>@item.Trigger</code></td>
                     <td class="replacement-cell">@item.Replacement</td>
                     <td class="chevron-cell">@(expanded ? "▾" : "▸")</td>
@@ -74,6 +93,16 @@
             }
         </tbody>
     </table>
+
+    @if (_selectMode && _selectedIds.Count > 0)
+    {
+        <div class="select-action-bar">
+            <MudButton Variant="Variant.Text" OnClick="ToggleSelectMode">Cancel</MudButton>
+            <MudButton Class="bulk-delete-hotstrings" Variant="Variant.Filled" Color="Color.Error"
+                       StartIcon="@Icons.Material.Filled.DeleteSweep"
+                       OnClick="RaiseBulkDelete">Delete @_selectedIds.Count</MudButton>
+        </div>
+    }
 </MudStack>
 
 @code {
@@ -82,11 +111,48 @@
     [Parameter] public IReadOnlyList<CategoryDto> Categories { get; set; } = [];
     [Parameter] public EventCallback<HotstringEditModel> OnEdit { get; set; }
     [Parameter] public EventCallback<HotstringEditModel> OnDelete { get; set; }
+    [Parameter] public EventCallback<IReadOnlyList<Guid>> OnBulkDelete { get; set; }
 
     private Guid? _expandedId;
+    private bool _selectMode;
+    private readonly HashSet<Guid> _selectedIds = [];
 
-    private void ToggleExpand(HotstringEditModel item)
+    private void OnRowClick(HotstringEditModel item)
     {
-        _expandedId = _expandedId == item.Id ? null : item.Id;
+        if (_selectMode)
+        {
+            if (item.Id is { } id) ToggleSelected(id);
+        }
+        else
+        {
+            _expandedId = _expandedId == item.Id ? null : item.Id;
+        }
+    }
+
+    private void OnRowCheckboxChanged(HotstringEditModel item, bool isChecked)
+    {
+        if (item.Id is not { } id) return;
+        if (isChecked) _selectedIds.Add(id);
+        else _selectedIds.Remove(id);
+    }
+
+    private void ToggleSelected(Guid id)
+    {
+        if (!_selectedIds.Add(id)) _selectedIds.Remove(id);
+    }
+
+    private void ToggleSelectMode()
+    {
+        _selectMode = !_selectMode;
+        _selectedIds.Clear();
+        _expandedId = null;
+    }
+
+    private async Task RaiseBulkDelete()
+    {
+        IReadOnlyList<Guid> ids = [.. _selectedIds];
+        await OnBulkDelete.InvokeAsync(ids);
+        _selectMode = false;
+        _selectedIds.Clear();
     }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
@@ -14,85 +14,87 @@
     {
         <MudText Class="pa-4 text-center" Typo="Typo.body2">No hotstrings yet.</MudText>
     }
-
-    <table class="mobile-list">
-        <thead>
-            <tr class="mobile-header">
-                @if (_selectMode)
-                {
-                    <th style="width:36px"></th>
-                }
-                <th>Trigger</th>
-                <th>Replacement</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (HotstringEditModel item in Items)
-            {
-                bool expanded = !_selectMode && _expandedId == item.Id;
-                <tr class="mobile-row" @onclick="() => OnRowClick(item)">
+    else
+    {
+        <table class="mobile-list">
+            <thead>
+                <tr class="mobile-header">
                     @if (_selectMode)
                     {
-                        <td class="checkbox-cell" @onclick:stopPropagation="true">
-                            <input type="checkbox" class="row-checkbox"
-                                   checked="@(_selectedIds.Contains(item.Id!.Value))"
-                                   @onchange="e => OnRowCheckboxChanged(item, (bool)e.Value!)" />
-                        </td>
+                        <th class="checkbox-column"></th>
                     }
-                    <td class="trigger-cell"><code>@item.Trigger</code></td>
-                    <td class="replacement-cell">@item.Replacement</td>
-                    <td class="chevron-cell">@(expanded ? "▾" : "▸")</td>
+                    <th>Trigger</th>
+                    <th>Replacement</th>
+                    <th></th>
                 </tr>
-                @if (expanded)
+            </thead>
+            <tbody>
+                @foreach (HotstringEditModel item in Items)
                 {
-                    <tr class="mobile-row-expanded">
-                        <td colspan="3">
-                            <MudStack Spacing="1" Class="pa-3">
-                                @if (!string.IsNullOrWhiteSpace(item.Description))
-                                {
-                                    <MudText Typo="Typo.body2"><strong>Description:</strong> @item.Description</MudText>
-                                }
-                                <MudText Typo="Typo.body2"><strong>Profiles:</strong>
-                                    @if (item.AppliesToAllProfiles)
+                    bool expanded = item.Id is { } id && !_selectMode && _expandedId == id;
+                    <tr class="mobile-row" @onclick="() => OnRowClick(item)">
+                        @if (_selectMode)
+                        {
+                            <td class="checkbox-cell" @onclick:stopPropagation="true">
+                                <input type="checkbox" class="row-checkbox"
+                                       checked="@(item.Id is { } checkboxId && _selectedIds.Contains(checkboxId))"
+                                       @onchange="e => OnRowCheckboxChanged(item, IsChecked(e))" />
+                            </td>
+                        }
+                        <td class="trigger-cell"><code>@item.Trigger</code></td>
+                        <td class="replacement-cell">@item.Replacement</td>
+                        <td class="chevron-cell">@(expanded ? "▾" : "▸")</td>
+                    </tr>
+                    @if (expanded)
+                    {
+                        <tr class="mobile-row-expanded">
+                            <td colspan="3">
+                                <MudStack Spacing="1" Class="pa-3">
+                                    @if (!string.IsNullOrWhiteSpace(item.Description))
                                     {
-                                        <MudChip T="string" Size="Size.Small" Color="Color.Info">Any</MudChip>
+                                        <MudText Typo="Typo.body2"><strong>Description:</strong> @item.Description</MudText>
                                     }
-                                    else
-                                    {
-                                        @foreach (Guid pid in item.ProfileIds)
+                                    <MudText Typo="Typo.body2"><strong>Profiles:</strong>
+                                        @if (item.AppliesToAllProfiles)
                                         {
-                                            string name = Profiles.FirstOrDefault(p => p.Id == pid)?.Name ?? pid.ToString()[..8];
+                                            <MudChip T="string" Size="Size.Small" Color="Color.Info">Any</MudChip>
+                                        }
+                                        else
+                                        {
+                                            @foreach (Guid pid in item.ProfileIds)
+                                            {
+                                                string name = Profiles.FirstOrDefault(p => p.Id == pid)?.Name ?? pid.ToString()[..8];
+                                                <MudChip T="string" Size="Size.Small">@name</MudChip>
+                                            }
+                                        }
+                                    </MudText>
+                                    <MudText Typo="Typo.body2"><strong>Categories:</strong>
+                                        @foreach (Guid cid in item.CategoryIds)
+                                        {
+                                            string name = Categories.FirstOrDefault(c => c.Id == cid)?.Name ?? cid.ToString()[..8];
                                             <MudChip T="string" Size="Size.Small">@name</MudChip>
                                         }
-                                    }
-                                </MudText>
-                                <MudText Typo="Typo.body2"><strong>Categories:</strong>
-                                    @foreach (Guid cid in item.CategoryIds)
-                                    {
-                                        string name = Categories.FirstOrDefault(c => c.Id == cid)?.Name ?? cid.ToString()[..8];
-                                        <MudChip T="string" Size="Size.Small">@name</MudChip>
-                                    }
-                                </MudText>
-                                <MudText Typo="Typo.body2">
-                                    <strong>End-char:</strong> @(item.IsEndingCharacterRequired ? "✓" : "✗") &nbsp;
-                                    <strong>In-word:</strong> @(item.IsTriggerInsideWord ? "✓" : "✗")
-                                </MudText>
-                                <MudStack Row="true" Spacing="2" Class="mt-2">
-                                    <MudButton Class="start-edit" Variant="Variant.Filled" Color="Color.Primary"
-                                               StartIcon="@Icons.Material.Filled.Edit"
-                                               OnClick="@(async () => await OnEdit.InvokeAsync(item))">Edit</MudButton>
-                                    <MudButton Class="delete" Variant="Variant.Filled" Color="Color.Error"
-                                               StartIcon="@Icons.Material.Filled.Delete"
-                                               OnClick="@(async () => await OnDelete.InvokeAsync(item))">Delete</MudButton>
+                                    </MudText>
+                                    <MudText Typo="Typo.body2">
+                                        <strong>End-char:</strong> @(item.IsEndingCharacterRequired ? "✓" : "✗") &nbsp;
+                                        <strong>In-word:</strong> @(item.IsTriggerInsideWord ? "✓" : "✗")
+                                    </MudText>
+                                    <MudStack Row="true" Spacing="2" Class="mt-2">
+                                        <MudButton Class="start-edit" Variant="Variant.Filled" Color="Color.Primary"
+                                                   StartIcon="@Icons.Material.Filled.Edit"
+                                                   OnClick="@(async () => await OnEdit.InvokeAsync(item))">Edit</MudButton>
+                                        <MudButton Class="delete" Variant="Variant.Filled" Color="Color.Error"
+                                                   StartIcon="@Icons.Material.Filled.Delete"
+                                                   OnClick="@(async () => await OnDelete.InvokeAsync(item))">Delete</MudButton>
+                                    </MudStack>
                                 </MudStack>
-                            </MudStack>
-                        </td>
-                    </tr>
+                            </td>
+                        </tr>
+                    }
                 }
-            }
-        </tbody>
-    </table>
+            </tbody>
+        </table>
+    }
 
     @if (_selectMode && _selectedIds.Count > 0)
     {
@@ -123,9 +125,9 @@
         {
             if (item.Id is { } id) ToggleSelected(id);
         }
-        else
+        else if (item.Id is { } id)
         {
-            _expandedId = _expandedId == item.Id ? null : item.Id;
+            _expandedId = _expandedId == id ? null : id;
         }
     }
 
@@ -140,6 +142,14 @@
     {
         if (!_selectedIds.Add(id)) _selectedIds.Remove(id);
     }
+
+    private static bool IsChecked(ChangeEventArgs e) =>
+        e.Value switch
+        {
+            bool value => value,
+            string value when bool.TryParse(value, out bool parsed) => parsed,
+            _ => false,
+        };
 
     private void ToggleSelectMode()
     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor.css
@@ -47,3 +47,23 @@
 .mobile-list .mobile-row-expanded {
     background: var(--mud-palette-background-grey);
 }
+
+.mobile-list {
+    table-layout: fixed;
+}
+
+.mobile-list .checkbox-cell {
+    width: 36px;
+    text-align: center;
+}
+
+.select-action-bar {
+    position: sticky;
+    bottom: 0;
+    background: var(--mud-palette-surface);
+    border-top: 1px solid var(--mud-palette-divider);
+    padding: 8px 12px;
+    display: flex;
+    justify-content: space-between;
+    z-index: 10;
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor.css
@@ -1,0 +1,49 @@
+.mobile-list {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+
+.mobile-list .mobile-header {
+    background: var(--mud-palette-background-grey);
+}
+
+.mobile-list .mobile-header th {
+    text-align: left;
+    padding: 6px 12px;
+    font-weight: 500;
+    font-size: 0.75rem;
+    color: var(--mud-palette-text-secondary);
+}
+
+.mobile-list .mobile-row {
+    border-top: 1px solid var(--mud-palette-divider);
+    cursor: pointer;
+}
+
+.mobile-list .mobile-row td {
+    padding: 10px 12px;
+    vertical-align: middle;
+}
+
+.mobile-list .trigger-cell {
+    width: 30%;
+    white-space: nowrap;
+}
+
+.mobile-list .replacement-cell {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 0;
+}
+
+.mobile-list .chevron-cell {
+    width: 24px;
+    text-align: right;
+    color: var(--mud-palette-text-secondary);
+}
+
+.mobile-list .mobile-row-expanded {
+    background: var(--mud-palette-background-grey);
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor.css
@@ -16,6 +16,10 @@
     color: var(--mud-palette-text-secondary);
 }
 
+.mobile-list .checkbox-column {
+    width: 36px;
+}
+
 .mobile-list .mobile-row {
     border-top: 1px solid var(--mud-palette-divider);
     cursor: pointer;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Layout/MainLayout.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Layout/MainLayout.razor
@@ -21,7 +21,7 @@
         <NavMenu />
     </MudDrawer>
     <MudMainContent>
-        <MudContainer MaxWidth="MaxWidth.Large" Class="mt-6">
+        <MudContainer MaxWidth="MaxWidth.False" Class="mt-6">
             @Body
         </MudContainer>
     </MudMainContent>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
@@ -222,7 +222,7 @@
 </div>
 
 <div class="mobile-branch">
-    <MudPaper Class="pa-2" Style="position:relative;min-height:80vh;">
+    <MudPaper Class="pa-2 mobile-shell">
         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
             <MudIconButton Class="reload-hotkeys-mobile" Icon="@Icons.Material.Filled.Refresh"
                            OnClick="ReloadAsync" Disabled="@(!_isAuthenticated || _loading)" />
@@ -239,7 +239,7 @@
 
         @if (_categories.Count > 0)
         {
-            <div class="chip-strip mb-2" style="overflow-x:auto;white-space:nowrap;">
+            <div class="chip-strip mb-2">
                 <MudChipSet T="Guid" SelectionMode="SelectionMode.MultiSelection"
                             SelectedValues="_selectedCategoryIds"
                             SelectedValuesChanged="OnCategoryFilterChangedAsync">
@@ -263,12 +263,14 @@
                          OnDelete="DeleteAsync"
                          OnBulkDelete="MobileBulkDeleteAsync" />
 
-        <MudPagination Class="mt-2" Count="_mobileTotalPages" Selected="_mobilePage"
-                       SelectedChanged="OnMobilePageChangedAsync" />
+        @if (_mobileTotalPages > 1)
+        {
+            <MudPagination Class="mt-2" Count="_mobileTotalPages" Selected="_mobilePage"
+                           SelectedChanged="OnMobilePageChangedAsync" />
+        }
 
         <MudFab Class="add-hotkey-fab" Color="Color.Primary"
                 StartIcon="@Icons.Material.Filled.Add"
-                Style="position:fixed;right:16px;bottom:16px;z-index:100;"
                 OnClick="OpenCreateDialogAsync" />
     </MudPaper>
 </div>
@@ -302,7 +304,9 @@
     private readonly int _mobilePageSize = 10;
     private int _mobileTotalPages;
     private HotkeyListRequest? _cachedListRequest;
+    // Same-request cache only; every mutation path must call ClearListCache before reloading.
     private PagedList<HotkeyDto>? _cachedListPage;
+    private bool _dialogOpen;
 
     protected override async Task OnInitializedAsync()
     {
@@ -660,57 +664,65 @@
 
     private async Task OpenCreateDialogAsync()
     {
-        DialogParameters parameters = new()
-        {
-            [nameof(HotkeyEditDialog.Item)] = new HotkeyEditModel(),
-            [nameof(HotkeyEditDialog.Profiles)] = _profiles,
-            [nameof(HotkeyEditDialog.Categories)] = _categories,
-        };
+        if (_dialogOpen)
+            return;
 
-        IDialogReference dialog = await DialogService.ShowAsync<HotkeyEditDialog>(
-            "New hotkey", parameters,
-            new DialogOptions { FullScreen = true, CloseButton = false });
-
-        DialogResult? result = await dialog.Result;
-        if (result?.Canceled == false)
+        _dialogOpen = true;
+        try
         {
-            Snackbar.Add("Hotkey created.", Severity.Success);
-            await ReloadAllAsync();
+            DialogParameters parameters = new()
+            {
+                [nameof(HotkeyEditDialog.Item)] = new HotkeyEditModel(),
+                [nameof(HotkeyEditDialog.Profiles)] = _profiles,
+                [nameof(HotkeyEditDialog.Categories)] = _categories,
+            };
+
+            IDialogReference dialog = await DialogService.ShowAsync<HotkeyEditDialog>(
+                "New hotkey", parameters,
+                new DialogOptions { FullScreen = true, CloseButton = false });
+
+            DialogResult? result = await dialog.Result;
+            if (result?.Canceled == false)
+            {
+                Snackbar.Add("Hotkey created.", Severity.Success);
+                await ReloadAllAsync();
+            }
+        }
+        finally
+        {
+            _dialogOpen = false;
         }
     }
 
     private async Task OpenEditDialogAsync(HotkeyEditModel item)
     {
-        DialogParameters parameters = new()
-        {
-            [nameof(HotkeyEditDialog.Item)] = HotkeyEditModel.FromDto(new HotkeyDto(
-                item.Id!.Value,
-                [.. item.ProfileIds],
-                item.AppliesToAllProfiles,
-                item.Description,
-                item.Key,
-                item.Ctrl,
-                item.Alt,
-                item.Shift,
-                item.Win,
-                item.Action,
-                item.Parameters,
-                DateTimeOffset.UtcNow,
-                DateTimeOffset.UtcNow,
-                [.. item.CategoryIds])),
-            [nameof(HotkeyEditDialog.Profiles)] = _profiles,
-            [nameof(HotkeyEditDialog.Categories)] = _categories,
-        };
+        if (_dialogOpen || item.Id is null)
+            return;
 
-        IDialogReference dialog = await DialogService.ShowAsync<HotkeyEditDialog>(
-            "Edit hotkey", parameters,
-            new DialogOptions { FullScreen = true, CloseButton = false });
-
-        DialogResult? result = await dialog.Result;
-        if (result?.Canceled == false)
+        _dialogOpen = true;
+        try
         {
-            Snackbar.Add("Hotkey updated.", Severity.Success);
-            await ReloadAllAsync();
+            DialogParameters parameters = new()
+            {
+                [nameof(HotkeyEditDialog.Item)] = item.Clone(),
+                [nameof(HotkeyEditDialog.Profiles)] = _profiles,
+                [nameof(HotkeyEditDialog.Categories)] = _categories,
+            };
+
+            IDialogReference dialog = await DialogService.ShowAsync<HotkeyEditDialog>(
+                "Edit hotkey", parameters,
+                new DialogOptions { FullScreen = true, CloseButton = false });
+
+            DialogResult? result = await dialog.Result;
+            if (result?.Canceled == false)
+            {
+                Snackbar.Add("Hotkey updated.", Severity.Success);
+                await ReloadAllAsync();
+            }
+        }
+        finally
+        {
+            _dialogOpen = false;
         }
     }
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
@@ -11,7 +11,6 @@
 
 <MudText Typo="Typo.h4" GutterBottom="true">Hotkeys</MudText>
 
-<MudHidden Breakpoint="Breakpoint.SmAndDown">
 <div class="desktop-branch">
 <MudPaper Class="pa-4">
     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap" Class="mb-4">
@@ -221,9 +220,7 @@
     </MudDataGrid>
 </MudPaper>
 </div>
-</MudHidden>
 
-<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
 <div class="mobile-branch">
     <MudPaper Class="pa-2" Style="position:relative;min-height:80vh;">
         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
@@ -275,7 +272,6 @@
                 OnClick="OpenCreateDialogAsync" />
     </MudPaper>
 </div>
-</MudHidden>
 
 @code {
     [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
@@ -11,6 +11,7 @@
 
 <MudText Typo="Typo.h4" GutterBottom="true">Hotkeys</MudText>
 
+<MudHidden Breakpoint="Breakpoint.SmAndDown">
 <div class="desktop-branch">
 <MudPaper Class="pa-4">
     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap" Class="mb-4">
@@ -220,7 +221,9 @@
     </MudDataGrid>
 </MudPaper>
 </div>
+</MudHidden>
 
+<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
 <div class="mobile-branch">
     <MudPaper Class="pa-2" Style="position:relative;min-height:80vh;">
         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
@@ -272,6 +275,7 @@
                 OnClick="OpenCreateDialogAsync" />
     </MudPaper>
 </div>
+</MudHidden>
 
 @code {
     [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
@@ -301,6 +305,8 @@
     private int _mobilePage = 1;
     private readonly int _mobilePageSize = 10;
     private int _mobileTotalPages;
+    private HotkeyListRequest? _cachedListRequest;
+    private PagedList<HotkeyDto>? _cachedListPage;
 
     protected override async Task OnInitializedAsync()
     {
@@ -333,7 +339,7 @@
 
         (string? sortField, bool sortDescending) = GetSort(state);
 
-        ApiResult<PagedList<HotkeyDto>> result = await Api.ListAsync(
+        ApiResult<PagedList<HotkeyDto>> result = await ListAsync(
             new HotkeyListRequest(
                 Page: state.Page + 1,
                 PageSize: state.PageSize,
@@ -539,6 +545,7 @@
                 _pendingCreate = null;
                 _editingItem = null;
                 Snackbar.Add("Hotkey created.", Severity.Success);
+                ClearListCache();
 
                 if (_grid is not null)
                     await _grid.ReloadServerData();
@@ -552,6 +559,7 @@
             {
                 _editingItem = null;
                 Snackbar.Add("Hotkey updated.", Severity.Success);
+                ClearListCache();
 
                 if (_grid is not null)
                     await _grid.ReloadServerData();
@@ -575,6 +583,7 @@
         if (result.IsSuccess)
         {
             Snackbar.Add("Hotkey deleted.", Severity.Success);
+            ClearListCache();
             await ReloadAllAsync();
         }
         else Snackbar.Add(ApiErrorMessageFactory.Build(result.Status, result.Problem), Severity.Error);
@@ -609,6 +618,7 @@
                 : $"Deleted {deleted} hotkey(s).";
             Snackbar.Add(message, Severity.Success);
             _selected = [];
+            ClearListCache();
 
             if (_grid is not null)
                 await _grid.ReloadServerData();
@@ -624,7 +634,7 @@
         _loading = true;
         _loadError = null;
 
-        ApiResult<PagedList<HotkeyDto>> result = await Api.ListAsync(
+        ApiResult<PagedList<HotkeyDto>> result = await ListAsync(
             new HotkeyListRequest(
                 Page: _mobilePage,
                 PageSize: _mobilePageSize,
@@ -722,6 +732,7 @@
         if (result.IsSuccess)
         {
             Snackbar.Add($"Deleted {result.Value!.DeletedCount} hotkey(s).", Severity.Success);
+            ClearListCache();
             await ReloadAllAsync();
         }
         else
@@ -732,8 +743,34 @@
 
     private async Task ReloadAllAsync()
     {
+        ClearListCache();
         if (_grid is not null) await _grid.ReloadServerData();
         await LoadMobileAsync();
+    }
+
+    private async Task<ApiResult<PagedList<HotkeyDto>>> ListAsync(HotkeyListRequest request, CancellationToken ct)
+    {
+        if (_cachedListRequest == request && _cachedListPage is not null)
+            return ApiResult<PagedList<HotkeyDto>>.Ok(_cachedListPage);
+
+        ApiResult<PagedList<HotkeyDto>> result = await Api.ListAsync(request, ct);
+        if (result.IsSuccess)
+        {
+            _cachedListRequest = request;
+            _cachedListPage = result.Value;
+        }
+        else
+        {
+            ClearListCache();
+        }
+
+        return result;
+    }
+
+    private void ClearListCache()
+    {
+        _cachedListRequest = null;
+        _cachedListPage = null;
     }
 
     private RenderFragment RenderProfiles(bool appliesToAllProfiles, IReadOnlyCollection<Guid> profileIds) => @<text>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
@@ -61,6 +61,7 @@
     }
 
     <MudDataGrid @ref="_grid" T="HotkeyEditModel" ServerData="LoadServerData"
+                 Class="hotkeys-grid"
                  MultiSelection="true" SelectOnRowClick="false"
                  SelectedItems="_selected" SelectedItemsChanged="OnSelectedItemsChanged"
                  Dense="true" Hover="true" RowsPerPage="_rowsPerPage"

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
@@ -2,6 +2,7 @@
 @using AHKFlowApp.UI.Blazor.DTOs
 @using AHKFlowApp.UI.Blazor.Services
 @using AHKFlowApp.UI.Blazor.Validation
+@using AHKFlowApp.UI.Blazor.Components.Hotkeys
 @using MudBlazor
 @using Microsoft.AspNetCore.Components.Authorization
 @implements IDisposable
@@ -10,6 +11,7 @@
 
 <MudText Typo="Typo.h4" GutterBottom="true">Hotkeys</MudText>
 
+<div class="desktop-branch">
 <MudPaper Class="pa-4">
     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap" Class="mb-4">
         <MudButton Class="add-hotkey" Variant="Variant.Filled" Color="Color.Primary"
@@ -216,6 +218,59 @@
         </PagerContent>
     </MudDataGrid>
 </MudPaper>
+</div>
+
+<div class="mobile-branch">
+    <MudPaper Class="pa-2" Style="position:relative;min-height:80vh;">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
+            <MudIconButton Class="reload-hotkeys-mobile" Icon="@Icons.Material.Filled.Refresh"
+                           OnClick="ReloadAsync" Disabled="@(!_isAuthenticated || _loading)" />
+            <MudSpacer />
+        </MudStack>
+
+        <MudTextField T="string" @bind-Value="_search" @bind-Value:after="OnSearchChangedAsync"
+                      DebounceInterval="300"
+                      Placeholder="Search hotkeys"
+                      Adornment="Adornment.Start"
+                      AdornmentIcon="@Icons.Material.Filled.Search"
+                      Class="search-hotkeys mb-2"
+                      FullWidth="true" Immediate="true" />
+
+        @if (_categories.Count > 0)
+        {
+            <div class="chip-strip mb-2" style="overflow-x:auto;white-space:nowrap;">
+                <MudChipSet T="Guid" SelectionMode="SelectionMode.MultiSelection"
+                            SelectedValues="_selectedCategoryIds"
+                            SelectedValuesChanged="OnCategoryFilterChangedAsync">
+                    @foreach (CategoryDto c in _categories)
+                    {
+                        <MudChip T="Guid" Value="@c.Id" Variant="Variant.Outlined">@c.Name</MudChip>
+                    }
+                </MudChipSet>
+            </div>
+        }
+
+        @if (_loadError is not null)
+        {
+            <MudAlert Severity="Severity.Error" Class="mb-3">@_loadError</MudAlert>
+        }
+
+        <HotkeyMobileList Items="_mobileItems"
+                         Profiles="_profiles"
+                         Categories="_categories"
+                         OnEdit="OpenEditDialogAsync"
+                         OnDelete="DeleteAsync"
+                         OnBulkDelete="MobileBulkDeleteAsync" />
+
+        <MudPagination Class="mt-2" Count="_mobileTotalPages" Selected="_mobilePage"
+                       SelectedChanged="OnMobilePageChangedAsync" />
+
+        <MudFab Class="add-hotkey-fab" Color="Color.Primary"
+                StartIcon="@Icons.Material.Filled.Add"
+                Style="position:fixed;right:16px;bottom:16px;z-index:100;"
+                OnClick="OpenCreateDialogAsync" />
+    </MudPaper>
+</div>
 
 @code {
     [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
@@ -241,6 +296,11 @@
     private int _rowsPerPage = UserPreferences.Default.RowsPerPage;
     private readonly CancellationTokenSource _cts = new();
 
+    private IReadOnlyList<HotkeyEditModel> _mobileItems = [];
+    private int _mobilePage = 1;
+    private readonly int _mobilePageSize = 10;
+    private int _mobileTotalPages;
+
     protected override async Task OnInitializedAsync()
     {
         if (AuthState is not null)
@@ -260,6 +320,8 @@
 
             ApiResult<PagedList<CategoryDto>> catResult = await CategoriesApi.ListAsync(new CategoryListRequest(PageSize: 200), _cts.Token);
             if (catResult.IsSuccess) _categories = catResult.Value?.Items ?? [];
+
+            await LoadMobileAsync();
         }
     }
 
@@ -408,12 +470,14 @@
 
     private async Task ReloadAsync()
     {
-        if (_grid is not null) await _grid.ReloadServerData();
+        await ReloadAllAsync();
     }
 
     private async Task OnSearchChangedAsync()
     {
         if (_grid is not null) await _grid.ReloadServerData();
+        _mobilePage = 1;
+        await LoadMobileAsync();
     }
 
     private async Task StartAddAsync()
@@ -510,7 +574,7 @@
         if (result.IsSuccess)
         {
             Snackbar.Add("Hotkey deleted.", Severity.Success);
-            if (_grid is not null) await _grid.ReloadServerData();
+            await ReloadAllAsync();
         }
         else Snackbar.Add(ApiErrorMessageFactory.Build(result.Status, result.Problem), Severity.Error);
     }
@@ -552,6 +616,123 @@
         {
             Snackbar.Add(ApiErrorMessageFactory.Build(result.Status, result.Problem), Severity.Error);
         }
+    }
+
+    private async Task LoadMobileAsync()
+    {
+        _loading = true;
+        _loadError = null;
+
+        ApiResult<PagedList<HotkeyDto>> result = await Api.ListAsync(
+            new HotkeyListRequest(
+                Page: _mobilePage,
+                PageSize: _mobilePageSize,
+                Search: string.IsNullOrWhiteSpace(_search) ? null : _search,
+                CategoryIds: _selectedCategoryIds.Count > 0 ? _selectedCategoryIds : null),
+            _cts.Token);
+
+        _loading = false;
+
+        if (!result.IsSuccess)
+        {
+            _loadError = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+            _mobileItems = [];
+            _mobileTotalPages = 0;
+            return;
+        }
+
+        _mobileItems = [.. result.Value!.Items.Select(HotkeyEditModel.FromDto)];
+        _mobileTotalPages = (int)Math.Ceiling((double)result.Value.TotalCount / _mobilePageSize);
+    }
+
+    private async Task OnMobilePageChangedAsync(int page)
+    {
+        _mobilePage = page;
+        await LoadMobileAsync();
+    }
+
+    private async Task OpenCreateDialogAsync()
+    {
+        DialogParameters parameters = new()
+        {
+            [nameof(HotkeyEditDialog.Item)] = new HotkeyEditModel(),
+            [nameof(HotkeyEditDialog.Profiles)] = _profiles,
+            [nameof(HotkeyEditDialog.Categories)] = _categories,
+        };
+
+        IDialogReference dialog = await DialogService.ShowAsync<HotkeyEditDialog>(
+            "New hotkey", parameters,
+            new DialogOptions { FullScreen = true, CloseButton = false });
+
+        DialogResult? result = await dialog.Result;
+        if (result?.Canceled == false)
+        {
+            Snackbar.Add("Hotkey created.", Severity.Success);
+            await ReloadAllAsync();
+        }
+    }
+
+    private async Task OpenEditDialogAsync(HotkeyEditModel item)
+    {
+        DialogParameters parameters = new()
+        {
+            [nameof(HotkeyEditDialog.Item)] = HotkeyEditModel.FromDto(new HotkeyDto(
+                item.Id!.Value,
+                [.. item.ProfileIds],
+                item.AppliesToAllProfiles,
+                item.Description,
+                item.Key,
+                item.Ctrl,
+                item.Alt,
+                item.Shift,
+                item.Win,
+                item.Action,
+                item.Parameters,
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow,
+                [.. item.CategoryIds])),
+            [nameof(HotkeyEditDialog.Profiles)] = _profiles,
+            [nameof(HotkeyEditDialog.Categories)] = _categories,
+        };
+
+        IDialogReference dialog = await DialogService.ShowAsync<HotkeyEditDialog>(
+            "Edit hotkey", parameters,
+            new DialogOptions { FullScreen = true, CloseButton = false });
+
+        DialogResult? result = await dialog.Result;
+        if (result?.Canceled == false)
+        {
+            Snackbar.Add("Hotkey updated.", Severity.Success);
+            await ReloadAllAsync();
+        }
+    }
+
+    private async Task MobileBulkDeleteAsync(IReadOnlyList<Guid> ids)
+    {
+        if (ids.Count == 0) return;
+
+        bool? confirm = await DialogService.ShowMessageBoxAsync(
+            title: "Delete hotkeys?",
+            message: $"Delete {ids.Count} hotkey(s)? This cannot be undone.",
+            yesText: "Delete", cancelText: "Cancel");
+        if (confirm != true) return;
+
+        ApiResult<BulkDeleteResultDto> result = await Api.BulkDeleteAsync(ids, _cts.Token);
+        if (result.IsSuccess)
+        {
+            Snackbar.Add($"Deleted {result.Value!.DeletedCount} hotkey(s).", Severity.Success);
+            await ReloadAllAsync();
+        }
+        else
+        {
+            Snackbar.Add(ApiErrorMessageFactory.Build(result.Status, result.Problem), Severity.Error);
+        }
+    }
+
+    private async Task ReloadAllAsync()
+    {
+        if (_grid is not null) await _grid.ReloadServerData();
+        await LoadMobileAsync();
     }
 
     private RenderFragment RenderProfiles(bool appliesToAllProfiles, IReadOnlyCollection<Guid> profileIds) => @<text>
@@ -622,6 +803,8 @@
     {
         _selectedCategoryIds = [.. ids];
         if (_grid is not null) await _grid.ReloadServerData();
+        _mobilePage = 1;
+        await LoadMobileAsync();
     }
 
     private RenderFragment RenderActions(HotkeyEditModel item) => @<text>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor.css
@@ -1,13 +1,18 @@
-/* Show only the appropriate branch based on viewport */
+.desktop-branch {
+    display: block;
+}
+
+.mobile-branch {
+    display: none;
+}
+
 @media (max-width: 959.95px) {
     .desktop-branch {
         display: none;
     }
-}
 
-@media (min-width: 960px) {
     .mobile-branch {
-        display: none;
+        display: block;
     }
 }
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor.css
@@ -6,6 +6,23 @@
     display: none;
 }
 
+.mobile-shell {
+    position: relative;
+    min-height: 80vh;
+}
+
+.chip-strip {
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+.add-hotkey-fab {
+    position: fixed;
+    right: 16px;
+    bottom: 16px;
+    z-index: 100;
+}
+
 @media (max-width: 959.95px) {
     .desktop-branch {
         display: none;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor.css
@@ -1,0 +1,12 @@
+/* Show only the appropriate branch based on viewport */
+@media (max-width: 959.95px) {
+    .desktop-branch {
+        display: none;
+    }
+}
+
+@media (min-width: 960px) {
+    .mobile-branch {
+        display: none;
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor.css
@@ -10,3 +10,71 @@
         display: none;
     }
 }
+
+::deep .hotkeys-grid .mud-table-root {
+    table-layout: fixed;
+    width: 100%;
+    min-width: 0;
+}
+
+::deep .hotkeys-grid .mud-table-cell,
+::deep .hotkeys-grid .column-header {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+::deep .hotkeys-grid .mud-table-cell {
+    white-space: nowrap;
+}
+
+::deep .hotkeys-grid th:nth-child(1),
+::deep .hotkeys-grid td:nth-child(1) {
+    width: 56px;
+}
+
+::deep .hotkeys-grid th:nth-child(2),
+::deep .hotkeys-grid td:nth-child(2) {
+    width: 16%;
+}
+
+::deep .hotkeys-grid th:nth-child(3),
+::deep .hotkeys-grid td:nth-child(3) {
+    width: 72px;
+}
+
+::deep .hotkeys-grid th:nth-child(4),
+::deep .hotkeys-grid td:nth-child(4),
+::deep .hotkeys-grid th:nth-child(5),
+::deep .hotkeys-grid td:nth-child(5),
+::deep .hotkeys-grid th:nth-child(6),
+::deep .hotkeys-grid td:nth-child(6),
+::deep .hotkeys-grid th:nth-child(7),
+::deep .hotkeys-grid td:nth-child(7) {
+    width: 56px;
+    text-align: center;
+}
+
+::deep .hotkeys-grid th:nth-child(8),
+::deep .hotkeys-grid td:nth-child(8) {
+    width: 88px;
+}
+
+::deep .hotkeys-grid th:nth-child(9),
+::deep .hotkeys-grid td:nth-child(9) {
+    width: 10%;
+}
+
+::deep .hotkeys-grid th:nth-child(10),
+::deep .hotkeys-grid td:nth-child(10) {
+    width: 16%;
+}
+
+::deep .hotkeys-grid th:nth-child(11),
+::deep .hotkeys-grid td:nth-child(11) {
+    width: 10%;
+}
+
+::deep .hotkeys-grid th:nth-child(12),
+::deep .hotkeys-grid td:nth-child(12) {
+    width: 88px;
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -11,7 +11,8 @@
 
 <MudText Typo="Typo.h4" GutterBottom="true">Hotstrings</MudText>
 
-<div class="desktop-branch">
+<MudHidden Breakpoint="Breakpoint.SmAndDown">
+    <div class="desktop-branch">
         <MudPaper Class="pa-4">
             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap" Class="mb-4">
                 <MudButton Class="add-hotstring" Variant="Variant.Filled" Color="Color.Primary"
@@ -177,8 +178,10 @@
             </MudDataGrid>
         </MudPaper>
 </div>
+</MudHidden>
 
-<div class="mobile-branch">
+<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
+    <div class="mobile-branch">
         <MudPaper Class="pa-2" Style="position:relative;min-height:80vh;">
             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
                 <MudIconButton Class="reload-hotstrings-mobile" Icon="@Icons.Material.Filled.Refresh"
@@ -229,6 +232,7 @@
                     OnClick="OpenCreateDialogAsync" />
         </MudPaper>
 </div>
+</MudHidden>
 
 @code {
     [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
@@ -258,6 +262,8 @@
     private int _mobilePage = 1;
     private readonly int _mobilePageSize = 10;
     private int _mobileTotalPages;
+    private HotstringListRequest? _cachedListRequest;
+    private PagedList<HotstringDto>? _cachedListPage;
 
     protected override async Task OnInitializedAsync()
     {
@@ -291,7 +297,7 @@
 
         (string? sortField, bool sortDescending) = GetSort(state);
 
-        ApiResult<PagedList<HotstringDto>> result = await Api.ListAsync(
+        ApiResult<PagedList<HotstringDto>> result = await ListAsync(
             new HotstringListRequest(
                 Page: state.Page + 1,
                 PageSize: state.PageSize,
@@ -477,6 +483,7 @@
                 _pendingCreate = null;
                 _editingItem = null;
                 Snackbar.Add("Hotstring created.", Severity.Success);
+                ClearListCache();
 
                 if (_grid is not null)
                     await _grid.ReloadServerData();
@@ -490,6 +497,7 @@
             {
                 _editingItem = null;
                 Snackbar.Add("Hotstring updated.", Severity.Success);
+                ClearListCache();
 
                 if (_grid is not null)
                     await _grid.ReloadServerData();
@@ -513,6 +521,7 @@
         if (result.IsSuccess)
         {
             Snackbar.Add("Hotstring deleted.", Severity.Success);
+            ClearListCache();
             await ReloadAllAsync();
         }
         else Snackbar.Add(ApiErrorMessageFactory.Build(result.Status, result.Problem), Severity.Error);
@@ -547,6 +556,7 @@
                 : $"Deleted {deleted} hotstring(s).";
             Snackbar.Add(message, Severity.Success);
             _selected = [];
+            ClearListCache();
 
             if (_grid is not null)
                 await _grid.ReloadServerData();
@@ -562,7 +572,7 @@
         _loading = true;
         _loadError = null;
 
-        ApiResult<PagedList<HotstringDto>> result = await Api.ListAsync(
+        ApiResult<PagedList<HotstringDto>> result = await ListAsync(
             new HotstringListRequest(
                 Page: _mobilePage,
                 PageSize: _mobilePageSize,
@@ -657,6 +667,7 @@
         if (result.IsSuccess)
         {
             Snackbar.Add($"Deleted {result.Value!.DeletedCount} hotstring(s).", Severity.Success);
+            ClearListCache();
             await ReloadAllAsync();
         }
         else
@@ -667,8 +678,34 @@
 
     private async Task ReloadAllAsync()
     {
+        ClearListCache();
         if (_grid is not null) await _grid.ReloadServerData();
         await LoadMobileAsync();
+    }
+
+    private async Task<ApiResult<PagedList<HotstringDto>>> ListAsync(HotstringListRequest request, CancellationToken ct)
+    {
+        if (_cachedListRequest == request && _cachedListPage is not null)
+            return ApiResult<PagedList<HotstringDto>>.Ok(_cachedListPage);
+
+        ApiResult<PagedList<HotstringDto>> result = await Api.ListAsync(request, ct);
+        if (result.IsSuccess)
+        {
+            _cachedListRequest = request;
+            _cachedListPage = result.Value;
+        }
+        else
+        {
+            ClearListCache();
+        }
+
+        return result;
+    }
+
+    private void ClearListCache()
+    {
+        _cachedListRequest = null;
+        _cachedListPage = null;
     }
 
     private async Task OnCategoryFilterChangedAsync(IReadOnlyCollection<Guid> ids)

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -11,37 +11,36 @@
 
 <MudText Typo="Typo.h4" GutterBottom="true">Hotstrings</MudText>
 
-<MudHidden Breakpoint="Breakpoint.SmAndDown">
-    <div class="desktop-branch">
-        <MudPaper Class="pa-4">
-            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap" Class="mb-4">
-                <MudButton Class="add-hotstring" Variant="Variant.Filled" Color="Color.Primary"
-                           StartIcon="@Icons.Material.Filled.Add" OnClick="StartAddAsync"
-                           Disabled="@(!_isAuthenticated || _pendingCreate is not null || _editingItem is not null)">
-                    Add
+<div class="desktop-branch">
+    <MudPaper Class="pa-4">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap" Class="mb-4">
+            <MudButton Class="add-hotstring" Variant="Variant.Filled" Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Add" OnClick="StartAddAsync"
+                       Disabled="@(!_isAuthenticated || _pendingCreate is not null || _editingItem is not null)">
+                Add
+            </MudButton>
+            <MudButton Class="reload-hotstrings" Variant="Variant.Filled" Color="Color.Secondary"
+                       StartIcon="@Icons.Material.Filled.Refresh" OnClick="ReloadAsync"
+                       Disabled="@(!_isAuthenticated || _loading)">
+                Reload
+            </MudButton>
+            @if (_selected.Count > 0)
+            {
+                <MudButton Class="bulk-delete-hotstrings" Variant="Variant.Filled" Color="Color.Error"
+                           StartIcon="@Icons.Material.Filled.DeleteSweep" OnClick="BulkDeleteAsync">
+                    Delete @_selected.Count selected
                 </MudButton>
-                <MudButton Class="reload-hotstrings" Variant="Variant.Filled" Color="Color.Secondary"
-                           StartIcon="@Icons.Material.Filled.Refresh" OnClick="ReloadAsync"
-                           Disabled="@(!_isAuthenticated || _loading)">
-                    Reload
-                </MudButton>
-                @if (_selected.Count > 0)
-                {
-                    <MudButton Class="bulk-delete-hotstrings" Variant="Variant.Filled" Color="Color.Error"
-                               StartIcon="@Icons.Material.Filled.DeleteSweep" OnClick="BulkDeleteAsync">
-                        Delete @_selected.Count selected
-                    </MudButton>
-                }
-                <MudSpacer />
-                <MudTextField T="string" @bind-Value="_search" @bind-Value:after="OnSearchChangedAsync"
-                              DebounceInterval="300"
-                              Placeholder="Search For Hotstrings"
-                              Adornment="Adornment.Start"
-                              AdornmentIcon="@Icons.Material.Filled.Search"
-                              Class="search-hotstrings"
-                              Style="max-width: 360px;"
-                              Immediate="true" />
-            </MudStack>
+            }
+            <MudSpacer />
+            <MudTextField T="string" @bind-Value="_search" @bind-Value:after="OnSearchChangedAsync"
+                          DebounceInterval="300"
+                          Placeholder="Search For Hotstrings"
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Filled.Search"
+                          Class="search-hotstrings"
+                          Style="max-width: 360px;"
+                          Immediate="true" />
+        </MudStack>
 
             @if (_loadError is not null)
             {
@@ -176,18 +175,16 @@
                     <MudDataGridPager T="HotstringEditModel" PageSizeOptions="UserPreferences.AllowedRowsPerPage" />
                 </PagerContent>
             </MudDataGrid>
-        </MudPaper>
+    </MudPaper>
 </div>
-</MudHidden>
 
-<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
-    <div class="mobile-branch">
-        <MudPaper Class="pa-2" Style="position:relative;min-height:80vh;">
-            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
-                <MudIconButton Class="reload-hotstrings-mobile" Icon="@Icons.Material.Filled.Refresh"
-                               OnClick="ReloadAsync" Disabled="@(!_isAuthenticated || _loading)" />
-                <MudSpacer />
-            </MudStack>
+<div class="mobile-branch">
+    <MudPaper Class="pa-2" Style="position:relative;min-height:80vh;">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
+            <MudIconButton Class="reload-hotstrings-mobile" Icon="@Icons.Material.Filled.Refresh"
+                           OnClick="ReloadAsync" Disabled="@(!_isAuthenticated || _loading)" />
+            <MudSpacer />
+        </MudStack>
 
             <MudTextField T="string" @bind-Value="_search" @bind-Value:after="OnSearchChangedAsync"
                           DebounceInterval="300"
@@ -230,9 +227,8 @@
                     StartIcon="@Icons.Material.Filled.Add"
                     Style="position:fixed;right:16px;bottom:16px;z-index:100;"
                     OnClick="OpenCreateDialogAsync" />
-        </MudPaper>
+    </MudPaper>
 </div>
-</MudHidden>
 
 @code {
     [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -2,6 +2,7 @@
 @using AHKFlowApp.UI.Blazor.DTOs
 @using AHKFlowApp.UI.Blazor.Services
 @using AHKFlowApp.UI.Blazor.Validation
+@using AHKFlowApp.UI.Blazor.Components.Hotstrings
 @using MudBlazor
 @using Microsoft.AspNetCore.Components.Authorization
 @implements IDisposable
@@ -10,169 +11,223 @@
 
 <MudText Typo="Typo.h4" GutterBottom="true">Hotstrings</MudText>
 
-<MudPaper Class="pa-4">
-    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap" Class="mb-4">
-        <MudButton Class="add-hotstring" Variant="Variant.Filled" Color="Color.Primary"
-                   StartIcon="@Icons.Material.Filled.Add" OnClick="StartAddAsync"
-                   Disabled="@(!_isAuthenticated || _pendingCreate is not null || _editingItem is not null)">
-            Add
-        </MudButton>
-        <MudButton Class="reload-hotstrings" Variant="Variant.Filled" Color="Color.Secondary"
-                   StartIcon="@Icons.Material.Filled.Refresh" OnClick="ReloadAsync"
-                   Disabled="@(!_isAuthenticated || _loading)">
-            Reload
-        </MudButton>
-        @if (_selected.Count > 0)
-        {
-            <MudButton Class="bulk-delete-hotstrings" Variant="Variant.Filled" Color="Color.Error"
-                       StartIcon="@Icons.Material.Filled.DeleteSweep" OnClick="BulkDeleteAsync">
-                Delete @_selected.Count selected
-            </MudButton>
-        }
-        <MudSpacer />
-        <MudTextField T="string" @bind-Value="_search" @bind-Value:after="OnSearchChangedAsync"
-                      DebounceInterval="300"
-                      Placeholder="Search For Hotstrings"
-                      Adornment="Adornment.Start"
-                      AdornmentIcon="@Icons.Material.Filled.Search"
-                      Class="search-hotstrings"
-                      Style="max-width: 360px;"
-                      Immediate="true" />
-    </MudStack>
+<div class="desktop-branch">
+        <MudPaper Class="pa-4">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap" Class="mb-4">
+                <MudButton Class="add-hotstring" Variant="Variant.Filled" Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Add" OnClick="StartAddAsync"
+                           Disabled="@(!_isAuthenticated || _pendingCreate is not null || _editingItem is not null)">
+                    Add
+                </MudButton>
+                <MudButton Class="reload-hotstrings" Variant="Variant.Filled" Color="Color.Secondary"
+                           StartIcon="@Icons.Material.Filled.Refresh" OnClick="ReloadAsync"
+                           Disabled="@(!_isAuthenticated || _loading)">
+                    Reload
+                </MudButton>
+                @if (_selected.Count > 0)
+                {
+                    <MudButton Class="bulk-delete-hotstrings" Variant="Variant.Filled" Color="Color.Error"
+                               StartIcon="@Icons.Material.Filled.DeleteSweep" OnClick="BulkDeleteAsync">
+                        Delete @_selected.Count selected
+                    </MudButton>
+                }
+                <MudSpacer />
+                <MudTextField T="string" @bind-Value="_search" @bind-Value:after="OnSearchChangedAsync"
+                              DebounceInterval="300"
+                              Placeholder="Search For Hotstrings"
+                              Adornment="Adornment.Start"
+                              AdornmentIcon="@Icons.Material.Filled.Search"
+                              Class="search-hotstrings"
+                              Style="max-width: 360px;"
+                              Immediate="true" />
+            </MudStack>
 
-    @if (_loadError is not null)
-    {
-        <MudAlert Severity="Severity.Error" Class="mb-3">@_loadError</MudAlert>
-    }
-
-    @if (_categories.Count > 0)
-    {
-        <MudChipSet T="Guid" SelectionMode="SelectionMode.MultiSelection"
-                    SelectedValues="_selectedCategoryIds"
-                    SelectedValuesChanged="OnCategoryFilterChangedAsync"
-                    Class="mb-2">
-            @foreach (CategoryDto c in _categories)
+            @if (_loadError is not null)
             {
-                <MudChip T="Guid" Value="@c.Id" Variant="Variant.Outlined">@c.Name</MudChip>
+                <MudAlert Severity="Severity.Error" Class="mb-3">@_loadError</MudAlert>
             }
-        </MudChipSet>
-    }
 
-    <MudDataGrid @ref="_grid" T="HotstringEditModel" ServerData="LoadServerData"
-                 MultiSelection="true" SelectOnRowClick="false"
-                 SelectedItems="_selected" SelectedItemsChanged="OnSelectedItemsChanged"
-                 Dense="true" Hover="true" RowsPerPage="_rowsPerPage"
-                 Filterable="true" FilterMode="DataGridFilterMode.ColumnFilterMenu"
-                 SortMode="SortMode.Single" ReadOnly="true"
-                 RowClassFunc="@GetRowClass">
-        <Columns>
-            <SelectColumn T="HotstringEditModel" />
-            <PropertyColumn Property="x => x.Trigger" Title="Trigger">
-                <CellTemplate>
-                    @if (IsEditing(context.Item))
+            @if (_categories.Count > 0)
+            {
+                <MudChipSet T="Guid" SelectionMode="SelectionMode.MultiSelection"
+                            SelectedValues="_selectedCategoryIds"
+                            SelectedValuesChanged="OnCategoryFilterChangedAsync"
+                            Class="mb-2">
+                    @foreach (CategoryDto c in _categories)
                     {
-                        <MudTextField @bind-Value="context.Item.Trigger"
-                                      Validation="@(new Func<string, string?>(ValidateTrigger))"
-                                      Error="@(_commitAttempted && ValidateTrigger(context.Item.Trigger) is not null)"
-                                      ErrorText="@(_commitAttempted ? ValidateTrigger(context.Item.Trigger) : null)"
-                                      Immediate="true" MaxLength="50"
-                                      UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "trigger-input" })" />
+                        <MudChip T="Guid" Value="@c.Id" Variant="Variant.Outlined">@c.Name</MudChip>
                     }
-                    else
-                    {
-                        @context.Item.Trigger
-                    }
-                </CellTemplate>
-            </PropertyColumn>
-            <PropertyColumn Property="x => x.Replacement" Title="Replacement">
-                <CellTemplate>
-                    @if (IsEditing(context.Item))
-                    {
-                        <MudTextField @bind-Value="context.Item.Replacement"
-                                      Validation="@(new Func<string, string?>(ValidateReplacement))"
-                                      Error="@(_commitAttempted && ValidateReplacement(context.Item.Replacement) is not null)"
-                                      ErrorText="@(_commitAttempted ? ValidateReplacement(context.Item.Replacement) : null)"
-                                      Immediate="true" MaxLength="4000"
-                                      UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "replacement-input" })" />
-                    }
-                    else
-                    {
-                        @context.Item.Replacement
-                    }
-                </CellTemplate>
-            </PropertyColumn>
-            <PropertyColumn Property="x => x.Description" Title="Description" Hideable="true">
-                <CellTemplate>
-                    @if (IsEditing(context.Item))
-                    {
-                        <MudTextField @bind-Value="context.Item.Description"
-                                      Immediate="true" MaxLength="200"
-                                      UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "description-input" })" />
-                    }
-                    else
-                    {
-                        @context.Item.Description
-                    }
-                </CellTemplate>
-            </PropertyColumn>
-            <TemplateColumn Title="Profiles" Sortable="false" Filterable="false">
-                <CellTemplate>
-                    @if (IsEditing(context.Item))
-                    {
-                        @RenderProfileEditor(context.Item)
-                    }
-                    else
-                    {
-                        @RenderProfiles(context.Item.AppliesToAllProfiles, context.Item.ProfileIds)
-                    }
-                </CellTemplate>
-            </TemplateColumn>
-            <PropertyColumn Property="x => x.IsEndingCharacterRequired" Title="Ending char required">
-                <CellTemplate>
-                    @if (IsEditing(context.Item))
-                    {
-                        <MudCheckBox T="bool" @bind-Value="context.Item.IsEndingCharacterRequired" />
-                    }
-                    else
-                    {
-                        <MudCheckBox T="bool" Value="@context.Item.IsEndingCharacterRequired" ReadOnly="true" />
-                    }
-                </CellTemplate>
-            </PropertyColumn>
-            <PropertyColumn Property="x => x.IsTriggerInsideWord" Title="Trigger inside word">
-                <CellTemplate>
-                    @if (IsEditing(context.Item))
-                    {
-                        <MudCheckBox T="bool" @bind-Value="context.Item.IsTriggerInsideWord" />
-                    }
-                    else
-                    {
-                        <MudCheckBox T="bool" Value="@context.Item.IsTriggerInsideWord" ReadOnly="true" />
-                    }
-                </CellTemplate>
-            </PropertyColumn>
-            <TemplateColumn Title="Categories" Sortable="false" Filterable="false">
-                <CellTemplate>
-                    @if (IsEditing(context.Item))
-                    {
-                        @RenderCategoryEditor(context.Item)
-                    }
-                    else
-                    {
-                        @RenderCategories(context.Item.CategoryIds)
-                    }
-                </CellTemplate>
-            </TemplateColumn>
-            <TemplateColumn Title="Actions" Sortable="false" Filterable="false" HeaderStyle="width:160px">
-                <CellTemplate>@RenderActions(context.Item)</CellTemplate>
-            </TemplateColumn>
-        </Columns>
-        <NoRecordsContent><MudText>No hotstrings yet.</MudText></NoRecordsContent>
-        <PagerContent>
-            <MudDataGridPager T="HotstringEditModel" PageSizeOptions="UserPreferences.AllowedRowsPerPage" />
-        </PagerContent>
-    </MudDataGrid>
-</MudPaper>
+                </MudChipSet>
+            }
+
+            <MudDataGrid @ref="_grid" T="HotstringEditModel" ServerData="LoadServerData"
+                         MultiSelection="true" SelectOnRowClick="false"
+                         SelectedItems="_selected" SelectedItemsChanged="OnSelectedItemsChanged"
+                         Dense="true" Hover="true" RowsPerPage="_rowsPerPage"
+                         Filterable="true" FilterMode="DataGridFilterMode.ColumnFilterMenu"
+                         SortMode="SortMode.Single" ReadOnly="true"
+                         RowClassFunc="@GetRowClass">
+                <Columns>
+                    <SelectColumn T="HotstringEditModel" />
+                    <PropertyColumn Property="x => x.Trigger" Title="Trigger">
+                        <CellTemplate>
+                            @if (IsEditing(context.Item))
+                            {
+                                <MudTextField @bind-Value="context.Item.Trigger"
+                                              Validation="@(new Func<string, string?>(ValidateTrigger))"
+                                              Error="@(_commitAttempted && ValidateTrigger(context.Item.Trigger) is not null)"
+                                              ErrorText="@(_commitAttempted ? ValidateTrigger(context.Item.Trigger) : null)"
+                                              Immediate="true" MaxLength="50"
+                                              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "trigger-input" })" />
+                            }
+                            else
+                            {
+                                @context.Item.Trigger
+                            }
+                        </CellTemplate>
+                    </PropertyColumn>
+                    <PropertyColumn Property="x => x.Replacement" Title="Replacement">
+                        <CellTemplate>
+                            @if (IsEditing(context.Item))
+                            {
+                                <MudTextField @bind-Value="context.Item.Replacement"
+                                              Validation="@(new Func<string, string?>(ValidateReplacement))"
+                                              Error="@(_commitAttempted && ValidateReplacement(context.Item.Replacement) is not null)"
+                                              ErrorText="@(_commitAttempted ? ValidateReplacement(context.Item.Replacement) : null)"
+                                              Immediate="true" MaxLength="4000"
+                                              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "replacement-input" })" />
+                            }
+                            else
+                            {
+                                @context.Item.Replacement
+                            }
+                        </CellTemplate>
+                    </PropertyColumn>
+                    <PropertyColumn Property="x => x.Description" Title="Description" Hideable="true">
+                        <CellTemplate>
+                            @if (IsEditing(context.Item))
+                            {
+                                <MudTextField @bind-Value="context.Item.Description"
+                                              Immediate="true" MaxLength="200"
+                                              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "description-input" })" />
+                            }
+                            else
+                            {
+                                @context.Item.Description
+                            }
+                        </CellTemplate>
+                    </PropertyColumn>
+                    <TemplateColumn Title="Profiles" Sortable="false" Filterable="false">
+                        <CellTemplate>
+                            @if (IsEditing(context.Item))
+                            {
+                                @RenderProfileEditor(context.Item)
+                            }
+                            else
+                            {
+                                @RenderProfiles(context.Item.AppliesToAllProfiles, context.Item.ProfileIds)
+                            }
+                        </CellTemplate>
+                    </TemplateColumn>
+                    <PropertyColumn Property="x => x.IsEndingCharacterRequired" Title="Ending char required">
+                        <CellTemplate>
+                            @if (IsEditing(context.Item))
+                            {
+                                <MudCheckBox T="bool" @bind-Value="context.Item.IsEndingCharacterRequired" />
+                            }
+                            else
+                            {
+                                <MudCheckBox T="bool" Value="@context.Item.IsEndingCharacterRequired" ReadOnly="true" />
+                            }
+                        </CellTemplate>
+                    </PropertyColumn>
+                    <PropertyColumn Property="x => x.IsTriggerInsideWord" Title="Trigger inside word">
+                        <CellTemplate>
+                            @if (IsEditing(context.Item))
+                            {
+                                <MudCheckBox T="bool" @bind-Value="context.Item.IsTriggerInsideWord" />
+                            }
+                            else
+                            {
+                                <MudCheckBox T="bool" Value="@context.Item.IsTriggerInsideWord" ReadOnly="true" />
+                            }
+                        </CellTemplate>
+                    </PropertyColumn>
+                    <TemplateColumn Title="Categories" Sortable="false" Filterable="false">
+                        <CellTemplate>
+                            @if (IsEditing(context.Item))
+                            {
+                                @RenderCategoryEditor(context.Item)
+                            }
+                            else
+                            {
+                                @RenderCategories(context.Item.CategoryIds)
+                            }
+                        </CellTemplate>
+                    </TemplateColumn>
+                    <TemplateColumn Title="Actions" Sortable="false" Filterable="false" HeaderStyle="width:160px">
+                        <CellTemplate>@RenderActions(context.Item)</CellTemplate>
+                    </TemplateColumn>
+                </Columns>
+                <NoRecordsContent><MudText>No hotstrings yet.</MudText></NoRecordsContent>
+                <PagerContent>
+                    <MudDataGridPager T="HotstringEditModel" PageSizeOptions="UserPreferences.AllowedRowsPerPage" />
+                </PagerContent>
+            </MudDataGrid>
+        </MudPaper>
+</div>
+
+<div class="mobile-branch">
+        <MudPaper Class="pa-2" Style="position:relative;min-height:80vh;">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
+                <MudIconButton Class="reload-hotstrings-mobile" Icon="@Icons.Material.Filled.Refresh"
+                               OnClick="ReloadAsync" Disabled="@(!_isAuthenticated || _loading)" />
+                <MudSpacer />
+            </MudStack>
+
+            <MudTextField T="string" @bind-Value="_search" @bind-Value:after="OnSearchChangedAsync"
+                          DebounceInterval="300"
+                          Placeholder="Search hotstrings"
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Filled.Search"
+                          Class="search-hotstrings mb-2"
+                          FullWidth="true" Immediate="true" />
+
+            @if (_categories.Count > 0)
+            {
+                <div class="chip-strip mb-2" style="overflow-x:auto;white-space:nowrap;">
+                    <MudChipSet T="Guid" SelectionMode="SelectionMode.MultiSelection"
+                                SelectedValues="_selectedCategoryIds"
+                                SelectedValuesChanged="OnCategoryFilterChangedAsync">
+                        @foreach (CategoryDto c in _categories)
+                        {
+                            <MudChip T="Guid" Value="@c.Id" Variant="Variant.Outlined">@c.Name</MudChip>
+                        }
+                    </MudChipSet>
+                </div>
+            }
+
+            @if (_loadError is not null)
+            {
+                <MudAlert Severity="Severity.Error" Class="mb-3">@_loadError</MudAlert>
+            }
+
+            <HotstringMobileList Items="_mobileItems"
+                                 Profiles="_profiles"
+                                 Categories="_categories"
+                                 OnEdit="OpenEditDialogAsync"
+                                 OnDelete="DeleteAsync"
+                                 OnBulkDelete="MobileBulkDeleteAsync" />
+
+            <MudPagination Class="mt-2" Count="_mobileTotalPages" Selected="_mobilePage"
+                           SelectedChanged="OnMobilePageChangedAsync" />
+
+            <MudFab Class="add-hotstring-fab" Color="Color.Primary"
+                    StartIcon="@Icons.Material.Filled.Add"
+                    Style="position:fixed;right:16px;bottom:16px;z-index:100;"
+                    OnClick="OpenCreateDialogAsync" />
+        </MudPaper>
+</div>
 
 @code {
     [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
@@ -198,6 +253,11 @@
     private int _rowsPerPage = UserPreferences.Default.RowsPerPage;
     private readonly CancellationTokenSource _cts = new();
 
+    private IReadOnlyList<HotstringEditModel> _mobileItems = [];
+    private int _mobilePage = 1;
+    private readonly int _mobilePageSize = 10;
+    private int _mobileTotalPages;
+
     protected override async Task OnInitializedAsync()
     {
         if (AuthState is not null)
@@ -218,6 +278,7 @@
             ApiResult<PagedList<CategoryDto>> catResult = await CategoriesApi.ListAsync(new CategoryListRequest(PageSize: 200), _cts.Token);
             if (catResult.IsSuccess) _categories = catResult.Value?.Items ?? [];
         }
+
     }
 
     private async Task<GridData<HotstringEditModel>> LoadServerData(GridState<HotstringEditModel> state, CancellationToken ct)
@@ -351,6 +412,8 @@
     private async Task OnSearchChangedAsync()
     {
         if (_grid is not null) await _grid.ReloadServerData();
+        _mobilePage = 1;
+        await LoadMobileAsync();
     }
 
     private async Task StartAddAsync()
@@ -447,7 +510,7 @@
         if (result.IsSuccess)
         {
             Snackbar.Add("Hotstring deleted.", Severity.Success);
-            if (_grid is not null) await _grid.ReloadServerData();
+            await ReloadAllAsync();
         }
         else Snackbar.Add(ApiErrorMessageFactory.Build(result.Status, result.Problem), Severity.Error);
     }
@@ -489,6 +552,130 @@
         {
             Snackbar.Add(ApiErrorMessageFactory.Build(result.Status, result.Problem), Severity.Error);
         }
+    }
+
+    private async Task LoadMobileAsync()
+    {
+        _loading = true;
+        _loadError = null;
+
+        ApiResult<PagedList<HotstringDto>> result = await Api.ListAsync(
+            new HotstringListRequest(
+                Page: _mobilePage,
+                PageSize: _mobilePageSize,
+                Search: string.IsNullOrWhiteSpace(_search) ? null : _search,
+                CategoryIds: _selectedCategoryIds.Count > 0 ? _selectedCategoryIds : null),
+            _cts.Token);
+
+        _loading = false;
+
+        if (!result.IsSuccess)
+        {
+            _loadError = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+            _mobileItems = [];
+            _mobileTotalPages = 0;
+            await InvokeAsync(StateHasChanged);
+            return;
+        }
+
+        _mobileItems = [.. result.Value!.Items.Select(HotstringEditModel.FromDto)];
+        _mobileTotalPages = (int)Math.Ceiling((double)result.Value.TotalCount / _mobilePageSize);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnMobilePageChangedAsync(int page)
+    {
+        _mobilePage = page;
+        await LoadMobileAsync();
+    }
+
+    private async Task OpenCreateDialogAsync()
+    {
+        DialogParameters parameters = new()
+        {
+            [nameof(HotstringEditDialog.Item)] = new HotstringEditModel(),
+            [nameof(HotstringEditDialog.Profiles)] = _profiles,
+            [nameof(HotstringEditDialog.Categories)] = _categories,
+        };
+
+        IDialogReference dialog = await DialogService.ShowAsync<HotstringEditDialog>(
+            "New hotstring", parameters,
+            new DialogOptions { FullScreen = true, CloseButton = false });
+
+        DialogResult? result = await dialog.Result;
+        if (result?.Canceled == false)
+        {
+            Snackbar.Add("Hotstring created.", Severity.Success);
+            await ReloadAllAsync();
+        }
+    }
+
+    private async Task OpenEditDialogAsync(HotstringEditModel item)
+    {
+        DialogParameters parameters = new()
+        {
+            [nameof(HotstringEditDialog.Item)] = HotstringEditModel.FromDto(new HotstringDto(
+                item.Id!.Value,
+                [.. item.ProfileIds],
+                item.AppliesToAllProfiles,
+                item.Trigger,
+                item.Replacement,
+                item.Description,
+                item.IsEndingCharacterRequired,
+                item.IsTriggerInsideWord,
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow,
+                [.. item.CategoryIds])),
+            [nameof(HotstringEditDialog.Profiles)] = _profiles,
+            [nameof(HotstringEditDialog.Categories)] = _categories,
+        };
+
+        IDialogReference dialog = await DialogService.ShowAsync<HotstringEditDialog>(
+            "Edit hotstring", parameters,
+            new DialogOptions { FullScreen = true, CloseButton = false });
+
+        DialogResult? result = await dialog.Result;
+        if (result?.Canceled == false)
+        {
+            Snackbar.Add("Hotstring updated.", Severity.Success);
+            await ReloadAllAsync();
+        }
+    }
+
+    private async Task MobileBulkDeleteAsync(IReadOnlyList<Guid> ids)
+    {
+        if (ids.Count == 0) return;
+
+        bool? confirm = await DialogService.ShowMessageBoxAsync(
+            title: "Delete hotstrings?",
+            message: $"Delete {ids.Count} hotstring(s)? This cannot be undone.",
+            yesText: "Delete", cancelText: "Cancel");
+        if (confirm != true) return;
+
+        ApiResult<BulkDeleteResultDto> result = await Api.BulkDeleteAsync(ids, _cts.Token);
+        if (result.IsSuccess)
+        {
+            Snackbar.Add($"Deleted {result.Value!.DeletedCount} hotstring(s).", Severity.Success);
+            await ReloadAllAsync();
+        }
+        else
+        {
+            Snackbar.Add(ApiErrorMessageFactory.Build(result.Status, result.Problem), Severity.Error);
+        }
+    }
+
+    private async Task ReloadAllAsync()
+    {
+        if (_grid is not null) await _grid.ReloadServerData();
+        await LoadMobileAsync();
+    }
+
+    private async Task OnCategoryFilterChangedAsync(IReadOnlyCollection<Guid> ids)
+    {
+        _selectedCategoryIds = [.. ids];
+        if (_grid is not null) await _grid.ReloadServerData();
+        _mobilePage = 1;
+        await LoadMobileAsync();
     }
 
     private RenderFragment RenderProfiles(bool appliesToAllProfiles, IReadOnlyCollection<Guid> profileIds) => @<text>
@@ -554,12 +741,6 @@
             <MudChip T="string" Size="Size.Small">@name</MudChip>
         }
     </text>;
-
-    private async Task OnCategoryFilterChangedAsync(IReadOnlyCollection<Guid> ids)
-    {
-        _selectedCategoryIds = [.. ids];
-        if (_grid is not null) await _grid.ReloadServerData();
-    }
 
     private RenderFragment RenderActions(HotstringEditModel item) => @<text>
         @if (IsEditing(item))

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -61,6 +61,7 @@
             }
 
             <MudDataGrid @ref="_grid" T="HotstringEditModel" ServerData="LoadServerData"
+                         Class="hotstrings-grid"
                          MultiSelection="true" SelectOnRowClick="false"
                          SelectedItems="_selected" SelectedItemsChanged="OnSelectedItemsChanged"
                          Dense="true" Hover="true" RowsPerPage="_rowsPerPage"

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -277,6 +277,8 @@
 
             ApiResult<PagedList<CategoryDto>> catResult = await CategoriesApi.ListAsync(new CategoryListRequest(PageSize: 200), _cts.Token);
             if (catResult.IsSuccess) _categories = catResult.Value?.Items ?? [];
+
+            await LoadMobileAsync();
         }
 
     }
@@ -406,7 +408,7 @@
 
     private async Task ReloadAsync()
     {
-        if (_grid is not null) await _grid.ReloadServerData();
+        await ReloadAllAsync();
     }
 
     private async Task OnSearchChangedAsync()
@@ -574,13 +576,11 @@
             _loadError = ApiErrorMessageFactory.Build(result.Status, result.Problem);
             _mobileItems = [];
             _mobileTotalPages = 0;
-            await InvokeAsync(StateHasChanged);
             return;
         }
 
         _mobileItems = [.. result.Value!.Items.Select(HotstringEditModel.FromDto)];
         _mobileTotalPages = (int)Math.Ceiling((double)result.Value.TotalCount / _mobilePageSize);
-        await InvokeAsync(StateHasChanged);
     }
 
     private async Task OnMobilePageChangedAsync(int page)

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -179,7 +179,7 @@
 </div>
 
 <div class="mobile-branch">
-    <MudPaper Class="pa-2" Style="position:relative;min-height:80vh;">
+    <MudPaper Class="pa-2 mobile-shell">
         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
             <MudIconButton Class="reload-hotstrings-mobile" Icon="@Icons.Material.Filled.Refresh"
                            OnClick="ReloadAsync" Disabled="@(!_isAuthenticated || _loading)" />
@@ -196,7 +196,7 @@
 
             @if (_categories.Count > 0)
             {
-                <div class="chip-strip mb-2" style="overflow-x:auto;white-space:nowrap;">
+                <div class="chip-strip mb-2">
                     <MudChipSet T="Guid" SelectionMode="SelectionMode.MultiSelection"
                                 SelectedValues="_selectedCategoryIds"
                                 SelectedValuesChanged="OnCategoryFilterChangedAsync">
@@ -220,12 +220,14 @@
                                  OnDelete="DeleteAsync"
                                  OnBulkDelete="MobileBulkDeleteAsync" />
 
-            <MudPagination Class="mt-2" Count="_mobileTotalPages" Selected="_mobilePage"
-                           SelectedChanged="OnMobilePageChangedAsync" />
+            @if (_mobileTotalPages > 1)
+            {
+                <MudPagination Class="mt-2" Count="_mobileTotalPages" Selected="_mobilePage"
+                               SelectedChanged="OnMobilePageChangedAsync" />
+            }
 
             <MudFab Class="add-hotstring-fab" Color="Color.Primary"
                     StartIcon="@Icons.Material.Filled.Add"
-                    Style="position:fixed;right:16px;bottom:16px;z-index:100;"
                     OnClick="OpenCreateDialogAsync" />
     </MudPaper>
 </div>
@@ -259,7 +261,9 @@
     private readonly int _mobilePageSize = 10;
     private int _mobileTotalPages;
     private HotstringListRequest? _cachedListRequest;
+    // Same-request cache only; every mutation path must call ClearListCache before reloading.
     private PagedList<HotstringDto>? _cachedListPage;
+    private bool _dialogOpen;
 
     protected override async Task OnInitializedAsync()
     {
@@ -283,7 +287,6 @@
 
             await LoadMobileAsync();
         }
-
     }
 
     private async Task<GridData<HotstringEditModel>> LoadServerData(GridState<HotstringEditModel> state, CancellationToken ct)
@@ -598,54 +601,65 @@
 
     private async Task OpenCreateDialogAsync()
     {
-        DialogParameters parameters = new()
-        {
-            [nameof(HotstringEditDialog.Item)] = new HotstringEditModel(),
-            [nameof(HotstringEditDialog.Profiles)] = _profiles,
-            [nameof(HotstringEditDialog.Categories)] = _categories,
-        };
+        if (_dialogOpen)
+            return;
 
-        IDialogReference dialog = await DialogService.ShowAsync<HotstringEditDialog>(
-            "New hotstring", parameters,
-            new DialogOptions { FullScreen = true, CloseButton = false });
-
-        DialogResult? result = await dialog.Result;
-        if (result?.Canceled == false)
+        _dialogOpen = true;
+        try
         {
-            Snackbar.Add("Hotstring created.", Severity.Success);
-            await ReloadAllAsync();
+            DialogParameters parameters = new()
+            {
+                [nameof(HotstringEditDialog.Item)] = new HotstringEditModel(),
+                [nameof(HotstringEditDialog.Profiles)] = _profiles,
+                [nameof(HotstringEditDialog.Categories)] = _categories,
+            };
+
+            IDialogReference dialog = await DialogService.ShowAsync<HotstringEditDialog>(
+                "New hotstring", parameters,
+                new DialogOptions { FullScreen = true, CloseButton = false });
+
+            DialogResult? result = await dialog.Result;
+            if (result?.Canceled == false)
+            {
+                Snackbar.Add("Hotstring created.", Severity.Success);
+                await ReloadAllAsync();
+            }
+        }
+        finally
+        {
+            _dialogOpen = false;
         }
     }
 
     private async Task OpenEditDialogAsync(HotstringEditModel item)
     {
-        DialogParameters parameters = new()
-        {
-            [nameof(HotstringEditDialog.Item)] = HotstringEditModel.FromDto(new HotstringDto(
-                item.Id!.Value,
-                [.. item.ProfileIds],
-                item.AppliesToAllProfiles,
-                item.Trigger,
-                item.Replacement,
-                item.Description,
-                item.IsEndingCharacterRequired,
-                item.IsTriggerInsideWord,
-                DateTimeOffset.UtcNow,
-                DateTimeOffset.UtcNow,
-                [.. item.CategoryIds])),
-            [nameof(HotstringEditDialog.Profiles)] = _profiles,
-            [nameof(HotstringEditDialog.Categories)] = _categories,
-        };
+        if (_dialogOpen || item.Id is null)
+            return;
 
-        IDialogReference dialog = await DialogService.ShowAsync<HotstringEditDialog>(
-            "Edit hotstring", parameters,
-            new DialogOptions { FullScreen = true, CloseButton = false });
-
-        DialogResult? result = await dialog.Result;
-        if (result?.Canceled == false)
+        _dialogOpen = true;
+        try
         {
-            Snackbar.Add("Hotstring updated.", Severity.Success);
-            await ReloadAllAsync();
+            DialogParameters parameters = new()
+            {
+                [nameof(HotstringEditDialog.Item)] = item.Clone(),
+                [nameof(HotstringEditDialog.Profiles)] = _profiles,
+                [nameof(HotstringEditDialog.Categories)] = _categories,
+            };
+
+            IDialogReference dialog = await DialogService.ShowAsync<HotstringEditDialog>(
+                "Edit hotstring", parameters,
+                new DialogOptions { FullScreen = true, CloseButton = false });
+
+            DialogResult? result = await dialog.Result;
+            if (result?.Canceled == false)
+            {
+                Snackbar.Add("Hotstring updated.", Severity.Success);
+                await ReloadAllAsync();
+            }
+        }
+        finally
+        {
+            _dialogOpen = false;
         }
     }
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
@@ -17,3 +17,62 @@
         display: block;
     }
 }
+
+::deep .hotstrings-grid .mud-table-root {
+    table-layout: fixed;
+    width: 100%;
+    min-width: 0;
+}
+
+::deep .hotstrings-grid .mud-table-cell,
+::deep .hotstrings-grid .column-header {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+::deep .hotstrings-grid .mud-table-cell {
+    white-space: nowrap;
+}
+
+::deep .hotstrings-grid th:nth-child(1),
+::deep .hotstrings-grid td:nth-child(1) {
+    width: 56px;
+}
+
+::deep .hotstrings-grid th:nth-child(2),
+::deep .hotstrings-grid td:nth-child(2) {
+    width: 12%;
+}
+
+::deep .hotstrings-grid th:nth-child(3),
+::deep .hotstrings-grid td:nth-child(3) {
+    width: 24%;
+}
+
+::deep .hotstrings-grid th:nth-child(4),
+::deep .hotstrings-grid td:nth-child(4) {
+    width: 14%;
+}
+
+::deep .hotstrings-grid th:nth-child(5),
+::deep .hotstrings-grid td:nth-child(5) {
+    width: 10%;
+}
+
+::deep .hotstrings-grid th:nth-child(6),
+::deep .hotstrings-grid td:nth-child(6),
+::deep .hotstrings-grid th:nth-child(7),
+::deep .hotstrings-grid td:nth-child(7) {
+    width: 72px;
+    text-align: center;
+}
+
+::deep .hotstrings-grid th:nth-child(8),
+::deep .hotstrings-grid td:nth-child(8) {
+    width: 10%;
+}
+
+::deep .hotstrings-grid th:nth-child(9),
+::deep .hotstrings-grid td:nth-child(9) {
+    width: 88px;
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
@@ -1,0 +1,19 @@
+/* Show desktop branch on medium+ screens, hide on small */
+.desktop-branch {
+    display: block;
+}
+
+.mobile-branch {
+    display: none;
+}
+
+/* MudBlazor sm breakpoint = 600px */
+@media (max-width: 959.95px) {
+    .desktop-branch {
+        display: none;
+    }
+
+    .mobile-branch {
+        display: block;
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
@@ -6,6 +6,23 @@
     display: none;
 }
 
+.mobile-shell {
+    position: relative;
+    min-height: 80vh;
+}
+
+.chip-strip {
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+.add-hotstring-fab {
+    position: fixed;
+    right: 16px;
+    bottom: 16px;
+    z-index: 100;
+}
+
 @media (max-width: 959.95px) {
     .desktop-branch {
         display: none;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
@@ -1,4 +1,3 @@
-/* Show desktop branch on medium+ screens, hide on small */
 .desktop-branch {
     display: block;
 }
@@ -7,7 +6,6 @@
     display: none;
 }
 
-/* MudBlazor sm breakpoint = 600px */
 @media (max-width: 959.95px) {
     .desktop-branch {
         display: none;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Validation/HotkeyEditModel.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Validation/HotkeyEditModel.cs
@@ -44,6 +44,22 @@ public sealed class HotkeyEditModel
         CategoryIds = [.. dto.CategoryIds ?? []],
     };
 
+    public HotkeyEditModel Clone() => new()
+    {
+        Id = Id,
+        Description = Description,
+        Key = Key,
+        Ctrl = Ctrl,
+        Alt = Alt,
+        Shift = Shift,
+        Win = Win,
+        Action = Action,
+        Parameters = Parameters,
+        AppliesToAllProfiles = AppliesToAllProfiles,
+        ProfileIds = [.. ProfileIds],
+        CategoryIds = [.. CategoryIds],
+    };
+
     public CreateHotkeyDto ToCreateDto() =>
         new(Description, Key, Ctrl, Alt, Shift, Win, Action, Parameters,
             AppliesToAllProfiles ? null : [.. ProfileIds], AppliesToAllProfiles, [.. CategoryIds]);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Validation/HotstringEditModel.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Validation/HotstringEditModel.cs
@@ -37,6 +37,19 @@ public sealed class HotstringEditModel
         CategoryIds = [.. dto.CategoryIds ?? []],
     };
 
+    public HotstringEditModel Clone() => new()
+    {
+        Id = Id,
+        Trigger = Trigger,
+        Replacement = Replacement,
+        Description = Description,
+        AppliesToAllProfiles = AppliesToAllProfiles,
+        ProfileIds = [.. ProfileIds],
+        IsEndingCharacterRequired = IsEndingCharacterRequired,
+        IsTriggerInsideWord = IsTriggerInsideWord,
+        CategoryIds = [.. CategoryIds],
+    };
+
     public CreateHotstringDto ToCreateDto() =>
         new(Trigger, Replacement, AppliesToAllProfiles ? null : [.. ProfileIds], AppliesToAllProfiles, IsEndingCharacterRequired, IsTriggerInsideWord, Description, [.. CategoryIds]);
 

--- a/tests/AHKFlowApp.E2E.Tests/E2ETestCollection.cs
+++ b/tests/AHKFlowApp.E2E.Tests/E2ETestCollection.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace AHKFlowApp.E2E.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class E2ETestCollection
+{
+    public const string Name = "E2E";
+}

--- a/tests/AHKFlowApp.E2E.Tests/HotkeysMobileFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/HotkeysMobileFlowTests.cs
@@ -12,6 +12,34 @@ public sealed class HotkeysMobileFlowTests(StackFixture fixture) : IClassFixture
         ViewportSize = new ViewportSize { Width = 375, Height = 812 },
     };
 
+    private static readonly BrowserNewContextOptions TabletViewport = new()
+    {
+        ViewportSize = new ViewportSize { Width = 768, Height = 1024 },
+    };
+
+    private sealed class OverflowMetrics
+    {
+        public int BodyOverflow { get; init; }
+
+        public int DocumentOverflow { get; init; }
+    }
+
+    [Fact]
+    public async Task TabletViewport_DoesNotCreatePageHorizontalOverflow()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(TabletViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotkeys");
+        await page.WaitForSelectorAsync("button.add-hotkey-fab");
+
+        OverflowMetrics metrics = await page.EvaluateAsync<OverflowMetrics>(
+            "() => ({ BodyOverflow: document.body.scrollWidth - window.innerWidth, DocumentOverflow: document.documentElement.scrollWidth - window.innerWidth })");
+
+        Assert.True(metrics.BodyOverflow <= 0, $"Body overflowed by {metrics.BodyOverflow}px.");
+        Assert.True(metrics.DocumentOverflow <= 0, $"Document overflowed by {metrics.DocumentOverflow}px.");
+    }
+
     [Fact]
     public async Task CreateEditDelete_OnPhoneViewport_UsesFabAndFullScreenDialog()
     {
@@ -75,15 +103,40 @@ public sealed class HotkeysMobileFlowTests(StackFixture fixture) : IClassFixture
         // Enter select mode + select both
         await page.ClickAsync("button.toggle-select-mode");
         await page.WaitForSelectorAsync("input.row-checkbox");
-        ILocator boxes = page.Locator("input.row-checkbox");
-        int count = await boxes.CountAsync();
-        for (int i = 0; i < count; i++)
-            await boxes.Nth(i).CheckAsync();
+        foreach (string key in new[] { "F1", "F2" })
+            await page.Locator($"xpath=//tr[contains(@class,'mobile-row')][.//code[normalize-space(.)='{key}']]//input[contains(@class,'row-checkbox')]").CheckAsync();
 
         await page.ClickAsync("button.bulk-delete-hotkeys");
         await page.WaitForSelectorAsync("[role=\"dialog\"]");
         await page.Locator("[role=\"dialog\"]").GetByRole(AriaRole.Button, new() { Name = "Delete" }).ClickAsync();
 
         await page.WaitForSelectorAsync("text=Deleted 2 hotkey");
+    }
+
+    [Fact]
+    public async Task DuplicateKey_OnPhoneViewport_ShowsInlineConflict()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
+        IPage page = await ctx.NewPageAsync();
+        string key = $"F{Random.Shared.Next(13, 25)}";
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotkeys");
+        await page.ClickAsync("button.add-hotkey-fab");
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog");
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"description-input\"]", "Duplicate first");
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"key-input\"]", key);
+        await page.ClickAsync(".hotkey-edit-dialog input[data-test=\"ctrl-checkbox\"]");
+        await page.ClickAsync(".hotkey-edit-dialog button.commit-edit");
+        await page.WaitForSelectorAsync($".mobile-row:has-text(\"Ctrl+{key}\")");
+
+        await page.ClickAsync("button.add-hotkey-fab");
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog");
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"description-input\"]", "Duplicate second");
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"key-input\"]", key);
+        await page.ClickAsync(".hotkey-edit-dialog input[data-test=\"ctrl-checkbox\"]");
+        await page.ClickAsync(".hotkey-edit-dialog button.commit-edit");
+
+        await page.Locator(".hotkey-edit-dialog").GetByText("already exists").WaitForAsync();
+        Assert.Equal(0, await page.Locator(".hotkey-edit-dialog .mud-alert").CountAsync());
     }
 }

--- a/tests/AHKFlowApp.E2E.Tests/HotkeysMobileFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/HotkeysMobileFlowTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace AHKFlowApp.E2E.Tests;
 
+[Collection(E2ETestCollection.Name)]
 public sealed class HotkeysMobileFlowTests(StackFixture fixture) : IClassFixture<StackFixture>
 {
     private static readonly BrowserNewContextOptions PhoneViewport = new()

--- a/tests/AHKFlowApp.E2E.Tests/HotkeysMobileFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/HotkeysMobileFlowTests.cs
@@ -1,0 +1,88 @@
+using AHKFlowApp.E2E.Tests.Fixtures;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace AHKFlowApp.E2E.Tests;
+
+public sealed class HotkeysMobileFlowTests(StackFixture fixture) : IClassFixture<StackFixture>
+{
+    private static readonly BrowserNewContextOptions PhoneViewport = new()
+    {
+        ViewportSize = new ViewportSize { Width = 375, Height = 812 },
+    };
+
+    [Fact]
+    public async Task CreateEditDelete_OnPhoneViewport_UsesFabAndFullScreenDialog()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotkeys");
+        await page.WaitForSelectorAsync("button.add-hotkey-fab");
+
+        // Add via FAB
+        await page.ClickAsync("button.add-hotkey-fab");
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog");
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"description-input\"]", "Open palette");
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"key-input\"]", "K");
+        await page.ClickAsync(".hotkey-edit-dialog input[data-test=\"ctrl-checkbox\"]");
+        await page.ClickAsync(".hotkey-edit-dialog input[data-test=\"shift-checkbox\"]");
+        await page.ClickAsync(".hotkey-edit-dialog button.commit-edit");
+
+        await page.WaitForSelectorAsync("text=Hotkey created.");
+        await page.WaitForSelectorAsync(".mobile-row:has-text(\"Ctrl+Shift+K\")");
+
+        // Expand row, click edit, change key, save
+        await page.ClickAsync(".mobile-row:has-text(\"Ctrl+Shift+K\")");
+        await page.WaitForSelectorAsync(".mobile-row-expanded button.start-edit");
+        await page.ClickAsync(".mobile-row-expanded button.start-edit");
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog");
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"key-input\"]", "P");
+        await page.ClickAsync(".hotkey-edit-dialog button.commit-edit");
+
+        await page.WaitForSelectorAsync("text=Hotkey updated.");
+        await page.WaitForSelectorAsync(".mobile-row:has-text(\"Ctrl+Shift+P\")");
+
+        // Delete via expanded row (row stays expanded after dialog close)
+        await page.WaitForSelectorAsync(".mobile-row-expanded button.delete");
+        await page.ClickAsync(".mobile-row-expanded button.delete");
+        await page.WaitForSelectorAsync("[role=\"dialog\"]");
+        await page.Locator("[role=\"dialog\"]").GetByRole(AriaRole.Button, new() { Name = "Delete" }).ClickAsync();
+
+        await page.WaitForSelectorAsync("text=Hotkey deleted.");
+    }
+
+    [Fact]
+    public async Task BulkDelete_OnPhoneViewport_UsesSelectMode()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotkeys");
+
+        // Create two rows via FAB
+        foreach ((string desc, string key) in new[] { ("Macro A", "F1"), ("Macro B", "F2") })
+        {
+            await page.ClickAsync("button.add-hotkey-fab");
+            await page.WaitForSelectorAsync(".hotkey-edit-dialog");
+            await page.FillAsync(".hotkey-edit-dialog input[data-test=\"description-input\"]", desc);
+            await page.FillAsync(".hotkey-edit-dialog input[data-test=\"key-input\"]", key);
+            await page.ClickAsync(".hotkey-edit-dialog button.commit-edit");
+            await page.WaitForSelectorAsync($".mobile-row:has-text(\"{key}\")");
+        }
+
+        // Enter select mode + select both
+        await page.ClickAsync("button.toggle-select-mode");
+        await page.WaitForSelectorAsync("input.row-checkbox");
+        ILocator boxes = page.Locator("input.row-checkbox");
+        int count = await boxes.CountAsync();
+        for (int i = 0; i < count; i++)
+            await boxes.Nth(i).CheckAsync();
+
+        await page.ClickAsync("button.bulk-delete-hotkeys");
+        await page.WaitForSelectorAsync("[role=\"dialog\"]");
+        await page.Locator("[role=\"dialog\"]").GetByRole(AriaRole.Button, new() { Name = "Delete" }).ClickAsync();
+
+        await page.WaitForSelectorAsync("text=Deleted 2 hotkey");
+    }
+}

--- a/tests/AHKFlowApp.E2E.Tests/HotstringsCrudFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/HotstringsCrudFlowTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace AHKFlowApp.E2E.Tests;
 
+[Collection(E2ETestCollection.Name)]
 public sealed class HotstringsCrudFlowTests(StackFixture fixture) : IClassFixture<StackFixture>
 {
     [Fact]

--- a/tests/AHKFlowApp.E2E.Tests/HotstringsMobileFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/HotstringsMobileFlowTests.cs
@@ -12,6 +12,34 @@ public sealed class HotstringsMobileFlowTests(StackFixture fixture) : IClassFixt
         ViewportSize = new ViewportSize { Width = 375, Height = 812 },
     };
 
+    private static readonly BrowserNewContextOptions TabletViewport = new()
+    {
+        ViewportSize = new ViewportSize { Width = 768, Height = 1024 },
+    };
+
+    private sealed class OverflowMetrics
+    {
+        public int BodyOverflow { get; init; }
+
+        public int DocumentOverflow { get; init; }
+    }
+
+    [Fact]
+    public async Task TabletViewport_DoesNotCreatePageHorizontalOverflow()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(TabletViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotstrings");
+        await page.WaitForSelectorAsync("button.add-hotstring-fab");
+
+        OverflowMetrics metrics = await page.EvaluateAsync<OverflowMetrics>(
+            "() => ({ BodyOverflow: document.body.scrollWidth - window.innerWidth, DocumentOverflow: document.documentElement.scrollWidth - window.innerWidth })");
+
+        Assert.True(metrics.BodyOverflow <= 0, $"Body overflowed by {metrics.BodyOverflow}px.");
+        Assert.True(metrics.DocumentOverflow <= 0, $"Document overflowed by {metrics.DocumentOverflow}px.");
+    }
+
     [Fact]
     public async Task CreateEditDelete_OnPhoneViewport_UsesFabAndFullScreenDialog()
     {
@@ -73,15 +101,38 @@ public sealed class HotstringsMobileFlowTests(StackFixture fixture) : IClassFixt
         // Enter select mode + select both
         await page.ClickAsync("button.toggle-select-mode");
         await page.WaitForSelectorAsync("input.row-checkbox");
-        ILocator boxes = page.Locator("input.row-checkbox");
-        int count = await boxes.CountAsync();
-        for (int i = 0; i < count; i++)
-            await boxes.Nth(i).CheckAsync();
+        foreach (string trig in new[] { "bk1", "bk2" })
+            await page.Locator($"xpath=//tr[contains(@class,'mobile-row')][.//code[normalize-space(.)='{trig}']]//input[contains(@class,'row-checkbox')]").CheckAsync();
 
         await page.ClickAsync("button.bulk-delete-hotstrings");
         await page.WaitForSelectorAsync("[role=\"dialog\"]");
         await page.Locator("[role=\"dialog\"]").GetByRole(AriaRole.Button, new() { Name = "Delete" }).ClickAsync();
 
         await page.WaitForSelectorAsync("text=Deleted 2 hotstring");
+    }
+
+    [Fact]
+    public async Task DuplicateTrigger_OnPhoneViewport_ShowsInlineConflict()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
+        IPage page = await ctx.NewPageAsync();
+        string trigger = $"dup{Guid.NewGuid():N}"[..12];
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotstrings");
+        await page.ClickAsync("button.add-hotstring-fab");
+        await page.WaitForSelectorAsync(".hotstring-edit-dialog");
+        await page.FillAsync(".hotstring-edit-dialog input[data-test=\"trigger-input\"]", trigger);
+        await page.FillAsync(".hotstring-edit-dialog textarea[data-test=\"replacement-input\"]", "first");
+        await page.ClickAsync(".hotstring-edit-dialog button.commit-edit");
+        await page.WaitForSelectorAsync($".mobile-row:has-text(\"{trigger}\")");
+
+        await page.ClickAsync("button.add-hotstring-fab");
+        await page.WaitForSelectorAsync(".hotstring-edit-dialog");
+        await page.FillAsync(".hotstring-edit-dialog input[data-test=\"trigger-input\"]", trigger);
+        await page.FillAsync(".hotstring-edit-dialog textarea[data-test=\"replacement-input\"]", "second");
+        await page.ClickAsync(".hotstring-edit-dialog button.commit-edit");
+
+        await page.GetByText("Trigger already exists").WaitForAsync();
+        Assert.Equal(0, await page.Locator(".hotstring-edit-dialog .mud-alert").CountAsync());
     }
 }

--- a/tests/AHKFlowApp.E2E.Tests/HotstringsMobileFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/HotstringsMobileFlowTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace AHKFlowApp.E2E.Tests;
 
+[Collection(E2ETestCollection.Name)]
 public sealed class HotstringsMobileFlowTests(StackFixture fixture) : IClassFixture<StackFixture>
 {
     private static readonly BrowserNewContextOptions PhoneViewport = new()

--- a/tests/AHKFlowApp.E2E.Tests/HotstringsMobileFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/HotstringsMobileFlowTests.cs
@@ -1,0 +1,86 @@
+using AHKFlowApp.E2E.Tests.Fixtures;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace AHKFlowApp.E2E.Tests;
+
+public sealed class HotstringsMobileFlowTests(StackFixture fixture) : IClassFixture<StackFixture>
+{
+    private static readonly BrowserNewContextOptions PhoneViewport = new()
+    {
+        ViewportSize = new ViewportSize { Width = 375, Height = 812 },
+    };
+
+    [Fact]
+    public async Task CreateEditDelete_OnPhoneViewport_UsesFabAndFullScreenDialog()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotstrings");
+        await page.WaitForSelectorAsync("button.add-hotstring-fab");
+
+        // Add via FAB
+        await page.ClickAsync("button.add-hotstring-fab");
+        await page.WaitForSelectorAsync(".hotstring-edit-dialog");
+        await page.FillAsync(".hotstring-edit-dialog input[data-test=\"trigger-input\"]", "mob");
+        await page.FillAsync(".hotstring-edit-dialog textarea[data-test=\"replacement-input\"]", "mobile by the way");
+        await page.ClickAsync(".hotstring-edit-dialog button.commit-edit");
+
+        await page.WaitForSelectorAsync("text=Hotstring created.");
+        await page.WaitForSelectorAsync(".mobile-row:has-text(\"mob\")");
+
+        // Expand row, click edit, change, save
+        await page.ClickAsync(".mobile-row:has-text(\"mob\")");
+        await page.WaitForSelectorAsync(".mobile-row-expanded button.start-edit");
+        await page.ClickAsync(".mobile-row-expanded button.start-edit");
+        await page.WaitForSelectorAsync(".hotstring-edit-dialog");
+        await page.FillAsync(".hotstring-edit-dialog textarea[data-test=\"replacement-input\"]", "edited!");
+        await page.ClickAsync(".hotstring-edit-dialog button.commit-edit");
+
+        await page.WaitForSelectorAsync("text=Hotstring updated.");
+        await page.WaitForSelectorAsync(".mobile-row:has-text(\"edited!\")");
+
+        // Delete via expanded row (row stays expanded after dialog close)
+        await page.WaitForSelectorAsync(".mobile-row-expanded button.delete");
+        await page.ClickAsync(".mobile-row-expanded button.delete");
+        await page.WaitForSelectorAsync("[role=\"dialog\"]");
+        await page.Locator("[role=\"dialog\"]").GetByRole(AriaRole.Button, new() { Name = "Delete" }).ClickAsync();
+
+        await page.WaitForSelectorAsync("text=Hotstring deleted.");
+    }
+
+    [Fact]
+    public async Task BulkDelete_OnPhoneViewport_UsesSelectMode()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotstrings");
+
+        // Create two rows via FAB
+        foreach (string trig in new[] { "bk1", "bk2" })
+        {
+            await page.ClickAsync("button.add-hotstring-fab");
+            await page.WaitForSelectorAsync(".hotstring-edit-dialog");
+            await page.FillAsync(".hotstring-edit-dialog input[data-test=\"trigger-input\"]", trig);
+            await page.FillAsync(".hotstring-edit-dialog textarea[data-test=\"replacement-input\"]", "x");
+            await page.ClickAsync(".hotstring-edit-dialog button.commit-edit");
+            await page.WaitForSelectorAsync($".mobile-row:has-text(\"{trig}\")");
+        }
+
+        // Enter select mode + select both
+        await page.ClickAsync("button.toggle-select-mode");
+        await page.WaitForSelectorAsync("input.row-checkbox");
+        ILocator boxes = page.Locator("input.row-checkbox");
+        int count = await boxes.CountAsync();
+        for (int i = 0; i < count; i++)
+            await boxes.Nth(i).CheckAsync();
+
+        await page.ClickAsync("button.bulk-delete-hotstrings");
+        await page.WaitForSelectorAsync("[role=\"dialog\"]");
+        await page.Locator("[role=\"dialog\"]").GetByRole(AriaRole.Button, new() { Name = "Delete" }).ClickAsync();
+
+        await page.WaitForSelectorAsync("text=Deleted 2 hotstring");
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
@@ -155,4 +155,35 @@ public sealed class HotkeyEditDialogTests : BunitContext, IAsyncLifetime
             Arg.Is<UpdateHotkeyDto>(d => d.Key == "P"),
             Arg.Any<CancellationToken>()));
     }
+
+    [Fact]
+    public async Task SaveConflict_ShowsKeyErrorInline()
+    {
+        _api.CreateAsync(Arg.Any<CreateHotkeyDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotkeyDto>.Failure(ApiResultStatus.Conflict,
+                new ApiProblemDetails(null, "Conflict", 409, "Hotkey already exists", null, null)));
+
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+
+        await provider.InvokeAsync(async () =>
+        {
+            IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+            await dialogService.ShowAsync<HotkeyEditDialog>("New",
+                new DialogParameters
+                {
+                    [nameof(HotkeyEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                    [nameof(HotkeyEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+                },
+                new DialogOptions { FullScreen = true, CloseButton = false });
+        });
+
+        provider.WaitForAssertion(() => provider.Find("input[data-test=\"description-input\"]"));
+        provider.Find("input[data-test=\"description-input\"]").Change("Open palette");
+        provider.Find("input[data-test=\"key-input\"]").Change("K");
+        provider.Find("button.commit-edit").Click();
+
+        provider.WaitForAssertion(() => provider.Markup.Should().Contain("Hotkey already exists"));
+        provider.FindAll(".mud-alert").Should().BeEmpty();
+    }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
@@ -1,0 +1,158 @@
+using AHKFlowApp.UI.Blazor.Components.Hotkeys;
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Services;
+using AHKFlowApp.UI.Blazor.Validation;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using NSubstitute;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Components.Hotkeys;
+
+public sealed class HotkeyEditDialogTests : BunitContext, IAsyncLifetime
+{
+    private readonly IHotkeysApiClient _api = Substitute.For<IHotkeysApiClient>();
+
+    public HotkeyEditDialogTests()
+    {
+        Services.AddSingleton(_api);
+        Services.AddSingleton(Substitute.For<ISnackbar>());
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+
+    async Task IAsyncLifetime.DisposeAsync() => await DisposeAsync();
+
+    [Fact]
+    public async Task CreateMode_RendersEmptyFields()
+    {
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+
+        await provider.InvokeAsync(async () =>
+        {
+            IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+            await dialogService.ShowAsync<HotkeyEditDialog>("New",
+                new DialogParameters
+                {
+                    [nameof(HotkeyEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                    [nameof(HotkeyEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+                },
+                new DialogOptions { FullScreen = true, CloseButton = false });
+        });
+
+        provider.WaitForAssertion(() => provider.Find("input[data-test=\"key-input\"]").GetAttribute("value").Should().Be(""));
+        provider.Find("input[data-test=\"description-input\"]").GetAttribute("value").Should().Be("");
+    }
+
+    [Fact]
+    public async Task EditMode_PrefillsFieldsFromItem()
+    {
+        HotkeyEditModel item = new()
+        {
+            Id = Guid.NewGuid(),
+            Description = "Open palette",
+            Key = "K",
+            Ctrl = true,
+            Shift = true,
+        };
+
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+
+        await provider.InvokeAsync(async () =>
+        {
+            IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+            await dialogService.ShowAsync<HotkeyEditDialog>("Edit",
+                new DialogParameters
+                {
+                    [nameof(HotkeyEditDialog.Item)] = item,
+                    [nameof(HotkeyEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                    [nameof(HotkeyEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+                },
+                new DialogOptions { FullScreen = true, CloseButton = false });
+        });
+
+        provider.WaitForAssertion(() => provider.Find("input[data-test=\"key-input\"]").GetAttribute("value").Should().Be("K"));
+        provider.Find("input[data-test=\"description-input\"]").GetAttribute("value").Should().Be("Open palette");
+    }
+
+    [Fact]
+    public async Task SaveInCreateMode_CallsCreateAsync()
+    {
+        HotkeyDto created = new(Guid.NewGuid(), [], true, "Open palette", "K", true, false, true, false,
+            HotkeyAction.Send, "", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        _api.CreateAsync(Arg.Any<CreateHotkeyDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotkeyDto>.Ok(created));
+
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+
+        await provider.InvokeAsync(async () =>
+        {
+            IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+            await dialogService.ShowAsync<HotkeyEditDialog>("New",
+                new DialogParameters
+                {
+                    [nameof(HotkeyEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                    [nameof(HotkeyEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+                },
+                new DialogOptions { FullScreen = true, CloseButton = false });
+        });
+
+        provider.WaitForAssertion(() => provider.Find("input[data-test=\"description-input\"]"));
+        provider.Find("input[data-test=\"description-input\"]").Change("Open palette");
+        provider.Find("input[data-test=\"key-input\"]").Change("K");
+        provider.Find("button.commit-edit").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).CreateAsync(
+            Arg.Is<CreateHotkeyDto>(d => d.Description == "Open palette" && d.Key == "K"),
+            Arg.Any<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task SaveInEditMode_CallsUpdateAsync()
+    {
+        HotkeyEditModel item = new()
+        {
+            Id = Guid.NewGuid(),
+            Description = "Open palette",
+            Key = "K",
+            Ctrl = true,
+        };
+        _api.UpdateAsync(item.Id!.Value, Arg.Any<UpdateHotkeyDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotkeyDto>.Ok(
+                new HotkeyDto(item.Id.Value, [], true, "Open palette", "P", true, false, false, false,
+                    HotkeyAction.Send, "", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)));
+
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+
+        await provider.InvokeAsync(async () =>
+        {
+            IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+            await dialogService.ShowAsync<HotkeyEditDialog>("Edit",
+                new DialogParameters
+                {
+                    [nameof(HotkeyEditDialog.Item)] = item,
+                    [nameof(HotkeyEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                    [nameof(HotkeyEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+                },
+                new DialogOptions { FullScreen = true, CloseButton = false });
+        });
+
+        provider.WaitForAssertion(() => provider.Find("input[data-test=\"key-input\"]"));
+        provider.Find("input[data-test=\"key-input\"]").Change("P");
+        provider.Find("button.commit-edit").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).UpdateAsync(
+            item.Id.Value,
+            Arg.Is<UpdateHotkeyDto>(d => d.Key == "P"),
+            Arg.Any<CancellationToken>()));
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyMobileListTests.cs
@@ -37,6 +37,18 @@ public sealed class HotkeyMobileListTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public void EmptyState_DoesNotRenderTable()
+    {
+        IRenderedComponent<HotkeyMobileList> cut = Render<HotkeyMobileList>(p => p
+            .Add(c => c.Items, [])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        cut.Markup.Should().Contain("No hotkeys yet.");
+        cut.FindAll("table.mobile-list").Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task EditButton_RaisesOnEdit()
     {
         HotkeyEditModel item = Item();

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyMobileListTests.cs
@@ -1,0 +1,115 @@
+using AHKFlowApp.UI.Blazor.Components.Hotkeys;
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Validation;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Components.Hotkeys;
+
+public sealed class HotkeyMobileListTests : BunitContext, IAsyncLifetime
+{
+    public HotkeyMobileListTests()
+    {
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await DisposeAsync();
+
+    private static HotkeyEditModel Item(string description = "Open palette", string key = "K", bool ctrl = true, bool shift = true) =>
+        new() { Id = Guid.NewGuid(), Description = description, Key = key, Ctrl = ctrl, Shift = shift };
+
+    [Fact]
+    public void Renders_ComboAndDescription_PerRow()
+    {
+        IRenderedComponent<HotkeyMobileList> cut = Render<HotkeyMobileList>(p => p
+            .Add(c => c.Items, [Item("Open palette", "K", ctrl: true, shift: true)])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        cut.Markup.Should().Contain("Ctrl+Shift+K");
+        cut.Markup.Should().Contain("Open palette");
+    }
+
+    [Fact]
+    public async Task EditButton_RaisesOnEdit()
+    {
+        HotkeyEditModel item = Item();
+        HotkeyEditModel? edited = null;
+
+        IRenderedComponent<HotkeyMobileList> cut = Render<HotkeyMobileList>(p => p
+            .Add(c => c.Items, [item])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[])
+            .Add(c => c.OnEdit, EventCallback.Factory.Create<HotkeyEditModel>(this, m => edited = m)));
+
+        await cut.InvokeAsync(() => cut.Find("tr.mobile-row").Click());
+        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
+        await cut.InvokeAsync(() => cut.Find("button.start-edit").Click());
+
+        edited.Should().Be(item);
+    }
+
+    [Fact]
+    public async Task DeleteButton_RaisesOnDelete()
+    {
+        HotkeyEditModel item = Item();
+        HotkeyEditModel? deleted = null;
+
+        IRenderedComponent<HotkeyMobileList> cut = Render<HotkeyMobileList>(p => p
+            .Add(c => c.Items, [item])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[])
+            .Add(c => c.OnDelete, EventCallback.Factory.Create<HotkeyEditModel>(this, m => deleted = m)));
+
+        await cut.InvokeAsync(() => cut.Find("tr.mobile-row").Click());
+        cut.WaitForAssertion(() => cut.Find("button.delete"));
+        await cut.InvokeAsync(() => cut.Find("button.delete").Click());
+
+        deleted.Should().Be(item);
+    }
+
+    [Fact]
+    public async Task SelectModeToggle_RevealsCheckboxes()
+    {
+        IRenderedComponent<HotkeyMobileList> cut = Render<HotkeyMobileList>(p => p
+            .Add(c => c.Items, [Item()])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        cut.FindAll("input.row-checkbox").Should().BeEmpty();
+
+        await cut.InvokeAsync(() => cut.Find("button.toggle-select-mode").Click());
+
+        cut.WaitForAssertion(() => cut.FindAll("input.row-checkbox").Should().NotBeEmpty());
+    }
+
+    [Fact]
+    public async Task BulkDelete_RaisesOnBulkDelete_WithSelectedIds()
+    {
+        HotkeyEditModel a = Item("A", "A");
+        HotkeyEditModel b = Item("B", "B");
+        IReadOnlyList<Guid>? deletedIds = null;
+
+        IRenderedComponent<HotkeyMobileList> cut = Render<HotkeyMobileList>(p => p
+            .Add(c => c.Items, [a, b])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[])
+            .Add(c => c.OnBulkDelete, EventCallback.Factory.Create<IReadOnlyList<Guid>>(this, ids => deletedIds = ids)));
+
+        await cut.InvokeAsync(() => cut.Find("button.toggle-select-mode").Click());
+
+        cut.WaitForAssertion(() => cut.FindAll("input.row-checkbox").Count.Should().Be(2));
+        cut.FindAll("input.row-checkbox")[0].Change(true);
+        cut.FindAll("input.row-checkbox")[1].Change(true);
+
+        await cut.InvokeAsync(() => cut.Find("button.bulk-delete-hotkeys").Click());
+
+        deletedIds.Should().BeEquivalentTo(new[] { a.Id!.Value, b.Id!.Value });
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -1,0 +1,51 @@
+using AHKFlowApp.UI.Blazor.Components.Hotstrings;
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Services;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using NSubstitute;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Components.Hotstrings;
+
+public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
+{
+    private readonly IHotstringsApiClient _api = Substitute.For<IHotstringsApiClient>();
+
+    public HotstringEditDialogTests()
+    {
+        Services.AddSingleton(_api);
+        Services.AddSingleton(Substitute.For<ISnackbar>());
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+
+    async Task IAsyncLifetime.DisposeAsync() => await DisposeAsync();
+
+    [Fact]
+    public async Task CreateMode_RendersEmptyFields()
+    {
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+
+        await provider.InvokeAsync(async () =>
+        {
+            IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+            await dialogService.ShowAsync<HotstringEditDialog>("New",
+                new DialogParameters
+                {
+                    [nameof(HotstringEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                    [nameof(HotstringEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+                },
+                new DialogOptions { FullScreen = true, CloseButton = false });
+        });
+
+        provider.WaitForAssertion(() => provider.Find("input[data-test=\"trigger-input\"]").GetAttribute("value").Should().Be(""));
+        provider.Find("textarea[data-test=\"replacement-input\"]").TextContent.Should().Be("");
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -1,6 +1,7 @@
 using AHKFlowApp.UI.Blazor.Components.Hotstrings;
 using AHKFlowApp.UI.Blazor.DTOs;
 using AHKFlowApp.UI.Blazor.Services;
+using AHKFlowApp.UI.Blazor.Validation;
 using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,5 +48,107 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
 
         provider.WaitForAssertion(() => provider.Find("input[data-test=\"trigger-input\"]").GetAttribute("value").Should().Be(""));
         provider.Find("textarea[data-test=\"replacement-input\"]").TextContent.Should().Be("");
+    }
+
+    [Fact]
+    public async Task EditMode_PrefillsFieldsFromItem()
+    {
+        HotstringEditModel item = new()
+        {
+            Id = Guid.NewGuid(),
+            Trigger = "btw",
+            Replacement = "by the way",
+            Description = "polite filler",
+        };
+
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+
+        await provider.InvokeAsync(async () =>
+        {
+            IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+            await dialogService.ShowAsync<HotstringEditDialog>("Edit",
+                new DialogParameters
+                {
+                    [nameof(HotstringEditDialog.Item)] = item,
+                    [nameof(HotstringEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                    [nameof(HotstringEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+                },
+                new DialogOptions { FullScreen = true, CloseButton = false });
+        });
+
+        provider.WaitForAssertion(() => provider.Find("input[data-test=\"trigger-input\"]").GetAttribute("value").Should().Be("btw"));
+        provider.Find("textarea[data-test=\"replacement-input\"]").TextContent.Should().Contain("by the way");
+    }
+
+    [Fact]
+    public async Task SaveInCreateMode_CallsCreateAsync()
+    {
+        HotstringDto created = new(Guid.NewGuid(), [], true, "btw", "by the way", null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        _api.CreateAsync(Arg.Any<CreateHotstringDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringDto>.Ok(created));
+
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+
+        await provider.InvokeAsync(async () =>
+        {
+            IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+            await dialogService.ShowAsync<HotstringEditDialog>("New",
+                new DialogParameters
+                {
+                    [nameof(HotstringEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                    [nameof(HotstringEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+                },
+                new DialogOptions { FullScreen = true, CloseButton = false });
+        });
+
+        provider.WaitForAssertion(() => provider.Find("input[data-test=\"trigger-input\"]"));
+        provider.Find("input[data-test=\"trigger-input\"]").Change("btw");
+        provider.Find("textarea[data-test=\"replacement-input\"]").Change("by the way");
+        provider.Find("button.commit-edit").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).CreateAsync(
+            Arg.Is<CreateHotstringDto>(d => d.Trigger == "btw" && d.Replacement == "by the way"),
+            Arg.Any<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task SaveInEditMode_CallsUpdateAsync()
+    {
+        HotstringEditModel item = new()
+        {
+            Id = Guid.NewGuid(),
+            Trigger = "btw",
+            Replacement = "by the way",
+        };
+        _api.UpdateAsync(item.Id!.Value, Arg.Any<UpdateHotstringDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringDto>.Ok(
+                new HotstringDto(item.Id.Value, [], true, "btw", "by the way!", null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)));
+
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+
+        await provider.InvokeAsync(async () =>
+        {
+            IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+            await dialogService.ShowAsync<HotstringEditDialog>("Edit",
+                new DialogParameters
+                {
+                    [nameof(HotstringEditDialog.Item)] = item,
+                    [nameof(HotstringEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                    [nameof(HotstringEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+                },
+                new DialogOptions { FullScreen = true, CloseButton = false });
+        });
+
+        provider.WaitForAssertion(() => provider.Find("textarea[data-test=\"replacement-input\"]"));
+        provider.Find("textarea[data-test=\"replacement-input\"]").Change("by the way!");
+        provider.Find("button.commit-edit").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).UpdateAsync(
+            item.Id.Value,
+            Arg.Is<UpdateHotstringDto>(d => d.Replacement == "by the way!"),
+            Arg.Any<CancellationToken>()));
     }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -151,4 +151,35 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
             Arg.Is<UpdateHotstringDto>(d => d.Replacement == "by the way!"),
             Arg.Any<CancellationToken>()));
     }
+
+    [Fact]
+    public async Task SaveConflict_ShowsTriggerErrorInline()
+    {
+        _api.CreateAsync(Arg.Any<CreateHotstringDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringDto>.Failure(ApiResultStatus.Conflict,
+                new ApiProblemDetails(null, "Conflict", 409, "Trigger already exists", null, null)));
+
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+
+        await provider.InvokeAsync(async () =>
+        {
+            IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+            await dialogService.ShowAsync<HotstringEditDialog>("New",
+                new DialogParameters
+                {
+                    [nameof(HotstringEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                    [nameof(HotstringEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+                },
+                new DialogOptions { FullScreen = true, CloseButton = false });
+        });
+
+        provider.WaitForAssertion(() => provider.Find("input[data-test=\"trigger-input\"]"));
+        provider.Find("input[data-test=\"trigger-input\"]").Change("btw");
+        provider.Find("textarea[data-test=\"replacement-input\"]").Change("by the way");
+        provider.Find("button.commit-edit").Click();
+
+        provider.WaitForAssertion(() => provider.Markup.Should().Contain("Trigger already exists"));
+        provider.FindAll(".mud-alert").Should().BeEmpty();
+    }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
@@ -38,6 +38,18 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public void EmptyState_DoesNotRenderTable()
+    {
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        cut.Markup.Should().Contain("No hotstrings yet.");
+        cut.FindAll("table.mobile-list").Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task EditButton_RaisesOnEdit()
     {
         HotstringEditModel item = Item();

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
@@ -1,0 +1,78 @@
+using AHKFlowApp.UI.Blazor.Components.Hotstrings;
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Validation;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Components.Hotstrings;
+
+public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
+{
+    public HotstringMobileListTests()
+    {
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    async Task IAsyncLifetime.DisposeAsync() => await DisposeAsync();
+
+    private static HotstringEditModel Item(string trigger = "btw", string replacement = "by the way") =>
+        new() { Id = Guid.NewGuid(), Trigger = trigger, Replacement = replacement };
+
+    [Fact]
+    public void Renders_TriggerAndReplacement_PerRow()
+    {
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [Item("btw", "by the way"), Item("addr", "123 Main St")])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        cut.Markup.Should().Contain("btw");
+        cut.Markup.Should().Contain("by the way");
+        cut.Markup.Should().Contain("addr");
+    }
+
+    [Fact]
+    public async Task EditButton_RaisesOnEdit()
+    {
+        HotstringEditModel item = Item();
+        HotstringEditModel? edited = null;
+
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [item])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[])
+            .Add(c => c.OnEdit, EventCallback.Factory.Create<HotstringEditModel>(this, m => edited = m)));
+
+        // Expand the row first
+        await cut.InvokeAsync(() => cut.Find("tr.mobile-row").Click());
+        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
+        await cut.InvokeAsync(() => cut.Find("button.start-edit").Click());
+
+        edited.Should().Be(item);
+    }
+
+    [Fact]
+    public async Task DeleteButton_RaisesOnDelete()
+    {
+        HotstringEditModel item = Item();
+        HotstringEditModel? deleted = null;
+
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [item])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[])
+            .Add(c => c.OnDelete, EventCallback.Factory.Create<HotstringEditModel>(this, m => deleted = m)));
+
+        await cut.InvokeAsync(() => cut.Find("tr.mobile-row").Click());
+        cut.WaitForAssertion(() => cut.Find("button.delete"));
+        await cut.InvokeAsync(() => cut.Find("button.delete").Click());
+
+        deleted.Should().Be(item);
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
@@ -75,4 +75,43 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
 
         deleted.Should().Be(item);
     }
+
+    [Fact]
+    public async Task SelectModeToggle_RevealsCheckboxes()
+    {
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [Item()])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        cut.FindAll("input.row-checkbox").Should().BeEmpty();
+
+        await cut.InvokeAsync(() => cut.Find("button.toggle-select-mode").Click());
+
+        cut.WaitForAssertion(() => cut.FindAll("input.row-checkbox").Should().NotBeEmpty());
+    }
+
+    [Fact]
+    public async Task BulkDelete_RaisesOnBulkDelete_WithSelectedIds()
+    {
+        HotstringEditModel a = Item("a", "x");
+        HotstringEditModel b = Item("b", "y");
+        IReadOnlyList<Guid>? deletedIds = null;
+
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [a, b])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[])
+            .Add(c => c.OnBulkDelete, EventCallback.Factory.Create<IReadOnlyList<Guid>>(this, ids => deletedIds = ids)));
+
+        await cut.InvokeAsync(() => cut.Find("button.toggle-select-mode").Click());
+
+        cut.WaitForAssertion(() => cut.FindAll("input.row-checkbox").Count.Should().Be(2));
+        cut.FindAll("input.row-checkbox")[0].Change(true);
+        cut.FindAll("input.row-checkbox")[1].Change(true);
+
+        await cut.InvokeAsync(() => cut.Find("button.bulk-delete-hotstrings").Click());
+
+        deletedIds.Should().BeEquivalentTo(new[] { a.Id!.Value, b.Id!.Value });
+    }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
@@ -483,13 +483,16 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public void Page_RendersBothDesktopAndMobileBranches()
+    public void Page_RendersCssGatedDesktopAndMobileBranches()
     {
         StubList(Page());
 
         IRenderedComponent<Hotkeys> cut = RenderPage();
-        cut.WaitForAssertion(() => cut.Find("button.add-hotkey-fab"));
 
-        cut.FindComponents<MudHidden>().Should().HaveCount(2);
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".desktop-branch button.add-hotkey").Should().NotBeNull();
+            cut.Find(".mobile-branch button.add-hotkey-fab").Should().NotBeNull();
+        });
     }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
@@ -220,6 +220,8 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
         _api.ListAsync(Arg.Any<HotkeyListRequest>(), Arg.Any<CancellationToken>())
             .Returns(
                 ApiResult<PagedList<HotkeyDto>>.Ok(Page(dto)),
+                ApiResult<PagedList<HotkeyDto>>.Ok(Page(dto)),
+                ApiResult<PagedList<HotkeyDto>>.Ok(Page(dto)),
                 ApiResult<PagedList<HotkeyDto>>.Ok(Page(dto)));
 
         IRenderedComponent<Hotkeys> cut = RenderPage();
@@ -229,7 +231,7 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
 
         cut.Find("button.reload-hotkeys").Click();
 
-        cut.WaitForAssertion(() => _api.Received(2).ListAsync(Arg.Any<HotkeyListRequest>(), Arg.Any<CancellationToken>()));
+        cut.WaitForAssertion(() => _api.Received(4).ListAsync(Arg.Any<HotkeyListRequest>(), Arg.Any<CancellationToken>()));
         cut.WaitForAssertion(() =>
         {
             cut.Find("button.commit-edit").Should().NotBeNull();
@@ -477,5 +479,21 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
                 r.CategoryIds != null &&
                 r.CategoryIds.Contains(work.Id)),
             Arg.Any<CancellationToken>()));
+    }
+
+    [Fact]
+    public void Page_RendersBothDesktopAndMobileBranches()
+    {
+        StubList(Page());
+
+        IRenderedComponent<Hotkeys> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find("button.add-hotkey"));
+
+        // Desktop branch wrapper
+        cut.FindAll(".desktop-branch").Should().NotBeEmpty();
+        // Mobile branch wrapper
+        cut.FindAll(".mobile-branch").Should().NotBeEmpty();
+        // FAB only in mobile branch
+        cut.FindAll("button.add-hotkey-fab").Should().NotBeEmpty();
     }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
@@ -45,6 +45,7 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
     private IRenderedComponent<Hotkeys> RenderPage()
     {
         Render<MudPopoverProvider>();
+        Render<MudDialogProvider>();
         return Render<Hotkeys>(p => p.AddCascadingValue(AuthenticatedState));
     }
 
@@ -214,7 +215,7 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public void Page_ReloadWhileEditingExistingRow_KeepsEditControls()
+    public void Page_ReloadWhileExpanded_KeepsMobileRowControls()
     {
         HotkeyDto dto = MakeHotkey("Open terminal", "T");
         _api.ListAsync(Arg.Any<HotkeyListRequest>(), Arg.Any<CancellationToken>())
@@ -225,17 +226,17 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
                 ApiResult<PagedList<HotkeyDto>>.Ok(Page(dto)));
 
         IRenderedComponent<Hotkeys> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find(".mobile-row"));
+        cut.Find(".mobile-row").Click();
         cut.WaitForAssertion(() => cut.Find("button.start-edit"));
-        cut.Find("button.start-edit").Click();
-        cut.WaitForAssertion(() => cut.Find("button.commit-edit"));
 
-        cut.Find("button.reload-hotkeys").Click();
+        cut.Find("button.reload-hotkeys-mobile").Click();
 
-        cut.WaitForAssertion(() => _api.Received(4).ListAsync(Arg.Any<HotkeyListRequest>(), Arg.Any<CancellationToken>()));
+        cut.WaitForAssertion(() => _api.Received(2).ListAsync(Arg.Any<HotkeyListRequest>(), Arg.Any<CancellationToken>()));
         cut.WaitForAssertion(() =>
         {
-            cut.Find("button.commit-edit").Should().NotBeNull();
-            cut.Find("input[data-test=\"key-input\"]").Should().NotBeNull();
+            cut.Find("button.start-edit").Should().NotBeNull();
+            cut.Markup.Should().Contain("Open terminal");
         });
     }
 
@@ -487,13 +488,8 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
         StubList(Page());
 
         IRenderedComponent<Hotkeys> cut = RenderPage();
-        cut.WaitForAssertion(() => cut.Find("button.add-hotkey"));
+        cut.WaitForAssertion(() => cut.Find("button.add-hotkey-fab"));
 
-        // Desktop branch wrapper
-        cut.FindAll(".desktop-branch").Should().NotBeEmpty();
-        // Mobile branch wrapper
-        cut.FindAll(".mobile-branch").Should().NotBeEmpty();
-        // FAB only in mobile branch
-        cut.FindAll("button.add-hotkey-fab").Should().NotBeEmpty();
+        cut.FindComponents<MudHidden>().Should().HaveCount(2);
     }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -213,6 +213,8 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         _api.ListAsync(Arg.Any<HotstringListRequest>(), Arg.Any<CancellationToken>())
             .Returns(
                 ApiResult<PagedList<HotstringDto>>.Ok(Page(dto)),
+                ApiResult<PagedList<HotstringDto>>.Ok(Page(dto)),
+                ApiResult<PagedList<HotstringDto>>.Ok(Page(dto)),
                 ApiResult<PagedList<HotstringDto>>.Ok(Page(dto)));
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
@@ -222,7 +224,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
 
         cut.Find("button.reload-hotstrings").Click();
 
-        cut.WaitForAssertion(() => _api.Received(2).ListAsync(Arg.Any<HotstringListRequest>(), Arg.Any<CancellationToken>()));
+        cut.WaitForAssertion(() => _api.Received(4).ListAsync(Arg.Any<HotstringListRequest>(), Arg.Any<CancellationToken>()));
         cut.WaitForAssertion(() =>
         {
             cut.Find("button.commit-edit").Should().NotBeNull();

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -45,6 +45,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     private IRenderedComponent<Hotstrings> RenderPage()
     {
         Render<MudPopoverProvider>();
+        Render<MudDialogProvider>();
         return Render<Hotstrings>(p => p.AddCascadingValue(AuthenticatedState));
     }
 
@@ -207,7 +208,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public void Page_ReloadWhileEditingExistingRow_KeepsEditControls()
+    public void Page_ReloadWhileExpanded_KeepsMobileRowControls()
     {
         var dto = new HotstringDto(Guid.NewGuid(), [], true, "btw", "by the way", null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
         _api.ListAsync(Arg.Any<HotstringListRequest>(), Arg.Any<CancellationToken>())
@@ -218,17 +219,17 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
                 ApiResult<PagedList<HotstringDto>>.Ok(Page(dto)));
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find(".mobile-row"));
+        cut.Find(".mobile-row").Click();
         cut.WaitForAssertion(() => cut.Find("button.start-edit"));
-        cut.Find("button.start-edit").Click();
-        cut.WaitForAssertion(() => cut.Find("button.commit-edit"));
 
-        cut.Find("button.reload-hotstrings").Click();
+        cut.Find("button.reload-hotstrings-mobile").Click();
 
-        cut.WaitForAssertion(() => _api.Received(4).ListAsync(Arg.Any<HotstringListRequest>(), Arg.Any<CancellationToken>()));
+        cut.WaitForAssertion(() => _api.Received(2).ListAsync(Arg.Any<HotstringListRequest>(), Arg.Any<CancellationToken>()));
         cut.WaitForAssertion(() =>
         {
-            cut.Find("button.commit-edit").Should().NotBeNull();
-            cut.Find("input[data-test=\"trigger-input\"]").Should().NotBeNull();
+            cut.Find("button.start-edit").Should().NotBeNull();
+            cut.Markup.Should().Contain("by the way");
         });
     }
 
@@ -407,13 +408,8 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         StubList(Page());
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
-        cut.WaitForAssertion(() => cut.Find("button.add-hotstring"));
+        cut.WaitForAssertion(() => cut.Find("button.add-hotstring-fab"));
 
-        // Desktop branch wrapper
-        cut.FindAll(".desktop-branch").Should().NotBeEmpty();
-        // Mobile branch wrapper
-        cut.FindAll(".mobile-branch").Should().NotBeEmpty();
-        // FAB only in mobile branch
-        cut.FindAll("button.add-hotstring-fab").Should().NotBeEmpty();
+        cut.FindComponents<MudHidden>().Should().HaveCount(2);
     }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -403,13 +403,16 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public void Page_RendersBothDesktopAndMobileBranches()
+    public void Page_RendersCssGatedDesktopAndMobileBranches()
     {
         StubList(Page());
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
-        cut.WaitForAssertion(() => cut.Find("button.add-hotstring-fab"));
 
-        cut.FindComponents<MudHidden>().Should().HaveCount(2);
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".desktop-branch button.add-hotstring").Should().NotBeNull();
+            cut.Find(".mobile-branch button.add-hotstring-fab").Should().NotBeNull();
+        });
     }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -398,4 +398,20 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
                 r.CategoryIds.Contains(work.Id)),
             Arg.Any<CancellationToken>()));
     }
+
+    [Fact]
+    public void Page_RendersBothDesktopAndMobileBranches()
+    {
+        StubList(Page());
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find("button.add-hotstring"));
+
+        // Desktop branch wrapper
+        cut.FindAll(".desktop-branch").Should().NotBeEmpty();
+        // Mobile branch wrapper
+        cut.FindAll(".mobile-branch").Should().NotBeEmpty();
+        // FAB only in mobile branch
+        cut.FindAll("button.add-hotstring-fab").Should().NotBeEmpty();
+    }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Validation/HotkeyEditModelTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Validation/HotkeyEditModelTests.cs
@@ -1,0 +1,37 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Validation;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Validation;
+
+public sealed class HotkeyEditModelTests
+{
+    [Fact]
+    public void Clone_CopiesEditableFields_WithoutSharingCollections()
+    {
+        var profileId = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var model = new HotkeyEditModel
+        {
+            Id = Guid.NewGuid(),
+            Description = "Open palette",
+            Key = "K",
+            Ctrl = true,
+            Alt = true,
+            Shift = true,
+            Win = false,
+            Action = HotkeyAction.Run,
+            Parameters = "shell:AppsFolder",
+            AppliesToAllProfiles = false,
+            ProfileIds = [profileId],
+            CategoryIds = [categoryId],
+        };
+
+        HotkeyEditModel clone = model.Clone();
+
+        clone.Should().BeEquivalentTo(model);
+        clone.ProfileIds.Should().NotBeSameAs(model.ProfileIds);
+        clone.CategoryIds.Should().NotBeSameAs(model.CategoryIds);
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Validation/HotstringEditModelTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Validation/HotstringEditModelTests.cs
@@ -41,6 +41,7 @@ public sealed class HotstringEditModelTests
     public void ToCreateDto_MapsAllFields()
     {
         var profileId = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
         var model = new HotstringEditModel
         {
             Trigger = "btw",
@@ -48,6 +49,7 @@ public sealed class HotstringEditModelTests
             Description = "polite filler",
             AppliesToAllProfiles = false,
             ProfileIds = [profileId],
+            CategoryIds = [categoryId],
             IsEndingCharacterRequired = true,
             IsTriggerInsideWord = false
         };
@@ -59,8 +61,34 @@ public sealed class HotstringEditModelTests
         dto.Description.Should().Be("polite filler");
         dto.AppliesToAllProfiles.Should().BeFalse();
         dto.ProfileIds.Should().HaveCount(1).And.Contain(profileId);
+        dto.CategoryIds.Should().HaveCount(1).And.Contain(categoryId);
         dto.IsEndingCharacterRequired.Should().BeTrue();
         dto.IsTriggerInsideWord.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Clone_CopiesEditableFields_WithoutSharingCollections()
+    {
+        var profileId = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var model = new HotstringEditModel
+        {
+            Id = Guid.NewGuid(),
+            Trigger = "btw",
+            Replacement = "by the way",
+            Description = "polite filler",
+            AppliesToAllProfiles = false,
+            ProfileIds = [profileId],
+            CategoryIds = [categoryId],
+            IsEndingCharacterRequired = true,
+            IsTriggerInsideWord = false
+        };
+
+        HotstringEditModel clone = model.Clone();
+
+        clone.Should().BeEquivalentTo(model);
+        clone.ProfileIds.Should().NotBeSameAs(model.ProfileIds);
+        clone.CategoryIds.Should().NotBeSameAs(model.CategoryIds);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Mobile pattern (<960px): compact 2-col list, expandable rows, full-screen edit dialog, FAB, select-mode bulk delete
- Desktop (md+): inline-edit `MudDataGrid` remains available, with the app shell widened to avoid page-level horizontal scrolling
- Same pattern applied to Hotstrings + Hotkeys pages

Spec: `docs/superpowers/specs/2026-05-24-mobile-hotstrings-hotkeys-design.md`
Plan: `docs/superpowers/plans/2026-05-24-mobile-hotstrings-hotkeys.md`

## New components

| Component | Purpose |
|---|---|
| `Components/Hotstrings/HotstringEditDialog.razor` | Full-screen create/edit dialog (mobile) |
| `Components/Hotstrings/HotstringMobileList.razor` | Compact list + expand + select mode |
| `Components/Hotkeys/HotkeyEditDialog.razor` | Full-screen create/edit dialog (mobile) |
| `Components/Hotkeys/HotkeyMobileList.razor` | Compact list + `Ctrl+Shift+K` format + select mode |

## Follow-up updates

- Fixed the large-screen layout so wide Hotstrings/Hotkeys grids use the available viewport and no longer force an app-level horizontal scrollbar.
- Hardened mobile data loading so the grid and mobile list share one request path instead of issuing duplicate list calls.
- Surfaced create/edit conflict responses as field-level validation errors in the mobile dialogs.
- Simplified responsive branch gating by removing stacked `MudHidden` wrappers; the pages now use a single scoped CSS breakpoint contract for `.desktop-branch` and `.mobile-branch`.
- Updated the spec, plan, and frontend guidance to document the CSS-gated branch pattern and avoid reintroducing double breakpoint gating.

## Deferred-question defaults

| Question | Default chosen |
|---|---|
| Pager UI | `MudPagination`, page size 10 on mobile |
| Hotkeys primary-line truncation | Description ellipsizes first; modifier+key stays intact |
| FAB scroll behavior | Always visible |
| Select-mode action bar | Sticky bottom |

## Test plan

- [x] Focused bUnit coverage for Hotstrings/Hotkeys branch rendering and mobile reload behavior
- [x] E2E mobile flow tests for Hotstrings and Hotkeys at mobile viewport
- [x] `dotnet build AHKFlowApp.slnx --configuration Release --no-restore`
- [x] `dotnet format AHKFlowApp.slnx --verify-no-changes`
- [x] Playwright CLI viewport checks at 375x812, 768x1024, 1280x800, and 1536x900 for mobile/desktop branch visibility and horizontal overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
