### PR TITLE
[codex] Run merged worktree cleanup on create

### DIFF
--- a/.agents/worktrees/SKILL.md
+++ b/.agents/worktrees/SKILL.md
@@ -21,6 +21,30 @@ It creates the branch, places the worktree under `.claude/worktrees/<name>/`, co
 
 **Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
 
+### Cleanup of merged worktrees on create
+
+Creating a worktree first checks the other worktrees whose branch is already merged
+into `main`. Nothing is removed without an explicit opt-in:
+
+- **Interactive create (a real console, no flag):** it lists the merged, clean
+  worktrees and asks once — `Clean up merged worktrees? (y/n)`. `y` removes them all;
+  `n` skips.
+- **`-Cleanup` / `-c`:** removes every merged, clean worktree with no prompt (use in
+  scripts, or when you have already decided):
+
+  ```bash
+  pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name> -Cleanup
+  ```
+
+- **WorktreeCreate hook, or non-interactive without the flag:** detection is logged to
+  stderr only; nothing is removed.
+
+A worktree with uncommitted changes is never removed, even if its branch is merged.
+The worktree currently being created or reused is always excluded from the sweep, so a
+same-named recreate can never race its own removal. Removal reuses
+`remove-worktree-local-dev.ps1` (`git branch -d`, DB drop, Docker teardown, lock-safe
+folder delete).
+
 ## Removing
 
 `pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` removes the worktree and deletes the branch (`git branch -d`), then drops the DB and removes the Docker Compose project — but only if that branch delete succeeds. If the branch has unmerged commits, `git branch -d` fails and DB/Docker cleanup is skipped; the next `new-worktree.ps1` run's orphan prune, or `scripts\prune-worktree-databases.ps1` / `scripts\prune-worktree-docker.ps1`, reclaim them later. Without `-WorktreePath` it is a no-op.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,16 @@ jobs:
       - if: steps.filter.outputs.code == 'true'
         run: dotnet format AHKFlowApp.slnx --verify-no-changes
 
+  worktree-powershell-tests:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run worktree PowerShell tests
+        shell: pwsh
+        run: |
+          ./tests/WorktreePowerShellHost.Tests.ps1
+          ./tests/WorktreeMergedCleanup.Tests.ps1
+
   bicep-lint:
     runs-on: ubuntu-latest
     steps:

--- a/docs/superpowers/plans/2026-07-05-worktree-merged-cleanup.md
+++ b/docs/superpowers/plans/2026-07-05-worktree-merged-cleanup.md
@@ -584,7 +584,7 @@ try {
 - [ ] **Step 2: Run the test to verify it fails**
 
 Run: `pwsh -NoProfile -File tests/WorktreeMergedCleanup.Tests.ps1`
-Expected: FAIL — the current `new-worktree.ps1` has no `-Cleanup` switch and does not invoke cleanup, but more importantly the copied script errors on the missing invocation wiring; the run does not yet emit a single clean path line (the assertion on `$stdoutLines.Count` / path fails, or the process exits non-zero because `cleanup-merged-worktrees.ps1` is referenced but not yet called). Confirm the failure is in this new test block.
+Expected: FAIL — before Step 3, the copied `new-worktree.ps1` still creates the worktree but does not invoke cleanup, so the stderr-proof assertion fails because no `cleanup: eligible merged worktree` line is emitted. Confirm the failure is in this new test block.
 
 > Note: this test copies the **current** `scripts/*.ps1`. Before Step 3, `new-worktree.ps1` does not call cleanup, so the assertion that drives the integrated behavior fails. After Step 3 the copied script includes the wiring.
 
@@ -768,6 +768,7 @@ git commit -m "docs: document merged-worktree cleanup on create"
 - Architecture (standalone script, shared helpers reused) → Task 1/2.
 - Error handling (non-fatal detection/removal; hook output to stderr) → Task 1 (skip-and-continue), Task 2 (try/catch), Task 3 (`try` + `| Out-Null`).
 - Testing: host-resolution → Task 2 Step 5; eligibility matrix + `-ExcludePath` → Task 1; `--format` regression → Task 1; hook report-only → Task 2 Step 1; stdout-clean e2e (with stderr proof cleanup ran) → Task 3 Step 1.
+- Test limitation: the authorized removal path (`-Cleanup` or interactive `y`) is intentionally not driven end-to-end because `remove-worktree-local-dev.ps1` spawns a detached watcher and performs real branch/DB/Docker cleanup; the plan covers the decision matrix and shell-out shape but not watcher completion.
 - Documentation: README contract table → Task 4 Step 1; SKILL.md flag + question → Task 4 Step 2 (single source edit), Step 3 (re-sync), Step 4 (hash-check).
 
 **Placeholder scan:** No TBD/TODO; every code step shows complete content; no "similar to Task N" cross-refs left unfilled.
@@ -780,6 +781,7 @@ None. (Spec Open Questions were empty.)
 
 Implementation notes surfaced during planning, already handled above:
 - **Race safety:** `Get-EligibleMergedWorktrees` and `Invoke-MergedWorktreeCleanup` take `-ExcludePath`; `new-worktree.ps1` resolves `$worktreePath` before invoking cleanup and passes it as `-ExcludePath` (Task 3, Steps 3b/3c), so a same-named create/reuse can never race the async removal `remove-worktree-local-dev.ps1`'s detached-watcher hook mode kicks off for that same path.
+- **Interactive UX:** direct real-console creates intentionally stop once to ask `Clean up merged worktrees? (y/n)` when eligible merged, clean worktrees exist. Hook and redirected/non-interactive paths do not prompt.
 - `plugins/ahkflowapp/skills/worktrees/SKILL.md` is a **hard link** to `.agents/worktrees/SKILL.md` (confirmed same inode), not an independent copy — Task 4 edits the source once and re-syncs via `scripts/agents/setup-copilot-symlinks.ps1` rather than hand-editing both, then verifies byte-equality.
 - `Invoke-WorktreeRemoval` pipes empty stdin into `remove-worktree-local-dev.ps1` to avoid its unbounded `[Console]::In.ReadToEnd()` hanging when the cleanup run's own stdin is redirected.
 - `new-worktree.ps1`'s cleanup call is `| Out-Null`-guarded so cleanup output can never leak into the hook's stdout.

--- a/plugins/ahkflowapp/skills/worktrees/SKILL.md
+++ b/plugins/ahkflowapp/skills/worktrees/SKILL.md
@@ -21,6 +21,30 @@ It creates the branch, places the worktree under `.claude/worktrees/<name>/`, co
 
 **Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
 
+### Cleanup of merged worktrees on create
+
+Creating a worktree first checks the other worktrees whose branch is already merged
+into `main`. Nothing is removed without an explicit opt-in:
+
+- **Interactive create (a real console, no flag):** it lists the merged, clean
+  worktrees and asks once — `Clean up merged worktrees? (y/n)`. `y` removes them all;
+  `n` skips.
+- **`-Cleanup` / `-c`:** removes every merged, clean worktree with no prompt (use in
+  scripts, or when you have already decided):
+
+  ```bash
+  pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name> -Cleanup
+  ```
+
+- **WorktreeCreate hook, or non-interactive without the flag:** detection is logged to
+  stderr only; nothing is removed.
+
+A worktree with uncommitted changes is never removed, even if its branch is merged.
+The worktree currently being created or reused is always excluded from the sweep, so a
+same-named recreate can never race its own removal. Removal reuses
+`remove-worktree-local-dev.ps1` (`git branch -d`, DB drop, Docker teardown, lock-safe
+folder delete).
+
 ## Removing
 
 `pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` removes the worktree and deletes the branch (`git branch -d`), then drops the DB and removes the Docker Compose project — but only if that branch delete succeeds. If the branch has unmerged commits, `git branch -d` fails and DB/Docker cleanup is skipped; the next `new-worktree.ps1` run's orphan prune, or `scripts\prune-worktree-databases.ps1` / `scripts\prune-worktree-docker.ps1`, reclaim them later. Without `-WorktreePath` it is a no-op.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,6 +53,7 @@ These form one contract: change them together or not at all. They stay flat in
 | --- | --- |
 | `setup-worktree-local-dev.ps1` | Assigns deterministic localhost ports and writes worktree-local config. |
 | `remove-worktree-local-dev.ps1` | WorktreeRemove hook: deletes the worktree + branch when a worktree is removed. |
+| `cleanup-merged-worktrees.ps1` | Detects worktrees merged into `main` and removes the clean ones on opt-in (`-Cleanup`, or the interactive prompt); invoked by `new-worktree.ps1` before it creates a worktree. |
 | `prune-worktree-databases.ps1` | Drops orphaned per-worktree databases with no live git worktree. |
 | `prune-worktree-docker.ps1` | Removes orphaned per-worktree Docker compose projects with no live git worktree. |
 | `worktree-{database,docker,git,json,log,powershell}.common.ps1` | Shared helpers dot-sourced by the worktree scripts. |

--- a/scripts/cleanup-merged-worktrees.ps1
+++ b/scripts/cleanup-merged-worktrees.ps1
@@ -114,3 +114,90 @@ function Get-EligibleMergedWorktrees {
 
     return , $eligible
 }
+
+# Spawns remove-worktree-local-dev.ps1 (Hook mode) for one worktree. Empty stdin is
+# piped in: that script's hook path does an unbounded [Console]::In.ReadToEnd(), which
+# would hang if THIS run's own stdin is redirected (agent/CI) and left open.
+function Invoke-WorktreeRemoval {
+    param(
+        [Parameter(Mandatory)][string] $RepoRoot,
+        [Parameter(Mandatory)][string] $WorktreePath
+    )
+
+    $removeScript = Join-Path $RepoRoot 'scripts\remove-worktree-local-dev.ps1'
+    if (-not (Test-Path -LiteralPath $removeScript)) {
+        Write-Stderr "cleanup: remove-worktree-local-dev.ps1 not found; cannot remove '$WorktreePath'."
+        return
+    }
+
+    try {
+        $psExe = Resolve-PowerShellExecutable
+        $output = '' | & $psExe -NoProfile -ExecutionPolicy Bypass -File $removeScript -WorktreePath $WorktreePath 2>&1
+        foreach ($line in $output) {
+            if ($line) { Write-Stderr ([string] $line) }
+        }
+    } catch {
+        Write-Stderr "cleanup: removal of '$WorktreePath' failed: $($_.Exception.Message)"
+    }
+}
+
+# Drives the decision matrix. Detection/removal failures are logged to stderr and
+# skipped so worktree creation is never blocked. Emits nothing on the success stream.
+function Invoke-MergedWorktreeCleanup {
+    param(
+        [Parameter(Mandatory)][string] $RepoRoot,
+        [switch] $Cleanup,
+        [switch] $IsHook,
+        [string] $MainRef = 'main',
+        [string] $ExcludePath
+    )
+
+    $eligible = @(Get-EligibleMergedWorktrees -RepoRoot $RepoRoot -MainRef $MainRef -ExcludePath $ExcludePath)
+    if ($eligible.Count -eq 0) {
+        Write-Stderr 'cleanup: no merged worktrees eligible for cleanup.'
+        return
+    }
+
+    foreach ($wt in $eligible) {
+        Write-Stderr "cleanup: eligible merged worktree: $($wt.Path) [$($wt.Branch)]"
+    }
+
+    if ($IsHook) {
+        Write-Stderr 'cleanup: hook context is report-only; nothing removed.'
+        return
+    }
+
+    $authorized = $false
+    if ($Cleanup) {
+        $authorized = $true
+    } elseif (-not [Console]::IsInputRedirected) {
+        $answer = Read-Host 'Clean up merged worktrees? (y/n)'
+        $authorized = ($answer -match '^\s*(y|yes)\s*$')
+    } else {
+        Write-Stderr 'cleanup: non-interactive and no -Cleanup; skipping (removal needs an explicit opt-in).'
+        return
+    }
+
+    if (-not $authorized) {
+        Write-Stderr 'cleanup: declined; nothing removed.'
+        return
+    }
+
+    $removalLog = Join-Path $RepoRoot '.claude\worktrees\worktree-removal.log'
+    foreach ($wt in $eligible) {
+        Write-Stderr "cleanup: removing merged worktree: $($wt.Path) [$($wt.Branch)]"
+        try {
+            Write-WorktreeLog -LogPath $removalLog -Worktree (Split-Path -Leaf $wt.Path) -Message "Merged-cleanup requested removal (branch $($wt.Branch))."
+        } catch { }
+        Invoke-WorktreeRemoval -RepoRoot $RepoRoot -WorktreePath $wt.Path
+    }
+}
+
+# Run the sweep only when executed directly. When dot-sourced (e.g. by tests) to import
+# the functions, $MyInvocation.InvocationName is '.', so the entrypoint is skipped.
+if ($MyInvocation.InvocationName -ne '.') {
+    if (-not $RepoRoot) {
+        $RepoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+    }
+    Invoke-MergedWorktreeCleanup -RepoRoot $RepoRoot -Cleanup:$Cleanup -IsHook:$IsHook -MainRef $MainRef -ExcludePath $ExcludePath | Out-Null
+}

--- a/scripts/cleanup-merged-worktrees.ps1
+++ b/scripts/cleanup-merged-worktrees.ps1
@@ -1,0 +1,116 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Detects worktrees whose branch is already merged into main and, on an explicit
+    opt-in, removes the finished (clean) ones via remove-worktree-local-dev.ps1.
+.DESCRIPTION
+    Invoked by new-worktree.ps1 before it creates a new worktree, and runnable on its
+    own. Removal never happens without an explicit opt-in: the single interactive
+    question on a real console, or the -Cleanup switch. In a WorktreeCreate hook
+    context (-IsHook) detection runs but nothing is prompted or removed, and all
+    output stays on stderr so the hook's stdout contract is preserved.
+#>
+
+[CmdletBinding()]
+param(
+    [string] $RepoRoot,
+    [switch] $Cleanup,
+    [switch] $IsHook,
+    [string] $MainRef = 'main',
+    [string] $ExcludePath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'worktree-git.common.ps1')
+. (Join-Path $PSScriptRoot 'worktree-log.common.ps1')
+. (Join-Path $PSScriptRoot 'worktree-powershell.common.ps1')
+
+function Write-Stderr {
+    param([string] $Message)
+    [Console]::Error.WriteLine($Message)
+}
+
+# Parses `git worktree list --porcelain` into { Path; Branch } records. Branch is the
+# short name for a normal worktree, and $null for a detached-HEAD or bare entry.
+function ConvertFrom-WorktreePorcelain {
+    param([string[]] $Lines)
+
+    $worktrees = @()
+    $current = $null
+    foreach ($line in $Lines) {
+        if ($line -like 'worktree *') {
+            if ($current) { $worktrees += $current }
+            $current = [pscustomobject]@{ Path = $line.Substring('worktree '.Length); Branch = $null }
+        } elseif ($current -and ($line -like 'branch refs/heads/*')) {
+            $current.Branch = $line.Substring('branch refs/heads/'.Length)
+        }
+    }
+    if ($current) { $worktrees += $current }
+
+    return , $worktrees
+}
+
+# Returns the worktrees that are merged into $MainRef AND clean, excluding the main
+# checkout, any detached/bare worktree, and $ExcludePath when given. Each item:
+# { Path (normalized); Branch }.
+function Get-EligibleMergedWorktrees {
+    param(
+        [Parameter(Mandatory)][string] $RepoRoot,
+        [string] $MainRef = 'main',
+        [string] $ExcludePath
+    )
+
+    $repoRootFull = ([System.IO.Path]::GetFullPath($RepoRoot)).TrimEnd('\', '/')
+    $excludeFull = if ($ExcludePath) { ([System.IO.Path]::GetFullPath($ExcludePath)).TrimEnd('\', '/') } else { $null }
+
+    # Bare, marker-free short names. Plain `git branch --merged` prefixes '* '/'+ ',
+    # so --format is required or a naive compare skips every eligible worktree.
+    $mergedNames = & git -C $RepoRoot branch --format='%(refname:short)' --merged $MainRef 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Stderr "cleanup: 'git branch --merged $MainRef' failed; skipping merged-cleanup detection."
+        return , @()
+    }
+    $mergedSet = @{}
+    foreach ($name in $mergedNames) {
+        $trimmed = ([string] $name).Trim()
+        if ($trimmed) { $mergedSet[$trimmed] = $true }
+    }
+
+    $listLines = & git -C $RepoRoot worktree list --porcelain 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Stderr 'cleanup: git worktree list failed; skipping merged-cleanup detection.'
+        return , @()
+    }
+
+    $eligible = @()
+    foreach ($wt in (ConvertFrom-WorktreePorcelain $listLines)) {
+        if (-not $wt.Path) { continue }
+        $wtFull = ([System.IO.Path]::GetFullPath($wt.Path)).TrimEnd('\', '/')
+
+        if ([string]::Equals($wtFull, $repoRootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+        # The worktree this run is about to create/reuse: never sweep it out from under
+        # itself. remove-worktree-local-dev.ps1's hook mode spawns a detached watcher and
+        # returns immediately, so without this exclusion an async removal could still be
+        # renaming/deleting this exact path while new-worktree.ps1 reuses/creates it.
+        if ($excludeFull -and [string]::Equals($wtFull, $excludeFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+        if (-not $wt.Branch) { continue }
+        if (-not $mergedSet.ContainsKey($wt.Branch)) { continue }
+
+        $status = & git -C $wtFull status --porcelain 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Stderr "cleanup: status check failed for '$wtFull'; skipping it."
+            continue
+        }
+        if ($status) { continue }
+
+        $eligible += [pscustomobject]@{ Path = $wtFull; Branch = $wt.Branch }
+    }
+
+    return , $eligible
+}

--- a/scripts/new-worktree.ps1
+++ b/scripts/new-worktree.ps1
@@ -11,7 +11,10 @@
 param(
     [string] $Name,
     [string] $BranchName,
-    [string] $Path
+    [string] $Path,
+
+    [Alias('c')]
+    [switch] $Cleanup
 )
 
 Set-StrictMode -Version Latest
@@ -202,6 +205,10 @@ Assert-MainCheckout $repoRoot
 # A direct call supplies -Name and never needs hook stdin; only read it for hook invocations.
 $hookInput = if ($Name) { $null } else { Get-HookInput }
 
+# Hook-driven iff -Name absent AND hook JSON was read. Do NOT derive hook-ness from
+# [Console]::IsInputRedirected: that is also true for a redirected direct/agent call.
+$isHook = (-not $Name) -and ($null -ne $hookInput)
+
 if (-not $Name -and $hookInput -and $hookInput.PSObject.Properties.Name -contains 'name') {
     $Name = [string] $hookInput.name
 }
@@ -222,6 +229,16 @@ if (-not $Path) {
 $worktreePath = [System.IO.Path]::GetFullPath($Path)
 Assert-WorktreeLocation -RepoRoot $repoRoot -WorktreePath $worktreePath
 $worktreeExists = Test-Path -LiteralPath (Join-Path $worktreePath '.git')
+
+# Sweep other worktrees whose branch is already merged into main before creating/reusing
+# this one. -ExcludePath protects $worktreePath itself now that it is known: without it,
+# a same-named create/reuse could race the async removal. Best-effort: never block
+# creation, and pipe to Out-Null so cleanup output can never reach hook stdout.
+try {
+    & (Join-Path $PSScriptRoot 'cleanup-merged-worktrees.ps1') -RepoRoot $repoRoot -Cleanup:$Cleanup -IsHook:$isHook -ExcludePath $worktreePath | Out-Null
+} catch {
+    Write-Stderr "Merged-worktree cleanup skipped: $($_.Exception.Message)"
+}
 
 Invoke-OrphanDockerPrune $repoRoot
 

--- a/tests/WorktreeMergedCleanup.Tests.ps1
+++ b/tests/WorktreeMergedCleanup.Tests.ps1
@@ -158,6 +158,42 @@ try {
     Remove-TempTree $repo
 }
 
+# --- Test: redirected non-interactive runs skip removal without prompting -------
+$repo = New-TempGitRepo
+try {
+    $skipPath = Add-TestWorktree -RepoDir $repo -BranchName 'feat-noninteractive'
+
+    $stdinFile = Join-Path (Split-Path -Parent $repo) 'cleanup-stdin.txt'
+    $stdoutFile = Join-Path (Split-Path -Parent $repo) 'cleanup-stdout.txt'
+    $stderrFile = Join-Path (Split-Path -Parent $repo) 'cleanup-stderr.txt'
+    Set-Content -LiteralPath $stdinFile -Value '' -Encoding utf8
+
+    $psExe = [System.Diagnostics.Process]::GetCurrentProcess().Path
+    $cleanupScript = Join-Path $scriptsDir 'cleanup-merged-worktrees.ps1'
+    $proc = Start-Process -FilePath $psExe `
+        -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $cleanupScript, '-RepoRoot', $repo, '-MainRef', 'main') `
+        -WorkingDirectory $suiteRoot `
+        -RedirectStandardInput $stdinFile `
+        -RedirectStandardOutput $stdoutFile `
+        -RedirectStandardError $stderrFile `
+        -NoNewWindow -PassThru -Wait
+
+    Assert-Equal 0 $proc.ExitCode "cleanup-merged-worktrees.ps1 non-interactive path should exit 0. Stderr: $(Get-Content -Raw -LiteralPath $stderrFile)"
+
+    $stdout = Get-Content -Raw -LiteralPath $stdoutFile
+    Assert-True ([string]::IsNullOrWhiteSpace($stdout)) "Non-interactive cleanup must not write to stdout. Got: $stdout"
+
+    $stderrText = Get-Content -Raw -LiteralPath $stderrFile
+    Assert-True ($stderrText -match 'cleanup: eligible merged worktree') "Expected cleanup detection output on stderr. Stderr: $stderrText"
+    Assert-True ($stderrText -match 'cleanup: non-interactive and no -Cleanup; skipping') "Expected non-interactive skip output on stderr. Stderr: $stderrText"
+
+    Assert-True (Test-Path -LiteralPath $skipPath) 'Non-interactive cleanup without -Cleanup must not remove the eligible worktree folder.'
+    $branches = (Invoke-TestGit $repo @('branch', '--list', 'feat-noninteractive')) -join "`n"
+    Assert-True ($branches -match 'feat-noninteractive') 'Non-interactive cleanup without -Cleanup must not delete the eligible branch.'
+} finally {
+    Remove-TempTree $repo
+}
+
 # --- Test: hook path keeps stdout to exactly the new worktree path -------------
 function New-WorktreeToolingRepo {
     param([string] $ScriptsSource)

--- a/tests/WorktreeMergedCleanup.Tests.ps1
+++ b/tests/WorktreeMergedCleanup.Tests.ps1
@@ -158,4 +158,66 @@ try {
     Remove-TempTree $repo
 }
 
+# --- Test: hook path keeps stdout to exactly the new worktree path -------------
+function New-WorktreeToolingRepo {
+    param([string] $ScriptsSource)
+
+    $repo = New-TempGitRepo
+
+    $repoScripts = Join-Path $repo 'scripts'
+    New-Item -ItemType Directory -Path $repoScripts -Force | Out-Null
+    # Top-level *.ps1 only: the worktree contract files, without ci/ or a stray .env.worktree.
+    Copy-Item -Path (Join-Path $ScriptsSource '*.ps1') -Destination $repoScripts -Force
+
+    $appSettingsDir = Join-Path $repo 'src\Backend\AHKFlowApp.API'
+    New-Item -ItemType Directory -Path $appSettingsDir -Force | Out-Null
+    $appSettings = '{ "ConnectionStrings": { "DefaultConnection": "Server=localhost;Database=AHKFlowApp;Trusted_Connection=True;" }, "Cors": { "AllowedOrigins": [] } }'
+    Set-Content -LiteralPath (Join-Path $appSettingsDir 'appsettings.json') -Value $appSettings -Encoding utf8
+
+    Set-Content -LiteralPath (Join-Path $repo 'AHKFlowApp.slnx') -Value '<Solution />' -Encoding utf8
+
+    Invoke-TestGit $repo @('add', '-A') | Out-Null
+    Invoke-TestGit $repo @('commit', '-m', 'worktree tooling') | Out-Null
+
+    return $repo
+}
+
+$repo = New-WorktreeToolingRepo -ScriptsSource $scriptsDir
+try {
+    # An eligible (merged + clean) worktree so cleanup has something to report during the run.
+    Add-TestWorktree -RepoDir $repo -BranchName 'feat-eligible' | Out-Null
+
+    $stdinFile = Join-Path (Split-Path -Parent $repo) 'hook-stdin.json'
+    $stdoutFile = Join-Path (Split-Path -Parent $repo) 'hook-stdout.txt'
+    $stderrFile = Join-Path (Split-Path -Parent $repo) 'hook-stderr.txt'
+    Set-Content -LiteralPath $stdinFile -Value '{"name":"brandnew"}' -Encoding utf8
+
+    $psExe = [System.Diagnostics.Process]::GetCurrentProcess().Path
+    $newWorktreeScript = Join-Path $repo 'scripts\new-worktree.ps1'
+    $proc = Start-Process -FilePath $psExe `
+        -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $newWorktreeScript) `
+        -WorkingDirectory $repo `
+        -RedirectStandardInput $stdinFile `
+        -RedirectStandardOutput $stdoutFile `
+        -RedirectStandardError $stderrFile `
+        -NoNewWindow -PassThru -Wait
+
+    Assert-Equal 0 $proc.ExitCode "new-worktree.ps1 hook path should exit 0. Stderr: $(Get-Content -Raw -LiteralPath $stderrFile)"
+
+    $stdout = (Get-Content -Raw -LiteralPath $stdoutFile)
+    $stdoutLines = @(($stdout -split "`r?`n") | Where-Object { $_.Trim() })
+    $expected = ([System.IO.Path]::GetFullPath((Join-Path $repo '.claude\worktrees\brandnew'))).TrimEnd('\', '/')
+
+    Assert-Equal 1 $stdoutLines.Count "Hook stdout must be exactly one line. Got: $stdout"
+    Assert-Equal $expected ($stdoutLines[0].Trim().TrimEnd('\', '/')) 'Hook stdout must be exactly the new worktree path.'
+
+    # Proves cleanup actually ran as part of this hook invocation, not just that stdout
+    # happened to stay clean (which the pre-existing script would already satisfy).
+    $stderrText = Get-Content -Raw -LiteralPath $stderrFile
+    Assert-True ($stderrText -match 'cleanup: eligible merged worktree') "Expected cleanup detection output on stderr proving cleanup ran. Stderr: $stderrText"
+    Assert-True ($stderrText -match 'cleanup: hook context is report-only; nothing removed\.') "Expected the hook-context report-only line on stderr. Stderr: $stderrText"
+} finally {
+    Remove-TempTree $repo
+}
+
 Write-Host 'Worktree merged-cleanup tests passed.'

--- a/tests/WorktreeMergedCleanup.Tests.ps1
+++ b/tests/WorktreeMergedCleanup.Tests.ps1
@@ -1,0 +1,147 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$suiteRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+$scriptsDir = Join-Path $suiteRoot 'scripts'
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { throw $Message }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string] $Message)
+    if (-not [string]::Equals([string] $Expected, [string] $Actual, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "$Message (expected '$Expected', got '$Actual')"
+    }
+}
+
+function ConvertTo-Key {
+    param([string] $Value)
+    return ([System.IO.Path]::GetFullPath($Value)).TrimEnd('\', '/').ToLowerInvariant()
+}
+
+function Invoke-TestGit {
+    param([string] $RepoDir, [string[]] $GitArgs)
+    $out = & git -C $RepoDir @GitArgs 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($GitArgs -join ' ') failed: $out"
+    }
+    return $out
+}
+
+# Fresh main-checkout repo under a throwaway root. Returns the repo path; its parent
+# is the root to delete (worktrees are created as siblings of the repo).
+function New-TempGitRepo {
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ('wtclean-' + [guid]::NewGuid().ToString('N').Substring(0, 8))
+    $repo = Join-Path $root 'repo'
+    New-Item -ItemType Directory -Path $repo -Force | Out-Null
+
+    & git -C $repo init *> $null
+    # Force the initial branch to 'main' independent of the host's init.defaultBranch.
+    & git -C $repo symbolic-ref HEAD refs/heads/main *> $null
+    & git -C $repo config user.email 'test@example.com' *> $null
+    & git -C $repo config user.name 'Cleanup Test' *> $null
+
+    Set-Content -LiteralPath (Join-Path $repo 'README.md') -Value 'seed' -Encoding utf8
+    Invoke-TestGit $repo @('add', '-A') | Out-Null
+    Invoke-TestGit $repo @('commit', '-m', 'seed') | Out-Null
+
+    return (Resolve-Path -LiteralPath $repo).Path
+}
+
+# Adds a linked worktree on a new branch off main (merged + clean by default).
+# -Unmerged adds a commit not in main; -Dirty leaves an uncommitted change.
+function Add-TestWorktree {
+    param(
+        [string] $RepoDir,
+        [string] $BranchName,
+        [switch] $Unmerged,
+        [switch] $Dirty
+    )
+
+    $wtPath = Join-Path (Split-Path -Parent $RepoDir) ('wt-' + $BranchName)
+    Invoke-TestGit $RepoDir @('worktree', 'add', '-b', $BranchName, $wtPath, 'main') | Out-Null
+
+    if ($Unmerged) {
+        Set-Content -LiteralPath (Join-Path $wtPath 'extra.txt') -Value 'unmerged' -Encoding utf8
+        Invoke-TestGit $wtPath @('add', '-A') | Out-Null
+        Invoke-TestGit $wtPath @('commit', '-m', "work on $BranchName") | Out-Null
+    }
+    if ($Dirty) {
+        Set-Content -LiteralPath (Join-Path $wtPath 'dirty.txt') -Value 'uncommitted' -Encoding utf8
+    }
+
+    return (Resolve-Path -LiteralPath $wtPath).Path
+}
+
+function Remove-TempTree {
+    param([string] $RepoDir)
+    $root = Split-Path -Parent $RepoDir
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# Import the cleanup functions (guard keeps the standalone entrypoint from running).
+. (Join-Path $scriptsDir 'cleanup-merged-worktrees.ps1')
+
+# --- Test: eligibility matrix -------------------------------------------------
+$repo = New-TempGitRepo
+try {
+    $cleanPath = Add-TestWorktree -RepoDir $repo -BranchName 'feat-clean'
+    Add-TestWorktree -RepoDir $repo -BranchName 'feat-dirty' -Dirty | Out-Null
+    Add-TestWorktree -RepoDir $repo -BranchName 'feat-unmerged' -Unmerged | Out-Null
+
+    $eligible = Get-EligibleMergedWorktrees -RepoRoot $repo -MainRef 'main'
+    $keys = @($eligible | ForEach-Object { ConvertTo-Key $_.Path })
+
+    Assert-Equal 1 $eligible.Count 'Only the merged+clean worktree should be eligible.'
+    Assert-True ($keys -contains (ConvertTo-Key $cleanPath)) 'The merged+clean worktree must be eligible.'
+    Assert-Equal 'feat-clean' $eligible[0].Branch 'Eligible branch short name should be feat-clean.'
+    $mainKey = ConvertTo-Key $repo
+    Assert-True (-not ($keys -contains $mainKey)) 'The main checkout must never be eligible.'
+} finally {
+    Remove-TempTree $repo
+}
+
+# --- Test: ExcludePath protects the worktree this run is about to create/reuse ---
+$repo = New-TempGitRepo
+try {
+    $targetPath = Add-TestWorktree -RepoDir $repo -BranchName 'feat-target'
+
+    # Without exclusion the target itself would be eligible (merged + clean)...
+    $eligible = Get-EligibleMergedWorktrees -RepoRoot $repo -MainRef 'main'
+    Assert-True ((@($eligible | ForEach-Object { ConvertTo-Key $_.Path })) -contains (ConvertTo-Key $targetPath)) 'Sanity check: the target worktree must be eligible before exclusion is applied.'
+
+    # ...but passing -ExcludePath must remove it from the eligible set, so a run that is
+    # about to create/reuse this exact path can never race its own async removal.
+    $excluded = Get-EligibleMergedWorktrees -RepoRoot $repo -MainRef 'main' -ExcludePath $targetPath
+    $excludedKeys = @($excluded | ForEach-Object { ConvertTo-Key $_.Path })
+    Assert-True (-not ($excludedKeys -contains (ConvertTo-Key $targetPath))) '-ExcludePath must exclude the target worktree even though it is merged+clean.'
+} finally {
+    Remove-TempTree $repo
+}
+
+# --- Test: --format branch parsing (regression guard for the '+ ' marker) ------
+$repo = New-TempGitRepo
+try {
+    $mergedPath = Add-TestWorktree -RepoDir $repo -BranchName 'feat-plusprefix'
+
+    # A branch checked out in another worktree is prefixed with '+ ' by plain
+    # `git branch --merged`; a naive parse would drop it. Prove the marker is there...
+    $plain = (Invoke-TestGit $repo @('branch', '--merged', 'main')) -join "`n"
+    Assert-True ($plain -match '(?m)^\+\s+feat-plusprefix$') 'Expected the plain --merged output to prefix the worktree branch with "+ ".'
+
+    # ...then prove detection (which uses --format) still finds it.
+    $eligible = Get-EligibleMergedWorktrees -RepoRoot $repo -MainRef 'main'
+    $keys = @($eligible | ForEach-Object { ConvertTo-Key $_.Path })
+    Assert-True ($keys -contains (ConvertTo-Key $mergedPath)) 'A merged branch checked out in a worktree must be detected despite the "+ " marker.'
+} finally {
+    Remove-TempTree $repo
+}
+
+Write-Host 'Worktree merged-cleanup tests passed.'

--- a/tests/WorktreeMergedCleanup.Tests.ps1
+++ b/tests/WorktreeMergedCleanup.Tests.ps1
@@ -144,4 +144,18 @@ try {
     Remove-TempTree $repo
 }
 
+# --- Test: hook context is report-only (detects, never removes/prompts) --------
+$repo = New-TempGitRepo
+try {
+    $hookPath = Add-TestWorktree -RepoDir $repo -BranchName 'feat-hook'
+
+    Invoke-MergedWorktreeCleanup -RepoRoot $repo -IsHook -MainRef 'main'
+
+    Assert-True (Test-Path -LiteralPath $hookPath) 'Hook context must not remove the eligible worktree folder.'
+    $branches = (Invoke-TestGit $repo @('branch', '--list', 'feat-hook')) -join "`n"
+    Assert-True ($branches -match 'feat-hook') 'Hook context must not delete the eligible branch.'
+} finally {
+    Remove-TempTree $repo
+}
+
 Write-Host 'Worktree merged-cleanup tests passed.'

--- a/tests/WorktreePowerShellHost.Tests.ps1
+++ b/tests/WorktreePowerShellHost.Tests.ps1
@@ -44,6 +44,13 @@ $removeWorktreeContent = Get-Content -LiteralPath $removeWorktreePath -Raw
 Assert-DoesNotMatch $removeWorktreeContent 'Join-Path\s+\$PSHOME\s+''powershell\.exe''' 'remove-worktree-local-dev.ps1 must not assume powershell.exe lives under $PSHOME.'
 Assert-True ($removeWorktreeContent -match 'Resolve-PowerShellExecutable') 'remove-worktree-local-dev.ps1 should use the shared PowerShell host resolver.'
 
+$cleanupPath = Join-Path $repoRoot 'scripts\cleanup-merged-worktrees.ps1'
+Assert-True (Test-Path -LiteralPath $cleanupPath) 'Expected cleanup-merged-worktrees.ps1 to exist.'
+$cleanupContent = Get-Content -LiteralPath $cleanupPath -Raw
+Assert-DoesNotMatch $cleanupContent '(?m)&\s+powershell(\.exe)?\s+-NoProfile' 'cleanup-merged-worktrees.ps1 must not launch remove-worktree-local-dev.ps1 through bare powershell.'
+Assert-True ($cleanupContent -match [regex]::Escape('worktree-powershell.common.ps1')) 'cleanup-merged-worktrees.ps1 should use the shared PowerShell host resolver.'
+Assert-True ($cleanupContent -match 'Resolve-PowerShellExecutable') 'cleanup-merged-worktrees.ps1 should resolve the PowerShell host via the shared resolver.'
+
 $claudeSettingsPath = Join-Path $repoRoot '.claude\settings.json'
 $claudeSettingsContent = Get-Content -LiteralPath $claudeSettingsPath -Raw
 Assert-DoesNotMatch $claudeSettingsContent '"command":\s*"powershell\s+-NoProfile\s+-ExecutionPolicy\s+Bypass\s+-File\s+\\"?\$\{CLAUDE_PROJECT_DIR\}\\scripts\\(?:new-worktree|remove-worktree-local-dev)\.ps1' 'Claude Worktree hooks should not hard-code Windows PowerShell.'


### PR DESCRIPTION
## Summary
- Adds merged and clean worktree detection plus an opt-in cleanup path during new worktree creation.
- Keeps hook invocations report-only and stdout-safe while diagnostics stay on stderr.
- Documents cleanup behavior in the worktree skill and README, and keeps the plugin skill copy in sync.
- Adds PowerShell regression coverage for eligibility, hook stdout, non-interactive skip behavior, and host resolution, with a Windows CI job for the PowerShell contract suites.

## Validation
- pwsh -NoProfile -File tests\WorktreeMergedCleanup.Tests.ps1
- pwsh -NoProfile -File tests\WorktreePowerShellHost.Tests.ps1
- git diff --check (exit 0; Git reported the expected LF-to-CRLF warning for the PowerShell test file)
- git push -u origin feature/worktree-merged-cleanup-on-create (pre-push hook ran Release build, all Release tests, coverage report generation, and coverage threshold checks; all passed)

## Notes
- Authorized destructive removal paths remain opt-in. Hook context is report-only; redirected non-interactive runs skip removal unless -Cleanup is supplied.
- The new CI job runs the PowerShell contract tests on Windows because the worktree scripts are Windows-oriented.