### PR TITLE
fix: detect powershell vs pwsh exe for worktree removal

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -169,7 +169,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\scripts\\new-worktree.ps1\""
+            "command": "pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\scripts\\new-worktree.ps1\""
           }
         ]
       }
@@ -179,7 +179,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\scripts\\remove-worktree-local-dev.ps1\" -TimeoutSeconds 300"
+            "command": "pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\scripts\\remove-worktree-local-dev.ps1\" -TimeoutSeconds 300"
           }
         ]
       }

--- a/scripts/new-worktree.ps1
+++ b/scripts/new-worktree.ps1
@@ -18,6 +18,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'worktree-git.common.ps1')
+. (Join-Path $PSScriptRoot 'worktree-powershell.common.ps1')
 
 function Write-Stderr {
     param([string] $Message)
@@ -140,7 +141,8 @@ function Invoke-OrphanDockerPrune {
     }
 
     try {
-        $pruneOutput = & powershell -NoProfile -ExecutionPolicy Bypass -File $pruneScript -Quiet 2>&1
+        $psExe = Resolve-PowerShellExecutable
+        $pruneOutput = & $psExe -NoProfile -ExecutionPolicy Bypass -File $pruneScript -Quiet 2>&1
         foreach ($line in $pruneOutput) {
             if ($line) {
                 Write-Stderr ([string] $line)
@@ -236,7 +238,8 @@ if (-not (Test-Path -LiteralPath $setupScript)) {
     throw "Setup script was not found in the new worktree: $setupScript"
 }
 
-$setupOutput = & powershell -NoProfile -ExecutionPolicy Bypass -File $setupScript -RepoRoot $worktreePath -Quiet
+$psExe = Resolve-PowerShellExecutable
+$setupOutput = & $psExe -NoProfile -ExecutionPolicy Bypass -File $setupScript -RepoRoot $worktreePath -Quiet
 $setupExitCode = $LASTEXITCODE
 foreach ($line in $setupOutput) {
     if ($line) {

--- a/scripts/remove-worktree-local-dev.ps1
+++ b/scripts/remove-worktree-local-dev.ps1
@@ -61,6 +61,34 @@ if (Test-Path -LiteralPath $worktreeLogHelperPath) {
     . $worktreeLogHelperPath
 }
 
+$powerShellHelperPath = Join-Path $PSScriptRoot 'worktree-powershell.common.ps1'
+if (Test-Path -LiteralPath $powerShellHelperPath) {
+    . $powerShellHelperPath
+}
+
+if (-not (Get-Command Resolve-PowerShellExecutable -ErrorAction SilentlyContinue)) {
+    function Resolve-PowerShellExecutable {
+        $currentProcessPath = [System.Diagnostics.Process]::GetCurrentProcess().Path
+        if ($currentProcessPath -and (Test-Path -LiteralPath $currentProcessPath)) {
+            return $currentProcessPath
+        }
+
+        foreach ($name in @('pwsh.exe', 'powershell.exe')) {
+            $psHomeCandidate = Join-Path $PSHOME $name
+            if (Test-Path -LiteralPath $psHomeCandidate) {
+                return $psHomeCandidate
+            }
+
+            $command = Get-Command $name -ErrorAction SilentlyContinue
+            if ($command -and $command.Source -and (Test-Path -LiteralPath $command.Source)) {
+                return $command.Source
+            }
+        }
+
+        throw 'Could not resolve a PowerShell executable. Expected current host, pwsh.exe, or powershell.exe to be available.'
+    }
+}
+
 if (-not (Get-Command Write-WorktreeLog -ErrorAction SilentlyContinue)) {
     function Write-WorktreeLog {
         param(
@@ -548,15 +576,7 @@ function Invoke-HookMode {
     }
 
     # --- spawn the detached watcher OUTSIDE claude's job object (WMI) --------
-    # $PSHOME\powershell.exe only exists for Windows PowerShell 5.1. PowerShell
-    # 7+ ships pwsh.exe instead, so resolve the actual running host's exe.
-    $psExe = [System.Diagnostics.Process]::GetCurrentProcess().Path
-    if (-not $psExe -or -not (Test-Path -LiteralPath $psExe)) {
-        $psExe = Join-Path $PSHOME 'pwsh.exe'
-    }
-    if (-not (Test-Path -LiteralPath $psExe)) {
-        $psExe = Join-Path $PSHOME 'powershell.exe'
-    }
+    $psExe = Resolve-PowerShellExecutable
     $watcherCmd = '"{0}" -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "{1}" -Mode Watcher -ParamFile "{2}"' -f $psExe, $watcherScript, $paramFile
 
     $spawned = $false

--- a/scripts/remove-worktree-local-dev.ps1
+++ b/scripts/remove-worktree-local-dev.ps1
@@ -548,7 +548,15 @@ function Invoke-HookMode {
     }
 
     # --- spawn the detached watcher OUTSIDE claude's job object (WMI) --------
-    $psExe = Join-Path $PSHOME 'powershell.exe'
+    # $PSHOME\powershell.exe only exists for Windows PowerShell 5.1. PowerShell
+    # 7+ ships pwsh.exe instead, so resolve the actual running host's exe.
+    $psExe = [System.Diagnostics.Process]::GetCurrentProcess().Path
+    if (-not $psExe -or -not (Test-Path -LiteralPath $psExe)) {
+        $psExe = Join-Path $PSHOME 'pwsh.exe'
+    }
+    if (-not (Test-Path -LiteralPath $psExe)) {
+        $psExe = Join-Path $PSHOME 'powershell.exe'
+    }
     $watcherCmd = '"{0}" -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "{1}" -Mode Watcher -ParamFile "{2}"' -f $psExe, $watcherScript, $paramFile
 
     $spawned = $false

--- a/scripts/worktree-powershell.common.ps1
+++ b/scripts/worktree-powershell.common.ps1
@@ -1,0 +1,23 @@
+#Requires -Version 5.1
+# Shared PowerShell host resolution for worktree lifecycle scripts.
+
+function Resolve-PowerShellExecutable {
+    $currentProcessPath = [System.Diagnostics.Process]::GetCurrentProcess().Path
+    if ($currentProcessPath -and (Test-Path -LiteralPath $currentProcessPath)) {
+        return $currentProcessPath
+    }
+
+    foreach ($name in @('pwsh.exe', 'powershell.exe')) {
+        $psHomeCandidate = Join-Path $PSHOME $name
+        if (Test-Path -LiteralPath $psHomeCandidate) {
+            return $psHomeCandidate
+        }
+
+        $command = Get-Command $name -ErrorAction SilentlyContinue
+        if ($command -and $command.Source -and (Test-Path -LiteralPath $command.Source)) {
+            return $command.Source
+        }
+    }
+
+    throw 'Could not resolve a PowerShell executable. Expected current host, pwsh.exe, or powershell.exe to be available.'
+}

--- a/tests/WorktreePowerShellHost.Tests.ps1
+++ b/tests/WorktreePowerShellHost.Tests.ps1
@@ -1,0 +1,51 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Assert-DoesNotMatch {
+    param([string] $Actual, [string] $Pattern, [string] $Message)
+
+    if ($Actual -match $Pattern) {
+        throw $Message
+    }
+}
+
+$hostResolverPath = Join-Path $repoRoot 'scripts\worktree-powershell.common.ps1'
+Assert-True (Test-Path -LiteralPath $hostResolverPath) 'Expected shared PowerShell host resolver to exist.'
+
+. $hostResolverPath
+$resolvedHost = Resolve-PowerShellExecutable
+$currentHost = [System.Diagnostics.Process]::GetCurrentProcess().Path
+
+Assert-True (Test-Path -LiteralPath $resolvedHost) "Resolved PowerShell host does not exist: $resolvedHost"
+Assert-True ([string]::Equals($resolvedHost, $currentHost, [System.StringComparison]::OrdinalIgnoreCase)) "Expected resolver to prefer the current host. Expected '$currentHost', got '$resolvedHost'."
+
+$newWorktreePath = Join-Path $repoRoot 'scripts\new-worktree.ps1'
+$newWorktreeContent = Get-Content -LiteralPath $newWorktreePath -Raw
+Assert-DoesNotMatch $newWorktreeContent '(?m)&\s+powershell(\.exe)?\s+-NoProfile' 'new-worktree.ps1 must not launch child setup/prune scripts through bare powershell.'
+Assert-True ($newWorktreeContent -match [regex]::Escape("worktree-powershell.common.ps1")) 'new-worktree.ps1 should use the shared PowerShell host resolver.'
+
+$removeWorktreePath = Join-Path $repoRoot 'scripts\remove-worktree-local-dev.ps1'
+$removeWorktreeContent = Get-Content -LiteralPath $removeWorktreePath -Raw
+Assert-DoesNotMatch $removeWorktreeContent 'Join-Path\s+\$PSHOME\s+''powershell\.exe''' 'remove-worktree-local-dev.ps1 must not assume powershell.exe lives under $PSHOME.'
+Assert-True ($removeWorktreeContent -match 'Resolve-PowerShellExecutable') 'remove-worktree-local-dev.ps1 should use the shared PowerShell host resolver.'
+
+$claudeSettingsPath = Join-Path $repoRoot '.claude\settings.json'
+$claudeSettingsContent = Get-Content -LiteralPath $claudeSettingsPath -Raw
+Assert-DoesNotMatch $claudeSettingsContent '"command":\s*"powershell\s+-NoProfile\s+-ExecutionPolicy\s+Bypass\s+-File\s+\\"?\$\{CLAUDE_PROJECT_DIR\}\\scripts\\(?:new-worktree|remove-worktree-local-dev)\.ps1' 'Claude Worktree hooks should not hard-code Windows PowerShell.'
+
+Write-Host 'Worktree PowerShell host tests passed.'


### PR DESCRIPTION
Script hardcoded powershell.exe which doesn't exist under PowerShell 7 ($PSHOME\pwsh.exe instead). WMI and Start-Process spawn both failed, leaving worktree orphaned.

Resolve via GetCurrentProcess().Path (reliable on both PS5.1 and PS7), fallback to pwsh.exe, then powershell.exe for maximum compatibility.

## Summary

Brief description of changes.

## Checklist

- [ ] Tests pass (`dotnet test`)
- [ ] Build succeeds (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Breaking changes documented (if any)
