### PR TITLE
fix: correct worktree agent guidance, extract standalone skill

### DIFF
--- a/.agents/dck-workflow-mastery/SKILL.md
+++ b/.agents/dck-workflow-mastery/SKILL.md
@@ -8,22 +8,28 @@ description: Use when optimizing AHKFlowApp agent workflow, worktrees, planning,
 ## Core Principles
 
 1. **Plan non-trivial work** - For tasks touching several files or architecture, save or review a concrete plan before editing.
-2. **Use isolated branches/worktrees** - Never start implementation on `main`; use repo worktree hooks or Git worktrees for parallel work.
+2. **Use isolated branches/worktrees** - Never start implementation on `main`; create worktrees with `scripts/new-worktree.ps1` (see Worktrees below), never bare `git worktree add`.
 3. **Verify with commands** - `dotnet build`, `dotnet test`, `dotnet format`, setup scripts, and targeted greps are the proof.
 4. **Spend context deliberately** - Read files you will edit; use search, Roslyn MCP, and concise summaries for broad exploration.
 5. **Project rules win** - `AGENTS.md` and `.claude/rules/*` define AHKFlowApp conventions.
 
 ## Worktrees
 
-AHKFlowApp has worktree setup hooks in `.claude/settings.json` (`WorktreeCreate` and `WorktreeRemove`) and repo scripts for local dev isolation. Prefer those project mechanisms when available.
+AHKFlowApp worktrees carry local-dev isolation — per-worktree ports, database, and Docker Compose project — set up by `scripts/new-worktree.ps1`. Skipping that script leaves a worktree that collides with the main checkout on ports, DB, and containers. Always create worktrees through it.
 
-Manual fallback:
+**Claude Code:** use the native worktree feature. It fires the `WorktreeCreate` hook (`.claude/settings.json`) which runs `new-worktree.ps1` for you.
+
+**Codex, Copilot, plain git, or any non-hook path:** run the script directly from the main checkout:
 
 ```bash
-git worktree add .claude/worktrees/<branch-name> -b <branch-name>
+pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name>
 ```
 
-Before creating project-local worktrees, verify the directory is ignored.
+It creates the branch, places the worktree under `.claude/worktrees/<name>/`, copies `.worktreeinclude` entries, runs local-dev isolation setup, and prints the worktree path on success.
+
+**Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
+
+Removal: `pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1` tears down isolation cleanly. Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.
 
 ## Planning Strategy
 

--- a/.agents/dck-workflow-mastery/SKILL.md
+++ b/.agents/dck-workflow-mastery/SKILL.md
@@ -29,7 +29,7 @@ It creates the branch, places the worktree under `.claude/worktrees/<name>/`, co
 
 **Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
 
-Removal: `pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1` tears down isolation cleanly. Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.
+Removal: `pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` tears down isolation cleanly (drops the DB, removes the Docker Compose project, deletes the branch). Without `-WorktreePath` it is a no-op. Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.
 
 ## Planning Strategy
 

--- a/.agents/dck-workflow-mastery/SKILL.md
+++ b/.agents/dck-workflow-mastery/SKILL.md
@@ -8,28 +8,14 @@ description: Use when optimizing AHKFlowApp agent workflow, worktrees, planning,
 ## Core Principles
 
 1. **Plan non-trivial work** - For tasks touching several files or architecture, save or review a concrete plan before editing.
-2. **Use isolated branches/worktrees** - Never start implementation on `main`; create worktrees with `scripts/new-worktree.ps1` (see Worktrees below), never bare `git worktree add`.
+2. **Use isolated branches/worktrees** - Never start implementation on `main`; see the `worktrees` skill for creating/removing them, never bare `git worktree add`.
 3. **Verify with commands** - `dotnet build`, `dotnet test`, `dotnet format`, setup scripts, and targeted greps are the proof.
 4. **Spend context deliberately** - Read files you will edit; use search, Roslyn MCP, and concise summaries for broad exploration.
 5. **Project rules win** - `AGENTS.md` and `.claude/rules/*` define AHKFlowApp conventions.
 
 ## Worktrees
 
-AHKFlowApp worktrees carry local-dev isolation — per-worktree ports, database, and Docker Compose project — set up by `scripts/new-worktree.ps1`. Skipping that script leaves a worktree that collides with the main checkout on ports, DB, and containers. Always create worktrees through it.
-
-**Claude Code:** use the native worktree feature. It fires the `WorktreeCreate` hook (`.claude/settings.json`) which runs `new-worktree.ps1` for you.
-
-**Codex, Copilot, plain git, or any non-hook path:** run the script directly from the main checkout:
-
-```bash
-pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name>
-```
-
-It creates the branch, places the worktree under `.claude/worktrees/<name>/`, copies `.worktreeinclude` entries, runs local-dev isolation setup, and prints the worktree path on success.
-
-**Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
-
-Removal: `pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` tears down isolation cleanly (drops the DB, removes the Docker Compose project, deletes the branch). Without `-WorktreePath` it is a no-op. Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.
+See the `worktrees` skill for creating, removing, and troubleshooting AHKFlowApp git worktrees (Claude Code, Codex, and Copilot).
 
 ## Planning Strategy
 

--- a/.agents/worktrees/SKILL.md
+++ b/.agents/worktrees/SKILL.md
@@ -23,6 +23,6 @@ It creates the branch, places the worktree under `.claude/worktrees/<name>/`, co
 
 ## Removing
 
-`pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` tears down isolation cleanly (drops the DB, removes the Docker Compose project, deletes the branch). Without `-WorktreePath` it is a no-op.
+`pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` removes the worktree and deletes the branch (`git branch -d`), then drops the DB and removes the Docker Compose project — but only if that branch delete succeeds. If the branch has unmerged commits, `git branch -d` fails and DB/Docker cleanup is skipped; the next `new-worktree.ps1` run's orphan prune, or `scripts\prune-worktree-databases.ps1` / `scripts\prune-worktree-docker.ps1`, reclaim them later. Without `-WorktreePath` it is a no-op.
 
 Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.

--- a/.agents/worktrees/SKILL.md
+++ b/.agents/worktrees/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: worktrees
+description: Use when creating, removing, or troubleshooting AHKFlowApp git worktrees across Claude Code, Codex, or Copilot.
+---
+
+# Worktrees
+
+AHKFlowApp worktrees carry local-dev isolation — per-worktree ports, database, and Docker Compose project — set up by `scripts/new-worktree.ps1`. Skipping that script leaves a worktree that collides with the main checkout on ports, DB, and containers. Always create worktrees through it.
+
+## Creating
+
+**Claude Code:** use the native worktree feature. It fires the `WorktreeCreate` hook (`.claude/settings.json`) which runs `new-worktree.ps1` for you.
+
+**Codex, Copilot, plain git, or any non-hook path:** run the script directly from the main checkout:
+
+```bash
+pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name>
+```
+
+It creates the branch, places the worktree under `.claude/worktrees/<name>/`, copies `.worktreeinclude` entries, runs local-dev isolation setup, and prints the worktree path on success.
+
+**Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
+
+## Removing
+
+`pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` tears down isolation cleanly (drops the DB, removes the Docker Compose project, deletes the branch). Without `-WorktreePath` it is a no-op.
+
+Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.

--- a/.claude/skills/worktrees
+++ b/.claude/skills/worktrees
@@ -1,0 +1,1 @@
+../../.agents/worktrees

--- a/.github/skills/worktrees
+++ b/.github/skills/worktrees
@@ -1,0 +1,1 @@
+../../.agents/worktrees

--- a/plugins/ahkflowapp/skills/dck-workflow-mastery/SKILL.md
+++ b/plugins/ahkflowapp/skills/dck-workflow-mastery/SKILL.md
@@ -8,22 +8,28 @@ description: Use when optimizing AHKFlowApp agent workflow, worktrees, planning,
 ## Core Principles
 
 1. **Plan non-trivial work** - For tasks touching several files or architecture, save or review a concrete plan before editing.
-2. **Use isolated branches/worktrees** - Never start implementation on `main`; use repo worktree hooks or Git worktrees for parallel work.
+2. **Use isolated branches/worktrees** - Never start implementation on `main`; create worktrees with `scripts/new-worktree.ps1` (see Worktrees below), never bare `git worktree add`.
 3. **Verify with commands** - `dotnet build`, `dotnet test`, `dotnet format`, setup scripts, and targeted greps are the proof.
 4. **Spend context deliberately** - Read files you will edit; use search, Roslyn MCP, and concise summaries for broad exploration.
 5. **Project rules win** - `AGENTS.md` and `.claude/rules/*` define AHKFlowApp conventions.
 
 ## Worktrees
 
-AHKFlowApp has worktree setup hooks in `.claude/settings.json` (`WorktreeCreate` and `WorktreeRemove`) and repo scripts for local dev isolation. Prefer those project mechanisms when available.
+AHKFlowApp worktrees carry local-dev isolation — per-worktree ports, database, and Docker Compose project — set up by `scripts/new-worktree.ps1`. Skipping that script leaves a worktree that collides with the main checkout on ports, DB, and containers. Always create worktrees through it.
 
-Manual fallback:
+**Claude Code:** use the native worktree feature. It fires the `WorktreeCreate` hook (`.claude/settings.json`) which runs `new-worktree.ps1` for you.
+
+**Codex, Copilot, plain git, or any non-hook path:** run the script directly from the main checkout:
 
 ```bash
-git worktree add .claude/worktrees/<branch-name> -b <branch-name>
+pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name>
 ```
 
-Before creating project-local worktrees, verify the directory is ignored.
+It creates the branch, places the worktree under `.claude/worktrees/<name>/`, copies `.worktreeinclude` entries, runs local-dev isolation setup, and prints the worktree path on success.
+
+**Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
+
+Removal: `pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1` tears down isolation cleanly. Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.
 
 ## Planning Strategy
 

--- a/plugins/ahkflowapp/skills/dck-workflow-mastery/SKILL.md
+++ b/plugins/ahkflowapp/skills/dck-workflow-mastery/SKILL.md
@@ -29,7 +29,7 @@ It creates the branch, places the worktree under `.claude/worktrees/<name>/`, co
 
 **Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
 
-Removal: `pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1` tears down isolation cleanly. Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.
+Removal: `pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` tears down isolation cleanly (drops the DB, removes the Docker Compose project, deletes the branch). Without `-WorktreePath` it is a no-op. Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.
 
 ## Planning Strategy
 

--- a/plugins/ahkflowapp/skills/dck-workflow-mastery/SKILL.md
+++ b/plugins/ahkflowapp/skills/dck-workflow-mastery/SKILL.md
@@ -8,28 +8,14 @@ description: Use when optimizing AHKFlowApp agent workflow, worktrees, planning,
 ## Core Principles
 
 1. **Plan non-trivial work** - For tasks touching several files or architecture, save or review a concrete plan before editing.
-2. **Use isolated branches/worktrees** - Never start implementation on `main`; create worktrees with `scripts/new-worktree.ps1` (see Worktrees below), never bare `git worktree add`.
+2. **Use isolated branches/worktrees** - Never start implementation on `main`; see the `worktrees` skill for creating/removing them, never bare `git worktree add`.
 3. **Verify with commands** - `dotnet build`, `dotnet test`, `dotnet format`, setup scripts, and targeted greps are the proof.
 4. **Spend context deliberately** - Read files you will edit; use search, Roslyn MCP, and concise summaries for broad exploration.
 5. **Project rules win** - `AGENTS.md` and `.claude/rules/*` define AHKFlowApp conventions.
 
 ## Worktrees
 
-AHKFlowApp worktrees carry local-dev isolation — per-worktree ports, database, and Docker Compose project — set up by `scripts/new-worktree.ps1`. Skipping that script leaves a worktree that collides with the main checkout on ports, DB, and containers. Always create worktrees through it.
-
-**Claude Code:** use the native worktree feature. It fires the `WorktreeCreate` hook (`.claude/settings.json`) which runs `new-worktree.ps1` for you.
-
-**Codex, Copilot, plain git, or any non-hook path:** run the script directly from the main checkout:
-
-```bash
-pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name>
-```
-
-It creates the branch, places the worktree under `.claude/worktrees/<name>/`, copies `.worktreeinclude` entries, runs local-dev isolation setup, and prints the worktree path on success.
-
-**Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
-
-Removal: `pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` tears down isolation cleanly (drops the DB, removes the Docker Compose project, deletes the branch). Without `-WorktreePath` it is a no-op. Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.
+See the `worktrees` skill for creating, removing, and troubleshooting AHKFlowApp git worktrees (Claude Code, Codex, and Copilot).
 
 ## Planning Strategy
 

--- a/plugins/ahkflowapp/skills/worktrees/SKILL.md
+++ b/plugins/ahkflowapp/skills/worktrees/SKILL.md
@@ -23,6 +23,6 @@ It creates the branch, places the worktree under `.claude/worktrees/<name>/`, co
 
 ## Removing
 
-`pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` tears down isolation cleanly (drops the DB, removes the Docker Compose project, deletes the branch). Without `-WorktreePath` it is a no-op.
+`pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` removes the worktree and deletes the branch (`git branch -d`), then drops the DB and removes the Docker Compose project — but only if that branch delete succeeds. If the branch has unmerged commits, `git branch -d` fails and DB/Docker cleanup is skipped; the next `new-worktree.ps1` run's orphan prune, or `scripts\prune-worktree-databases.ps1` / `scripts\prune-worktree-docker.ps1`, reclaim them later. Without `-WorktreePath` it is a no-op.
 
 Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.

--- a/plugins/ahkflowapp/skills/worktrees/SKILL.md
+++ b/plugins/ahkflowapp/skills/worktrees/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: worktrees
+description: Use when creating, removing, or troubleshooting AHKFlowApp git worktrees across Claude Code, Codex, or Copilot.
+---
+
+# Worktrees
+
+AHKFlowApp worktrees carry local-dev isolation — per-worktree ports, database, and Docker Compose project — set up by `scripts/new-worktree.ps1`. Skipping that script leaves a worktree that collides with the main checkout on ports, DB, and containers. Always create worktrees through it.
+
+## Creating
+
+**Claude Code:** use the native worktree feature. It fires the `WorktreeCreate` hook (`.claude/settings.json`) which runs `new-worktree.ps1` for you.
+
+**Codex, Copilot, plain git, or any non-hook path:** run the script directly from the main checkout:
+
+```bash
+pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name>
+```
+
+It creates the branch, places the worktree under `.claude/worktrees/<name>/`, copies `.worktreeinclude` entries, runs local-dev isolation setup, and prints the worktree path on success.
+
+**Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
+
+## Removing
+
+`pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` tears down isolation cleanly (drops the DB, removes the Docker Compose project, deletes the branch). Without `-WorktreePath` it is a no-op.
+
+Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.

--- a/scripts/agents/setup-cross-agent-skills.sh
+++ b/scripts/agents/setup-cross-agent-skills.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 case "$(uname -s 2>/dev/null || echo unknown)" in
     MINGW*|MSYS*|CYGWIN*)
         echo "Error: setup-cross-agent-skills.sh is not supported on Windows Git Bash." >&2
-        echo "Run scripts/setup-cross-agent-skills.ps1 from PowerShell instead." >&2
+        echo "Run scripts/agents/setup-cross-agent-skills.ps1 from PowerShell instead." >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary
- Corrected `dck-workflow-mastery`'s worktree guidance, which told agents to run bare `git worktree add` (skips per-worktree port/DB/Docker isolation) — now points Codex/Copilot/plain-git at `scripts/new-worktree.ps1 -Name <name>` directly, and Claude Code at its native worktree feature/hook.
- Fixed the removal guidance: `scripts/remove-worktree-local-dev.ps1` is a no-op without `-WorktreePath`; documented the required flag and what it actually tears down (DB, Docker Compose project, branch).
- Extracted worktree guidance into a standalone `worktrees` skill (`.agents/worktrees/SKILL.md`), since it had drifted into AHKFlowApp-specific detail with no equivalent in the upstream `dotnet-claude-kit` skill that `dck-workflow-mastery` is vendored from. `dck-workflow-mastery` now points at it.
- Regenerated cross-agent skill mirrors (`.claude/skills`, `.github/skills` symlinks; Codex plugin hard-links) via `scripts/agents/setup-cross-agent-skills.ps1`.

## Test plan
- [x] Confirmed no bare `git worktree add .claude/worktrees` fallback remains in source
- [x] Confirmed all 4 locations (`.agents`, `.claude/skills`, `.github/skills`, Codex plugin hard-link) contain matching, updated content for both `dck-workflow-mastery` and the new `worktrees` skill
- [x] Confirmed `remove-worktree-local-dev.ps1`'s no-op-without-`-WorktreePath` behavior against the script source (`scripts/remove-worktree-local-dev.ps1:419`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)