### PR TITLE
fix: gate WorktreeRemove hook on merge + clean status

### DIFF
--- a/.agents/worktrees/SKILL.md
+++ b/.agents/worktrees/SKILL.md
@@ -103,6 +103,28 @@ stop; do not ask the cleanup question on the basis of a failed detection run.
 
 ## Removing
 
-`pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` removes the worktree and deletes the branch (`git branch -d`), then drops the DB and removes the Docker Compose project — but only if that branch delete succeeds. If the branch has unmerged commits, `git branch -d` fails and DB/Docker cleanup is skipped; the next `new-worktree.ps1` run's orphan prune, or `scripts\prune-worktree-databases.ps1` / `scripts\prune-worktree-docker.ps1`, reclaim them later. Without `-WorktreePath` it is a no-op.
+Claude Code's native `/exit` → "remove worktree" fires the `WorktreeRemove` hook
+(`scripts/remove-worktree-local-dev.ps1`). It only auto-removes when the worktree's
+branch is **merged into `main` AND** the working tree is **clean**; otherwise the
+worktree folder and branch are preserved and the log names the reason (unmerged /
+uncommitted changes / detached HEAD) plus manual `git worktree remove` + `prune` +
+`branch -d` commands. A detached-HEAD worktree is never auto-removed, even if it is
+clean and its commit is already in `main` — this matches the conservatism of the
+create-time cleanup (`cleanup-merged-worktrees.ps1`).
+
+To force removal of an unmerged or dirty worktree (folder deleted; branch still only
+removed via safe `git branch -d`, so an unmerged branch survives), set
+`AHKFLOW_WORKTREE_FORCE_REMOVE=1` before exiting:
+
+```powershell
+$env:AHKFLOW_WORKTREE_FORCE_REMOVE = '1'
+```
+
+When eligible (or forced), the script removes the worktree and deletes the branch
+(`git branch -d`), then drops the DB and removes the Docker Compose project — but only
+if that branch delete succeeds. If the branch has unmerged commits, `git branch -d`
+fails and DB/Docker cleanup is skipped; the next `new-worktree.ps1` run's orphan prune,
+or `scripts\prune-worktree-databases.ps1` / `scripts\prune-worktree-docker.ps1`, reclaim
+them later. Without `-WorktreePath` it is a no-op.
 
 Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
         run: |
           ./tests/WorktreePowerShellHost.Tests.ps1
           ./tests/WorktreeMergedCleanup.Tests.ps1
+          ./tests/WorktreeRemoveHook.Tests.ps1
 
   bicep-lint:
     runs-on: ubuntu-latest

--- a/docs/development/worktree-isolation-manual-testing.md
+++ b/docs/development/worktree-isolation-manual-testing.md
@@ -132,8 +132,14 @@ free it first:
   delete.
 
 Then remove the worktree. In a Claude Code session inside the worktree, type `/exit` and
-choose **remove worktree**. Plain git / Codex / Copilot users instead run, from the main
-checkout, `git worktree remove .claude\worktrees\wt-iso-1`, then `git worktree prune` and
+choose **remove worktree**. This only auto-deletes the worktree when its branch is
+**merged into `main` AND** the tree is **clean** — an unmerged, dirty, or detached-HEAD
+worktree is instead preserved, with the removal log naming the reason and printing
+manual-removal commands. If `wt-iso-1` isn't merged yet, either merge it first or set
+`AHKFLOW_WORKTREE_FORCE_REMOVE=1` before `/exit` to bypass the gate (the folder is
+deleted; an unmerged branch still survives via the safe `git branch -d`). Plain git /
+Codex / Copilot users instead run, from the main checkout,
+`git worktree remove .claude\worktrees\wt-iso-1`, then `git worktree prune` and
 `git branch -d wt-iso-1`. Docker teardown (`docker compose -p <project> down -v`) runs only
 after the folder and branch are gone.
 

--- a/docs/superpowers/plans/2026-07-08-worktree-remove-hook-merge-gate.md
+++ b/docs/superpowers/plans/2026-07-08-worktree-remove-hook-merge-gate.md
@@ -1,0 +1,187 @@
+# Gate WorktreeRemove Hook On Merge + Clean Status
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stop Claude Code's exit-time worktree removal from deleting worktrees whose branch is
+not yet merged into `main`. Only auto-remove a worktree when its branch is **merged into `main`
+AND** the working tree is **clean**; otherwise preserve folder + branch and log manual guidance.
+Provide an explicit `AHKFLOW_WORKTREE_FORCE_REMOVE=1` opt-out for discarding unmerged worktrees.
+
+**Tech Stack:** PowerShell 5.1 scripts, git worktrees, Claude Code `WorktreeRemove` hook,
+Markdown skill/docs, repository PowerShell test scripts.
+
+---
+
+## Context
+
+**Symptom.** A worktree `hotstrings-redesign` (branch `feature/hotstrings-redesign`, never merged
+into `main`) was opened in Claude Code, no changes were made, `/exit` → "remove worktree" was
+chosen, and the worktree folder was deleted. Confirmed in
+`.claude/worktrees/worktree-removal.log` (2026-07-08 10:06:22): the folder was removed; the branch
+survived only because `git branch -d` refused it ("branch contains unmerged commits").
+
+**Root cause.** Two *separate* removal mechanisms exist and were conflated:
+
+1. **Create-time cleanup** — `scripts/cleanup-merged-worktrees.ps1`, run by `new-worktree.ps1`.
+   Removes only worktrees that are **merged into `main` AND clean**, on explicit opt-in. This is
+   what the merged `docs/worktree-cleanup-ask-on-create-plan` governs.
+2. **Exit-time removal** — `scripts/remove-worktree-local-dev.ps1`, the `WorktreeRemove` hook
+   (registered in `.claude/settings.json`). Fires on Claude's native `/exit` → "remove worktree".
+   It removes the worktree **folder unconditionally** — no merge check. Only *branch deletion* is
+   gated (via `git branch -d`, which is why the branch survived).
+
+The expectation ("only delete worktrees already merged into `main` via a PR") describes mechanism
+#1, but the deletion came from #2, which has no such guard. The repo uses merge-commit PRs
+("Merge pull request #NNN"), so `git branch --merged main` / `git merge-base --is-ancestor`
+correctly classify PR-merged branches — the guard is reliable here.
+
+## Decisions
+
+- Gate in **Hook mode** (`Invoke-HookMode`), *before* the watcher is spawned, so the destructive
+  rename/delete never starts for an ineligible worktree. The worktree still exists at that point,
+  so both probes work against it. Watcher mode stays unchanged.
+- Eligibility = **has a branch AND merged AND clean**, matching the conservatism of
+  `Get-EligibleMergedWorktrees` in `cleanup-merged-worktrees.ps1` (which skips branch-less
+  worktrees at `:102` and requires a clean tree at `:110`).
+- **Detached HEAD** (no branch) is **not eligible** → preserve unless forced. The merge probe alone
+  (`HEAD` ancestor of `main`) would otherwise auto-remove a clean detached worktree parked on a
+  commit already in `main`, which the create-side helper never does. Exit-time removal deliberately
+  stays as conservative as create-time cleanup.
+- If `main` cannot be resolved (probe error), treat as **not merged** → preserve (fail safe).
+- Force override env var `AHKFLOW_WORKTREE_FORCE_REMOVE=1`; accepted truthy values `1|true|yes|y`
+  (case-insensitive), reusing the exact `Test-EnvironmentFlagEnabled` helper from
+  `new-worktree.ps1`.
+- **Force semantics = "bypass the gate; then behave exactly as the hook does today."** It does NOT
+  escalate destructiveness: the watcher still deletes only the folder and still uses safe
+  `git branch -d` (`remove-worktree-local-dev.ps1:758`), so an unmerged branch is **preserved** and
+  DB/Docker teardown still runs only if the branch actually deletes (`:770`). Fully discarding an
+  unmerged branch and its resources remains a deliberate manual `git branch -D` (already printed in
+  the branch-delete guidance). This keeps `FORCE_REMOVE` from silently destroying unmerged commits.
+- A brand-new zero-commit worktree (on a branch) is trivially an ancestor of `main` → merged →
+  removed. Acceptable (nothing to lose); matches the create-side semantics.
+
+Decision matrix (after branch + main-checkout are captured, before the watcher snapshot):
+
+```
+hasBranch = branchName is set (HEAD is not detached)
+merged    = hasBranch AND HEAD is ancestor of main  (git -C <worktree> merge-base --is-ancestor HEAD main)
+clean     = working tree has no changes             (git -C <worktree> status --porcelain is empty)
+force     = env AHKFLOW_WORKTREE_FORCE_REMOVE is truthy
+
+force                       -> remove (spawn watcher; folder-only removal + safe branch -d, as today)
+merged AND clean            -> remove (spawn watcher, as today)
+otherwise                   -> PRESERVE: log reason (unmerged / dirty / detached) + manual-removal
+(unmerged / dirty / detached)  guidance + force hint; return 0, no watcher
+```
+
+## File Structure
+
+- Modify `scripts/remove-worktree-local-dev.ps1` — the gate (main change).
+- Modify `Tests/WorktreeMergedCleanup.Tests.ps1` (or add `Tests/WorktreeRemoveHook.Tests.ps1`) —
+  regression tests.
+- Modify `.agents/worktrees/SKILL.md` — document the exit-time gate + force override; then resync.
+- Modify `scripts/README.md` — update the `remove-worktree-local-dev.ps1` row.
+- Modify `docs/development/worktree-isolation-manual-testing.md` — the "Remove the worktree" section.
+- Resync (not by hand) `plugins/ahkflowapp/skills/worktrees/SKILL.md` via
+  `scripts/agents/setup-copilot-symlinks.ps1`.
+
+---
+
+### Task 1: Add Failing Regression Tests
+
+**Files:** Modify `Tests/WorktreeMergedCleanup.Tests.ps1` (or new `Tests/WorktreeRemoveHook.Tests.ps1`).
+
+The harness already provides `Add-TestWorktree -Dirty` / `-Unmerged`
+(`Tests/WorktreeMergedCleanup.Tests.ps1:60`) and `New-WorktreeToolingRepo` (:198). Drive the hook
+by piping `{"worktree_path":"<path>"}` JSON to `remove-worktree-local-dev.ps1` and assert on the
+removal log / final folder state. Cover:
+
+- [ ] merged + clean → folder removed (unchanged behavior).
+- [ ] unmerged → folder **preserved**; log names the unmerged reason + manual guidance.
+- [ ] merged + dirty → folder **preserved**.
+- [ ] detached HEAD (clean, ancestor of `main`) → folder **preserved** (new-behavior divergence).
+- [ ] unmerged + `AHKFLOW_WORKTREE_FORCE_REMOVE=1` → folder removed **AND** the log records the
+  force-override decision (e.g. a "force override: bypassing merge/clean gate" line).
+
+The genuine red-green cases are the **preserve** ones (unmerged / dirty / detached): they fail on
+today's script, which removes unconditionally. The force case must **not** assert on folder
+absence alone — today's hook also removes an unmerged folder, so that assertion is green on both
+old and new code. Instead assert the **force-specific log signal** so the test proves the gate was
+consulted and the force branch was taken.
+
+The watcher is async/detached. For the *remove* cases, poll for folder state with a bounded wait
+(as the manual doc does) *and* assert the force/decision log line; for the *preserve* cases, assert
+on the hook-side stderr/log decision (no watcher is spawned), which is deterministic.
+
+Run and confirm the new preserve cases (and the force-signal assertion) FAIL against the current
+script.
+
+### Task 2: Implement The Gate In `remove-worktree-local-dev.ps1`
+
+**Files:** Modify `scripts/remove-worktree-local-dev.ps1`.
+
+- [ ] Add `Test-EnvironmentFlagEnabled` — copy verbatim from `scripts/new-worktree.ps1:31`
+  (truthy = `^(1|true|yes|y)$`). Keep both definitions identical.
+- [ ] Add a removability probe (function or inline) computing `merged` / `clean` via the existing
+  `Invoke-GitCapture` helper so probe output is logged consistently:
+  - `hasBranch`: `$branchName` is non-null (the hook already sets it to `$null` for detached HEAD,
+    `:467`). Detached ⇒ not eligible.
+  - `merged`: only when `hasBranch` — `Invoke-GitCapture @('-C', $worktreeFull, 'merge-base', '--is-ancestor', 'HEAD', 'main')`
+    → `ExitCode -eq 0`. Any error resolving `main` ⇒ not merged.
+  - `clean`: `Invoke-GitCapture @('-C', $worktreeFull, 'status', '--porcelain')` → no non-empty lines.
+- [ ] When `AHKFLOW_WORKTREE_FORCE_REMOVE` bypasses the gate, emit a distinct log line (e.g.
+  `Write-Log 'force override: AHKFLOW_WORKTREE_FORCE_REMOVE set; bypassing merge/clean gate.'`) so
+  the force path is observable to the Task 1 test and in the log. Force does **not** change the
+  watcher — folder-only removal + safe `git branch -d`, as today.
+- [ ] Add `Write-UnmergedPreserveGuidance` modeled on `Write-TimeoutGuidance` /
+  `Write-BranchDeleteGuidance`: log that the worktree was preserved, the specific reason
+  (unmerged / uncommitted changes / detached HEAD), the manual `git worktree remove` + `prune` +
+  `branch -d` commands, and the `AHKFLOW_WORKTREE_FORCE_REMOVE=1` opt-out.
+- [ ] Insert the gate in `Invoke-HookMode` after `Test-RegisteredLinkedWorktree` (~line 541) and
+  before the watcher snapshot (~line 547). Order the checks per the matrix; on preserve, call the
+  guidance writer and `return` (no watcher spawned).
+- [ ] Re-run Task 1 tests → all pass. Parse-check:
+  `pwsh -NoProfile -Command "[scriptblock]::Create((Get-Content -Raw scripts\remove-worktree-local-dev.ps1)) | Out-Null; 'parse OK'"`.
+
+### Task 3: Update Skill + Script Docs
+
+**Files:** `.agents/worktrees/SKILL.md`, `scripts/README.md`,
+`docs/development/worktree-isolation-manual-testing.md`; resync
+`plugins/ahkflowapp/skills/worktrees/SKILL.md`.
+
+- [ ] `.agents/worktrees/SKILL.md` — state that exit-time removal now requires merged + clean, and
+  document `AHKFLOW_WORKTREE_FORCE_REMOVE=1`.
+- [ ] `scripts/README.md` — update the `remove-worktree-local-dev.ps1` row (merged+clean gate + force var).
+- [ ] `docs/development/worktree-isolation-manual-testing.md` — the "Remove the worktree" section
+  (~line 134) currently implies `/exit` → "remove worktree" always deletes; add that it only
+  auto-deletes a merged, clean worktree, else preserves and logs guidance.
+- [ ] Resync: `pwsh -NoProfile -File scripts/agents/setup-copilot-symlinks.ps1`. Do NOT hand-edit
+  the plugin copy. Hash-verify `.agents/worktrees/SKILL.md` == `plugins/ahkflowapp/skills/worktrees/SKILL.md`.
+
+### Task 4: Final Verification
+
+- [ ] `pwsh -NoProfile -File Tests\WorktreeMergedCleanup.Tests.ps1` (+ new remove-hook test file) pass.
+- [ ] `pwsh -NoProfile -File Tests\WorktreePowerShellHost.Tests.ps1` passes.
+- [ ] `git diff --check` clean.
+- [ ] `dotnet build AHKFlowApp.slnx --configuration Release` (safety net; no C# touched).
+- [ ] Manual E2E (optional, scratch worktrees): unmerged worktree + `/exit` → preserved & logged;
+  merge branch, `/exit` → removed; unmerged + `$env:AHKFLOW_WORKTREE_FORCE_REMOVE='1'` → removed.
+
+---
+
+## Resolved (from review)
+
+- **Force scope.** `AHKFLOW_WORKTREE_FORCE_REMOVE=1` only bypasses the merged+clean gate; it keeps
+  today's removal behavior (folder deleted, unmerged branch preserved via safe `branch -d`, DB/Docker
+  reclaimed only if the branch deletes). It is **not** a `branch -D` / full-resource discard.
+- **Detached HEAD.** Preserved unless forced — exit-time removal stays as conservative as
+  create-time cleanup rather than auto-removing a clean ancestor-of-`main` detached worktree.
+- **Force test.** Asserts the force-override log signal, not folder absence alone (which is green on
+  the current script too).
+
+## Unresolved Questions
+
+- Force env name `AHKFLOW_WORKTREE_FORCE_REMOVE` ok, or another (e.g. `_REMOVE_FORCE`)?
+- Split tests into new `Tests/WorktreeRemoveHook.Tests.ps1`, or append to the existing file?
+- `main` ref hard-coded, or read a configurable main-branch name (repo only uses `main`)?

--- a/plugins/ahkflowapp/skills/worktrees/SKILL.md
+++ b/plugins/ahkflowapp/skills/worktrees/SKILL.md
@@ -103,6 +103,28 @@ stop; do not ask the cleanup question on the basis of a failed detection run.
 
 ## Removing
 
-`pwsh -NoProfile -File scripts/remove-worktree-local-dev.ps1 -WorktreePath .claude\worktrees\<name>` removes the worktree and deletes the branch (`git branch -d`), then drops the DB and removes the Docker Compose project — but only if that branch delete succeeds. If the branch has unmerged commits, `git branch -d` fails and DB/Docker cleanup is skipped; the next `new-worktree.ps1` run's orphan prune, or `scripts\prune-worktree-databases.ps1` / `scripts\prune-worktree-docker.ps1`, reclaim them later. Without `-WorktreePath` it is a no-op.
+Claude Code's native `/exit` → "remove worktree" fires the `WorktreeRemove` hook
+(`scripts/remove-worktree-local-dev.ps1`). It only auto-removes when the worktree's
+branch is **merged into `main` AND** the working tree is **clean**; otherwise the
+worktree folder and branch are preserved and the log names the reason (unmerged /
+uncommitted changes / detached HEAD) plus manual `git worktree remove` + `prune` +
+`branch -d` commands. A detached-HEAD worktree is never auto-removed, even if it is
+clean and its commit is already in `main` — this matches the conservatism of the
+create-time cleanup (`cleanup-merged-worktrees.ps1`).
+
+To force removal of an unmerged or dirty worktree (folder deleted; branch still only
+removed via safe `git branch -d`, so an unmerged branch survives), set
+`AHKFLOW_WORKTREE_FORCE_REMOVE=1` before exiting:
+
+```powershell
+$env:AHKFLOW_WORKTREE_FORCE_REMOVE = '1'
+```
+
+When eligible (or forced), the script removes the worktree and deletes the branch
+(`git branch -d`), then drops the DB and removes the Docker Compose project — but only
+if that branch delete succeeds. If the branch has unmerged commits, `git branch -d`
+fails and DB/Docker cleanup is skipped; the next `new-worktree.ps1` run's orphan prune,
+or `scripts\prune-worktree-databases.ps1` / `scripts\prune-worktree-docker.ps1`, reclaim
+them later. Without `-WorktreePath` it is a no-op.
 
 Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-worktree.ps1` run sweeps orphaned Docker projects as a safety net.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,7 +52,7 @@ These form one contract: change them together or not at all. They stay flat in
 | File | Purpose |
 | --- | --- |
 | `setup-worktree-local-dev.ps1` | Assigns deterministic localhost ports and writes worktree-local config. |
-| `remove-worktree-local-dev.ps1` | WorktreeRemove hook: deletes the worktree + branch when a worktree is removed. |
+| `remove-worktree-local-dev.ps1` | WorktreeRemove hook: removes the worktree + branch only when the branch is merged into `main` AND the tree is clean (detached HEAD is never eligible); otherwise preserves it and logs manual-cleanup guidance. `AHKFLOW_WORKTREE_FORCE_REMOVE=1` bypasses the gate. |
 | `cleanup-merged-worktrees.ps1` | Detects worktrees merged into `main` and removes the clean ones on opt-in (`-Cleanup`, `AHKFLOW_WORKTREE_CLEANUP=1` for Claude CLI native worktree creation, or the interactive prompt); invoked by `new-worktree.ps1` before it creates a worktree. |
 | `prune-worktree-databases.ps1` | Drops orphaned per-worktree databases with no live git worktree. |
 | `prune-worktree-docker.ps1` | Removes orphaned per-worktree Docker compose projects with no live git worktree. |

--- a/scripts/remove-worktree-local-dev.ps1
+++ b/scripts/remove-worktree-local-dev.ps1
@@ -215,6 +215,19 @@ function Read-RawStdin {
     try { return [Console]::In.ReadToEnd() } catch { return $null }
 }
 
+# Copied verbatim from scripts/new-worktree.ps1 (Test-EnvironmentFlagEnabled) so both
+# scripts recognize the same truthy values for their respective opt-in env vars.
+function Test-EnvironmentFlagEnabled {
+    param([string] $Name)
+
+    $value = [Environment]::GetEnvironmentVariable($Name, 'Process')
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return $false
+    }
+
+    return $value.Trim() -match '^(1|true|yes|y)$'
+}
+
 # Runs git and returns merged output + exit code.
 function Invoke-GitCapture {
     param([string[]] $GitArgs)
@@ -295,6 +308,60 @@ function Write-TimeoutGuidance {
             Write-Log ('  ' + (Format-GitCommand $null @('branch', '-d', '--', $BranchName)))
         }
     }
+    Write-Log "Details were logged to: $script:LogPath"
+}
+
+# Removability probe: merged = HEAD is an ancestor of main; clean = no working-tree
+# changes. Mirrors the conservatism of Get-EligibleMergedWorktrees in
+# cleanup-merged-worktrees.ps1 (branch-less worktrees skipped; clean tree required).
+function Test-WorktreeMergedIntoMain {
+    param([string] $WorktreeFull)
+
+    $result = Invoke-GitCapture @('-C', $WorktreeFull, 'merge-base', '--is-ancestor', 'HEAD', 'main')
+    Write-GitResult 'merge-base --is-ancestor HEAD main' $result
+    return ($result.ExitCode -eq 0)
+}
+
+function Test-WorktreeClean {
+    param([string] $WorktreeFull)
+
+    $result = Invoke-GitCapture @('-C', $WorktreeFull, 'status', '--porcelain')
+    Write-GitResult 'status --porcelain' $result
+    if ($result.ExitCode -ne 0) {
+        return $false
+    }
+    foreach ($line in $result.Lines) {
+        if ($line -and $line.Trim()) {
+            return $false
+        }
+    }
+    return $true
+}
+
+function Write-UnmergedPreserveGuidance {
+    param(
+        [string] $WorktreeFull,
+        [string] $MainCheckout,
+        [string] $BranchName,
+        [string] $Reason
+    )
+
+    Write-Log "Worktree was preserved (not removed): $Reason"
+    Write-Log 'To remove it manually once ready, run:'
+    if ($MainCheckout) {
+        Write-Log ('  ' + (Format-GitCommand $MainCheckout @('worktree', 'remove', $WorktreeFull)))
+        Write-Log ('  ' + (Format-GitCommand $MainCheckout @('worktree', 'prune')))
+        if ($BranchName) {
+            Write-Log ('  ' + (Format-GitCommand $MainCheckout @('branch', '-d', '--', $BranchName)))
+        }
+    } else {
+        Write-Log '  git worktree remove <worktree-path>'
+        Write-Log '  git worktree prune'
+        if ($BranchName) {
+            Write-Log ('  ' + (Format-GitCommand $null @('branch', '-d', '--', $BranchName)))
+        }
+    }
+    Write-Log 'To bypass this gate and remove now regardless of merge/clean status, set AHKFLOW_WORKTREE_FORCE_REMOVE=1 before exiting Claude Code.'
     Write-Log "Details were logged to: $script:LogPath"
 }
 
@@ -542,6 +609,27 @@ function Invoke-HookMode {
     if (-not $registration.IsRegistered) {
         Write-UnregisteredWorktreeRefusal $worktreeFull $mainCheckoutFromGit $registration
         return
+    }
+
+    # --- gate: only remove when merged into main AND clean, unless forced ---
+    $forceRemove = Test-EnvironmentFlagEnabled -Name 'AHKFLOW_WORKTREE_FORCE_REMOVE'
+    if ($forceRemove) {
+        Write-Log 'force override: AHKFLOW_WORKTREE_FORCE_REMOVE set; bypassing merge/clean gate.'
+    } else {
+        if (-not $branchName) {
+            Write-UnmergedPreserveGuidance -WorktreeFull $worktreeFull -MainCheckout $mainCheckoutFromGit -BranchName $branchName -Reason 'detached HEAD (no branch) is not eligible for automatic removal'
+            return
+        }
+
+        if (-not (Test-WorktreeMergedIntoMain -WorktreeFull $worktreeFull)) {
+            Write-UnmergedPreserveGuidance -WorktreeFull $worktreeFull -MainCheckout $mainCheckoutFromGit -BranchName $branchName -Reason "branch '$branchName' is not merged into main"
+            return
+        }
+
+        if (-not (Test-WorktreeClean -WorktreeFull $worktreeFull)) {
+            Write-UnmergedPreserveGuidance -WorktreeFull $worktreeFull -MainCheckout $mainCheckoutFromGit -BranchName $branchName -Reason 'worktree has uncommitted changes'
+            return
+        }
     }
 
     # --- snapshot watcher script + sidecar params outside the worktree ------

--- a/tests/WorktreeRemoveHook.Tests.ps1
+++ b/tests/WorktreeRemoveHook.Tests.ps1
@@ -1,0 +1,239 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$suiteRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+$scriptsDir = Join-Path $suiteRoot 'scripts'
+$removeScript = Join-Path $scriptsDir 'remove-worktree-local-dev.ps1'
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { throw $Message }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string] $Message)
+    if (-not [string]::Equals([string] $Expected, [string] $Actual, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "$Message (expected '$Expected', got '$Actual')"
+    }
+}
+
+function Invoke-TestGit {
+    param([string] $RepoDir, [string[]] $GitArgs)
+    $out = & git -C $RepoDir @GitArgs 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($GitArgs -join ' ') failed: $out"
+    }
+    return $out
+}
+
+# Fresh main-checkout repo under a throwaway root. Worktrees are created as siblings
+# of the repo, matching the harness used by WorktreeMergedCleanup.Tests.ps1.
+function New-TempGitRepo {
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ('wtremove-' + [guid]::NewGuid().ToString('N').Substring(0, 8))
+    $repo = Join-Path $root 'repo'
+    New-Item -ItemType Directory -Path $repo -Force | Out-Null
+
+    & git -C $repo init *> $null
+    & git -C $repo symbolic-ref HEAD refs/heads/main *> $null
+    & git -C $repo config user.email 'test@example.com' *> $null
+    & git -C $repo config user.name 'Remove Hook Test' *> $null
+
+    Set-Content -LiteralPath (Join-Path $repo 'README.md') -Value 'seed' -Encoding utf8
+    Invoke-TestGit $repo @('add', '-A') | Out-Null
+    Invoke-TestGit $repo @('commit', '-m', 'seed') | Out-Null
+
+    return (Resolve-Path -LiteralPath $repo).Path
+}
+
+# Adds a linked worktree on a new branch off main (merged + clean by default).
+function Add-TestWorktree {
+    param(
+        [string] $RepoDir,
+        [string] $BranchName,
+        [switch] $Unmerged,
+        [switch] $Dirty
+    )
+
+    $wtPath = Join-Path (Split-Path -Parent $RepoDir) ('wt-' + $BranchName)
+    Invoke-TestGit $RepoDir @('worktree', 'add', '-b', $BranchName, $wtPath, 'main') | Out-Null
+
+    if ($Unmerged) {
+        Set-Content -LiteralPath (Join-Path $wtPath 'extra.txt') -Value 'unmerged' -Encoding utf8
+        Invoke-TestGit $wtPath @('add', '-A') | Out-Null
+        Invoke-TestGit $wtPath @('commit', '-m', "work on $BranchName") | Out-Null
+    }
+    if ($Dirty) {
+        Set-Content -LiteralPath (Join-Path $wtPath 'dirty.txt') -Value 'uncommitted' -Encoding utf8
+    }
+
+    return (Resolve-Path -LiteralPath $wtPath).Path
+}
+
+# Adds a detached-HEAD worktree pinned at main (clean, ancestor of main, no branch).
+function Add-DetachedTestWorktree {
+    param([string] $RepoDir, [string] $Leaf)
+
+    $wtPath = Join-Path (Split-Path -Parent $RepoDir) ('wt-' + $Leaf)
+    Invoke-TestGit $RepoDir @('worktree', 'add', '--detach', $wtPath, 'main') | Out-Null
+    return (Resolve-Path -LiteralPath $wtPath).Path
+}
+
+function Remove-TempTree {
+    param([string] $RepoDir)
+    $root = Split-Path -Parent $RepoDir
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+function Get-RemovalLogPath {
+    param([string] $RepoDir)
+    return Join-Path $RepoDir '.claude\worktrees\worktree-removal.log'
+}
+
+# Invokes the hook by piping {"worktree_path":"<path>"} JSON to remove-worktree-local-dev.ps1,
+# exactly as Claude's WorktreeRemove hook does. Returns the process exit code; log content is
+# read separately by the caller once the process has exited.
+function Invoke-RemoveHook {
+    param(
+        [string] $WorktreePath,
+        [hashtable] $EnvOverrides
+    )
+
+    $stdinFile = [System.IO.Path]::GetTempFileName()
+    $stdoutFile = [System.IO.Path]::GetTempFileName()
+    $stderrFile = [System.IO.Path]::GetTempFileName()
+    try {
+        $payload = (@{ worktree_path = $WorktreePath } | ConvertTo-Json -Compress)
+        Set-Content -LiteralPath $stdinFile -Value $payload -Encoding utf8
+
+        $previousValues = @{}
+        if ($EnvOverrides) {
+            foreach ($key in $EnvOverrides.Keys) {
+                $previousValues[$key] = [Environment]::GetEnvironmentVariable($key, 'Process')
+                [Environment]::SetEnvironmentVariable($key, [string] $EnvOverrides[$key], 'Process')
+            }
+        }
+
+        try {
+            $psExe = [System.Diagnostics.Process]::GetCurrentProcess().Path
+            $proc = Start-Process -FilePath $psExe `
+                -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $removeScript, '-Mode', 'Hook') `
+                -WorkingDirectory $suiteRoot `
+                -RedirectStandardInput $stdinFile `
+                -RedirectStandardOutput $stdoutFile `
+                -RedirectStandardError $stderrFile `
+                -NoNewWindow -PassThru -Wait
+        } finally {
+            foreach ($key in $previousValues.Keys) {
+                [Environment]::SetEnvironmentVariable($key, $previousValues[$key], 'Process')
+            }
+        }
+
+        return [pscustomobject]@{
+            ExitCode = $proc.ExitCode
+            Stdout   = Get-Content -Raw -LiteralPath $stdoutFile -ErrorAction SilentlyContinue
+            Stderr   = Get-Content -Raw -LiteralPath $stderrFile -ErrorAction SilentlyContinue
+        }
+    } finally {
+        Remove-Item -LiteralPath $stdinFile, $stdoutFile, $stderrFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Wait-ForCondition {
+    param([scriptblock] $Condition, [int] $TimeoutSeconds = 20)
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        if (& $Condition) { return $true }
+        Start-Sleep -Milliseconds 250
+    }
+    return & $Condition
+}
+
+# --- Test: merged + clean -> folder removed (unchanged behavior) ---------------
+$repo = New-TempGitRepo
+try {
+    $wtPath = Add-TestWorktree -RepoDir $repo -BranchName 'feat-merged-clean'
+
+    $result = Invoke-RemoveHook -WorktreePath $wtPath
+    Assert-Equal 0 $result.ExitCode "Hook should exit 0. Stderr: $($result.Stderr)"
+
+    $removed = Wait-ForCondition { -not (Test-Path -LiteralPath $wtPath) }
+    Assert-True $removed "Merged + clean worktree should be removed by the watcher. Log: $(Get-Content -Raw -LiteralPath (Get-RemovalLogPath $repo) -ErrorAction SilentlyContinue)"
+} finally {
+    Remove-TempTree $repo
+}
+
+# --- Test: unmerged -> folder preserved, reason + guidance logged --------------
+$repo = New-TempGitRepo
+try {
+    $wtPath = Add-TestWorktree -RepoDir $repo -BranchName 'feat-unmerged' -Unmerged
+
+    $result = Invoke-RemoveHook -WorktreePath $wtPath
+    Assert-Equal 0 $result.ExitCode "Hook should exit 0. Stderr: $($result.Stderr)"
+
+    Assert-True (Test-Path -LiteralPath $wtPath) 'Unmerged worktree must be preserved (no watcher removal).'
+
+    $log = Get-Content -Raw -LiteralPath (Get-RemovalLogPath $repo)
+    Assert-True ($log -match '(?i)not merged') "Expected the log to name the unmerged reason. Log: $log"
+    Assert-True ($log -match 'AHKFLOW_WORKTREE_FORCE_REMOVE') "Expected the log to mention the force override opt-out. Log: $log"
+} finally {
+    Remove-TempTree $repo
+}
+
+# --- Test: merged + dirty -> folder preserved -----------------------------------
+$repo = New-TempGitRepo
+try {
+    $wtPath = Add-TestWorktree -RepoDir $repo -BranchName 'feat-dirty' -Dirty
+
+    $result = Invoke-RemoveHook -WorktreePath $wtPath
+    Assert-Equal 0 $result.ExitCode "Hook should exit 0. Stderr: $($result.Stderr)"
+
+    Assert-True (Test-Path -LiteralPath $wtPath) 'Merged but dirty worktree must be preserved.'
+
+    $log = Get-Content -Raw -LiteralPath (Get-RemovalLogPath $repo)
+    Assert-True ($log -match '(?i)uncommitted') "Expected the log to name the dirty-tree reason. Log: $log"
+} finally {
+    Remove-TempTree $repo
+}
+
+# --- Test: detached HEAD (clean, ancestor of main) -> folder preserved ---------
+$repo = New-TempGitRepo
+try {
+    $wtPath = Add-DetachedTestWorktree -RepoDir $repo -Leaf 'detached'
+
+    $result = Invoke-RemoveHook -WorktreePath $wtPath
+    Assert-Equal 0 $result.ExitCode "Hook should exit 0. Stderr: $($result.Stderr)"
+
+    Assert-True (Test-Path -LiteralPath $wtPath) 'Detached HEAD worktree must be preserved even though it is clean and an ancestor of main.'
+
+    $log = Get-Content -Raw -LiteralPath (Get-RemovalLogPath $repo)
+    Assert-True ($log -match '(?i)detached') "Expected the log to name the detached-HEAD reason. Log: $log"
+} finally {
+    Remove-TempTree $repo
+}
+
+# --- Test: unmerged + AHKFLOW_WORKTREE_FORCE_REMOVE=1 -> removed, force logged --
+$repo = New-TempGitRepo
+try {
+    $wtPath = Add-TestWorktree -RepoDir $repo -BranchName 'feat-forced' -Unmerged
+
+    $result = Invoke-RemoveHook -WorktreePath $wtPath -EnvOverrides @{ AHKFLOW_WORKTREE_FORCE_REMOVE = '1' }
+    Assert-Equal 0 $result.ExitCode "Hook should exit 0. Stderr: $($result.Stderr)"
+
+    $removed = Wait-ForCondition { -not (Test-Path -LiteralPath $wtPath) }
+    Assert-True $removed "Forced removal of an unmerged worktree should still remove the folder. Log: $(Get-Content -Raw -LiteralPath (Get-RemovalLogPath $repo) -ErrorAction SilentlyContinue)"
+
+    # The genuine proof this test exercises the gate: without it, an unmerged worktree would
+    # also be removed on today's script (that assertion alone is green on old and new code).
+    $log = Get-Content -Raw -LiteralPath (Get-RemovalLogPath $repo)
+    Assert-True ($log -match '(?i)force override.*bypassing merge/clean gate') "Expected a force-override log line proving the gate was consulted and bypassed. Log: $log"
+} finally {
+    Remove-TempTree $repo
+}
+
+Write-Host 'Worktree remove-hook gate tests passed.'


### PR DESCRIPTION
## Summary
- Exit-time worktree removal (`WorktreeRemove` hook) deleted a worktree folder unconditionally, regardless of merge status — only branch deletion was gated via `git branch -d`. Now the hook only auto-removes when the branch is merged into `main` AND the tree is clean; detached HEAD is never eligible.
- Preserved worktrees log the specific reason (unmerged / dirty / detached) plus manual `git worktree remove` + `prune` + `branch -d` guidance.
- `AHKFLOW_WORKTREE_FORCE_REMOVE=1` bypasses the gate without changing today's safe removal semantics (folder deleted, branch only removed via safe `git branch -d`).

## Test plan
- [x] `Tests/WorktreeRemoveHook.Tests.ps1` (new) — merged+clean removed, unmerged/dirty/detached preserved, forced removal + force-signal log line
- [x] `Tests/WorktreeMergedCleanup.Tests.ps1` passes
- [x] `Tests/WorktreePowerShellHost.Tests.ps1` passes
- [x] `git diff --check` clean
- [x] `dotnet build AHKFlowApp.slnx --configuration Release` — 0 errors/warnings
- [x] Resynced `plugins/ahkflowapp/skills/worktrees/SKILL.md`, hash-verified identical to `.agents/worktrees/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)