### PR TITLE
fix: worktree cleanup no longer flags the main checkout

### DIFF
--- a/scripts/cleanup-merged-worktrees.ps1
+++ b/scripts/cleanup-merged-worktrees.ps1
@@ -100,6 +100,12 @@ function Get-EligibleMergedWorktrees {
             continue
         }
         if (-not $wt.Branch) { continue }
+        # Belt-and-suspenders: a branch is always "merged" into itself, so the main-ref
+        # worktree would otherwise pass the merged check below. The repoRootFull compare
+        # above only excludes it when $RepoRoot happens to resolve to that exact worktree
+        # (guaranteed via new-worktree.ps1's Assert-MainCheckout, NOT guaranteed for a
+        # standalone run from inside a linked worktree) so this check must not depend on it.
+        if ([string]::Equals($wt.Branch, $MainRef, [System.StringComparison]::OrdinalIgnoreCase)) { continue }
         if (-not $mergedSet.ContainsKey($wt.Branch)) { continue }
 
         $status = & git -C $wtFull status --porcelain 2>$null

--- a/scripts/cleanup-merged-worktrees.ps1
+++ b/scripts/cleanup-merged-worktrees.ps1
@@ -65,6 +65,16 @@ function Get-EligibleMergedWorktrees {
     $repoRootFull = ([System.IO.Path]::GetFullPath($RepoRoot)).TrimEnd('\', '/')
     $excludeFull = if ($ExcludePath) { ([System.IO.Path]::GetFullPath($ExcludePath)).TrimEnd('\', '/') } else { $null }
 
+    # Resolve $MainRef to the local branch short name it denotes, so the main-ref exclusion
+    # below matches regardless of the ref form the caller passed ('main' vs 'refs/heads/main').
+    # Falls back to the raw value when $MainRef isn't a local branch (e.g. 'origin/main') --
+    # then only the repoRootFull path check above can exclude the main checkout.
+    $mainBranchShortName = $MainRef
+    $mainSymbolicRef = & git -C $RepoRoot rev-parse --symbolic-full-name $MainRef 2>$null
+    if ($LASTEXITCODE -eq 0 -and $mainSymbolicRef -like 'refs/heads/*') {
+        $mainBranchShortName = $mainSymbolicRef.Substring('refs/heads/'.Length)
+    }
+
     # Bare, marker-free short names. Plain `git branch --merged` prefixes '* '/'+ ',
     # so --format is required or a naive compare skips every eligible worktree.
     $mergedNames = & git -C $RepoRoot branch --format='%(refname:short)' --merged $MainRef 2>$null
@@ -105,7 +115,7 @@ function Get-EligibleMergedWorktrees {
         # above only excludes it when $RepoRoot happens to resolve to that exact worktree
         # (guaranteed via new-worktree.ps1's Assert-MainCheckout, NOT guaranteed for a
         # standalone run from inside a linked worktree) so this check must not depend on it.
-        if ([string]::Equals($wt.Branch, $MainRef, [System.StringComparison]::OrdinalIgnoreCase)) { continue }
+        if ([string]::Equals($wt.Branch, $mainBranchShortName, [System.StringComparison]::OrdinalIgnoreCase)) { continue }
         if (-not $mergedSet.ContainsKey($wt.Branch)) { continue }
 
         $status = & git -C $wtFull status --porcelain 2>$null

--- a/tests/WorktreeMergedCleanup.Tests.ps1
+++ b/tests/WorktreeMergedCleanup.Tests.ps1
@@ -108,6 +108,23 @@ try {
     Remove-TempTree $repo
 }
 
+# --- Test: main-ref worktree is excluded even when $RepoRoot points elsewhere ---
+# Regression guard: a standalone run from inside a linked worktree (no new-worktree.ps1
+# Assert-MainCheckout gate) resolves $RepoRoot to that linked worktree, not the real main
+# checkout. Since `git branch --merged main` always includes `main` itself, the path-based
+# exclusion alone previously let the main checkout slip into the eligible set.
+$repo = New-TempGitRepo
+try {
+    $otherPath = Add-TestWorktree -RepoDir $repo -BranchName 'feat-other'
+
+    $eligible = Get-EligibleMergedWorktrees -RepoRoot $otherPath -MainRef 'main'
+    $keys = @($eligible | ForEach-Object { ConvertTo-Key $_.Path })
+
+    Assert-True (-not ($keys -contains (ConvertTo-Key $repo))) 'The main-ref worktree must never be eligible, even when $RepoRoot is a different (linked) worktree.'
+} finally {
+    Remove-TempTree $repo
+}
+
 # --- Test: ExcludePath protects the worktree this run is about to create/reuse ---
 $repo = New-TempGitRepo
 try {

--- a/tests/WorktreeMergedCleanup.Tests.ps1
+++ b/tests/WorktreeMergedCleanup.Tests.ps1
@@ -125,6 +125,22 @@ try {
     Remove-TempTree $repo
 }
 
+# --- Test: main-ref exclusion matches a fully-qualified -MainRef too ------------
+# Regression guard: -MainRef 'refs/heads/main' must exclude the main checkout the same
+# way -MainRef 'main' does. $wt.Branch is always a short name, so a naive string compare
+# against an unresolved 'refs/heads/main' never matches.
+$repo = New-TempGitRepo
+try {
+    Add-TestWorktree -RepoDir $repo -BranchName 'feat-other' | Out-Null
+
+    $eligible = Get-EligibleMergedWorktrees -RepoRoot $repo -MainRef 'refs/heads/main'
+    $keys = @($eligible | ForEach-Object { ConvertTo-Key $_.Path })
+
+    Assert-True (-not ($keys -contains (ConvertTo-Key $repo))) 'The main-ref worktree must never be eligible when -MainRef is the fully-qualified refs/heads/main form.'
+} finally {
+    Remove-TempTree $repo
+}
+
 # --- Test: ExcludePath protects the worktree this run is about to create/reuse ---
 $repo = New-TempGitRepo
 try {


### PR DESCRIPTION
## Summary
- `cleanup-merged-worktrees.ps1` excluded the main checkout only by comparing paths against `$RepoRoot`, which isn't guaranteed to be the real main checkout for a standalone run from inside a linked worktree. Since a branch is always "merged" into itself, main could then be offered for removal. Added a branch-name-based exclusion as a resolution-independent safeguard.
- Follow-up: that exclusion compared `$wt.Branch` (always a short name) against a raw `-MainRef`, so `-MainRef refs/heads/main` still slipped past it. Resolve `$MainRef` to its local branch short name via `git rev-parse --symbolic-full-name` before comparing.

## Test plan
- [x] `pwsh -NoProfile -File tests\WorktreeMergedCleanup.Tests.ps1` passes, including new regression tests for both scenarios
- [x] Reproduced and re-verified both original failures no longer flag main
- [x] Parse-checked changed files; `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)