### PR TITLE
fix: stop double-wrapping eligible-worktree array in cleanup sweep

### DIFF
--- a/scripts/cleanup-merged-worktrees.ps1
+++ b/scripts/cleanup-merged-worktrees.ps1
@@ -152,7 +152,7 @@ function Invoke-MergedWorktreeCleanup {
         [string] $ExcludePath
     )
 
-    $eligible = @(Get-EligibleMergedWorktrees -RepoRoot $RepoRoot -MainRef $MainRef -ExcludePath $ExcludePath)
+    $eligible = Get-EligibleMergedWorktrees -RepoRoot $RepoRoot -MainRef $MainRef -ExcludePath $ExcludePath
     if ($eligible.Count -eq 0) {
         Write-Stderr 'cleanup: no merged worktrees eligible for cleanup.'
         return


### PR DESCRIPTION
@() around Get-EligibleMergedWorktrees (which already returns its array via the unary-comma pattern) wrapped a 4-item array into a 1-item array containing that array. Count checks stayed correct but foreach ran once over the whole nested array, so Path/Branch auto-enumerated and Invoke-WorktreeRemoval got an array instead of a string. Only surfaced with 2+ eligible worktrees at once, which no existing test covered.

## Summary

Brief description of changes.

## Checklist

- [ ] Tests pass (`dotnet test`)
- [ ] Build succeeds (`dotnet build`)
- [ ] No new warnings introduced
- [ ] Breaking changes documented (if any)
