### PR TITLE
fix: launcher honors worktree ports (parity with isolation-kit launcher)

### DIFF
--- a/LauncherPlan.cs
+++ b/LauncherPlan.cs
@@ -5,26 +5,84 @@ internal sealed record ProjectLaunch(
     string ProjectPath,
     string LaunchProfile,
     string ReadyUrl,
-    string? BrowserUrl);
+    string? BrowserUrl,
+    string UrlOverride);
 
 internal static class LauncherPlan
 {
     public const string ApiUrl = "http://localhost:5600";
     public const string FrontendUrl = "http://localhost:5601";
 
-    public static IReadOnlyList<ProjectLaunch> Create(string apiProfile, string uiProfile) =>
+    public static IReadOnlyList<ProjectLaunch> Create(
+        string apiProfile,
+        string uiProfile,
+        string apiUrl = ApiUrl,
+        string frontendUrl = FrontendUrl) =>
         [
             new(
                 "API",
                 Path.Combine("src", "Backend", "AHKFlowApp.API", "AHKFlowApp.API.csproj"),
                 apiProfile,
-                $"{ApiUrl}/swagger/index.html",
-                BrowserUrl: null),
+                $"{apiUrl}/swagger/index.html",
+                BrowserUrl: null,
+                UrlOverride: apiUrl),
             new(
                 "UI",
                 Path.Combine("src", "Frontend", "AHKFlowApp.UI.Blazor", "AHKFlowApp.UI.Blazor.csproj"),
                 uiProfile,
-                FrontendUrl,
-                FrontendUrl)
+                frontendUrl,
+                frontendUrl,
+                UrlOverride: frontendUrl)
         ];
+}
+
+internal sealed record WorktreeLocalDevManifest(int ApiPort, int UiPort, string ApiUrl, string UiUrl)
+{
+    private const string ApiPortKey = "AHKFLOW_API_PORT";
+    private const string UiPortKey = "AHKFLOW_UI_PORT";
+    private const string ApiUrlKey = "AHKFLOW_API_URL";
+    private const string UiUrlKey = "AHKFLOW_UI_URL";
+
+    public static WorktreeLocalDevManifest Parse(string text)
+    {
+        var values = text
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Split('=', 2))
+            .Where(parts => parts.Length == 2)
+            .ToDictionary(parts => parts[0].Trim(), parts => parts[1].Trim(), StringComparer.OrdinalIgnoreCase);
+
+        int apiPort = TryGetPort(values, ApiPortKey) ?? GetPortFromUrl(LauncherPlan.ApiUrl);
+        int uiPort = TryGetPort(values, UiPortKey) ?? GetPortFromUrl(LauncherPlan.FrontendUrl);
+        string apiUrl = values.TryGetValue(ApiUrlKey, out string? configuredApiUrl)
+            ? configuredApiUrl
+            : $"http://localhost:{apiPort}";
+        string uiUrl = values.TryGetValue(UiUrlKey, out string? configuredUiUrl)
+            ? configuredUiUrl
+            : $"http://localhost:{uiPort}";
+
+        return new WorktreeLocalDevManifest(
+            GetPortFromUrl(apiUrl, fallbackPort: apiPort),
+            GetPortFromUrl(uiUrl, fallbackPort: uiPort),
+            apiUrl,
+            uiUrl);
+    }
+
+    private static int? TryGetPort(IReadOnlyDictionary<string, string> values, string key)
+    {
+        if (!values.TryGetValue(key, out string? value))
+        {
+            return null;
+        }
+
+        return int.TryParse(value, out int port) && port is > 0 and <= 65535
+            ? port
+            : null;
+    }
+
+    private static int GetPortFromUrl(string url, int? fallbackPort = null)
+    {
+        return Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) && uri.Port > 0
+            ? uri.Port
+            : fallbackPort ?? 0;
+    }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -7,18 +7,34 @@ internal static class Program
 {
     private const string DefaultApiProfile = "LocalDB SQL";
     private const string DefaultUiProfile = "http";
+    private const string ApiProfileEnvironmentVariable = "AHKFLOW_API_PROFILE";
+    private const string UiProfileEnvironmentVariable = "AHKFLOW_UI_PROFILE";
+    private const string ApiUrlEnvironmentVariable = "AHKFLOW_API_URL";
+    private const string UiUrlEnvironmentVariable = "AHKFLOW_UI_URL";
+    private const string WorktreeManifestRelativePath = "scripts/.env.worktree";
+    private const string SolutionMarker = "AHKFlowApp.slnx";
     private const int ReadinessAttempts = 120;
-    private static readonly TimeSpan ReadinessDelay = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan s_readinessDelay = TimeSpan.FromMilliseconds(500);
 
     public static async Task<int> Main()
     {
         string rootDirectory = FindRepositoryRoot();
-        string apiProfile = Environment.GetEnvironmentVariable("AHKFLOW_API_PROFILE") ?? DefaultApiProfile;
-        string uiProfile = Environment.GetEnvironmentVariable("AHKFLOW_UI_PROFILE") ?? DefaultUiProfile;
-        IReadOnlyList<ProjectLaunch> launches = LauncherPlan.Create(apiProfile, uiProfile);
+        string apiProfile = Environment.GetEnvironmentVariable(ApiProfileEnvironmentVariable) ?? DefaultApiProfile;
+        string uiProfile = Environment.GetEnvironmentVariable(UiProfileEnvironmentVariable) ?? DefaultUiProfile;
+
+        string manifestPath = Path.Combine(rootDirectory, WorktreeManifestRelativePath);
+        WorktreeLocalDevManifest manifest = File.Exists(manifestPath)
+            ? WorktreeLocalDevManifest.Parse(await File.ReadAllTextAsync(manifestPath))
+            : WorktreeLocalDevManifest.Parse("");
+
+        string apiUrl = Environment.GetEnvironmentVariable(ApiUrlEnvironmentVariable) ?? manifest.ApiUrl;
+        string uiUrl = Environment.GetEnvironmentVariable(UiUrlEnvironmentVariable) ?? manifest.UiUrl;
+
+        IReadOnlyList<ProjectLaunch> launches = LauncherPlan.Create(apiProfile, uiProfile, apiUrl, uiUrl);
 
         using CancellationTokenSource shutdown = new();
         List<Process> processes = [];
+        Dictionary<string, int> pidsByName = [];
 
         Console.CancelKeyPress += (_, eventArgs) =>
         {
@@ -32,14 +48,18 @@ internal static class Program
         {
             foreach (ProjectLaunch launch in launches)
             {
-                processes.Add(StartProject(rootDirectory, launch));
+                Process process = StartProject(rootDirectory, launch);
+                processes.Add(process);
+                pidsByName[launch.Name] = process.Id;
             }
+
+            UpdateManifestWithPids(manifestPath, pidsByName);
 
             Console.WriteLine("AHKFlowApp is starting.");
             Console.WriteLine($"API profile: {apiProfile}");
             Console.WriteLine($"UI profile: {uiProfile}");
-            Console.WriteLine($"API: {LauncherPlan.ApiUrl}");
-            Console.WriteLine($"UI:  {LauncherPlan.FrontendUrl}");
+            Console.WriteLine($"API: {apiUrl}");
+            Console.WriteLine($"UI:  {uiUrl}");
             Console.WriteLine("Opening the UI in the browser when it is ready.");
             Console.WriteLine("Press Ctrl+C to stop both projects.");
 
@@ -72,7 +92,7 @@ internal static class Program
     private static string? SearchParents(string startDirectory)
     {
         string directory = startDirectory;
-        while (!File.Exists(Path.Combine(directory, "AHKFlowApp.slnx")))
+        while (!File.Exists(Path.Combine(directory, SolutionMarker)))
         {
             DirectoryInfo? parent = Directory.GetParent(directory);
             if (parent is null)
@@ -99,6 +119,9 @@ internal static class Program
         startInfo.ArgumentList.Add(launch.ProjectPath);
         startInfo.ArgumentList.Add("--launch-profile");
         startInfo.ArgumentList.Add(launch.LaunchProfile);
+        startInfo.ArgumentList.Add("--");
+        startInfo.ArgumentList.Add("--urls");
+        startInfo.ArgumentList.Add(launch.UrlOverride);
 
         Process process = Process.Start(startInfo)
             ?? throw new InvalidOperationException($"Failed to start {launch.Name} project.");
@@ -107,14 +130,40 @@ internal static class Program
         return process;
     }
 
+    private static void UpdateManifestWithPids(string manifestPath, IReadOnlyDictionary<string, int> pidsByName)
+    {
+        try
+        {
+            string existingContent = File.Exists(manifestPath) ? File.ReadAllText(manifestPath) : "";
+            List<string> lines = [.. existingContent.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)];
+
+            foreach (KeyValuePair<string, int> entry in pidsByName)
+            {
+                string pidKey = $"AHKFLOW_{entry.Key.ToUpperInvariant()}_PID=";
+                lines.RemoveAll(line => line.StartsWith(pidKey, StringComparison.OrdinalIgnoreCase));
+            }
+
+            foreach (KeyValuePair<string, int> entry in pidsByName)
+            {
+                string pidKey = $"AHKFLOW_{entry.Key.ToUpperInvariant()}_PID";
+                lines.Add($"{pidKey}={entry.Value}");
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(manifestPath)!);
+            File.WriteAllText(manifestPath, string.Join(Environment.NewLine, lines) + Environment.NewLine);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Console.WriteLine($"Warning: could not write PIDs to manifest: {ex.Message}");
+        }
+    }
+
     private static async Task OpenBrowsersWhenReadyAsync(
         IReadOnlyList<ProjectLaunch> launches,
         CancellationToken cancellationToken)
     {
         using HttpClient httpClient = new();
-        Task[] browserTasks = launches
-            .Select(launch => OpenBrowserWhenReadyAsync(httpClient, launch, cancellationToken))
-            .ToArray();
+        Task[] browserTasks = [.. launches.Select(launch => OpenBrowserWhenReadyAsync(httpClient, launch, cancellationToken))];
 
         await Task.WhenAll(browserTasks);
     }
@@ -160,7 +209,7 @@ internal static class Program
             {
             }
 
-            await Task.Delay(ReadinessDelay, cancellationToken);
+            await Task.Delay(s_readinessDelay, cancellationToken);
         }
 
         return false;
@@ -189,7 +238,7 @@ internal static class Program
         IReadOnlyList<Process> processes,
         CancellationToken cancellationToken)
     {
-        Task[] waitTasks = processes.Select(process => process.WaitForExitAsync(cancellationToken)).ToArray();
+        Task[] waitTasks = [.. processes.Select(process => process.WaitForExitAsync(cancellationToken))];
 
         try
         {

--- a/tests/AHKFlowApp.CLI.Tests/Launcher/LauncherPlanTests.cs
+++ b/tests/AHKFlowApp.CLI.Tests/Launcher/LauncherPlanTests.cs
@@ -20,13 +20,102 @@ public sealed class LauncherPlanTests
                     Path.Combine("src", "Backend", "AHKFlowApp.API", "AHKFlowApp.API.csproj"),
                     "LocalDB SQL",
                     "http://localhost:5600/swagger/index.html",
-                    BrowserUrl: null),
+                    BrowserUrl: null,
+                    UrlOverride: "http://localhost:5600"),
                 new ProjectLaunch(
                     "UI",
                     Path.Combine("src", "Frontend", "AHKFlowApp.UI.Blazor", "AHKFlowApp.UI.Blazor.csproj"),
                     "http",
                     "http://localhost:5601",
-                    "http://localhost:5601")
+                    "http://localhost:5601",
+                    UrlOverride: "http://localhost:5601")
             ]);
+    }
+
+    [Fact]
+    public void Create_WhenUrlsProvided_ConfiguresDynamicApiAndFrontendLaunches()
+    {
+        IReadOnlyList<ProjectLaunch> launches = LauncherPlan.Create(
+            apiProfile: "LocalDB SQL",
+            uiProfile: "http",
+            apiUrl: "http://localhost:5604",
+            frontendUrl: "http://localhost:5605");
+
+        launches.Should().BeEquivalentTo(
+            [
+                new ProjectLaunch(
+                    "API",
+                    Path.Combine("src", "Backend", "AHKFlowApp.API", "AHKFlowApp.API.csproj"),
+                    "LocalDB SQL",
+                    "http://localhost:5604/swagger/index.html",
+                    BrowserUrl: null,
+                    UrlOverride: "http://localhost:5604"),
+                new ProjectLaunch(
+                    "UI",
+                    Path.Combine("src", "Frontend", "AHKFlowApp.UI.Blazor", "AHKFlowApp.UI.Blazor.csproj"),
+                    "http",
+                    "http://localhost:5605",
+                    "http://localhost:5605",
+                    UrlOverride: "http://localhost:5605")
+            ]);
+    }
+
+    [Fact]
+    public void WorktreeLocalDevManifest_Parse_WhenValuesExist_ReturnsUrls()
+    {
+        const string text = """
+            AHKFLOW_API_PORT=5604
+            AHKFLOW_UI_PORT=5605
+            AHKFLOW_API_URL=http://localhost:5604
+            AHKFLOW_UI_URL=http://localhost:5605
+            """;
+
+        var manifest = WorktreeLocalDevManifest.Parse(text);
+
+        manifest.ApiPort.Should().Be(5604);
+        manifest.UiPort.Should().Be(5605);
+        manifest.ApiUrl.Should().Be("http://localhost:5604");
+        manifest.UiUrl.Should().Be("http://localhost:5605");
+    }
+
+    [Fact]
+    public void WorktreeLocalDevManifest_Parse_WhenValuesAbsent_ReturnsDefaults()
+    {
+        var manifest = WorktreeLocalDevManifest.Parse("");
+
+        manifest.ApiUrl.Should().Be("http://localhost:5600");
+        manifest.UiUrl.Should().Be("http://localhost:5601");
+    }
+
+    [Fact]
+    public void WorktreeLocalDevManifest_Parse_WhenOnlyPortsExist_ReturnsUrlsFromPorts()
+    {
+        const string text = """
+            AHKFLOW_API_PORT=5608
+            AHKFLOW_UI_PORT=5609
+            """;
+
+        var manifest = WorktreeLocalDevManifest.Parse(text);
+
+        manifest.ApiPort.Should().Be(5608);
+        manifest.UiPort.Should().Be(5609);
+        manifest.ApiUrl.Should().Be("http://localhost:5608");
+        manifest.UiUrl.Should().Be("http://localhost:5609");
+    }
+
+    [Fact]
+    public void WorktreeLocalDevManifest_Parse_WhenInvalidPortsExist_IgnoresPorts()
+    {
+        const string text = """
+            AHKFLOW_API_PORT=not-a-port
+            AHKFLOW_UI_PORT=70000
+            """;
+
+        var manifest = WorktreeLocalDevManifest.Parse(text);
+
+        manifest.ApiPort.Should().Be(5600);
+        manifest.UiPort.Should().Be(5601);
+        manifest.ApiUrl.Should().Be("http://localhost:5600");
+        manifest.UiUrl.Should().Be("http://localhost:5601");
     }
 }


### PR DESCRIPTION
The root launcher hardcoded 5600/5601 for the banner, readiness poll, and browser-open, so in a worktree it showed/opened the wrong ports while the child processes bound to the assigned worktree ports. Bring it to parity with the isolation-kit's launcher: parse scripts/.env.worktree (AHKFLOW_API_URL/UI_URL, or derive from *_PORT), use the resolved URLs for the banner/readiness/browser, pass `-- --urls` to the children so they bind to the worktree ports regardless of launchSettings, and record child PIDs (AHKFLOW_*_PID) back into the manifest. Mirror the kit's six launcher tests.

## Summary

Brief description of changes.

## Checklist

- [ ] Tests pass (`dotnet test`)
- [ ] Build succeeds (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Breaking changes documented (if any)
