### PR TITLE
fix: stabilize VS Code Blazor full-stack debugging

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "ms-dotnettools.blazorwasm-companion",
+    "ms-dotnettools.csdevkit",
+    "ms-dotnettools.csharp"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "ms-dotnettools.csdevkit",
+    "ms-dotnettools.csharp",
+    "ms-vscode.powershell",
+    "ms-azuretools.vscode-bicep"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,0 @@
-{
-  "recommendations": [
-    "ms-dotnettools.blazorwasm-companion",
-    "ms-dotnettools.csdevkit",
-    "ms-dotnettools.csharp"
-  ]
-}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,7 +44,7 @@
       // Keep the UI debugger on an isolated Chrome profile. Reusing the default profile
       // can hand startup off to an existing Chrome process and reintroduce cold-start crashes.
       "browserConfig": {
-        "userDataDir": "${workspaceFolder}\\.vscode\\chrome-debug-profile"
+        "userDataDir": "${workspaceFolder}/.vscode/chrome-debug-profile"
       }
     },
     {
@@ -61,7 +61,10 @@
         "action": "startDebugging",
         "pattern": "\\bNow listening on:",
         "name": "UI: http"
-      }
+      },
+      "cascadeTerminateToConfigurations": [
+        "UI: http"
+      ]
     },
     {
       "name": "Full Stack: LocalDB SQL",
@@ -77,7 +80,10 @@
         "action": "startDebugging",
         "pattern": "\\bNow listening on:",
         "name": "UI: http"
-      }
+      },
+      "cascadeTerminateToConfigurations": [
+        "UI: http"
+      ]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "cwd": "${workspaceFolder}/src/Backend/AHKFlowApp.API",
       "launchSettingsFilePath": "${workspaceFolder}/src/Backend/AHKFlowApp.API/Properties/launchSettings.json",
       "launchSettingsProfile": "Docker SQL (Recommended)",
-      "console": "externalTerminal",
+      "console": "internalConsole",
       "serverReadyAction": {
         "action": "openExternally",
         "pattern": "\\bNow listening on:",
@@ -26,7 +26,7 @@
       "cwd": "${workspaceFolder}/src/Backend/AHKFlowApp.API",
       "launchSettingsFilePath": "${workspaceFolder}/src/Backend/AHKFlowApp.API/Properties/launchSettings.json",
       "launchSettingsProfile": "LocalDB SQL",
-      "console": "externalTerminal",
+      "console": "internalConsole",
       "serverReadyAction": {
         "action": "openExternally",
         "pattern": "\\bNow listening on:",
@@ -35,27 +35,54 @@
     },
     {
       "name": "UI: http",
-      "type": "dotnet",
+      "type": "blazorwasm",
       "request": "launch",
-      "projectPath": "${workspaceFolder}/src/Frontend/AHKFlowApp.UI.Blazor/AHKFlowApp.UI.Blazor.csproj"
-    }
-  ],
-  "compounds": [
+      "cwd": "${workspaceFolder}/src/Frontend/AHKFlowApp.UI.Blazor",
+      "browser": "chrome",
+      "url": "http://localhost:5601",
+      "timeout": 60000,
+      "trace": "verbose",
+      "browserConfig": {
+        "outputCapture": "std",
+        "userDataDir": "${workspaceFolder}\\.vscode\\chrome-debug-profile",
+        "runtimeArgs": [
+          "--enable-logging=stderr",
+          "--v=1",
+          "--disable-extensions"
+        ]
+      }
+    },
     {
       "name": "Full Stack: Docker SQL (Recommended)",
-      "configurations": [
-        "API: Docker SQL (Recommended)",
-        "UI: http"
-      ],
-      "stopAll": true
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build: Full Stack",
+      "program": "${workspaceFolder}/src/Backend/AHKFlowApp.API/bin/Debug/net10.0/AHKFlowApp.API.dll",
+      "cwd": "${workspaceFolder}/src/Backend/AHKFlowApp.API",
+      "launchSettingsFilePath": "${workspaceFolder}/src/Backend/AHKFlowApp.API/Properties/launchSettings.json",
+      "launchSettingsProfile": "Docker SQL (Recommended)",
+      "console": "internalConsole",
+      "serverReadyAction": {
+        "action": "startDebugging",
+        "pattern": "\\bNow listening on:",
+        "name": "UI: http"
+      }
     },
     {
       "name": "Full Stack: LocalDB SQL",
-      "configurations": [
-        "API: LocalDB SQL",
-        "UI: http"
-      ],
-      "stopAll": true
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build: Full Stack",
+      "program": "${workspaceFolder}/src/Backend/AHKFlowApp.API/bin/Debug/net10.0/AHKFlowApp.API.dll",
+      "cwd": "${workspaceFolder}/src/Backend/AHKFlowApp.API",
+      "launchSettingsFilePath": "${workspaceFolder}/src/Backend/AHKFlowApp.API/Properties/launchSettings.json",
+      "launchSettingsProfile": "LocalDB SQL",
+      "console": "internalConsole",
+      "serverReadyAction": {
+        "action": "startDebugging",
+        "pattern": "\\bNow listening on:",
+        "name": "UI: http"
+      }
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,12 +43,7 @@
       "timeout": 60000,
       "trace": "verbose",
       "browserConfig": {
-        "outputCapture": "std",
-        "userDataDir": "${workspaceFolder}\\.vscode\\chrome-debug-profile",
-        "runtimeArgs": [
-          "--enable-logging=stderr",
-          "--v=1"
-        ]
+        "userDataDir": "${workspaceFolder}\\.vscode\\chrome-debug-profile"
       }
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,7 +41,6 @@
       "browser": "chrome",
       "url": "http://localhost:5601",
       "timeout": 60000,
-      "trace": "verbose",
       // Keep the UI debugger on an isolated Chrome profile. Reusing the default profile
       // can hand startup off to an existing Chrome process and reintroduce cold-start crashes.
       "browserConfig": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,6 +42,8 @@
       "url": "http://localhost:5601",
       "timeout": 60000,
       "trace": "verbose",
+      // Keep the UI debugger on an isolated Chrome profile. Reusing the default profile
+      // can hand startup off to an existing Chrome process and reintroduce cold-start crashes.
       "browserConfig": {
         "userDataDir": "${workspaceFolder}\\.vscode\\chrome-debug-profile"
       }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,7 +40,16 @@
       "cwd": "${workspaceFolder}/src/Frontend/AHKFlowApp.UI.Blazor",
       "browser": "chrome",
       "url": "http://localhost:5601",
-      "timeout": 60000
+      "timeout": 60000,
+      "trace": "verbose",
+      "browserConfig": {
+        "outputCapture": "std",
+        "userDataDir": "${workspaceFolder}\\.vscode\\chrome-debug-profile",
+        "runtimeArgs": [
+          "--enable-logging=stderr",
+          "--v=1"
+        ]
+      }
     },
     {
       "name": "Full Stack: Docker SQL (Recommended)",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "cwd": "${workspaceFolder}/src/Backend/AHKFlowApp.API",
       "launchSettingsFilePath": "${workspaceFolder}/src/Backend/AHKFlowApp.API/Properties/launchSettings.json",
       "launchSettingsProfile": "Docker SQL (Recommended)",
-      "console": "internalConsole",
+      "console": "externalTerminal",
       "serverReadyAction": {
         "action": "openExternally",
         "pattern": "\\bNow listening on:",
@@ -26,7 +26,7 @@
       "cwd": "${workspaceFolder}/src/Backend/AHKFlowApp.API",
       "launchSettingsFilePath": "${workspaceFolder}/src/Backend/AHKFlowApp.API/Properties/launchSettings.json",
       "launchSettingsProfile": "LocalDB SQL",
-      "console": "internalConsole",
+      "console": "externalTerminal",
       "serverReadyAction": {
         "action": "openExternally",
         "pattern": "\\bNow listening on:",
@@ -40,17 +40,7 @@
       "cwd": "${workspaceFolder}/src/Frontend/AHKFlowApp.UI.Blazor",
       "browser": "chrome",
       "url": "http://localhost:5601",
-      "timeout": 60000,
-      "trace": "verbose",
-      "browserConfig": {
-        "outputCapture": "std",
-        "userDataDir": "${workspaceFolder}\\.vscode\\chrome-debug-profile",
-        "runtimeArgs": [
-          "--enable-logging=stderr",
-          "--v=1",
-          "--disable-extensions"
-        ]
-      }
+      "timeout": 60000
     },
     {
       "name": "Full Stack: Docker SQL (Recommended)",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,34 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "build: Full Stack",
+      "dependsOn": [
+        "build: AHKFlowApp.API",
+        "build: AHKFlowApp.UI.Blazor"
+      ],
+      "dependsOrder": "parallel",
+      "problemMatcher": []
+    },
+    {
+      "label": "build: AHKFlowApp.UI.Blazor",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "${workspaceFolder}/src/Frontend/AHKFlowApp.UI.Blazor/AHKFlowApp.UI.Blazor.csproj",
+        "--configuration",
+        "Debug",
+        "--verbosity",
+        "minimal"
+      ],
+      "group": "build",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
       "label": "build: AHKFlowApp.API",
       "type": "process",
       "command": "dotnet",

--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ Individual seed endpoints (`/dev/hotstrings/seed`, `/dev/hotkeys/seed`, `/dev/ca
 
 ### VS Code full-stack debugging
 
-The VS Code launch configuration intentionally uses a few non-obvious choices to keep the Blazor WebAssembly debug flow stable:
+These VS Code debug safeguards are intentional:
 
-- The Blazor UI launch profile uses `type: "blazorwasm"`, not `dotnet` or `coreclr`.
-- The Blazor UI launch profile sets `browserConfig.userDataDir` to a workspace-local Chrome profile so VS Code gets an isolated browser process instead of reusing your default Chrome profile, which caused cold-start UI crashes.
-- The full-stack launch profiles start the API first and then start the UI from `serverReadyAction` instead of using a parallel compound launch.
-- Localhost development skips service-worker registration and unregisters existing localhost workers because the service worker destabilized VS Code Blazor/MSAL login debugging.
+- The UI launch profile uses `type: "blazorwasm"`; `dotnet` and `coreclr` do not provide the correct Blazor WebAssembly debug flow.
+- The full-stack launch profiles start the UI from `serverReadyAction` after the API is listening instead of using a parallel compound launch.
+- The UI launch profile sets `browserConfig.userDataDir` to a workspace-local Chrome profile so VS Code gets an isolated browser process; reusing the default profile caused cold-start UI crashes.
+- Localhost development skips service-worker registration and unregisters existing localhost workers because persisted worker state destabilized VS Code Blazor/MSAL login debugging.
 
-These settings are intentional. If you revisit `.vscode/launch.json` or `src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/js/registerServiceWorker.js`, preserve this behavior unless you have re-verified the cold-start and login-debug flow in VS Code.
+If you revisit `.vscode/launch.json` or `src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/js/registerServiceWorker.js`, re-verify the cold-start and login-debug flow in VS Code before removing any of these safeguards.
 
 ### Environments
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ Individual seed endpoints (`/dev/hotstrings/seed`, `/dev/hotkeys/seed`, `/dev/ca
 | OpenAPI JSON | http://localhost:5600/swagger/v1/swagger.json |
 | Frontend | http://localhost:5601 |
 
+### VS Code full-stack debugging
+
+The VS Code launch configuration intentionally uses a few non-obvious choices to keep the Blazor WebAssembly debug flow stable:
+
+- The Blazor UI launch profile uses `type: "blazorwasm"`, not `dotnet` or `coreclr`.
+- The full-stack launch profiles start the API first and then start the UI from `serverReadyAction` instead of using a parallel compound launch.
+- Localhost development skips service-worker registration and unregisters existing localhost workers because the service worker destabilized VS Code Blazor/MSAL login debugging.
+
+These settings are intentional. If you revisit `.vscode/launch.json` or `src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/js/registerServiceWorker.js`, preserve this behavior unless you have re-verified the cold-start and login-debug flow in VS Code.
+
 ### Environments
 
 The application supports three distinct environments:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Individual seed endpoints (`/dev/hotstrings/seed`, `/dev/hotkeys/seed`, `/dev/ca
 The VS Code launch configuration intentionally uses a few non-obvious choices to keep the Blazor WebAssembly debug flow stable:
 
 - The Blazor UI launch profile uses `type: "blazorwasm"`, not `dotnet` or `coreclr`.
+- The Blazor UI launch profile sets `browserConfig.userDataDir` to a workspace-local Chrome profile so VS Code gets an isolated browser process instead of reusing your default Chrome profile, which caused cold-start UI crashes.
 - The full-stack launch profiles start the API first and then start the UI from `serverReadyAction` instead of using a parallel compound launch.
 - Localhost development skips service-worker registration and unregisters existing localhost workers because the service worker destabilized VS Code Blazor/MSAL login debugging.
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Properties/launchSettings.json
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Properties/launchSettings.json
@@ -5,6 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "applicationUrl": "http://localhost:5601",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/js/registerServiceWorker.js
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/js/registerServiceWorker.js
@@ -21,7 +21,9 @@ if ('serviceWorker' in navigator) {
                     return;
                 }
 
-                sessionStorage.removeItem(localServiceWorkerReloadKey);
+                if (!navigator.serviceWorker.controller) {
+                    sessionStorage.removeItem(localServiceWorkerReloadKey);
+                }
             })
             .catch(function (err) {
                 console.error('Service worker cleanup failed:', err);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/js/registerServiceWorker.js
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/js/registerServiceWorker.js
@@ -1,7 +1,9 @@
 const isLocalDevelopmentHost =
     window.location.hostname === 'localhost' ||
     window.location.hostname === '127.0.0.1' ||
+    window.location.hostname === '::1' ||
     window.location.hostname === '[::1]';
+const localServiceWorkerReloadKey = 'ahkflowapp-local-sw-cleanup-reload';
 
 if ('serviceWorker' in navigator) {
     if (isLocalDevelopmentHost) {
@@ -11,6 +13,15 @@ if ('serviceWorker' in navigator) {
                 return Promise.all(registrations.map(function (registration) {
                     return registration.unregister();
                 }));
+            })
+            .then(function () {
+                if (navigator.serviceWorker.controller && sessionStorage.getItem(localServiceWorkerReloadKey) !== 'true') {
+                    sessionStorage.setItem(localServiceWorkerReloadKey, 'true');
+                    window.location.reload();
+                    return;
+                }
+
+                sessionStorage.removeItem(localServiceWorkerReloadKey);
             })
             .catch(function (err) {
                 console.error('Service worker cleanup failed:', err);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/js/registerServiceWorker.js
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/js/registerServiceWorker.js
@@ -1,6 +1,23 @@
+const isLocalDevelopmentHost =
+    window.location.hostname === 'localhost' ||
+    window.location.hostname === '127.0.0.1' ||
+    window.location.hostname === '[::1]';
+
 if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('service-worker.js', { updateViaCache: 'none' })
-        .catch(function (err) {
-            console.error('Service worker registration failed:', err);
-        });
+    if (isLocalDevelopmentHost) {
+        navigator.serviceWorker.getRegistrations()
+            .then(function (registrations) {
+                return Promise.all(registrations.map(function (registration) {
+                    return registration.unregister();
+                }));
+            })
+            .catch(function (err) {
+                console.error('Service worker cleanup failed:', err);
+            });
+    } else {
+        navigator.serviceWorker.register('service-worker.js', { updateViaCache: 'none' })
+            .catch(function (err) {
+                console.error('Service worker registration failed:', err);
+            });
+    }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/js/registerServiceWorker.js
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/js/registerServiceWorker.js
@@ -5,6 +5,7 @@ const isLocalDevelopmentHost =
 
 if ('serviceWorker' in navigator) {
     if (isLocalDevelopmentHost) {
+        // Keep localhost free of service workers because they destabilize VS Code Blazor/MSAL login debugging.
         navigator.serviceWorker.getRegistrations()
             .then(function (registrations) {
                 return Promise.all(registrations.map(function (registration) {


### PR DESCRIPTION
## Summary
Stabilize VS Code full-stack debugging for the Blazor WebAssembly UI.

## What changed
- switched the VS Code UI launch profile to the dedicated `blazorwasm` debugger flow
- changed the full-stack launch profiles to build both projects, start the API first, and launch the UI from `serverReadyAction`
- kept the Chrome launch profile minimal while preserving an isolated `browserConfig.userDataDir` to avoid cold-start crashes caused by default-profile reuse
- restored stop-together behavior with `cascadeTerminateToConfigurations` so stopping the API session also stops the spawned UI session
- hardened localhost service worker cleanup to skip registration on local hosts, handle both `::1` and `[::1]`, and reload once when an old worker is still controlling the page
- documented the intentional debug safeguards in `README.md`
- added repo extension recommendations for PowerShell and Bicep work

## Why
Cold-start VS Code debugging was flaky because the UI browser session could launch before the Blazor debugger path was ready, and shared Chrome profile state could be reused across launches. The updated launch flow makes startup deterministic and keeps the local browser state isolated.

## Files of interest
- `.vscode/launch.json`
- `.vscode/tasks.json`
- `.vscode/extensions.json`
- `src/Frontend/AHKFlowApp.UI.Blazor/Properties/launchSettings.json`
- `src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/js/registerServiceWorker.js`
- `README.md`
