### PR TITLE
feat: DateTime hotstring kind (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This changelog starts forward-only. Existing releases before this file was intro
 - Type/Options badge column in the hotstrings grid (replaces the two option checkbox columns).
 - "Edit details" dialog for hotstrings on desktop.
 - `ahkflow hotstring list` shows a Kind column.
+- DateTime hotstring kind: curated date/time format presets with optional date offset, emitted as `SendText(FormatTime(...))`. Supported in the edit dialog, grid, mobile list, history, and CLI.
 
 ### Changed
 

--- a/docs/superpowers/plans/2026-07-08-hotstrings-redesign-phase2.md
+++ b/docs/superpowers/plans/2026-07-08-hotstrings-redesign-phase2.md
@@ -1,0 +1,145 @@
+# Hotstrings Redesign — Phase 2: Date & Time Kind
+
+## Context
+
+Phase 1 of the hotstrings redesign (spec: `docs/superpowers/specs/2026-07-07-hotstrings-redesign-design.md`) merged in PR #173: `HotstringKind` enum, `IsCaseSensitive`/`OmitEndingCharacter` flags, `HotstringDefinition` record, `HotstringEmitter`, grid badge column, dialog option toggles, CLI Kind column. This phase implements **Phase 2 (spec §9)**: the DateTime hotstring kind — users pick a date/time format (curated presets + custom, D3) and optional date offset; the generated script emits `:X:trig::SendText(FormatTime(A_Now, "fmt"))` (with `DateAdd` for offsets). The dialog kind selector appears this phase (D4). Per spec §8, the phase also round-trips the new fields through history snapshots and extends the CLI display.
+
+Branch: `feature/hotstrings-datetime-kind` (worktree, clean at `b009dd8`).
+
+**User-confirmed decisions:** convert `/today` + `/now` seeds to real DateTime rows; Kind filter = clearable toolbar `MudSelect` next to search. Offset amount `0` is allowed (harmless `DateAdd(A_Now, 0, "Days")`).
+
+## Design
+
+### New fields (all layers)
+`string? DateTimeFormat` (nvarchar(50) null), `int? DateOffsetAmount`, `DateOffsetUnit? DateOffsetUnit` — new Domain enum `DateOffsetUnit { Seconds=0, Minutes=1, Hours=2, Days=3 }` (names exactly match AHK `DateAdd` unit strings). Appended as trailing defaulted params everywhere (DTOs, snapshot, `HotstringDefinition`) — wire/positional-call compatible.
+
+### Curated presets (12 + "Custom…")
+| Label | Format |
+|---|---|
+| ISO date | `yyyy-MM-dd` |
+| European date | `dd-MM-yyyy` |
+| US date | `MM/dd/yyyy` |
+| Long date | `dddd d MMMM yyyy` |
+| Short day + date | `ddd d MMM yyyy` |
+| Month + year | `MMMM yyyy` |
+| Time (24h) | `HH:mm` |
+| Time (24h, seconds) | `HH:mm:ss` |
+| Time (12h) | `h:mm tt` |
+| Date + time | `yyyy-MM-dd HH:mm` |
+| Timestamp | `yyyy-MM-dd HH:mm:ss` |
+| Compact stamp | `yyyyMMdd-HHmmss` |
+
+All 12 pass the server whitelist; presets and Custom share one validator (D3). Day/month names are locale-dependent in both AHK and .NET — preview is representative, not byte-identical (code comment).
+
+### Format whitelist (server-authoritative)
+Format lands inside AHK literal `FormatTime(A_Now, "…")` → security boundary: no `"`, backtick, `'`, `\`, `%`, `;`, `{}`, newlines; only tokens identical between AHK FormatTime and .NET custom formats (keeps client preview accurate):
+
+```csharp
+public const int DateTimeFormatMaxLength = 50;
+// letters restricted to tokens shared by AHK FormatTime and .NET custom formats
+[GeneratedRegex(@"^(?=.*[yMdHhmst])[yMdHhmst0-9 \-./:,()]+$")]
+```
+
+.NET preview pitfall: 1-char format (`d`) is a *standard* .NET specifier — preview must use `format.Length == 1 ? "%" + format : format`.
+
+### Emitter output
+Option order `X * ? C O` (never `T` with `X`, per D1; `O` still suppressed when `*`):
+- defaults → `:X:dd::SendText(FormatTime(A_Now, "yyyy-MM-dd"))`
+- expand immediately → `:X*:dd::…`
+- all options → `:X*?C:dd::…`
+- offset → body `SendText(FormatTime(DateAdd(A_Now, 7, "Days"), "dddd d MMMM yyyy"))`; negative amounts pass through (`-7`).
+Trigger still `Escape()`d; format embedded raw (whitelist guarantees safety — comment). `Replacement` validated empty (stored `""`, column stays non-null).
+
+## Tasks (one conventional commit each; TDD for validators + emitter goldens)
+
+### Task 0 — Commit this plan
+Save to `docs/superpowers/plans/2026-07-08-hotstrings-redesign-phase2.md` (project convention). Commit: `docs: phase 2 plan (date/time kind)`.
+
+### Task 1 — Domain
+- New `src/Backend/AHKFlowApp.Domain/Enums/DateOffsetUnit.cs`
+- `Domain/Entities/HotstringDefinition.cs` — 3 trailing defaulted params
+- `Domain/Entities/Hotstring.cs` — 3 private-set props, assigned in `Apply`
+- `tests/AHKFlowApp.TestUtilities/Builders/HotstringBuilder.cs` — `WithDateTimeFormat`, `WithDateOffset`
+- Domain tests (`tests/AHKFlowApp.Domain.Tests/Entities/HotstringTests.cs`): Create/Restore round-trip new fields.
+Commit: `feat: date/time fields on hotstring domain model`
+
+### Task 2 — EF config + migration #2
+- `Infrastructure/Persistence/Configurations/HotstringConfiguration.cs`: `DateTimeFormat` `.HasMaxLength(50)`, `DateOffsetUnit` nullable `.HasConversion<int>()` (mirror Kind pattern)
+- `dotnet ef migrations add AddHotstringDateTimeFields` (additive, 3 nullable columns; verify script)
+- `tests/AHKFlowApp.Infrastructure.Tests/Persistence/HotstringPersistenceTests.cs`: column round-trip.
+Commit: `feat: persist hotstring date/time columns`
+
+### Task 3 — Emitter (goldens first)
+- Tests in `tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs`: option-combo theory, offset ±/all 4 units, spec §7 examples #3/#4 exact strings, trigger escaping under `X`
+- `Application/Services/HotstringEmitter.cs`: kind branch in `BuildOptions` (`X` prefix, skip `T`) + `BuildDateTimeBody`.
+Commit: `feat: emit :X: date/time hotstrings via FormatTime/DateAdd`
+
+### Task 4 — Validation (TDD)
+- `Application/Validation/HotstringRules.cs`: `DateTimeFormatMaxLength=50`, `DateOffsetAmountMax=3650`, `[GeneratedRegex]` whitelist, `ValidDateTimeFormat<T>()`, shared `AddDateTimeKindRules<T>(...)` (mirrors `AddProfileAssociationRules` expression style)
+- Create/Update validators: Kind rule → allow `Text or DateTime` (Macro/Script still rejected); Replacement `ValidReplacement().When(Kind != DateTime)` / must be empty when DateTime; DateTimeFormat required+whitelisted when DateTime, must be null otherwise; offset both-or-neither, `InclusiveBetween(-3650, 3650)`, `IsInEnum()`, null when not DateTime
+- Update `Kind_NonText_Fails` tests → `Kind_MacroOrScript_Fails`; add acceptance theory (all 12 presets) + rejection theory (`"`, backtick, `'`, `\`, `%`, `;`, `{}`, newline, non-token letters `f z K n`, empty, 51 chars, separator-only).
+Commit: `feat: kind-conditional hotstring validation + date format whitelist`
+
+### Task 5 — DTOs, mapping, handlers, list query, API
+- `Application/DTOs/HotstringDto.cs`: 3 fields on all three records
+- **Both** mapping sites: `Application/Mapping/HotstringMappings.cs` `ToDto` AND inline projection in `ListHotstringsQueryHandler.ExecuteAsync` (known duplication)
+- Create/Update handlers: thread fields into `HotstringDefinition`
+- `Application/Queries/Hotstrings/ListHotstringsQuery.cs`: `HotstringKind? Kind = null` as last param; `"kind"` in `AllowedSortFields` + `ApplySorting` case; `Where(h => h.Kind == kind)` filter
+- `API/Controllers/HotstringsController.cs` `List`: `[FromQuery] HotstringKind? kind = null`, threaded positionally
+- Tests: API `Post_DateTimeKind_ReturnsCreatedWithDateFields`, Script-still-400 (update existing `Post_NonTextKind_Returns400`), list `?kind=` filter + `sortField=kind`; handler filter/sort tests; validator sort-field test.
+Commit: `feat: date/time DTO fields + kind filter/sort in list query`
+
+### Task 6 — History round-trip
+- `HistorySnapshots.cs` `HotstringSnapshot`: 3 defaulted members (legacy JSON → nulls)
+- `EntityHistoryRecorder.RecordHotstringsAsync` snapshot construction; `RestoreHotstringCommand.cs` + `RevertHotstringCommand.cs` → thread into `HotstringDefinition`
+- Tests (templates exist): `History/HotstringNewFieldHistoryTests.cs` — revert restores date fields, restore-after-delete rehydrates; `HotstringSnapshotCompatibilityTests.cs` — legacy JSON → nulls, Kind=Text.
+Commit: `feat: round-trip date/time fields through history snapshots`
+
+### Task 7 — Seed conversion (confirmed)
+- `ListHotstringsQuery` `s_lazySeed` + `Commands/Dev/SeedHotstringsCommand.cs` `s_samples` (update both): `/today` → DateTime, `yyyy-MM-dd`; `/now` → DateTime, `HH:mm`; Replacement `""`. Verify seed tests still pass (none pin `{{date:` text).
+Commit: `feat: seed /today and /now as date/time hotstrings`
+
+### Task 8 — CLI (display-only, D6)
+- `src/Tools/AHKFlowApp.CLI/Services/IHotstringsApiClient.cs`: mirror `DateOffsetUnit`, 3 fields on CLI `HotstringDto` (Create DTO stays Text-only)
+- `Output/HotstringTableFormatter.cs`: DateTime rows render Replacement column as `yyyy-MM-dd` / `yyyy-MM-dd (+7 days)` / `(-2 hours)` (lowercase unit, singular at |1|; `—` fallback if format null)
+- `tests/AHKFlowApp.CLI.Tests/Output/HotstringTableFormatterTests.cs`: with/without/negative offset.
+Commit: `feat: date/time summary in CLI hotstring table`
+
+### Task 9 — Frontend plumbing
+Under `src/Frontend/AHKFlowApp.UI.Blazor/`:
+- New `DTOs/DateOffsetUnit.cs` mirror; 3 trailing params on `HotstringDto`/`CreateHotstringDto`/`UpdateHotstringDto`; `HotstringListRequest` + `Kind`
+- `Services/HotstringsApiClient.ListAsync`: kind query param
+- `Validation/HotstringEditModel.cs`: 3 props; update `FromDto`/`Clone`/`ToCreateDto`/`ToUpdateDto` (force `Replacement=""` for DateTime); **drop `[Required]` from Replacement** (requiredness → dialog field `Required` param + server); add `IsInlineEditable => Kind == HotstringKind.Text`, `DateTimeSummary` (shared grid/mobile), `static SafePreview(format)` (try/catch, `%`-prefix for 1-char)
+- `Validation/HotstringEditModelTests.cs` updates.
+Commit: `feat: mirror date/time fields in Blazor DTOs and edit model`
+
+### Task 10 — Dialog: kind selector + DateTime panel
+`Components/Hotstrings/HotstringEditDialog.razor` (verify `MudToggleGroup`/`MudToggleItem` params via `mcp__mudblazor__get_component_parameters` — no existing usage in codebase; frontend CLAUDE.md mandates MudMCP verification):
+- `MudToggleGroup<HotstringKind>` at top, items Text + Date & time only (`data-test="kind-selector"`). Kind switch preserves Trigger/Description/options/profiles/categories; confirm via message box before discarding non-empty kind-specific content; DateTime→Text nulls format/offset (else server 400s)
+- Replacement field only when `Kind != DateTime`; `Required="@(Item.Kind != HotstringKind.DateTime)"`
+- DateTime panel: format `MudSelect<string>` over 12 presets (`Label — live example`) + "Custom…" sentinel revealing `MudTextField` MaxLength 50 (`data-test="datetime-format-select"` / `-custom`); on edit-open select matching preset else Custom; `MudSwitch` "Adjust date" (`data-test="date-offset-switch"`, on → Amount=1/Days defaults, off → nulls) with `MudNumericField<int?>` (−3650…3650) + `MudSelect<DateOffsetUnit?>`; live preview `MudText` (`data-test="datetime-preview"`) via `SafePreview`, offset applied, "Invalid format" fallback
+- bUnit tests per existing dialog pattern (selector renders; switch hides Replacement/shows panel; preset sets format; Custom reveals field; preview valid/invalid; offset toggle; save posts DateTime DTO with empty Replacement; switch-away confirm clears fields).
+Commit: `feat: dialog kind selector + date/time panel`
+
+### Task 11 — Grid + mobile rendering, kind filter/sort, inline-edit gating
+- `Pages/Hotstrings.razor`: Replacement read-mode renders `DateTimeSummary` for DateTime rows; hide `.start-edit` pencil when `!IsInlineEditable` (edit-details button stays on all rows); toolbar clearable `MudSelect<HotstringKind?>` "Type" (`data-test="kind-filter"`) feeding `Kind` into both `HotstringListRequest` builds (desktop + mobile) with reload à la `OnCategoryFilterChangedAsync`; Type column `Sortable` with `GetSort` mapping → `"kind"` (verify TemplateColumn sort params via MudMCP)
+- `Components/Hotstrings/HotstringMobileList.razor`: DateTime summary in replacement cell + "Format:" line in expanded row
+- bUnit page tests: summary rendering, pencil hidden, filter reload with Kind, mobile summary.
+Commit: `feat: grid/mobile date-time rendering, kind filter/sort, inline-edit gating`
+
+### Task 12 — Verify + changelog
+- `dck-verify` skill (build, all tests incl. Testcontainers + bUnit, format, diagnostics)
+- Changelog entry + regenerate changelog.json (repo convention)
+- E2E smoke (spec §11): run API + Blazor, create DateTime hotstring via dialog, download script, confirm `:X*:dd::SendText(FormatTime(A_Now, "yyyy-MM-dd"))`; `playwright-cli` smoke of DateTime panel; verify inline edit still works for Text rows.
+Commit: `docs: changelog for date/time hotstring kind`
+
+Then PR to `main` via `gh`.
+
+## Edge cases covered
+Negative offset; bounds ±3650; amount 0 allowed; amount/unit both-or-neither; format injection rejections; 1-char format preview (`%d`); DateTime+non-empty Replacement → 400; Text+date fields → 400; kind transitions in Update; `O` suppressed under `*` with `X`; `T` never with `X`; legacy snapshots → nulls; CLI against old API → graceful fallback; pencil hidden for DateTime rows.
+
+## Verification
+Per-task: `dotnet build` + targeted `dotnet test` project. End: full `dck-verify`, E2E smoke above.
+
+## Unresolved questions
+None — seeds conversion + toolbar-select filter confirmed by user; offset 0 allowed by default.

--- a/docs/superpowers/plans/2026-07-08-hotstrings-redesign-phase2.md
+++ b/docs/superpowers/plans/2026-07-08-hotstrings-redesign-phase2.md
@@ -4,7 +4,7 @@
 
 Phase 1 of the hotstrings redesign (spec: `docs/superpowers/specs/2026-07-07-hotstrings-redesign-design.md`) merged in PR #173: `HotstringKind` enum, `IsCaseSensitive`/`OmitEndingCharacter` flags, `HotstringDefinition` record, `HotstringEmitter`, grid badge column, dialog option toggles, CLI Kind column. This phase implements **Phase 2 (spec §9)**: the DateTime hotstring kind — users pick a date/time format (curated presets + custom, D3) and optional date offset; the generated script emits `:X:trig::SendText(FormatTime(A_Now, "fmt"))` (with `DateAdd` for offsets). The dialog kind selector appears this phase (D4). Per spec §8, the phase also round-trips the new fields through history snapshots and extends the CLI display.
 
-Branch: `feature/hotstrings-datetime-kind` (worktree, clean at `b009dd8`).
+Branch: `feature/hotstrings-datetime-kind` (worktree, clean at `9324162`).
 
 **User-confirmed decisions:** convert `/today` + `/now` seeds to real DateTime rows; Kind filter = clearable toolbar `MudSelect` next to search. Offset amount `0` is allowed (harmless `DateAdd(A_Now, 0, "Days")`).
 
@@ -50,10 +50,13 @@ Option order `X * ? C O` (never `T` with `X`, per D1; `O` still suppressed when 
 - offset → body `SendText(FormatTime(DateAdd(A_Now, 7, "Days"), "dddd d MMMM yyyy"))`; negative amounts pass through (`-7`).
 Trigger still `Escape()`d; format embedded raw (whitelist guarantees safety — comment). `Replacement` validated empty (stored `""`, column stays non-null).
 
+### Search/filter/sort
+`Replacement` stores `""` for DateTime rows, so raw `h.Replacement` is useless for search/filter/sort on those rows. One EF-translatable expression, reused at all three call sites in `ListHotstringsQuery.cs`: `h.Kind == HotstringKind.DateTime ? (h.DateTimeFormat ?? "") : h.Replacement`. Scope is the raw format string only (not the humanized offset text CLI/grid render) — keeps the query minimal.
+
 ## Tasks (one conventional commit each; TDD for validators + emitter goldens)
 
-### Task 0 — Commit this plan
-Save to `docs/superpowers/plans/2026-07-08-hotstrings-redesign-phase2.md` (project convention). Commit: `docs: phase 2 plan (date/time kind)`.
+### Task 0 — Commit this plan (done: `9324162`)
+Plan already saved and committed as `docs: phase 2 plan (date/time kind)`.
 
 ### Task 1 — Domain
 - New `src/Backend/AHKFlowApp.Domain/Enums/DateOffsetUnit.cs`
@@ -84,15 +87,16 @@ Commit: `feat: kind-conditional hotstring validation + date format whitelist`
 - `Application/DTOs/HotstringDto.cs`: 3 fields on all three records
 - **Both** mapping sites: `Application/Mapping/HotstringMappings.cs` `ToDto` AND inline projection in `ListHotstringsQueryHandler.ExecuteAsync` (known duplication)
 - Create/Update handlers: thread fields into `HotstringDefinition`
-- `Application/Queries/Hotstrings/ListHotstringsQuery.cs`: `HotstringKind? Kind = null` as last param; `"kind"` in `AllowedSortFields` + `ApplySorting` case; `Where(h => h.Kind == kind)` filter
+- `Application/Queries/Hotstrings/ListHotstringsQuery.cs`: `HotstringKind? Kind = null` as last param; `"kind"` in `AllowedSortFields` + `ApplySorting` case; `Where(h => h.Kind == kind)` filter; apply the Search/filter/sort expression (design section above) to global `Search`'s replacement clause, `ReplacementFilter`, and the `"replacement"` `ApplySorting` case, so DateTime rows are searchable/filterable/sortable by `DateTimeFormat`
 - `API/Controllers/HotstringsController.cs` `List`: `[FromQuery] HotstringKind? kind = null`, threaded positionally
-- Tests: API `Post_DateTimeKind_ReturnsCreatedWithDateFields`, Script-still-400 (update existing `Post_NonTextKind_Returns400`), list `?kind=` filter + `sortField=kind`; handler filter/sort tests; validator sort-field test.
+- Tests: API `Post_DateTimeKind_ReturnsCreatedWithDateFields`, Script-still-400 (update existing `Post_NonTextKind_Returns400`), list `?kind=` filter + `sortField=kind`; handler filter/sort tests; validator sort-field test; list search/`ReplacementFilter` by `DateTimeFormat` substring finds DateTime rows; sort by `replacement` orders DateTime rows by format.
 Commit: `feat: date/time DTO fields + kind filter/sort in list query`
 
 ### Task 6 — History round-trip
 - `HistorySnapshots.cs` `HotstringSnapshot`: 3 defaulted members (legacy JSON → nulls)
 - `EntityHistoryRecorder.RecordHotstringsAsync` snapshot construction; `RestoreHotstringCommand.cs` + `RevertHotstringCommand.cs` → thread into `HotstringDefinition`
 - Tests (templates exist): `History/HotstringNewFieldHistoryTests.cs` — revert restores date fields, restore-after-delete rehydrates; `HotstringSnapshotCompatibilityTests.cs` — legacy JSON → nulls, Kind=Text.
+- Backend-only — frontend history DTO/dialog updates are Task 12 (depends on the summary helper Task 9 introduces).
 Commit: `feat: round-trip date/time fields through history snapshots`
 
 ### Task 7 — Seed conversion (confirmed)
@@ -127,10 +131,16 @@ Commit: `feat: dialog kind selector + date/time panel`
 - bUnit page tests: summary rendering, pencil hidden, filter reload with Kind, mobile summary.
 Commit: `feat: grid/mobile date-time rendering, kind filter/sort, inline-edit gating`
 
-### Task 12 — Verify + changelog
+### Task 12 — Frontend history: date/time fields + dialog rendering
+- `UI.Blazor/DTOs/HistoryDtos.cs`: add `Kind = HotstringKind.Text`, `DateTimeFormat`, `DateOffsetAmount`, `DateOffsetUnit` (defaulted/nullable) to `HotstringSnapshot`, mirroring the backend record (`Application/DTOs/HistorySnapshots.cs`)
+- `HotstringHistoryDialog.razor`: when `_preview.Snapshot.Kind == HotstringKind.DateTime`, render the summary (reuse `HotstringEditModel.DateTimeSummary`/`SafePreview` from Task 9) instead of the raw (empty) Replacement line; Text-kind rows unchanged
+- bUnit test: history preview for a DateTime snapshot shows the format summary, not a blank Replacement line
+Commit: `feat: date/time fields in frontend history snapshot + dialog`
+
+### Task 13 — Verify + changelog
 - `dck-verify` skill (build, all tests incl. Testcontainers + bUnit, format, diagnostics)
 - Changelog entry + regenerate changelog.json (repo convention)
-- E2E smoke (spec §11): run API + Blazor, create DateTime hotstring via dialog, download script, confirm `:X*:dd::SendText(FormatTime(A_Now, "yyyy-MM-dd"))`; `playwright-cli` smoke of DateTime panel; verify inline edit still works for Text rows.
+- E2E smoke (spec §11): run API + Blazor, create DateTime hotstring via dialog, download script, confirm `:X*:dd::SendText(FormatTime(A_Now, "yyyy-MM-dd"))`; `playwright-cli` smoke of DateTime panel; verify inline edit still works for Text rows; verify history dialog renders the date/time summary for a DateTime hotstring.
 Commit: `docs: changelog for date/time hotstring kind`
 
 Then PR to `main` via `gh`.

--- a/src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs
@@ -3,6 +3,7 @@ using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.Commands.Hotstrings;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Application.Queries.Hotstrings;
+using AHKFlowApp.Domain.Enums;
 using Ardalis.Result;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -50,6 +51,7 @@ public sealed class HotstringsController(
         [FromQuery] bool? isEndingCharacterRequired = null,
         [FromQuery] bool? isTriggerInsideWord = null,
         [FromQuery] Guid[]? categoryIds = null,
+        [FromQuery] HotstringKind? kind = null,
         CancellationToken ct = default) =>
         (await listHotstrings.ExecuteAsync(new ListHotstringsQuery(
             profileId,
@@ -64,7 +66,8 @@ public sealed class HotstringsController(
             appliesToAllProfiles,
             isEndingCharacterRequired,
             isTriggerInsideWord,
-            categoryIds), ct)).ToProblemActionResult(this);
+            categoryIds,
+            kind), ct)).ToProblemActionResult(this);
 
     /// <summary>Get a hotstring by id.</summary>
     [HttpGet("{id:guid}", Name = "GetHotstring")]

--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotstringsCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotstringsCommand.cs
@@ -1,6 +1,7 @@
 using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
 using Ardalis.Result;
 using Microsoft.EntityFrameworkCore;
 
@@ -23,20 +24,22 @@ internal sealed class SeedHotstringsCommandHandler(
         string Replacement,
         bool Ending,
         bool InsideWord,
-        string[] Categories)[] s_samples =
+        string[] Categories,
+        HotstringKind Kind,
+        string? DateTimeFormat)[] s_samples =
     [
-        ("recieve", "receive",              true,  true,  ["Autocorrect"]),
-        ("btw",     "by the way",           true,  false, ["Communication"]),
-        ("brb",     "be right back",        true,  false, ["Communication"]),
-        ("fyi",     "for your information", true,  false, ["Communication"]),
-        ("/today",  "{{date:yyyy-MM-dd}}",  false, false, ["DateTime"]),
-        ("/now",    "{{datetime:HH:mm}}",   false, false, ["DateTime"]),
-        ("@sig",    "Example User\nuser@example.com\nExample Company", false, false, ["Email"]),
-        (";arrow",  "→",               false, false, ["Symbols"]),
-        (";check",  "✓",               false, false, ["Symbols"]),
-        (";shrug",  "¯\\_(ツ)_/¯", false, false, ["Symbols"]),
-        (";e:",     "ë",               false, false, ["Symbols"]),
-        (";todo",   "TODO(name): ",         false, false, ["Code"]),
+        ("recieve", "receive",              true,  true,  ["Autocorrect"],  HotstringKind.Text,     null),
+        ("btw",     "by the way",           true,  false, ["Communication"], HotstringKind.Text,    null),
+        ("brb",     "be right back",        true,  false, ["Communication"], HotstringKind.Text,    null),
+        ("fyi",     "for your information", true,  false, ["Communication"], HotstringKind.Text,    null),
+        ("/today",  "",                     false, false, ["DateTime"],     HotstringKind.DateTime, "yyyy-MM-dd"),
+        ("/now",    "",                     false, false, ["DateTime"],     HotstringKind.DateTime, "HH:mm"),
+        ("@sig",    "Example User\nuser@example.com\nExample Company", false, false, ["Email"], HotstringKind.Text, null),
+        (";arrow",  "→",               false, false, ["Symbols"], HotstringKind.Text, null),
+        (";check",  "✓",               false, false, ["Symbols"], HotstringKind.Text, null),
+        (";shrug",  "¯\\_(ツ)_/¯", false, false, ["Symbols"], HotstringKind.Text, null),
+        (";e:",     "ë",               false, false, ["Symbols"], HotstringKind.Text, null),
+        (";todo",   "TODO(name): ",         false, false, ["Code"], HotstringKind.Text, null),
     ];
 
     public async Task<Result<PagedList<HotstringDto>>> ExecuteAsync(SeedHotstringsCommand request, CancellationToken ct)
@@ -73,7 +76,7 @@ internal sealed class SeedHotstringsCommandHandler(
                 .Select(x => (x.HotstringId, x.CategoryId))
                 .ToHashSet();
 
-        foreach ((string trigger, string replacement, bool ending, bool inside, string[] cats) in s_samples)
+        foreach ((string trigger, string replacement, bool ending, bool inside, string[] cats, HotstringKind kind, string? dateTimeFormat) in s_samples)
         {
             Hotstring? existing = request.Reset
                 ? null
@@ -91,7 +94,8 @@ internal sealed class SeedHotstringsCommandHandler(
                     ownerOid,
                     new HotstringDefinition(
                         trigger, replacement, Description: null, AppliesToAllProfiles: true,
-                        IsEndingCharacterRequired: ending, IsTriggerInsideWord: inside),
+                        IsEndingCharacterRequired: ending, IsTriggerInsideWord: inside,
+                        Kind: kind, DateTimeFormat: dateTimeFormat),
                     clock);
                 db.Hotstrings.Add(entity);
                 hotstringId = entity.Id;

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/CreateHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/CreateHotstringCommand.cs
@@ -18,16 +18,21 @@ public sealed class CreateHotstringCommandValidator : AbstractValidator<CreateHo
     public CreateHotstringCommandValidator()
     {
         RuleFor(x => x.Input.Trigger).ValidTrigger();
-        RuleFor(x => x.Input.Replacement).ValidReplacement();
         RuleFor(x => x.Input.Description)
             .MaximumLength(HotstringRules.DescriptionMaxLength)
             .WithMessage($"Description must be {HotstringRules.DescriptionMaxLength} characters or fewer.");
         RuleFor(x => x.Input.Kind)
-            .Must(k => k == HotstringKind.Text)
-            .WithMessage("Only Text hotstrings are supported.");
+            .Must(k => k is HotstringKind.Text or HotstringKind.DateTime)
+            .WithMessage("Only Text and Date & time hotstrings are supported.");
         this.AddProfileAssociationRules(
             x => x.Input.AppliesToAllProfiles,
             x => x.Input.ProfileIds);
+        this.AddDateTimeKindRules(
+            x => x.Input.Kind,
+            x => x.Input.Replacement,
+            x => x.Input.DateTimeFormat,
+            x => x.Input.DateOffsetAmount,
+            x => x.Input.DateOffsetUnit);
     }
 }
 

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/CreateHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/CreateHotstringCommand.cs
@@ -84,7 +84,10 @@ internal sealed class CreateHotstringCommandHandler(
                 input.IsTriggerInsideWord,
                 input.Kind,
                 input.IsCaseSensitive,
-                input.OmitEndingCharacter),
+                input.OmitEndingCharacter,
+                input.DateTimeFormat,
+                input.DateOffsetAmount,
+                input.DateOffsetUnit),
             clock);
 
         db.Hotstrings.Add(entity);

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/RestoreHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/RestoreHotstringCommand.cs
@@ -66,7 +66,10 @@ internal sealed class RestoreHotstringCommandHandler(
                 snapshot.IsTriggerInsideWord,
                 snapshot.Kind,
                 snapshot.IsCaseSensitive,
-                snapshot.OmitEndingCharacter),
+                snapshot.OmitEndingCharacter,
+                snapshot.DateTimeFormat,
+                snapshot.DateOffsetAmount,
+                snapshot.DateOffsetUnit),
             snapshot.CreatedAt,
             clock);
 

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/RevertHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/RevertHotstringCommand.cs
@@ -67,7 +67,10 @@ internal sealed class RevertHotstringCommandHandler(
                 snapshot.IsTriggerInsideWord,
                 snapshot.Kind,
                 snapshot.IsCaseSensitive,
-                snapshot.OmitEndingCharacter),
+                snapshot.OmitEndingCharacter,
+                snapshot.DateTimeFormat,
+                snapshot.DateOffsetAmount,
+                snapshot.DateOffsetUnit),
             clock);
 
         db.HotstringProfiles.RemoveRange(entity.Profiles);

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/UpdateHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/UpdateHotstringCommand.cs
@@ -89,7 +89,10 @@ internal sealed class UpdateHotstringCommandHandler(
                 input.IsTriggerInsideWord,
                 input.Kind,
                 input.IsCaseSensitive,
-                input.OmitEndingCharacter),
+                input.OmitEndingCharacter,
+                input.DateTimeFormat,
+                input.DateOffsetAmount,
+                input.DateOffsetUnit),
             clock);
 
         // Replace junction rows via the navigation collections only; adding to the

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/UpdateHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/UpdateHotstringCommand.cs
@@ -18,16 +18,21 @@ public sealed class UpdateHotstringCommandValidator : AbstractValidator<UpdateHo
     public UpdateHotstringCommandValidator()
     {
         RuleFor(x => x.Input.Trigger).ValidTrigger();
-        RuleFor(x => x.Input.Replacement).ValidReplacement();
         RuleFor(x => x.Input.Description)
             .MaximumLength(HotstringRules.DescriptionMaxLength)
             .WithMessage($"Description must be {HotstringRules.DescriptionMaxLength} characters or fewer.");
         RuleFor(x => x.Input.Kind)
-            .Must(k => k == HotstringKind.Text)
-            .WithMessage("Only Text hotstrings are supported.");
+            .Must(k => k is HotstringKind.Text or HotstringKind.DateTime)
+            .WithMessage("Only Text and Date & time hotstrings are supported.");
         this.AddProfileAssociationRules(
             x => x.Input.AppliesToAllProfiles,
             x => x.Input.ProfileIds);
+        this.AddDateTimeKindRules(
+            x => x.Input.Kind,
+            x => x.Input.Replacement,
+            x => x.Input.DateTimeFormat,
+            x => x.Input.DateOffsetAmount,
+            x => x.Input.DateOffsetUnit);
     }
 }
 

--- a/src/Backend/AHKFlowApp.Application/DTOs/HistorySnapshots.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/HistorySnapshots.cs
@@ -16,6 +16,9 @@ namespace AHKFlowApp.Application.DTOs;
 /// <param name="Kind">Hotstring kind at capture time. Defaults to <see cref="HotstringKind.Text"/> for pre-Phase-1 snapshots.</param>
 /// <param name="IsCaseSensitive">AutoHotkey's <c>C</c> option at capture time. Defaults to false for pre-Phase-1 snapshots.</param>
 /// <param name="OmitEndingCharacter">AutoHotkey's <c>O</c> option at capture time. Defaults to false for pre-Phase-1 snapshots.</param>
+/// <param name="DateTimeFormat">Date/time format token pattern at capture time. Defaults to null for pre-Phase-2 snapshots.</param>
+/// <param name="DateOffsetAmount">Signed offset applied to the current date/time at capture time. Defaults to null for pre-Phase-2 snapshots.</param>
+/// <param name="DateOffsetUnit">Unit for <paramref name="DateOffsetAmount"/> at capture time. Defaults to null for pre-Phase-2 snapshots.</param>
 public sealed record HotstringSnapshot(
     string Trigger,
     string Replacement,
@@ -29,7 +32,10 @@ public sealed record HotstringSnapshot(
     DateTimeOffset UpdatedAt,
     HotstringKind Kind = HotstringKind.Text,
     bool IsCaseSensitive = false,
-    bool OmitEndingCharacter = false);
+    bool OmitEndingCharacter = false,
+    string? DateTimeFormat = null,
+    int? DateOffsetAmount = null,
+    DateOffsetUnit? DateOffsetUnit = null);
 
 /// <summary>Point-in-time snapshot of a hotkey aggregate, stored as history JSON.</summary>
 /// <param name="Description">Human-readable label.</param>

--- a/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
@@ -14,9 +14,12 @@ namespace AHKFlowApp.Application.DTOs;
 /// <param name="CreatedAt">UTC creation timestamp.</param>
 /// <param name="UpdatedAt">UTC last-update timestamp.</param>
 /// <param name="CategoryIds">Categories assigned to this hotstring.</param>
-/// <param name="Kind">Hotstring kind. Phase 1 only supports <see cref="HotstringKind.Text"/>.</param>
+/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/> and <see cref="HotstringKind.DateTime"/> are supported via the API; Macro/Script are domain-only.</param>
 /// <param name="IsCaseSensitive">Controls AutoHotkey's <c>C</c> option.</param>
 /// <param name="OmitEndingCharacter">Controls AutoHotkey's <c>O</c> option.</param>
+/// <param name="DateTimeFormat">Set when <paramref name="Kind"/> is <see cref="HotstringKind.DateTime"/>; a whitelisted AHK/.NET date/time token pattern.</param>
+/// <param name="DateOffsetAmount">Optional signed offset applied to the current date/time; requires <paramref name="DateOffsetUnit"/>.</param>
+/// <param name="DateOffsetUnit">Unit for <paramref name="DateOffsetAmount"/>; requires <paramref name="DateOffsetAmount"/>.</param>
 public sealed record HotstringDto(
     Guid Id,
     Guid[] ProfileIds,
@@ -31,7 +34,10 @@ public sealed record HotstringDto(
     Guid[] CategoryIds,
     HotstringKind Kind = HotstringKind.Text,
     bool IsCaseSensitive = false,
-    bool OmitEndingCharacter = false);
+    bool OmitEndingCharacter = false,
+    string? DateTimeFormat = null,
+    int? DateOffsetAmount = null,
+    DateOffsetUnit? DateOffsetUnit = null);
 
 /// <summary>Payload to create a new hotstring.</summary>
 /// <param name="Trigger">Abbreviation that activates the replacement.</param>
@@ -42,7 +48,7 @@ public sealed record HotstringDto(
 /// <param name="IsTriggerInsideWord">Controls AutoHotkey's <c>?</c> option.</param>
 /// <param name="Description">Optional human-readable note for the hotstring.</param>
 /// <param name="CategoryIds">Categories to assign to the new hotstring.</param>
-/// <param name="Kind">Hotstring kind. Phase 1 only supports <see cref="HotstringKind.Text"/>.</param>
+/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/> and <see cref="HotstringKind.DateTime"/> are supported via the API; Macro/Script are domain-only.</param>
 /// <param name="IsCaseSensitive">Controls AutoHotkey's <c>C</c> option.</param>
 /// <param name="OmitEndingCharacter">Controls AutoHotkey's <c>O</c> option.</param>
 /// <param name="DateTimeFormat">Required when <paramref name="Kind"/> is <see cref="HotstringKind.DateTime"/>; a whitelisted AHK/.NET date/time token pattern.</param>
@@ -73,7 +79,7 @@ public sealed record CreateHotstringDto(
 /// <param name="IsTriggerInsideWord">Controls AutoHotkey's <c>?</c> option.</param>
 /// <param name="Description">Optional human-readable note for the hotstring.</param>
 /// <param name="CategoryIds">Replacement category assignment set.</param>
-/// <param name="Kind">Hotstring kind. Phase 1 only supports <see cref="HotstringKind.Text"/>.</param>
+/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/> and <see cref="HotstringKind.DateTime"/> are supported via the API; Macro/Script are domain-only.</param>
 /// <param name="IsCaseSensitive">Controls AutoHotkey's <c>C</c> option.</param>
 /// <param name="OmitEndingCharacter">Controls AutoHotkey's <c>O</c> option.</param>
 /// <param name="DateTimeFormat">Required when <paramref name="Kind"/> is <see cref="HotstringKind.DateTime"/>; a whitelisted AHK/.NET date/time token pattern.</param>

--- a/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
@@ -45,6 +45,9 @@ public sealed record HotstringDto(
 /// <param name="Kind">Hotstring kind. Phase 1 only supports <see cref="HotstringKind.Text"/>.</param>
 /// <param name="IsCaseSensitive">Controls AutoHotkey's <c>C</c> option.</param>
 /// <param name="OmitEndingCharacter">Controls AutoHotkey's <c>O</c> option.</param>
+/// <param name="DateTimeFormat">Required when <paramref name="Kind"/> is <see cref="HotstringKind.DateTime"/>; a whitelisted AHK/.NET date/time token pattern.</param>
+/// <param name="DateOffsetAmount">Optional signed offset applied to the current date/time; requires <paramref name="DateOffsetUnit"/>.</param>
+/// <param name="DateOffsetUnit">Unit for <paramref name="DateOffsetAmount"/>; requires <paramref name="DateOffsetAmount"/>.</param>
 public sealed record CreateHotstringDto(
     string Trigger,
     string Replacement,
@@ -56,7 +59,10 @@ public sealed record CreateHotstringDto(
     Guid[]? CategoryIds = null,
     HotstringKind Kind = HotstringKind.Text,
     bool IsCaseSensitive = false,
-    bool OmitEndingCharacter = false);
+    bool OmitEndingCharacter = false,
+    string? DateTimeFormat = null,
+    int? DateOffsetAmount = null,
+    DateOffsetUnit? DateOffsetUnit = null);
 
 /// <summary>Payload to replace the editable fields of an existing hotstring.</summary>
 /// <param name="Trigger">Abbreviation that activates the replacement.</param>
@@ -70,6 +76,9 @@ public sealed record CreateHotstringDto(
 /// <param name="Kind">Hotstring kind. Phase 1 only supports <see cref="HotstringKind.Text"/>.</param>
 /// <param name="IsCaseSensitive">Controls AutoHotkey's <c>C</c> option.</param>
 /// <param name="OmitEndingCharacter">Controls AutoHotkey's <c>O</c> option.</param>
+/// <param name="DateTimeFormat">Required when <paramref name="Kind"/> is <see cref="HotstringKind.DateTime"/>; a whitelisted AHK/.NET date/time token pattern.</param>
+/// <param name="DateOffsetAmount">Optional signed offset applied to the current date/time; requires <paramref name="DateOffsetUnit"/>.</param>
+/// <param name="DateOffsetUnit">Unit for <paramref name="DateOffsetAmount"/>; requires <paramref name="DateOffsetAmount"/>.</param>
 public sealed record UpdateHotstringDto(
     string Trigger,
     string Replacement,
@@ -81,4 +90,7 @@ public sealed record UpdateHotstringDto(
     Guid[]? CategoryIds = null,
     HotstringKind Kind = HotstringKind.Text,
     bool IsCaseSensitive = false,
-    bool OmitEndingCharacter = false);
+    bool OmitEndingCharacter = false,
+    string? DateTimeFormat = null,
+    int? DateOffsetAmount = null,
+    DateOffsetUnit? DateOffsetUnit = null);

--- a/src/Backend/AHKFlowApp.Application/Mapping/HotstringMappings.cs
+++ b/src/Backend/AHKFlowApp.Application/Mapping/HotstringMappings.cs
@@ -19,5 +19,8 @@ internal static class HotstringMappings
         h.Categories.Select(hc => hc.CategoryId).ToArray(),
         h.Kind,
         h.IsCaseSensitive,
-        h.OmitEndingCharacter);
+        h.OmitEndingCharacter,
+        h.DateTimeFormat,
+        h.DateOffsetAmount,
+        h.DateOffsetUnit);
 }

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
@@ -1,8 +1,11 @@
+using System.Linq.Expressions;
+using System.Reflection;
 using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.Common;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Domain.Constants;
 using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
 using Ardalis.Result;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
@@ -22,7 +25,8 @@ public sealed record ListHotstringsQuery(
     bool? AppliesToAllProfiles = null,
     bool? IsEndingCharacterRequired = null,
     bool? IsTriggerInsideWord = null,
-    IReadOnlyList<Guid>? CategoryIds = null);
+    IReadOnlyList<Guid>? CategoryIds = null,
+    HotstringKind? Kind = null);
 
 public sealed class ListHotstringsQueryValidator : AbstractValidator<ListHotstringsQuery>
 {
@@ -35,6 +39,7 @@ public sealed class ListHotstringsQueryValidator : AbstractValidator<ListHotstri
         "description",
         "isEndingCharacterRequired",
         "isTriggerInsideWord",
+        "kind",
     ];
 
     public ListHotstringsQueryValidator()
@@ -75,6 +80,45 @@ internal sealed class ListHotstringsQueryHandler(
         (";todo",   "TODO(name): ",         false, false, ["Code"]),
     ];
 
+    // Shared, EF-translatable "searchable replacement" selector: DateTime-kind hotstrings store
+    // Replacement = "" and carry their format string in DateTimeFormat instead. Search/filter/sort
+    // on the replacement column must fall back to DateTimeFormat for those rows. Defined once here
+    // and reused for the global Search clause, ReplacementFilter, and the "replacement" sort case.
+    private static readonly Expression<Func<Hotstring, string>> SearchableReplacementSelector =
+        h => h.Kind == HotstringKind.DateTime ? (h.DateTimeFormat ?? "") : h.Replacement;
+
+    private static readonly MethodInfo LikeMethod = typeof(DbFunctionsExtensions).GetMethod(
+        nameof(DbFunctionsExtensions.Like),
+        [typeof(DbFunctions), typeof(string), typeof(string)])!;
+
+    /// <summary>Builds <c>h => EF.Functions.Like(SearchableReplacementSelector-body, pattern)</c>,
+    /// reusing <see cref="SearchableReplacementSelector"/>'s body and parameter directly.</summary>
+    private static Expression<Func<Hotstring, bool>> SearchableReplacementLike(string pattern)
+    {
+        MethodCallExpression call = Expression.Call(
+            LikeMethod,
+            Expression.Property(null, typeof(EF), nameof(EF.Functions)),
+            SearchableReplacementSelector.Body,
+            Expression.Constant(pattern));
+
+        return Expression.Lambda<Func<Hotstring, bool>>(call, SearchableReplacementSelector.Parameters[0]);
+    }
+
+    /// <summary>Combines two <see cref="Hotstring"/> predicates with OR, rebinding <paramref name="right"/>
+    /// onto <paramref name="left"/>'s parameter so the result is a single valid expression tree.</summary>
+    private static Expression<Func<Hotstring, bool>> Or(
+        Expression<Func<Hotstring, bool>> left,
+        Expression<Func<Hotstring, bool>> right)
+    {
+        Expression rightBody = new ParameterRebinder(right.Parameters[0], left.Parameters[0]).Visit(right.Body)!;
+        return Expression.Lambda<Func<Hotstring, bool>>(Expression.OrElse(left.Body, rightBody), left.Parameters[0]);
+    }
+
+    private sealed class ParameterRebinder(ParameterExpression from, ParameterExpression to) : ExpressionVisitor
+    {
+        protected override Expression VisitParameter(ParameterExpression node) => node == from ? to : base.VisitParameter(node);
+    }
+
     public async Task<Result<PagedList<HotstringDto>>> ExecuteAsync(ListHotstringsQuery request, CancellationToken ct)
     {
         if (currentUser.Oid is not Guid ownerOid)
@@ -99,10 +143,10 @@ internal sealed class ListHotstringsQueryHandler(
         if (!string.IsNullOrWhiteSpace(request.Search))
         {
             string pattern = $"%{request.Search.Trim()}%";
-            query = query.Where(h =>
-                EF.Functions.Like(h.Trigger, pattern) ||
-                EF.Functions.Like(h.Replacement, pattern) ||
-                (h.Description != null && EF.Functions.Like(h.Description, pattern)));
+            Expression<Func<Hotstring, bool>> triggerLike = h => EF.Functions.Like(h.Trigger, pattern);
+            Expression<Func<Hotstring, bool>> replacementLike = SearchableReplacementLike(pattern);
+            Expression<Func<Hotstring, bool>> descriptionLike = h => h.Description != null && EF.Functions.Like(h.Description, pattern);
+            query = query.Where(Or(Or(triggerLike, replacementLike), descriptionLike));
         }
 
         if (!string.IsNullOrWhiteSpace(request.TriggerFilter))
@@ -114,7 +158,7 @@ internal sealed class ListHotstringsQueryHandler(
         if (!string.IsNullOrWhiteSpace(request.ReplacementFilter))
         {
             string pattern = $"%{request.ReplacementFilter.Trim()}%";
-            query = query.Where(h => EF.Functions.Like(h.Replacement, pattern));
+            query = query.Where(SearchableReplacementLike(pattern));
         }
 
         if (!string.IsNullOrWhiteSpace(request.DescriptionFilter))
@@ -131,6 +175,9 @@ internal sealed class ListHotstringsQueryHandler(
 
         if (request.IsTriggerInsideWord is { } isTriggerInsideWord)
             query = query.Where(h => h.IsTriggerInsideWord == isTriggerInsideWord);
+
+        if (request.Kind.HasValue)
+            query = query.Where(h => h.Kind == request.Kind.Value);
 
         if (request.CategoryIds is { Count: > 0 })
         {
@@ -157,7 +204,10 @@ internal sealed class ListHotstringsQueryHandler(
                 h.Categories.Select(hc => hc.CategoryId).ToArray(),
                 h.Kind,
                 h.IsCaseSensitive,
-                h.OmitEndingCharacter))
+                h.OmitEndingCharacter,
+                h.DateTimeFormat,
+                h.DateOffsetAmount,
+                h.DateOffsetUnit))
             .ToListAsync(ct);
 
         return Result.Success(new PagedList<HotstringDto>(items, request.Page, request.PageSize, total));
@@ -265,11 +315,12 @@ internal sealed class ListHotstringsQueryHandler(
         IOrderedQueryable<Hotstring> ordered = normalized switch
         {
             "trigger" => descending ? query.OrderByDescending(h => h.Trigger) : query.OrderBy(h => h.Trigger),
-            "replacement" => descending ? query.OrderByDescending(h => h.Replacement) : query.OrderBy(h => h.Replacement),
+            "replacement" => descending ? query.OrderByDescending(SearchableReplacementSelector) : query.OrderBy(SearchableReplacementSelector),
             "description" => descending ? query.OrderByDescending(h => h.Description) : query.OrderBy(h => h.Description),
             "isendingcharacterrequired" => descending ? query.OrderByDescending(h => h.IsEndingCharacterRequired) : query.OrderBy(h => h.IsEndingCharacterRequired),
             "istriggerinsideword" => descending ? query.OrderByDescending(h => h.IsTriggerInsideWord) : query.OrderBy(h => h.IsTriggerInsideWord),
             "updatedat" => descending ? query.OrderByDescending(h => h.UpdatedAt) : query.OrderBy(h => h.UpdatedAt),
+            "kind" => descending ? query.OrderByDescending(h => h.Kind) : query.OrderBy(h => h.Kind),
             _ => descending ? query.OrderByDescending(h => h.CreatedAt) : query.OrderBy(h => h.CreatedAt),
         };
 

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
@@ -64,20 +64,27 @@ internal sealed class ListHotstringsQueryHandler(
     : IUseCaseHandler<ListHotstringsQuery, Result<PagedList<HotstringDto>>>
 {
     // Mirrors SeedHotstringsCommand.s_samples — update both if seed set changes.
-    private static readonly (string Trigger, string Replacement, bool Ending, bool InsideWord, string[] Categories)[] s_lazySeed =
+    private static readonly (
+        string Trigger,
+        string Replacement,
+        bool Ending,
+        bool InsideWord,
+        string[] Categories,
+        HotstringKind Kind,
+        string? DateTimeFormat)[] s_lazySeed =
     [
-        ("recieve", "receive",              true,  true,  ["Autocorrect"]),
-        ("btw",     "by the way",           true,  false, ["Communication"]),
-        ("brb",     "be right back",        true,  false, ["Communication"]),
-        ("fyi",     "for your information", true,  false, ["Communication"]),
-        ("/today",  "{{date:yyyy-MM-dd}}",  false, false, ["DateTime"]),
-        ("/now",    "{{datetime:HH:mm}}",   false, false, ["DateTime"]),
-        ("@sig",    "Example User\nuser@example.com\nExample Company", false, false, ["Email"]),
-        (";arrow",  "→",               false, false, ["Symbols"]),
-        (";check",  "✓",               false, false, ["Symbols"]),
-        (";shrug",  "¯\\_(ツ)_/¯", false, false, ["Symbols"]),
-        (";e:",     "ë",               false, false, ["Symbols"]),
-        (";todo",   "TODO(name): ",         false, false, ["Code"]),
+        ("recieve", "receive",              true,  true,  ["Autocorrect"],  HotstringKind.Text,     null),
+        ("btw",     "by the way",           true,  false, ["Communication"], HotstringKind.Text,    null),
+        ("brb",     "be right back",        true,  false, ["Communication"], HotstringKind.Text,    null),
+        ("fyi",     "for your information", true,  false, ["Communication"], HotstringKind.Text,    null),
+        ("/today",  "",                     false, false, ["DateTime"],     HotstringKind.DateTime, "yyyy-MM-dd"),
+        ("/now",    "",                     false, false, ["DateTime"],     HotstringKind.DateTime, "HH:mm"),
+        ("@sig",    "Example User\nuser@example.com\nExample Company", false, false, ["Email"], HotstringKind.Text, null),
+        (";arrow",  "→",               false, false, ["Symbols"], HotstringKind.Text, null),
+        (";check",  "✓",               false, false, ["Symbols"], HotstringKind.Text, null),
+        (";shrug",  "¯\\_(ツ)_/¯", false, false, ["Symbols"], HotstringKind.Text, null),
+        (";e:",     "ë",               false, false, ["Symbols"], HotstringKind.Text, null),
+        (";todo",   "TODO(name): ",         false, false, ["Code"], HotstringKind.Text, null),
     ];
 
     // Shared, EF-translatable "searchable replacement" selector: DateTime-kind hotstrings store
@@ -245,13 +252,14 @@ internal sealed class ListHotstringsQueryHandler(
                 .ToDictionary(c => c.Name, c => c.Id, StringComparer.OrdinalIgnoreCase);
         }
 
-        foreach ((string trigger, string replacement, bool ending, bool inside, string[] cats) in s_lazySeed)
+        foreach ((string trigger, string replacement, bool ending, bool inside, string[] cats, HotstringKind kind, string? dateTimeFormat) in s_lazySeed)
         {
             var hs = Hotstring.Create(
                 ownerOid,
                 new HotstringDefinition(
                     trigger, replacement, Description: null,
-                    AppliesToAllProfiles: true, ending, inside),
+                    AppliesToAllProfiles: true, ending, inside,
+                    Kind: kind, DateTimeFormat: dateTimeFormat),
                 clock);
             db.Hotstrings.Add(hs);
             foreach (string catName in cats)

--- a/src/Backend/AHKFlowApp.Application/Services/EntityHistoryRecorder.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/EntityHistoryRecorder.cs
@@ -40,7 +40,10 @@ internal sealed class EntityHistoryRecorder(IAppDbContext db, TimeProvider clock
                         entity.UpdatedAt,
                         entity.Kind,
                         entity.IsCaseSensitive,
-                        entity.OmitEndingCharacter);
+                        entity.OmitEndingCharacter,
+                        entity.DateTimeFormat,
+                        entity.DateOffsetAmount,
+                        entity.DateOffsetUnit);
 
                     return new HistorySnapshot(
                         entity.OwnerOid,

--- a/src/Backend/AHKFlowApp.Application/Services/HotstringEmitter.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/HotstringEmitter.cs
@@ -1,25 +1,40 @@
 using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
 
 namespace AHKFlowApp.Application.Services;
 
 /// <summary>
 /// Single emission point for hotstring lines. Deterministic option order: X * ? C O T
-/// (X arrives with non-Text kinds in later phases).
+/// — X leads for DateTime kind (T is never emitted for it); T trails for Text kind.
 /// </summary>
 internal static class HotstringEmitter
 {
     public static string Emit(Hotstring hs) =>
-        $":{BuildOptions(hs)}:{Escape(hs.Trigger)}::{Escape(hs.Replacement)}";
+        $":{BuildOptions(hs)}:{Escape(hs.Trigger)}::{BuildBody(hs)}";
 
     private static string BuildOptions(Hotstring hs)
     {
-        string options = "";
+        bool isDateTime = hs.Kind == HotstringKind.DateTime;
+        string options = isDateTime ? "X" : "";
         if (!hs.IsEndingCharacterRequired) options += "*";
         if (hs.IsTriggerInsideWord) options += "?";
         if (hs.IsCaseSensitive) options += "C";
         if (hs.OmitEndingCharacter && hs.IsEndingCharacterRequired) options += "O"; // O is meaningless with *
-        options += "T"; // Text kind always emits literally (WYSIWYG) — resolved decision D1
+        if (!isDateTime) options += "T"; // Text kind always emits literally (WYSIWYG) — resolved decision D1
         return options;
+    }
+
+    private static string BuildBody(Hotstring hs) =>
+        hs.Kind == HotstringKind.DateTime ? BuildDateTimeBody(hs) : Escape(hs.Replacement);
+
+    private static string BuildDateTimeBody(Hotstring hs)
+    {
+        // DateTimeFormat is embedded raw (no escaping) because it has already passed a
+        // server-side whitelist regex before reaching the emitter — validation lives elsewhere.
+        string nowExpression = hs.DateOffsetAmount is int amount && hs.DateOffsetUnit is DateOffsetUnit unit
+            ? $"DateAdd(A_Now, {amount}, \"{unit}\")"
+            : "A_Now";
+        return $"SendText(FormatTime({nowExpression}, \"{hs.DateTimeFormat}\"))";
     }
 
     // Keep every hotstring on one physical line and its trigger free of characters

--- a/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
+++ b/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
@@ -1,12 +1,17 @@
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+using AHKFlowApp.Domain.Enums;
 using FluentValidation;
 
 namespace AHKFlowApp.Application.Validation;
 
-internal static class HotstringRules
+internal static partial class HotstringRules
 {
     public const int TriggerMaxLength = 50;
     public const int ReplacementMaxLength = 4000;
     public const int DescriptionMaxLength = 200;
+    public const int DateTimeFormatMaxLength = 50;
+    public const int DateOffsetAmountMax = 3650;
 
     public static IRuleBuilderOptions<T, string> ValidTrigger<T>(this IRuleBuilderInitial<T, string> rb) =>
         rb.Cascade(CascadeMode.Stop)
@@ -23,6 +28,18 @@ internal static class HotstringRules
           .MaximumLength(ReplacementMaxLength).WithMessage($"Replacement must be {ReplacementMaxLength} characters or fewer.");
 
     /// <summary>
+    /// Adds validation for a nullable date/time format string: required, max length, and a
+    /// whitelist of AHK/.NET-shared date/time tokens plus a small set of separator characters.
+    /// </summary>
+    public static IRuleBuilderOptions<T, string?> ValidDateTimeFormat<T>(this IRuleBuilderInitial<T, string?> rb) =>
+        rb.Cascade(CascadeMode.Stop)
+          .NotEmpty().WithMessage("DateTimeFormat is required.")
+          .MaximumLength(DateTimeFormatMaxLength)
+              .WithMessage($"DateTimeFormat must be {DateTimeFormatMaxLength} characters or fewer.")
+          .Must(f => f is not null && DateTimeFormatWhitelistRegex().IsMatch(f))
+              .WithMessage("DateTimeFormat contains unsupported characters or tokens.");
+
+    /// <summary>
     /// Adds profile-association validation rules to a validator.
     /// When <paramref name="appliesToAll"/> is true, <paramref name="profileIds"/> must be null/empty.
     /// When false, at least one non-empty, non-duplicated GUID must be provided.
@@ -30,8 +47,8 @@ internal static class HotstringRules
     /// </summary>
     public static void AddProfileAssociationRules<T>(
         this AbstractValidator<T> validator,
-        System.Linq.Expressions.Expression<Func<T, bool>> appliesToAll,
-        System.Linq.Expressions.Expression<Func<T, Guid[]?>> profileIds)
+        Expression<Func<T, bool>> appliesToAll,
+        Expression<Func<T, Guid[]?>> profileIds)
     {
         Func<T, bool> appliesToAllFn = appliesToAll.Compile();
 
@@ -59,4 +76,78 @@ internal static class HotstringRules
             .When(x => !appliesToAllFn(x))
             .WithMessage("ProfileIds must not contain duplicates.");
     }
+
+    /// <summary>
+    /// Adds kind-conditional rules for Date &amp; time hotstrings.
+    /// When <paramref name="kind"/> is <see cref="HotstringKind.DateTime"/>: <paramref name="replacement"/> must be
+    /// empty, <paramref name="dateTimeFormat"/> is required and whitelisted, and <paramref name="dateOffsetAmount"/> /
+    /// <paramref name="dateOffsetUnit"/> must be both-set-or-both-null (amount bound to +/-<see cref="DateOffsetAmountMax"/>,
+    /// 0 explicitly allowed).
+    /// Otherwise: <paramref name="replacement"/> follows the normal <see cref="ValidReplacement{T}"/> rule, and the
+    /// three Date &amp; time-only fields must all be null.
+    /// </summary>
+    public static void AddDateTimeKindRules<T>(
+        this AbstractValidator<T> validator,
+        Expression<Func<T, HotstringKind>> kind,
+        Expression<Func<T, string>> replacement,
+        Expression<Func<T, string?>> dateTimeFormat,
+        Expression<Func<T, int?>> dateOffsetAmount,
+        Expression<Func<T, DateOffsetUnit?>> dateOffsetUnit)
+    {
+        Func<T, HotstringKind> kindFn = kind.Compile();
+        Func<T, int?> amountFn = dateOffsetAmount.Compile();
+        Func<T, DateOffsetUnit?> unitFn = dateOffsetUnit.Compile();
+
+        bool IsDateTime(T x) => kindFn(x) == HotstringKind.DateTime;
+        bool BothOffsetsSet(T x) => amountFn(x) is not null && unitFn(x) is not null;
+
+        // Replacement: normal rules for non-DateTime kinds, must be empty for DateTime
+        validator.RuleFor(replacement)
+            .ValidReplacement()
+            .When(x => !IsDateTime(x));
+
+        validator.RuleFor(replacement)
+            .Must(r => r == string.Empty)
+            .When(IsDateTime)
+            .WithMessage("Replacement must be empty when Kind is Date & time.");
+
+        // DateTimeFormat: required + whitelisted for DateTime, must be null otherwise
+        validator.RuleFor(dateTimeFormat)
+            .ValidDateTimeFormat()
+            .When(IsDateTime);
+
+        validator.RuleFor(dateTimeFormat)
+            .Must(f => f is null)
+            .When(x => !IsDateTime(x))
+            .WithMessage("DateTimeFormat must be null unless Kind is Date & time.");
+
+        // DateOffsetAmount / DateOffsetUnit: must be null unless DateTime
+        validator.RuleFor(dateOffsetAmount)
+            .Must(a => a is null)
+            .When(x => !IsDateTime(x))
+            .WithMessage("DateOffsetAmount must be null unless Kind is Date & time.");
+
+        validator.RuleFor(dateOffsetUnit)
+            .Must(u => u is null)
+            .When(x => !IsDateTime(x))
+            .WithMessage("DateOffsetUnit must be null unless Kind is Date & time.");
+
+        // For DateTime: both-or-neither, range + enum checks when both are set (0 is a valid amount)
+        validator.RuleFor(dateOffsetAmount)
+            .Must((x, a) => (a is null) == (unitFn(x) is null))
+            .When(IsDateTime)
+            .WithMessage("DateOffsetAmount and DateOffsetUnit must both be set or both be null.");
+
+        validator.RuleFor(dateOffsetAmount)
+            .InclusiveBetween(-DateOffsetAmountMax, DateOffsetAmountMax)
+            .When(x => IsDateTime(x) && BothOffsetsSet(x))
+            .WithMessage($"DateOffsetAmount must be between -{DateOffsetAmountMax} and {DateOffsetAmountMax}.");
+
+        validator.RuleFor(dateOffsetUnit)
+            .IsInEnum()
+            .When(x => IsDateTime(x) && BothOffsetsSet(x));
+    }
+
+    [GeneratedRegex(@"^(?=.*[yMdHhmst])[yMdHhmst0-9 \-./:,()]+$")]
+    private static partial Regex DateTimeFormatWhitelistRegex();
 }

--- a/src/Backend/AHKFlowApp.Domain/Entities/Hotstring.cs
+++ b/src/Backend/AHKFlowApp.Domain/Entities/Hotstring.cs
@@ -21,6 +21,9 @@ public sealed class Hotstring
     public HotstringKind Kind { get; private set; }
     public bool IsCaseSensitive { get; private set; }
     public bool OmitEndingCharacter { get; private set; }
+    public string? DateTimeFormat { get; private set; }
+    public int? DateOffsetAmount { get; private set; }
+    public DateOffsetUnit? DateOffsetUnit { get; private set; }
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset UpdatedAt { get; private set; }
 
@@ -76,5 +79,8 @@ public sealed class Hotstring
         Kind = definition.Kind;
         IsCaseSensitive = definition.IsCaseSensitive;
         OmitEndingCharacter = definition.OmitEndingCharacter;
+        DateTimeFormat = definition.DateTimeFormat;
+        DateOffsetAmount = definition.DateOffsetAmount;
+        DateOffsetUnit = definition.DateOffsetUnit;
     }
 }

--- a/src/Backend/AHKFlowApp.Domain/Entities/HotstringDefinition.cs
+++ b/src/Backend/AHKFlowApp.Domain/Entities/HotstringDefinition.cs
@@ -15,4 +15,7 @@ public sealed record HotstringDefinition(
     bool IsTriggerInsideWord,
     HotstringKind Kind = HotstringKind.Text,
     bool IsCaseSensitive = false,
-    bool OmitEndingCharacter = false);
+    bool OmitEndingCharacter = false,
+    string? DateTimeFormat = null,
+    int? DateOffsetAmount = null,
+    DateOffsetUnit? DateOffsetUnit = null);

--- a/src/Backend/AHKFlowApp.Domain/Enums/DateOffsetUnit.cs
+++ b/src/Backend/AHKFlowApp.Domain/Enums/DateOffsetUnit.cs
@@ -1,0 +1,12 @@
+namespace AHKFlowApp.Domain.Enums;
+
+/// <summary>
+/// Unit for a date/time offset. Names match AHK's <c>DateAdd</c> unit strings exactly.
+/// </summary>
+public enum DateOffsetUnit
+{
+    Seconds = 0,
+    Minutes = 1,
+    Hours = 2,
+    Days = 3,
+}

--- a/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260708205409_AddHotstringDateTimeFields.Designer.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260708205409_AddHotstringDateTimeFields.Designer.cs
@@ -4,6 +4,7 @@ using AHKFlowApp.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AHKFlowApp.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260708205409_AddHotstringDateTimeFields")]
+    partial class AddHotstringDateTimeFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260708205409_AddHotstringDateTimeFields.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260708205409_AddHotstringDateTimeFields.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AHKFlowApp.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddHotstringDateTimeFields : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<int>(
+            name: "DateOffsetAmount",
+            table: "Hotstrings",
+            type: "int",
+            nullable: true);
+
+        migrationBuilder.AddColumn<int>(
+            name: "DateOffsetUnit",
+            table: "Hotstrings",
+            type: "int",
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "DateTimeFormat",
+            table: "Hotstrings",
+            type: "nvarchar(50)",
+            maxLength: 50,
+            nullable: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "DateOffsetAmount",
+            table: "Hotstrings");
+
+        migrationBuilder.DropColumn(
+            name: "DateOffsetUnit",
+            table: "Hotstrings");
+
+        migrationBuilder.DropColumn(
+            name: "DateTimeFormat",
+            table: "Hotstrings");
+    }
+}

--- a/src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/HotstringConfiguration.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/HotstringConfiguration.cs
@@ -36,6 +36,13 @@ internal sealed class HotstringConfiguration : IEntityTypeConfiguration<Hotstrin
         builder.Property(x => x.IsCaseSensitive).IsRequired();
         builder.Property(x => x.OmitEndingCharacter).IsRequired();
 
+        builder.Property(x => x.DateTimeFormat)
+            .HasMaxLength(50);
+
+        // Persist enum as int (default for EF, made explicit here for clarity).
+        builder.Property(x => x.DateOffsetUnit)
+            .HasConversion<int>();
+
         builder.Property(x => x.CreatedAt).IsRequired();
         builder.Property(x => x.UpdatedAt).IsRequired();
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -15,13 +15,60 @@
     <DialogContent>
         <MudForm @ref="_form">
         <MudStack Spacing="3" Class="pa-2">
+            <MudToggleGroup T="HotstringKind" Value="Item.Kind" ValueChanged="OnKindChangedAsync"
+                             UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "kind-selector" })">
+                <MudToggleItem Value="HotstringKind.Text" Text="Text" />
+                <MudToggleItem Value="HotstringKind.DateTime" Text="Date & time" />
+            </MudToggleGroup>
+
             <MudTextField T="string" Label="Trigger" @bind-Value="Item.Trigger"
                           Required="true" RequiredError="Trigger is required" MaxLength="50"
                           Error="@(_triggerError is not null)" ErrorText="@_triggerError"
                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "trigger-input" })" />
-            <MudTextField T="string" Label="Replacement" @bind-Value="Item.Replacement"
-                          Lines="3" Required="true" RequiredError="Replacement is required" MaxLength="4000"
-                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "replacement-input" })" />
+            @if (Item.Kind != HotstringKind.DateTime)
+            {
+                <MudTextField T="string" Label="Replacement" @bind-Value="Item.Replacement"
+                              Lines="3" Required="@(Item.Kind != HotstringKind.DateTime)" RequiredError="Replacement is required" MaxLength="4000"
+                              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "replacement-input" })" />
+            }
+            @if (Item.Kind == HotstringKind.DateTime)
+            {
+                <MudText Typo="Typo.subtitle2" Class="mt-1">Date &amp; time</MudText>
+                <MudSelect T="string" Value="_selectedFormatOption" ValueChanged="OnFormatOptionChanged" Label="Format"
+                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "datetime-format-select" })">
+                    @foreach ((string label, string format) in DateTimeFormatPresets)
+                    {
+                        <MudSelectItem T="string" Value="@format">@($"{label} — {HotstringEditModel.SafePreview(format)}")</MudSelectItem>
+                    }
+                    <MudSelectItem T="string" Value="@CustomFormatSentinel">Custom…</MudSelectItem>
+                </MudSelect>
+                @if (_selectedFormatOption == CustomFormatSentinel)
+                {
+                    <MudTextField T="string" Label="Custom format" @bind-Value="Item.DateTimeFormat" MaxLength="50"
+                                  UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "datetime-format-custom" })" />
+                }
+
+                <MudSwitch T="bool" Value="@(Item.DateOffsetAmount is not null)" ValueChanged="OnOffsetSwitchChanged" Label="Adjust date"
+                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "date-offset-switch" })" />
+                @if (Item.DateOffsetAmount is not null)
+                {
+                    <MudStack Row="true" Spacing="2">
+                        <MudNumericField T="int?" Label="Amount" @bind-Value="Item.DateOffsetAmount" Min="-3650" Max="3650"
+                                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "date-offset-amount" })" />
+                        <MudSelect T="DateOffsetUnit?" @bind-Value="Item.DateOffsetUnit" Label="Unit"
+                                   UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "date-offset-unit" })">
+                            <MudSelectItem T="DateOffsetUnit?" Value="DateOffsetUnit.Seconds">Seconds</MudSelectItem>
+                            <MudSelectItem T="DateOffsetUnit?" Value="DateOffsetUnit.Minutes">Minutes</MudSelectItem>
+                            <MudSelectItem T="DateOffsetUnit?" Value="DateOffsetUnit.Hours">Hours</MudSelectItem>
+                            <MudSelectItem T="DateOffsetUnit?" Value="DateOffsetUnit.Days">Days</MudSelectItem>
+                        </MudSelect>
+                    </MudStack>
+                }
+
+                <MudText Typo="Typo.body2" UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "datetime-preview" })">
+                    @PreviewWithOffset()
+                </MudText>
+            }
             <MudTextField T="string" Label="Description" @bind-Value="Item.Description"
                           MaxLength="200"
                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "description-input" })" />
@@ -62,8 +109,27 @@
 </MudDialog>
 
 @code {
+    private const string CustomFormatSentinel = "__custom__";
+
+    private static readonly (string Label, string Format)[] DateTimeFormatPresets =
+    [
+        ("ISO date", "yyyy-MM-dd"),
+        ("European date", "dd-MM-yyyy"),
+        ("US date", "MM/dd/yyyy"),
+        ("Long date", "dddd d MMMM yyyy"),
+        ("Short day + date", "ddd d MMM yyyy"),
+        ("Month + year", "MMMM yyyy"),
+        ("Time (24h)", "HH:mm"),
+        ("Time (24h, seconds)", "HH:mm:ss"),
+        ("Time (12h)", "h:mm tt"),
+        ("Date + time", "yyyy-MM-dd HH:mm"),
+        ("Timestamp", "yyyy-MM-dd HH:mm:ss"),
+        ("Compact stamp", "yyyyMMdd-HHmmss"),
+    ];
+
     [CascadingParameter] private IMudDialogInstance Dialog { get; set; } = default!;
     [Inject] private IHotstringsApiClient Api { get; set; } = default!;
+    [Inject] private IDialogService DialogService { get; set; } = default!;
 
     [Parameter] public HotstringEditModel Item { get; set; } = new();
     [Parameter] public IReadOnlyList<ProfileDto> Profiles { get; set; } = [];
@@ -76,14 +142,115 @@
     private readonly CancellationTokenSource _cts = new();
     private IReadOnlyList<EntityOption> _profileOptions = [];
     private IReadOnlyList<EntityOption> _categoryOptions = [];
+    private HotstringEditModel? _lastItem;
+    private string _selectedFormatOption = CustomFormatSentinel;
 
     protected override void OnParametersSet()
     {
         _profileOptions = [.. Profiles.Select(p => new EntityOption(p.Id, p.Name))];
         _categoryOptions = [.. Categories.Select(c => new EntityOption(c.Id, c.Name))];
+
+        if (!ReferenceEquals(_lastItem, Item))
+        {
+            _lastItem = Item;
+            _selectedFormatOption = Item.DateTimeFormat is not null
+                && DateTimeFormatPresets.Any(preset => preset.Format == Item.DateTimeFormat)
+                ? Item.DateTimeFormat
+                : CustomFormatSentinel;
+        }
     }
 
     private void Cancel() => Dialog.Cancel();
+
+    private async Task OnKindChangedAsync(HotstringKind newKind)
+    {
+        if (newKind == Item.Kind)
+            return;
+
+        if (newKind == HotstringKind.DateTime)
+        {
+            if (!string.IsNullOrEmpty(Item.Replacement))
+            {
+                bool? confirm = await DialogService.ShowMessageBoxAsync(
+                    title: "Switch to Date & time?",
+                    message: "Switching to Date & time will clear the current replacement text. Continue?",
+                    yesText: "Switch", cancelText: "Cancel");
+                if (confirm != true) return;
+            }
+
+            Item.Replacement = "";
+            Item.Kind = HotstringKind.DateTime;
+        }
+        else if (newKind == HotstringKind.Text)
+        {
+            if (Item.DateTimeFormat is not null)
+            {
+                bool? confirm = await DialogService.ShowMessageBoxAsync(
+                    title: "Switch to Text?",
+                    message: "Switching to Text will clear the date/time format and offset. Continue?",
+                    yesText: "Switch", cancelText: "Cancel");
+                if (confirm != true) return;
+            }
+
+            Item.DateTimeFormat = null;
+            Item.DateOffsetAmount = null;
+            Item.DateOffsetUnit = null;
+            Item.Kind = HotstringKind.Text;
+        }
+    }
+
+    private void OnFormatOptionChanged(string option)
+    {
+        _selectedFormatOption = option;
+        if (_selectedFormatOption != CustomFormatSentinel)
+            Item.DateTimeFormat = _selectedFormatOption;
+    }
+
+    private void OnOffsetSwitchChanged(bool isOn)
+    {
+        if (isOn)
+        {
+            if (Item.DateOffsetAmount is null && Item.DateOffsetUnit is null)
+            {
+                Item.DateOffsetAmount = 1;
+                Item.DateOffsetUnit = DateOffsetUnit.Days;
+            }
+        }
+        else
+        {
+            Item.DateOffsetAmount = null;
+            Item.DateOffsetUnit = null;
+        }
+    }
+
+    private string PreviewWithOffset()
+    {
+        if (string.IsNullOrEmpty(Item.DateTimeFormat))
+            return "";
+
+        DateTime moment = DateTime.Now;
+        if (Item.DateOffsetAmount is { } amount && Item.DateOffsetUnit is { } unit)
+        {
+            moment = unit switch
+            {
+                DateOffsetUnit.Seconds => moment.AddSeconds(amount),
+                DateOffsetUnit.Minutes => moment.AddMinutes(amount),
+                DateOffsetUnit.Hours => moment.AddHours(amount),
+                DateOffsetUnit.Days => moment.AddDays(amount),
+                _ => moment,
+            };
+        }
+
+        try
+        {
+            string actualFormat = Item.DateTimeFormat.Length == 1 ? "%" + Item.DateTimeFormat : Item.DateTimeFormat;
+            return moment.ToString(actualFormat);
+        }
+        catch (FormatException)
+        {
+            return "Invalid format";
+        }
+    }
 
     private async Task SaveAsync()
     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringHistoryDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringHistoryDialog.razor
@@ -1,5 +1,6 @@
 @using AHKFlowApp.UI.Blazor.DTOs
 @using AHKFlowApp.UI.Blazor.Services
+@using AHKFlowApp.UI.Blazor.Validation
 @using MudBlazor
 @implements IDisposable
 
@@ -42,8 +43,16 @@
                     <MudPaper Class="pa-3" Style="min-width: 280px;">
                         <MudText Typo="Typo.subtitle2">Trigger</MudText>
                         <MudText Class="mb-2">@_preview.Snapshot.Trigger</MudText>
-                        <MudText Typo="Typo.subtitle2">Replacement</MudText>
-                        <MudText Class="mb-2" Style="white-space: pre-wrap">@_preview.Snapshot.Replacement</MudText>
+                        @if (_preview.Snapshot.Kind == HotstringKind.DateTime)
+                        {
+                            <MudText Typo="Typo.subtitle2">Format</MudText>
+                            <MudText Class="mb-2" Style="white-space: pre-wrap">@DateTimeSummary(_preview.Snapshot)</MudText>
+                        }
+                        else
+                        {
+                            <MudText Typo="Typo.subtitle2">Replacement</MudText>
+                            <MudText Class="mb-2" Style="white-space: pre-wrap">@_preview.Snapshot.Replacement</MudText>
+                        }
                         @if (_preview.Snapshot.Description is { Length: > 0 } description)
                         {
                             <MudText Typo="Typo.subtitle2">Description</MudText>
@@ -123,6 +132,14 @@
             _busy = false;
         }
     }
+
+    private static string? DateTimeSummary(HotstringSnapshot snapshot) => new HotstringEditModel
+    {
+        Kind = snapshot.Kind,
+        DateTimeFormat = snapshot.DateTimeFormat,
+        DateOffsetAmount = snapshot.DateOffsetAmount,
+        DateOffsetUnit = snapshot.DateOffsetUnit,
+    }.DateTimeSummary;
 
     private static string ProfileText(HotstringSnapshot snapshot) =>
         snapshot.AppliesToAllProfiles ? "All profiles" : $"{snapshot.ProfileIds.Length} profile(s)";

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
@@ -42,7 +42,7 @@
                             </td>
                         }
                         <td class="trigger-cell"><code>@item.Trigger</code></td>
-                        <td class="replacement-cell">@item.Replacement</td>
+                        <td class="replacement-cell">@(item.Kind == HotstringKind.DateTime ? item.DateTimeSummary : item.Replacement)</td>
                         <td class="chevron-cell">@(expanded ? "▾" : "▸")</td>
                     </tr>
                     @if (expanded)
@@ -50,9 +50,18 @@
                         <tr class="mobile-row-expanded">
                             <td colspan="3">
                                 <MudStack Spacing="1" Class="pa-3">
-                                    <MudText Typo="Typo.body2" Style="white-space: pre-wrap">
-                                        <strong>Replacement:</strong> @item.Replacement
-                                    </MudText>
+                                    @if (item.Kind == HotstringKind.DateTime)
+                                    {
+                                        <MudText Typo="Typo.body2" Style="white-space: pre-wrap">
+                                            <strong>Format:</strong> @item.DateTimeSummary
+                                        </MudText>
+                                    }
+                                    else
+                                    {
+                                        <MudText Typo="Typo.body2" Style="white-space: pre-wrap">
+                                            <strong>Replacement:</strong> @item.Replacement
+                                        </MudText>
+                                    }
                                     @if (!string.IsNullOrWhiteSpace(item.Description))
                                     {
                                         <MudText Typo="Typo.body2"><strong>Description:</strong> @item.Description</MudText>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/CreateHotstringDto.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/CreateHotstringDto.cs
@@ -11,4 +11,7 @@ public sealed record CreateHotstringDto(
     Guid[]? CategoryIds = null,
     HotstringKind Kind = HotstringKind.Text,
     bool IsCaseSensitive = false,
-    bool OmitEndingCharacter = false);
+    bool OmitEndingCharacter = false,
+    string? DateTimeFormat = null,
+    int? DateOffsetAmount = null,
+    DateOffsetUnit? DateOffsetUnit = null);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/DateOffsetUnit.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/DateOffsetUnit.cs
@@ -1,0 +1,9 @@
+namespace AHKFlowApp.UI.Blazor.DTOs;
+
+public enum DateOffsetUnit
+{
+    Seconds = 0,
+    Minutes = 1,
+    Hours = 2,
+    Days = 3,
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HistoryDtos.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HistoryDtos.cs
@@ -19,7 +19,11 @@ public sealed record HotstringSnapshot(
     Guid[] ProfileIds,
     Guid[] CategoryIds,
     DateTimeOffset CreatedAt,
-    DateTimeOffset UpdatedAt);
+    DateTimeOffset UpdatedAt,
+    HotstringKind Kind = HotstringKind.Text,
+    string? DateTimeFormat = null,
+    int? DateOffsetAmount = null,
+    DateOffsetUnit? DateOffsetUnit = null);
 
 public sealed record HotkeySnapshot(
     string Description,

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HotstringDto.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HotstringDto.cs
@@ -14,4 +14,7 @@ public sealed record HotstringDto(
     Guid[]? CategoryIds = null,
     HotstringKind Kind = HotstringKind.Text,
     bool IsCaseSensitive = false,
-    bool OmitEndingCharacter = false);
+    bool OmitEndingCharacter = false,
+    string? DateTimeFormat = null,
+    int? DateOffsetAmount = null,
+    DateOffsetUnit? DateOffsetUnit = null);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HotstringListRequest.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HotstringListRequest.cs
@@ -13,4 +13,5 @@ public sealed record HotstringListRequest(
     bool? AppliesToAllProfiles = null,
     bool? IsEndingCharacterRequired = null,
     bool? IsTriggerInsideWord = null,
-    IReadOnlyList<Guid>? CategoryIds = null);
+    IReadOnlyList<Guid>? CategoryIds = null,
+    HotstringKind? Kind = null);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/UpdateHotstringDto.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/UpdateHotstringDto.cs
@@ -11,4 +11,7 @@ public sealed record UpdateHotstringDto(
     Guid[]? CategoryIds = null,
     HotstringKind Kind = HotstringKind.Text,
     bool IsCaseSensitive = false,
-    bool OmitEndingCharacter = false);
+    bool OmitEndingCharacter = false,
+    string? DateTimeFormat = null,
+    int? DateOffsetAmount = null,
+    DateOffsetUnit? DateOffsetUnit = null);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -185,6 +185,14 @@
                           Class="search-hotstrings mb-2"
                           FullWidth="true" Clearable="true" Immediate="true" />
 
+            <MudSelect T="HotstringKind?" @bind-Value="_selectedKind" @bind-Value:after="OnKindFilterChangedAsync"
+                       Label="Type" Placeholder="All" Clearable="true"
+                       Class="kind-filter-mobile mb-2" FullWidth="true"
+                       UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "kind-filter-mobile" })">
+                <MudSelectItem T="HotstringKind?" Value="HotstringKind.Text">Text</MudSelectItem>
+                <MudSelectItem T="HotstringKind?" Value="HotstringKind.DateTime">Date &amp; time</MudSelectItem>
+            </MudSelect>
+
             @if (_categories.Count > 0)
             {
                 <div class="chip-strip mb-2">

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -37,6 +37,13 @@
                 </MudButton>
             }
             <MudSpacer />
+            <MudSelect T="HotstringKind?" @bind-Value="_selectedKind" @bind-Value:after="OnKindFilterChangedAsync"
+                       Label="Type" Placeholder="All" Clearable="true"
+                       Class="kind-filter" Style="max-width: 200px;"
+                       UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "kind-filter" })">
+                <MudSelectItem T="HotstringKind?" Value="HotstringKind.Text">Text</MudSelectItem>
+                <MudSelectItem T="HotstringKind?" Value="HotstringKind.DateTime">Date &amp; time</MudSelectItem>
+            </MudSelect>
             <MudTextField T="string" @bind-Value="_search" @bind-Value:after="OnSearchChangedAsync"
                           DebounceInterval="300"
                           Placeholder="Search For Hotstrings"
@@ -98,7 +105,7 @@
                             }
                             else
                             {
-                                <span style="white-space: pre-wrap">@context.Item.Replacement</span>
+                                <span style="white-space: pre-wrap">@(context.Item.Kind == HotstringKind.DateTime ? context.Item.DateTimeSummary : context.Item.Replacement)</span>
                             }
                         </CellTemplate>
                     </PropertyColumn>
@@ -128,7 +135,7 @@
                             }
                         </CellTemplate>
                     </TemplateColumn>
-                    <TemplateColumn Title="Type" Sortable="false" Filterable="false">
+                    <TemplateColumn Title="Type" Sortable="true" SortBy="x => x.Kind" Filterable="false">
                         <CellTemplate>
                             <MudTooltip Text="@OptionsTooltip(context.Item)">
                                 <span class="type-badge">
@@ -236,6 +243,7 @@
     private IReadOnlyList<EntityOption> _profileOptions = [];
     private IReadOnlyList<EntityOption> _categoryOptions = [];
     private IReadOnlyList<Guid> _selectedCategoryIds = [];
+    private HotstringKind? _selectedKind;
     private bool _isAuthenticated;
     private bool _loading;
     private string? _loadError;
@@ -296,7 +304,8 @@
                 TriggerFilter: StringFilter(state, "trigger"),
                 ReplacementFilter: StringFilter(state, "replacement"),
                 DescriptionFilter: StringFilter(state, "description"),
-                CategoryIds: _selectedCategoryIds.Count > 0 ? _selectedCategoryIds : null),
+                CategoryIds: _selectedCategoryIds.Count > 0 ? _selectedCategoryIds : null,
+                Kind: _selectedKind),
             ct);
 
         _loading = false;
@@ -351,7 +360,12 @@
             "trigger" or nameof(HotstringEditModel.Trigger) => "trigger",
             "replacement" or nameof(HotstringEditModel.Replacement) => "replacement",
             "description" or nameof(HotstringEditModel.Description) => "description",
-            _ => null,
+            // The Type column is a TemplateColumn: MudBlazor 9.3.0 auto-generates its PropertyName
+            // as a random GUID (TemplateColumn<T>.PropertyName has no settable parameter), so it
+            // can't be matched by literal string. It's the only other sortable column in this grid
+            // (SortMode.Single), so any value that isn't one of the known property names is
+            // attributed to it by elimination.
+            _ => "kind",
         };
 
         return (sortField, sort.Descending);
@@ -575,7 +589,8 @@
                 Page: _mobilePage,
                 PageSize: _mobilePageSize,
                 Search: string.IsNullOrWhiteSpace(_search) ? null : _search,
-                CategoryIds: _selectedCategoryIds.Count > 0 ? _selectedCategoryIds : null),
+                CategoryIds: _selectedCategoryIds.Count > 0 ? _selectedCategoryIds : null,
+                Kind: _selectedKind),
             _cts.Token);
 
         _loading = false;
@@ -757,6 +772,13 @@
         await LoadMobileAsync();
     }
 
+    private async Task OnKindFilterChangedAsync()
+    {
+        if (_grid is not null) await _grid.ReloadServerData();
+        _mobilePage = 1;
+        await LoadMobileAsync();
+    }
+
     private RenderFragment RenderProfiles(bool appliesToAllProfiles, IReadOnlyCollection<Guid> profileIds) =>
         @<EntityChips Ids="profileIds" Options="_profileOptions" Any="appliesToAllProfiles" />;
 
@@ -838,8 +860,11 @@
                            OnClick="() => ShowHistoryAsync(item)" />
             <MudIconButton Class="delete" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
                            OnClick="() => DeleteAsync(item)" />
-            <MudIconButton Class="start-edit" Icon="@Icons.Material.Filled.Edit"
-                           OnClick="() => StartEditAsync(item)" />
+            @if (item.IsInlineEditable)
+            {
+                <MudIconButton Class="start-edit" Icon="@Icons.Material.Filled.Edit"
+                               OnClick="() => StartEditAsync(item)" />
+            }
         }
     </text>;
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/HotstringsApiClient.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/HotstringsApiClient.cs
@@ -32,6 +32,8 @@ public sealed class HotstringsApiClient(HttpClient httpClient) : ApiClientBase(h
             foreach (Guid id in request.CategoryIds)
                 parts.Add($"categoryIds={id}");
         }
+        if (request.Kind.HasValue)
+            parts.Add($"kind={request.Kind.Value}");
         return SendAsync<PagedList<HotstringDto>>(HttpMethod.Get, $"{BasePath}?{string.Join("&", parts)}", content: null, ct);
     }
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Validation/HotstringEditModel.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Validation/HotstringEditModel.cs
@@ -11,7 +11,8 @@ public sealed class HotstringEditModel
     [MaxLength(50, ErrorMessage = "Trigger must be 50 characters or fewer.")]
     public string Trigger { get; set; } = "";
 
-    [Required(ErrorMessage = "Replacement is required.")]
+    // Requiredness is conditional on Kind (not required for DateTime) — enforced by the
+    // dialog's field-level Required param (Task 10) and by server-side validation.
     [MaxLength(4000, ErrorMessage = "Replacement must be 4000 characters or fewer.")]
     public string Replacement { get; set; } = "";
 
@@ -26,12 +27,38 @@ public sealed class HotstringEditModel
     public HotstringKind Kind { get; set; } = HotstringKind.Text;
     public bool IsCaseSensitive { get; set; }
     public bool OmitEndingCharacter { get; set; }
+    public string? DateTimeFormat { get; set; }
+    public int? DateOffsetAmount { get; set; }
+    public DateOffsetUnit? DateOffsetUnit { get; set; }
 
     /// <summary>UI-facing inverse of <see cref="IsEndingCharacterRequired"/> (spec label "Expand immediately").</summary>
     public bool ExpandImmediately
     {
         get => !IsEndingCharacterRequired;
         set => IsEndingCharacterRequired = !value;
+    }
+
+    /// <summary>Grid rows can only offer inline edit for Text-kind hotstrings (Task 11).</summary>
+    public bool IsInlineEditable => Kind == HotstringKind.Text;
+
+    /// <summary>
+    /// Humanized date/time summary for grid/mobile display. Null unless <see cref="Kind"/> is
+    /// <see cref="HotstringKind.DateTime"/> — callers fall back to plain Replacement text otherwise.
+    /// Mirrors AHKFlowApp.CLI.Output.HotstringTableFormatter's FormatReplacementColumn logic.
+    /// </summary>
+    public string? DateTimeSummary
+    {
+        get
+        {
+            if (Kind != HotstringKind.DateTime) return null;
+            if (DateTimeFormat is null) return "—";
+            if (DateOffsetAmount is null || DateOffsetUnit is null) return DateTimeFormat;
+
+            int amount = DateOffsetAmount.Value;
+            string sign = amount < 0 ? "-" : "+";
+            string unitName = FormatUnitName(DateOffsetUnit.Value, amount);
+            return $"{DateTimeFormat} ({sign}{Math.Abs(amount)} {unitName})";
+        }
     }
 
     public static HotstringEditModel FromDto(HotstringDto dto) => new()
@@ -48,6 +75,9 @@ public sealed class HotstringEditModel
         Kind = dto.Kind,
         IsCaseSensitive = dto.IsCaseSensitive,
         OmitEndingCharacter = dto.OmitEndingCharacter,
+        DateTimeFormat = dto.DateTimeFormat,
+        DateOffsetAmount = dto.DateOffsetAmount,
+        DateOffsetUnit = dto.DateOffsetUnit,
     };
 
     public HotstringEditModel Clone() => new()
@@ -64,11 +94,52 @@ public sealed class HotstringEditModel
         Kind = Kind,
         IsCaseSensitive = IsCaseSensitive,
         OmitEndingCharacter = OmitEndingCharacter,
+        DateTimeFormat = DateTimeFormat,
+        DateOffsetAmount = DateOffsetAmount,
+        DateOffsetUnit = DateOffsetUnit,
     };
 
-    public CreateHotstringDto ToCreateDto() =>
-        new(Trigger, Replacement, AppliesToAllProfiles ? null : [.. ProfileIds], AppliesToAllProfiles, IsEndingCharacterRequired, IsTriggerInsideWord, Description, [.. CategoryIds], Kind, IsCaseSensitive, OmitEndingCharacter);
+    public CreateHotstringDto ToCreateDto()
+    {
+        string replacement = Kind == HotstringKind.DateTime ? "" : Replacement;
+        return new(Trigger, replacement, AppliesToAllProfiles ? null : [.. ProfileIds], AppliesToAllProfiles,
+            IsEndingCharacterRequired, IsTriggerInsideWord, Description, [.. CategoryIds], Kind, IsCaseSensitive,
+            OmitEndingCharacter, DateTimeFormat, DateOffsetAmount, DateOffsetUnit);
+    }
 
-    public UpdateHotstringDto ToUpdateDto() =>
-        new(Trigger, Replacement, AppliesToAllProfiles ? null : [.. ProfileIds], AppliesToAllProfiles, IsEndingCharacterRequired, IsTriggerInsideWord, Description, [.. CategoryIds], Kind, IsCaseSensitive, OmitEndingCharacter);
+    public UpdateHotstringDto ToUpdateDto()
+    {
+        string replacement = Kind == HotstringKind.DateTime ? "" : Replacement;
+        return new(Trigger, replacement, AppliesToAllProfiles ? null : [.. ProfileIds], AppliesToAllProfiles,
+            IsEndingCharacterRequired, IsTriggerInsideWord, Description, [.. CategoryIds], Kind, IsCaseSensitive,
+            OmitEndingCharacter, DateTimeFormat, DateOffsetAmount, DateOffsetUnit);
+    }
+
+    /// <summary>
+    /// Previews what <paramref name="format"/> would produce for the current moment, without
+    /// throwing on invalid or partial input while the user is typing. Offset-free — a raw format
+    /// preview only (Task 10 owns any offset preview on top of this).
+    /// </summary>
+    public static string SafePreview(string? format)
+    {
+        if (string.IsNullOrEmpty(format)) return "";
+
+        try
+        {
+            // A single-character custom format specifier (e.g. "d") is ambiguous with .NET's
+            // standard format specifiers. Prefixing with '%' forces custom-specifier interpretation.
+            string actualFormat = format.Length == 1 ? "%" + format : format;
+            return DateTime.Now.ToString(actualFormat);
+        }
+        catch (FormatException)
+        {
+            return "Invalid format";
+        }
+    }
+
+    private static string FormatUnitName(DateOffsetUnit unit, int amount)
+    {
+        string name = unit.ToString().ToLowerInvariant();
+        return Math.Abs(amount) == 1 ? name[..^1] : name;
+    }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/changelog.json
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/changelog.json
@@ -13,7 +13,8 @@
             "Hotstring option toggles: case sensitive and omit ending character.",
             "Type/Options badge column in the hotstrings grid (replaces the two option checkbox columns).",
             "\"Edit details\" dialog for hotstrings on desktop.",
-            "`ahkflow hotstring list` shows a Kind column."
+            "`ahkflow hotstring list` shows a Kind column.",
+            "DateTime hotstring kind: curated date/time format presets with optional date offset, emitted as `SendText(FormatTime(...))`. Supported in the edit dialog, grid, mobile list, history, and CLI."
           ]
         },
         {

--- a/src/Tools/AHKFlowApp.CLI/Output/HotstringTableFormatter.cs
+++ b/src/Tools/AHKFlowApp.CLI/Output/HotstringTableFormatter.cs
@@ -40,7 +40,7 @@ public static class HotstringTableFormatter
             writer.WriteLine(string.Join("  ",
                 Pad(Truncate(dto.Trigger, TriggerWidth), TriggerWidth),
                 Pad(KindLabel(dto.Kind), KindWidth),
-                Pad(Truncate(dto.Replacement, ReplacementWidth), ReplacementWidth),
+                Pad(FormatReplacementColumn(dto), ReplacementWidth),
                 Pad(Truncate(FormatProfiles(dto, profileNamesById), ProfilesWidth), ProfilesWidth),
                 updated));
         }
@@ -71,6 +71,30 @@ public static class HotstringTableFormatter
         string head = string.Join(", ", resolved.Take(3));
         int more = Math.Max(0, resolved.Count - 3) + unresolved;
         return more > 0 ? $"{head} +{more} more" : head;
+    }
+
+    private static string FormatReplacementColumn(HotstringDto dto)
+    {
+        if (dto.Kind != HotstringKind.DateTime)
+            return Truncate(dto.Replacement, ReplacementWidth);
+
+        if (dto.DateTimeFormat is null)
+            return Truncate("—", ReplacementWidth);
+
+        if (dto.DateOffsetAmount is null || dto.DateOffsetUnit is null)
+            return Truncate(dto.DateTimeFormat, ReplacementWidth);
+
+        int amount = dto.DateOffsetAmount.Value;
+        string sign = amount < 0 ? "-" : "+";
+        string unitName = FormatUnitName(dto.DateOffsetUnit.Value, amount);
+        string summary = $"{dto.DateTimeFormat} ({sign}{Math.Abs(amount)} {unitName})";
+        return Truncate(summary, ReplacementWidth);
+    }
+
+    private static string FormatUnitName(DateOffsetUnit unit, int amount)
+    {
+        string name = unit.ToString().ToLowerInvariant();
+        return Math.Abs(amount) == 1 ? name[..^1] : name;
     }
 
     private static string KindLabel(HotstringKind kind) => kind switch

--- a/src/Tools/AHKFlowApp.CLI/Services/IHotstringsApiClient.cs
+++ b/src/Tools/AHKFlowApp.CLI/Services/IHotstringsApiClient.cs
@@ -20,6 +20,14 @@ public enum HotstringKind
     Script = 3,
 }
 
+public enum DateOffsetUnit
+{
+    Seconds = 0,
+    Minutes = 1,
+    Hours = 2,
+    Days = 3,
+}
+
 public sealed record HotstringDto(
     Guid Id,
     Guid[] ProfileIds,
@@ -32,7 +40,10 @@ public sealed record HotstringDto(
     DateTimeOffset UpdatedAt,
     HotstringKind Kind = HotstringKind.Text,
     bool IsCaseSensitive = false,
-    bool OmitEndingCharacter = false);
+    bool OmitEndingCharacter = false,
+    string? DateTimeFormat = null,
+    int? DateOffsetAmount = null,
+    DateOffsetUnit? DateOffsetUnit = null);
 
 public sealed record CreateHotstringDto(
     string Trigger,

--- a/tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs
@@ -379,4 +379,101 @@ public sealed class HotstringsEndpointsTests(ApiTestFixture fixture)
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+
+    [Fact]
+    public async Task Post_DateTimeKind_ReturnsCreatedWithDateFields()
+    {
+        using HttpClient client = CreateAuthed();
+        CreateHotstringDto dto = new(
+            "dtstamp",
+            "",
+            Kind: HotstringKind.DateTime,
+            DateTimeFormat: "yyyy-MM-dd",
+            DateOffsetAmount: 7,
+            DateOffsetUnit: DateOffsetUnit.Days);
+
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/v1/hotstrings", dto);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        HotstringDto? body = await response.Content.ReadFromJsonAsync<HotstringDto>();
+        body!.Kind.Should().Be(HotstringKind.DateTime);
+        body.DateTimeFormat.Should().Be("yyyy-MM-dd");
+        body.DateOffsetAmount.Should().Be(7);
+        body.DateOffsetUnit.Should().Be(DateOffsetUnit.Days);
+    }
+
+    [Fact]
+    public async Task List_FiltersByKind_ReturnsOnlyMatchingKind()
+    {
+        var owner = Guid.NewGuid();
+        using HttpClient client = CreateAuthed(owner);
+
+        await client.PostAsJsonAsync("/api/v1/hotstrings", new CreateHotstringDto("kindtext", "x"));
+        await client.PostAsJsonAsync(
+            "/api/v1/hotstrings",
+            new CreateHotstringDto("kinddt", "", Kind: HotstringKind.DateTime, DateTimeFormat: "yyyy"));
+
+        HttpResponseMessage response = await client.GetAsync($"/api/v1/hotstrings?kind={HotstringKind.DateTime}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        PagedList<HotstringDto>? body = await response.Content.ReadFromJsonAsync<PagedList<HotstringDto>>();
+        body!.Items.Should().OnlyContain(h => h.Kind == HotstringKind.DateTime);
+        body.Items.Should().Contain(h => h.Trigger == "kinddt");
+    }
+
+    [Fact]
+    public async Task List_SortByKind_OrdersRows()
+    {
+        var owner = Guid.NewGuid();
+        using HttpClient client = CreateAuthed(owner);
+
+        await client.PostAsJsonAsync("/api/v1/hotstrings", new CreateHotstringDto("sktext", "x"));
+        await client.PostAsJsonAsync(
+            "/api/v1/hotstrings",
+            new CreateHotstringDto("skdt", "", Kind: HotstringKind.DateTime, DateTimeFormat: "yyyy"));
+
+        HttpResponseMessage response = await client.GetAsync(
+            "/api/v1/hotstrings?search=sk&sortField=kind&sortDescending=false");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        PagedList<HotstringDto>? body = await response.Content.ReadFromJsonAsync<PagedList<HotstringDto>>();
+        body!.Items.Select(h => h.Kind).Should().BeInAscendingOrder();
+    }
+
+    [Fact]
+    public async Task List_ReplacementFilter_MatchesDateTimeFormatForDateTimeRows()
+    {
+        var owner = Guid.NewGuid();
+        using HttpClient client = CreateAuthed(owner);
+
+        await client.PostAsJsonAsync(
+            "/api/v1/hotstrings",
+            new CreateHotstringDto("rfdt", "", Kind: HotstringKind.DateTime, DateTimeFormat: "ss"));
+        await client.PostAsJsonAsync("/api/v1/hotstrings", new CreateHotstringDto("rftext", "no match here"));
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/hotstrings?replacementFilter=ss");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        PagedList<HotstringDto>? body = await response.Content.ReadFromJsonAsync<PagedList<HotstringDto>>();
+        body!.Items.Should().ContainSingle().Which.Trigger.Should().Be("rfdt");
+    }
+
+    [Fact]
+    public async Task List_SortByReplacement_OrdersDateTimeRowsByFormat()
+    {
+        var owner = Guid.NewGuid();
+        using HttpClient client = CreateAuthed(owner);
+
+        await client.PostAsJsonAsync(
+            "/api/v1/hotstrings",
+            new CreateHotstringDto("srb", "", Kind: HotstringKind.DateTime, DateTimeFormat: "ttt"));
+        await client.PostAsJsonAsync("/api/v1/hotstrings", new CreateHotstringDto("sra", "aaa"));
+
+        HttpResponseMessage response = await client.GetAsync(
+            "/api/v1/hotstrings?search=sr&sortField=replacement&sortDescending=false");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        PagedList<HotstringDto>? body = await response.Content.ReadFromJsonAsync<PagedList<HotstringDto>>();
+        body!.Items.Select(h => h.Trigger).Should().Equal("sra", "srb");
+    }
 }

--- a/tests/AHKFlowApp.Application.Tests/History/HotstringNewFieldHistoryTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/History/HotstringNewFieldHistoryTests.cs
@@ -90,4 +90,88 @@ public sealed class HotstringNewFieldHistoryTests(HistoryDbFixture fx)
         result.Value.IsCaseSensitive.Should().BeTrue();
         result.Value.OmitEndingCharacter.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task RevertHotstring_RestoresDateTimeFields()
+    {
+        var owner = Guid.NewGuid();
+        Hotstring entity = new HotstringBuilder()
+            .WithOwner(owner).WithTrigger("dt1").WithReplacement("")
+            .WithKind(HotstringKind.DateTime)
+            .WithDateTimeFormat("yyyy-MM-dd")
+            .WithDateOffset(1, DateOffsetUnit.Days)
+            .Build();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotstrings.Add(entity);
+            await seed.SaveChangesAsync();
+        }
+
+        // Update switches the hotstring to Text kind — the before-image snapshot must carry the date fields.
+        await using (AppDbContext db = fx.CreateContext())
+        {
+            UpdateHotstringCommandHandler update = new(
+                db, CurrentUserHelper.For(owner), TimeProvider.System,
+                new EntityHistoryRecorder(db, TimeProvider.System));
+            Result<HotstringDto> updated = await update.ExecuteAsync(
+                new UpdateHotstringCommand(entity.Id,
+                    new UpdateHotstringDto("dt1", "x", null, true, true, true, null)), default);
+            updated.IsSuccess.Should().BeTrue();
+            updated.Value.Kind.Should().Be(HotstringKind.Text);
+        }
+
+        await using AppDbContext revertDb = fx.CreateContext();
+        RevertHotstringCommandHandler revert = new(
+            revertDb, CurrentUserHelper.For(owner), TimeProvider.System,
+            new EntityHistoryRecorder(revertDb, TimeProvider.System));
+        Result<HotstringDto> result = await revert.ExecuteAsync(
+            new RevertHotstringCommand(entity.Id, 1), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Kind.Should().Be(HotstringKind.DateTime);
+        result.Value.DateTimeFormat.Should().Be("yyyy-MM-dd");
+        result.Value.DateOffsetAmount.Should().Be(1);
+        result.Value.DateOffsetUnit.Should().Be(DateOffsetUnit.Days);
+    }
+
+    [Fact]
+    public async Task RestoreHotstring_AfterDelete_RehydratesDateTimeFields()
+    {
+        var owner = Guid.NewGuid();
+        Hotstring entity = new HotstringBuilder()
+            .WithOwner(owner).WithTrigger("dt2").WithReplacement("")
+            .WithKind(HotstringKind.DateTime)
+            .WithDateTimeFormat("HH:mm")
+            .WithDateOffset(-2, DateOffsetUnit.Hours)
+            .Build();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotstrings.Add(entity);
+            await seed.SaveChangesAsync();
+        }
+
+        // Delete via the real handler so the tombstone snapshot is written the production way.
+        await using (AppDbContext db = fx.CreateContext())
+        {
+            DeleteHotstringCommandHandler delete = new(
+                db, CurrentUserHelper.For(owner), new EntityHistoryRecorder(db, TimeProvider.System));
+            (await delete.ExecuteAsync(new DeleteHotstringCommand(entity.Id), default))
+                .IsSuccess.Should().BeTrue();
+        }
+
+        await using AppDbContext restoreDb = fx.CreateContext();
+        RestoreHotstringCommandHandler restore = new(
+            restoreDb, CurrentUserHelper.For(owner), TimeProvider.System,
+            new EntityHistoryRecorder(restoreDb, TimeProvider.System));
+        Result<HotstringDto> result = await restore.ExecuteAsync(
+            new RestoreHotstringCommand(entity.Id), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Kind.Should().Be(HotstringKind.DateTime);
+        result.Value.DateTimeFormat.Should().Be("HH:mm");
+        result.Value.DateOffsetAmount.Should().Be(-2);
+        result.Value.DateOffsetUnit.Should().Be(DateOffsetUnit.Hours);
+    }
 }

--- a/tests/AHKFlowApp.Application.Tests/History/HotstringSnapshotCompatibilityTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/History/HotstringSnapshotCompatibilityTests.cs
@@ -23,5 +23,8 @@ public sealed class HotstringSnapshotCompatibilityTests
         snapshot!.Kind.Should().Be(HotstringKind.Text);
         snapshot.IsCaseSensitive.Should().BeFalse();
         snapshot.OmitEndingCharacter.Should().BeFalse();
+        snapshot.DateTimeFormat.Should().BeNull();
+        snapshot.DateOffsetAmount.Should().BeNull();
+        snapshot.DateOffsetUnit.Should().BeNull();
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
@@ -16,8 +16,21 @@ public sealed class CreateHotstringCommandValidatorTests
         string replacement = "by the way",
         bool appliesToAllProfiles = true,
         Guid[]? profileIds = null,
-        string? description = null)
-        => new(new CreateHotstringDto(trigger, replacement, profileIds, appliesToAllProfiles, Description: description));
+        string? description = null,
+        HotstringKind kind = HotstringKind.Text,
+        string? dateTimeFormat = null,
+        int? dateOffsetAmount = null,
+        DateOffsetUnit? dateOffsetUnit = null)
+        => new(new CreateHotstringDto(
+            trigger,
+            replacement,
+            profileIds,
+            appliesToAllProfiles,
+            Description: description,
+            Kind: kind,
+            DateTimeFormat: dateTimeFormat,
+            DateOffsetAmount: dateOffsetAmount,
+            DateOffsetUnit: dateOffsetUnit));
 
     [Fact]
     public void Validate_WithAppliesToAllProfiles_Succeeds()
@@ -227,22 +240,213 @@ public sealed class CreateHotstringCommandValidatorTests
     [Fact]
     public void Kind_Text_Passes()
     {
-        CreateHotstringCommand cmd = new(new CreateHotstringDto("btw", "by the way", Kind: HotstringKind.Text));
-
-        ValidationResult result = _sut.Validate(cmd);
+        ValidationResult result = _sut.Validate(Cmd(kind: HotstringKind.Text));
 
         result.Errors.Should().NotContain(e => e.PropertyName == "Input.Kind");
     }
 
     [Fact]
-    public void Kind_NonText_Fails()
+    public void Kind_DateTime_Passes()
     {
-        CreateHotstringCommand cmd = new(new CreateHotstringDto("btw", "by the way", Kind: HotstringKind.Script));
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: "yyyy-MM-dd"));
 
-        ValidationResult result = _sut.Validate(cmd);
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Kind");
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
+    }
+
+    [Theory]
+    [InlineData(HotstringKind.Macro)]
+    [InlineData(HotstringKind.Script)]
+    public void Kind_MacroOrScript_Fails(HotstringKind kind)
+    {
+        ValidationResult result = _sut.Validate(Cmd(kind: kind));
 
         result.Errors.Should().Contain(e =>
             e.PropertyName == "Input.Kind" &&
-            e.ErrorMessage == "Only Text hotstrings are supported.");
+            e.ErrorMessage == "Only Text and Date & time hotstrings are supported.");
+    }
+
+    [Fact]
+    public void DateTimeKind_WithNonEmptyReplacement_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "not empty",
+            dateTimeFormat: "yyyy-MM-dd"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.Replacement");
+    }
+
+    [Fact]
+    public void DateTimeKind_WithNullDateTimeFormat_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: null));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateTimeFormat");
+    }
+
+    [Fact]
+    public void TextKind_WithNonNullDateTimeFormat_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Text,
+            dateTimeFormat: "yyyy-MM-dd"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateTimeFormat");
+    }
+
+    [Fact]
+    public void TextKind_WithNonNullDateOffsetAmountOrUnit_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Text,
+            dateOffsetAmount: 1,
+            dateOffsetUnit: DateOffsetUnit.Days));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateOffsetAmount");
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateOffsetUnit");
+    }
+
+    [Fact]
+    public void DateTimeKind_OffsetAmountZero_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: "yyyy-MM-dd",
+            dateOffsetAmount: 0,
+            dateOffsetUnit: DateOffsetUnit.Days));
+
+        result.Errors.Should().NotContain(e =>
+            e.PropertyName == "Input.DateOffsetAmount" || e.PropertyName == "Input.DateOffsetUnit");
+    }
+
+    [Fact]
+    public void DateTimeKind_OffsetAmountWithoutUnit_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: "yyyy-MM-dd",
+            dateOffsetAmount: 1,
+            dateOffsetUnit: null));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.DateOffsetAmount" &&
+            e.ErrorMessage == "DateOffsetAmount and DateOffsetUnit must both be set or both be null.");
+    }
+
+    [Theory]
+    [InlineData(-3650)]
+    [InlineData(3650)]
+    public void DateTimeKind_OffsetAmountAtBounds_Succeeds(int amount)
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: "yyyy-MM-dd",
+            dateOffsetAmount: amount,
+            dateOffsetUnit: DateOffsetUnit.Days));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.DateOffsetAmount");
+    }
+
+    [Theory]
+    [InlineData(-3651)]
+    [InlineData(3651)]
+    public void DateTimeKind_OffsetAmountBeyondBounds_Fails(int amount)
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: "yyyy-MM-dd",
+            dateOffsetAmount: amount,
+            dateOffsetUnit: DateOffsetUnit.Days));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateOffsetAmount");
+    }
+
+    [Theory]
+    [InlineData("yyyy-MM-dd")]
+    [InlineData("dd-MM-yyyy")]
+    [InlineData("MM/dd/yyyy")]
+    [InlineData("dddd d MMMM yyyy")]
+    [InlineData("ddd d MMM yyyy")]
+    [InlineData("MMMM yyyy")]
+    [InlineData("HH:mm")]
+    [InlineData("HH:mm:ss")]
+    [InlineData("h:mm tt")]
+    [InlineData("yyyy-MM-dd HH:mm")]
+    [InlineData("yyyy-MM-dd HH:mm:ss")]
+    [InlineData("yyyyMMdd-HHmmss")]
+    public void DateTimeFormat_CuratedPresets_Pass(string format)
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: format));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.DateTimeFormat");
+    }
+
+    [Theory]
+    [InlineData("\"yyyy\"")]
+    [InlineData("`yyyy`")]
+    [InlineData("'yyyy'")]
+    [InlineData("yyyy\\MM")]
+    [InlineData("yyyy%MM")]
+    [InlineData("yyyy;MM")]
+    [InlineData("yyyy{0}")]
+    [InlineData("yyyy\nMM")]
+    [InlineData("yyyy fMM")]
+    [InlineData("yyyy zMM")]
+    [InlineData("yyyy KMM")]
+    [InlineData("yyyy nMM")]
+    [InlineData("")]
+    [InlineData("---")]
+    public void DateTimeFormat_InvalidValues_Fail(string format)
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: format));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateTimeFormat");
+    }
+
+    [Fact]
+    public void DateTimeFormat_At51Chars_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: new string('y', 51)));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateTimeFormat");
+    }
+
+    [Fact]
+    public void DateTimeFormat_At50Chars_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: new string('y', 50)));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.DateTimeFormat");
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsQueryHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsQueryHandlerTests.cs
@@ -2,6 +2,7 @@ using AHKFlowApp.Application;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Application.Queries.Hotstrings;
 using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
 using AHKFlowApp.Infrastructure.Persistence;
 using Ardalis.Result;
 using FluentAssertions;
@@ -299,5 +300,135 @@ public sealed class ListHotstringsQueryHandlerTests(HotstringDbFixture fx)
             new ListHotstringsQuery(SortField: "description", SortDescending: false), default);
 
         result.Value.Items.Select(h => h.Description).Should().Equal("alpha", "bravo", "charlie");
+    }
+
+    [Fact]
+    public async Task Handle_KindFilter_ReturnsOnlyMatchingKind()
+    {
+        var owner = Guid.NewGuid();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotstrings.Add(Hotstring.Create(owner, new HotstringDefinition("txt", "x", null, true, true, true), TimeProvider.System));
+            seed.Hotstrings.Add(Hotstring.Create(
+                owner,
+                new HotstringDefinition(
+                    "dt", "", null, true, true, true,
+                    HotstringKind.DateTime, false, false, "yyyy-MM-dd", null, null),
+                TimeProvider.System));
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
+
+        Result<PagedList<HotstringDto>> result = await handler.ExecuteAsync(
+            new ListHotstringsQuery(Kind: HotstringKind.DateTime), default);
+
+        result.Value.Items.Should().ContainSingle().Which.Trigger.Should().Be("dt");
+    }
+
+    [Fact]
+    public async Task Handle_SortByKindAscending_ReturnsStableOrder()
+    {
+        var owner = Guid.NewGuid();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotstrings.Add(Hotstring.Create(
+                owner,
+                new HotstringDefinition(
+                    "dt", "", null, true, true, true,
+                    HotstringKind.DateTime, false, false, "yyyy-MM-dd", null, null),
+                TimeProvider.System));
+            seed.Hotstrings.Add(Hotstring.Create(owner, new HotstringDefinition("txt", "x", null, true, true, true), TimeProvider.System));
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
+
+        Result<PagedList<HotstringDto>> result = await handler.ExecuteAsync(
+            new ListHotstringsQuery(SortField: "kind", SortDescending: false), default);
+
+        result.Value.Items.Select(h => h.Kind).Should().Equal(HotstringKind.Text, HotstringKind.DateTime);
+    }
+
+    [Fact]
+    public async Task Handle_ReplacementFilter_MatchesDateTimeFormatForDateTimeRows()
+    {
+        var owner = Guid.NewGuid();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotstrings.Add(Hotstring.Create(
+                owner,
+                new HotstringDefinition(
+                    "dt", "", null, true, true, true,
+                    HotstringKind.DateTime, false, false, "yyyy-MM-dd", null, null),
+                TimeProvider.System));
+            seed.Hotstrings.Add(Hotstring.Create(owner, new HotstringDefinition("txt", "no match here", null, true, true, true), TimeProvider.System));
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
+
+        Result<PagedList<HotstringDto>> result = await handler.ExecuteAsync(
+            new ListHotstringsQuery(ReplacementFilter: "yyyy"), default);
+
+        result.Value.Items.Should().ContainSingle().Which.Trigger.Should().Be("dt");
+    }
+
+    [Fact]
+    public async Task Handle_Search_MatchesDateTimeFormatForDateTimeRows()
+    {
+        var owner = Guid.NewGuid();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotstrings.Add(Hotstring.Create(
+                owner,
+                new HotstringDefinition(
+                    "dt", "", null, true, true, true,
+                    HotstringKind.DateTime, false, false, "yyyy-MM-dd", null, null),
+                TimeProvider.System));
+            seed.Hotstrings.Add(Hotstring.Create(owner, new HotstringDefinition("txt", "no match here", null, true, true, true), TimeProvider.System));
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
+
+        Result<PagedList<HotstringDto>> result = await handler.ExecuteAsync(
+            new ListHotstringsQuery(Search: "yyyy"), default);
+
+        result.Value.Items.Should().ContainSingle().Which.Trigger.Should().Be("dt");
+    }
+
+    [Fact]
+    public async Task Handle_SortByReplacementAscending_OrdersDateTimeRowsByFormat()
+    {
+        var owner = Guid.NewGuid();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotstrings.Add(Hotstring.Create(
+                owner,
+                new HotstringDefinition(
+                    "dt", "", null, true, true, true,
+                    HotstringKind.DateTime, false, false, "ttt", null, null),
+                TimeProvider.System));
+            seed.Hotstrings.Add(Hotstring.Create(owner, new HotstringDefinition("txt", "aaa", null, true, true, true), TimeProvider.System));
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        ListHotstringsQueryHandler handler = new(db, CurrentUserHelper.For(owner), new AppEnvironment(false), TimeProvider.System);
+
+        Result<PagedList<HotstringDto>> result = await handler.ExecuteAsync(
+            new ListHotstringsQuery(SortField: "replacement", SortDescending: false), default);
+
+        result.Value.Items.Select(h => h.Trigger).Should().Equal("txt", "dt");
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsQueryValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsQueryValidatorTests.cs
@@ -90,6 +90,14 @@ public sealed class ListHotstringsQueryValidatorTests
     }
 
     [Fact]
+    public void Validate_WithKindSortField_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(new ListHotstringsQuery(SortField: "kind"));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
     public void Validate_WithTriggerFilterTooLong_Fails()
     {
         string filter = new('x', 201);

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/UpdateHotstringCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/UpdateHotstringCommandValidatorTests.cs
@@ -16,8 +16,23 @@ public sealed class UpdateHotstringCommandValidatorTests
         string replacement = "by the way",
         bool appliesToAllProfiles = true,
         Guid[]? profileIds = null,
-        string? description = null)
-        => new(Guid.NewGuid(), new UpdateHotstringDto(trigger, replacement, profileIds, appliesToAllProfiles, true, true, description));
+        string? description = null,
+        HotstringKind kind = HotstringKind.Text,
+        string? dateTimeFormat = null,
+        int? dateOffsetAmount = null,
+        DateOffsetUnit? dateOffsetUnit = null)
+        => new(Guid.NewGuid(), new UpdateHotstringDto(
+            trigger,
+            replacement,
+            profileIds,
+            appliesToAllProfiles,
+            true,
+            true,
+            description,
+            Kind: kind,
+            DateTimeFormat: dateTimeFormat,
+            DateOffsetAmount: dateOffsetAmount,
+            DateOffsetUnit: dateOffsetUnit));
 
     [Fact]
     public void Validate_AppliesToAll_NoProfiles_Succeeds()
@@ -211,15 +226,215 @@ public sealed class UpdateHotstringCommandValidatorTests
     }
 
     [Fact]
-    public void Kind_NonText_Fails()
+    public void Kind_Text_Passes()
     {
-        UpdateHotstringCommand cmd = new(Guid.NewGuid(),
-            new UpdateHotstringDto("btw", "x", null, true, true, true, null, null, HotstringKind.DateTime));
+        ValidationResult result = _sut.Validate(Cmd(kind: HotstringKind.Text));
 
-        ValidationResult result = _sut.Validate(cmd);
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Kind");
+    }
+
+    [Fact]
+    public void Kind_DateTime_Passes()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: "yyyy-MM-dd"));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Kind");
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
+    }
+
+    [Theory]
+    [InlineData(HotstringKind.Macro)]
+    [InlineData(HotstringKind.Script)]
+    public void Kind_MacroOrScript_Fails(HotstringKind kind)
+    {
+        ValidationResult result = _sut.Validate(Cmd(kind: kind));
 
         result.Errors.Should().Contain(e =>
             e.PropertyName == "Input.Kind" &&
-            e.ErrorMessage == "Only Text hotstrings are supported.");
+            e.ErrorMessage == "Only Text and Date & time hotstrings are supported.");
+    }
+
+    [Fact]
+    public void DateTimeKind_WithNonEmptyReplacement_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "not empty",
+            dateTimeFormat: "yyyy-MM-dd"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.Replacement");
+    }
+
+    [Fact]
+    public void DateTimeKind_WithNullDateTimeFormat_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: null));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateTimeFormat");
+    }
+
+    [Fact]
+    public void TextKind_WithNonNullDateTimeFormat_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Text,
+            dateTimeFormat: "yyyy-MM-dd"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateTimeFormat");
+    }
+
+    [Fact]
+    public void TextKind_WithNonNullDateOffsetAmountOrUnit_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Text,
+            dateOffsetAmount: 1,
+            dateOffsetUnit: DateOffsetUnit.Days));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateOffsetAmount");
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateOffsetUnit");
+    }
+
+    [Fact]
+    public void DateTimeKind_OffsetAmountZero_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: "yyyy-MM-dd",
+            dateOffsetAmount: 0,
+            dateOffsetUnit: DateOffsetUnit.Days));
+
+        result.Errors.Should().NotContain(e =>
+            e.PropertyName == "Input.DateOffsetAmount" || e.PropertyName == "Input.DateOffsetUnit");
+    }
+
+    [Fact]
+    public void DateTimeKind_OffsetAmountWithoutUnit_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: "yyyy-MM-dd",
+            dateOffsetAmount: 1,
+            dateOffsetUnit: null));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.DateOffsetAmount" &&
+            e.ErrorMessage == "DateOffsetAmount and DateOffsetUnit must both be set or both be null.");
+    }
+
+    [Theory]
+    [InlineData(-3650)]
+    [InlineData(3650)]
+    public void DateTimeKind_OffsetAmountAtBounds_Succeeds(int amount)
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: "yyyy-MM-dd",
+            dateOffsetAmount: amount,
+            dateOffsetUnit: DateOffsetUnit.Days));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.DateOffsetAmount");
+    }
+
+    [Theory]
+    [InlineData(-3651)]
+    [InlineData(3651)]
+    public void DateTimeKind_OffsetAmountBeyondBounds_Fails(int amount)
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: "yyyy-MM-dd",
+            dateOffsetAmount: amount,
+            dateOffsetUnit: DateOffsetUnit.Days));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateOffsetAmount");
+    }
+
+    [Theory]
+    [InlineData("yyyy-MM-dd")]
+    [InlineData("dd-MM-yyyy")]
+    [InlineData("MM/dd/yyyy")]
+    [InlineData("dddd d MMMM yyyy")]
+    [InlineData("ddd d MMM yyyy")]
+    [InlineData("MMMM yyyy")]
+    [InlineData("HH:mm")]
+    [InlineData("HH:mm:ss")]
+    [InlineData("h:mm tt")]
+    [InlineData("yyyy-MM-dd HH:mm")]
+    [InlineData("yyyy-MM-dd HH:mm:ss")]
+    [InlineData("yyyyMMdd-HHmmss")]
+    public void DateTimeFormat_CuratedPresets_Pass(string format)
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: format));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.DateTimeFormat");
+    }
+
+    [Theory]
+    [InlineData("\"yyyy\"")]
+    [InlineData("`yyyy`")]
+    [InlineData("'yyyy'")]
+    [InlineData("yyyy\\MM")]
+    [InlineData("yyyy%MM")]
+    [InlineData("yyyy;MM")]
+    [InlineData("yyyy{0}")]
+    [InlineData("yyyy\nMM")]
+    [InlineData("yyyy fMM")]
+    [InlineData("yyyy zMM")]
+    [InlineData("yyyy KMM")]
+    [InlineData("yyyy nMM")]
+    [InlineData("")]
+    [InlineData("---")]
+    public void DateTimeFormat_InvalidValues_Fail(string format)
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: format));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateTimeFormat");
+    }
+
+    [Fact]
+    public void DateTimeFormat_At51Chars_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: new string('y', 51)));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Input.DateTimeFormat");
+    }
+
+    [Fact]
+    public void DateTimeFormat_At50Chars_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.DateTime,
+            replacement: "",
+            dateTimeFormat: new string('y', 50)));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.DateTimeFormat");
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs
@@ -1,6 +1,7 @@
 using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.Services;
 using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
 using AHKFlowApp.TestUtilities.Builders;
 using FluentAssertions;
 using Microsoft.Extensions.Time.Testing;
@@ -278,6 +279,129 @@ public sealed class AhkScriptGeneratorTests
         int posUpper = output.IndexOf(":T:AA::upper", StringComparison.Ordinal);
         int posLower = output.IndexOf(":T:aa::lower", StringComparison.Ordinal);
         posUpper.Should().BeLessThan(posLower);  // 'A' (0x41) < 'a' (0x61) in Ordinal
+    }
+
+    [Theory]
+    [InlineData(true, false, false, false, ":X:dd::")]     // defaults
+    [InlineData(false, false, false, false, ":X*:dd::")]   // expand immediately
+    [InlineData(true, true, false, false, ":X?:dd::")]     // trigger inside word
+    [InlineData(true, false, true, false, ":XC:dd::")]     // case sensitive
+    [InlineData(true, false, false, true, ":XO:dd::")]     // omit ending character
+    [InlineData(false, false, false, true, ":X*:dd::")]    // O suppressed when *
+    [InlineData(false, true, true, true, ":X*?C:dd::")]    // deterministic order X * ? C O
+    public void Generate_DateTimeHotstring_FormatsOptionsCorrectly_XPrefix(
+        bool isEndingCharacterRequired,
+        bool isTriggerInsideWord,
+        bool isCaseSensitive,
+        bool omitEndingCharacter,
+        string expectedPrefix)
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("dd")
+            .WithKind(HotstringKind.DateTime)
+            .WithDateTimeFormat("yyyy-MM-dd")
+            .WithEndingCharacterRequired(isEndingCharacterRequired)
+            .WithTriggerInsideWord(isTriggerInsideWord)
+            .WithCaseSensitive(isCaseSensitive)
+            .WithOmitEndingCharacter(omitEndingCharacter)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain(expectedPrefix + "SendText(FormatTime(A_Now, \"yyyy-MM-dd\"))");
+    }
+
+    [Fact]
+    public void Generate_DateTimeHotstring_NoOffset_MatchesSpecExample3()
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("dd")
+            .WithKind(HotstringKind.DateTime)
+            .WithDateTimeFormat("yyyy-MM-dd")
+            .WithEndingCharacterRequired(false)
+            .WithTriggerInsideWord(false)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain(":X*:dd::SendText(FormatTime(A_Now, \"yyyy-MM-dd\"))");
+    }
+
+    [Fact]
+    public void Generate_DateTimeHotstring_WithOffset_MatchesSpecExample4()
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("nextweek")
+            .WithKind(HotstringKind.DateTime)
+            .WithDateTimeFormat("dddd d MMMM yyyy")
+            .WithDateOffset(7, DateOffsetUnit.Days)
+            .WithEndingCharacterRequired(false)
+            .WithTriggerInsideWord(false)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain(
+            ":X*:nextweek::SendText(FormatTime(DateAdd(A_Now, 7, \"Days\"), \"dddd d MMMM yyyy\"))");
+    }
+
+    [Theory]
+    [InlineData(DateOffsetUnit.Seconds, "Seconds")]
+    [InlineData(DateOffsetUnit.Minutes, "Minutes")]
+    [InlineData(DateOffsetUnit.Hours, "Hours")]
+    [InlineData(DateOffsetUnit.Days, "Days")]
+    public void Generate_DateTimeHotstring_WithOffset_EmitsCorrectUnitString(
+        DateOffsetUnit unit, string expectedUnitString)
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("t")
+            .WithKind(HotstringKind.DateTime)
+            .WithDateTimeFormat("yyyy")
+            .WithDateOffset(3, unit)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain($"DateAdd(A_Now, 3, \"{expectedUnitString}\")");
+    }
+
+    [Fact]
+    public void Generate_DateTimeHotstring_WithNegativeOffset_EmitsNegativeAmountUnchanged()
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("lastweek")
+            .WithKind(HotstringKind.DateTime)
+            .WithDateTimeFormat("yyyy-MM-dd")
+            .WithDateOffset(-7, DateOffsetUnit.Days)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain("DateAdd(A_Now, -7, \"Days\")");
+    }
+
+    [Theory]
+    [InlineData("back`tick", ":X:back``tick::SendText(FormatTime(A_Now, \"yyyy\"))")]
+    [InlineData("a ;b", ":X:a `;b::SendText(FormatTime(A_Now, \"yyyy\"))")]
+    public void Generate_DateTimeHotstring_TriggerWithSpecialChars_EscapesTriggerToo(
+        string trigger, string expectedLine)
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger(trigger)
+            .WithKind(HotstringKind.DateTime)
+            .WithDateTimeFormat("yyyy")
+            .WithTriggerInsideWord(false)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain(expectedLine);
     }
 
     private static AhkScriptGenerator TokenSut(string version = "1.2.3")

--- a/tests/AHKFlowApp.CLI.Tests/Output/HotstringTableFormatterTests.cs
+++ b/tests/AHKFlowApp.CLI.Tests/Output/HotstringTableFormatterTests.cs
@@ -25,6 +25,25 @@ public sealed class HotstringTableFormatterTests
             FixedTime,
             FixedTime);
 
+    private static HotstringDto DateTimeHotstring(
+        string? dateTimeFormat = "yyyy-MM-dd",
+        int? dateOffsetAmount = null,
+        DateOffsetUnit? dateOffsetUnit = null,
+        string trigger = "ddate") =>
+        new(Guid.NewGuid(),
+            [],
+            true,
+            trigger,
+            string.Empty,
+            true,
+            true,
+            FixedTime,
+            FixedTime,
+            HotstringKind.DateTime,
+            DateTimeFormat: dateTimeFormat,
+            DateOffsetAmount: dateOffsetAmount,
+            DateOffsetUnit: dateOffsetUnit);
+
     [Fact]
     public void Write_EmptyPage_WritesPlaceholderOnly()
     {
@@ -153,5 +172,113 @@ public sealed class HotstringTableFormatterTests
 
         sw.ToString().Should().Contain("Kind");
         sw.ToString().Should().Contain("Text");
+    }
+
+    [Fact]
+    public void Write_DateTimeRow_NoOffset_RendersRawFormat()
+    {
+        StringWriter sw = new();
+        PagedList<HotstringDto> page = new([DateTimeHotstring(dateTimeFormat: "yyyy-MM-dd")], 1, 50, 1);
+
+        HotstringTableFormatter.Write(sw, page, EmptyNames);
+
+        sw.ToString().Should().Contain("yyyy-MM-dd");
+    }
+
+    [Fact]
+    public void Write_DateTimeRow_PositiveOffset_RendersPluralWithSign()
+    {
+        StringWriter sw = new();
+        PagedList<HotstringDto> page = new(
+            [DateTimeHotstring(dateTimeFormat: "yyyy-MM-dd", dateOffsetAmount: 7, dateOffsetUnit: DateOffsetUnit.Days)],
+            1, 50, 1);
+
+        HotstringTableFormatter.Write(sw, page, EmptyNames);
+
+        sw.ToString().Should().Contain("yyyy-MM-dd (+7 days)");
+    }
+
+    [Fact]
+    public void Write_DateTimeRow_NegativeOffset_RendersPluralWithSign()
+    {
+        StringWriter sw = new();
+        PagedList<HotstringDto> page = new(
+            [DateTimeHotstring(dateTimeFormat: "dddd d MMMM yyyy", dateOffsetAmount: -2, dateOffsetUnit: DateOffsetUnit.Hours)],
+            1, 50, 1);
+
+        HotstringTableFormatter.Write(sw, page, EmptyNames);
+
+        sw.ToString().Should().Contain("dddd d MMMM yyyy (-2 hours)");
+    }
+
+    [Theory]
+    [InlineData(1, "day")]
+    [InlineData(-1, "hour")]
+    public void Write_DateTimeRow_SingularOffset_RendersSingularUnit(int amount, string expectedUnit)
+    {
+        DateOffsetUnit unit = expectedUnit.Contains("day")
+            ? DateOffsetUnit.Days
+            : DateOffsetUnit.Hours;
+        StringWriter sw = new();
+        PagedList<HotstringDto> page = new(
+            [DateTimeHotstring(dateTimeFormat: "yyyy-MM-dd", dateOffsetAmount: amount, dateOffsetUnit: unit)],
+            1, 50, 1);
+
+        HotstringTableFormatter.Write(sw, page, EmptyNames);
+
+        string sign = amount < 0 ? "-" : "+";
+        sw.ToString().Should().Contain($"({sign}{Math.Abs(amount)} {expectedUnit})");
+    }
+
+    [Fact]
+    public void Write_DateTimeRow_ZeroOffset_RendersPluralNotSingular()
+    {
+        StringWriter sw = new();
+        PagedList<HotstringDto> page = new(
+            [DateTimeHotstring(dateTimeFormat: "yyyy-MM-dd", dateOffsetAmount: 0, dateOffsetUnit: DateOffsetUnit.Days)],
+            1, 50, 1);
+
+        HotstringTableFormatter.Write(sw, page, EmptyNames);
+
+        sw.ToString().Should().Contain("(+0 days)");
+    }
+
+    [Fact]
+    public void Write_DateTimeRow_NullFormat_RendersEmDash()
+    {
+        StringWriter sw = new();
+        PagedList<HotstringDto> page = new([DateTimeHotstring(dateTimeFormat: null)], 1, 50, 1);
+
+        HotstringTableFormatter.Write(sw, page, EmptyNames);
+
+        sw.ToString().Should().Contain("—");
+    }
+
+    [Fact]
+    public void Write_TextRow_UnchangedReplacementRendering()
+    {
+        StringWriter sw = new();
+        PagedList<HotstringDto> page = new([Hotstring(replacement: "by the way")], 1, 50, 1);
+
+        HotstringTableFormatter.Write(sw, page, EmptyNames);
+
+        sw.ToString().Should().Contain("by the way");
+    }
+
+    [Theory]
+    [InlineData(DateOffsetUnit.Seconds, "seconds")]
+    [InlineData(DateOffsetUnit.Minutes, "minutes")]
+    [InlineData(DateOffsetUnit.Hours, "hours")]
+    [InlineData(DateOffsetUnit.Days, "days")]
+    public void Write_DateTimeRow_AllUnits_RenderLowercaseName(DateOffsetUnit unit, string expected)
+    {
+        StringWriter sw = new();
+        PagedList<HotstringDto> page = new(
+            [DateTimeHotstring(dateTimeFormat: "yyyy-MM-dd", dateOffsetAmount: 3, dateOffsetUnit: unit)],
+            1, 50, 1);
+
+        HotstringTableFormatter.Write(sw, page, EmptyNames);
+
+        sw.ToString().Should().Contain($"3 {expected}");
     }
 }

--- a/tests/AHKFlowApp.Domain.Tests/Entities/HotstringTests.cs
+++ b/tests/AHKFlowApp.Domain.Tests/Entities/HotstringTests.cs
@@ -175,4 +175,65 @@ public sealed class HotstringTests
         hs.IsCaseSensitive.Should().BeTrue();
         hs.OmitEndingCharacter.Should().BeTrue();
     }
+
+    [Fact]
+    public void Create_RoundTripsDateTimeFields()
+    {
+        var hs = Hotstring.Create(
+            Guid.NewGuid(),
+            new HotstringDefinition("btw", "by the way", null, true, true, false,
+                HotstringKind.DateTime, DateTimeFormat: "yyyy-MM-dd",
+                DateOffsetAmount: 3, DateOffsetUnit: DateOffsetUnit.Days),
+            _clock);
+
+        hs.DateTimeFormat.Should().Be("yyyy-MM-dd");
+        hs.DateOffsetAmount.Should().Be(3);
+        hs.DateOffsetUnit.Should().Be(DateOffsetUnit.Days);
+    }
+
+    [Fact]
+    public void Create_DefaultDefinition_HasNullDateTimeFields()
+    {
+        var hs = Hotstring.Create(
+            Guid.NewGuid(),
+            new HotstringDefinition("btw", "by the way", null, true, true, false),
+            _clock);
+
+        hs.DateTimeFormat.Should().BeNull();
+        hs.DateOffsetAmount.Should().BeNull();
+        hs.DateOffsetUnit.Should().BeNull();
+    }
+
+    [Fact]
+    public void Update_RoundTripsDateTimeFields()
+    {
+        var hs = Hotstring.Create(
+            Guid.NewGuid(), new HotstringDefinition("x", "y", null, true, true, false), _clock);
+
+        hs.Update(new HotstringDefinition("x", "y", null, true, true, false,
+            HotstringKind.DateTime, DateTimeFormat: "HH:mm:ss",
+            DateOffsetAmount: -1, DateOffsetUnit: DateOffsetUnit.Hours), _clock);
+
+        hs.DateTimeFormat.Should().Be("HH:mm:ss");
+        hs.DateOffsetAmount.Should().Be(-1);
+        hs.DateOffsetUnit.Should().Be(DateOffsetUnit.Hours);
+    }
+
+    [Fact]
+    public void Restore_RoundTripsDateTimeFields()
+    {
+        DateTimeOffset createdAt = DateTimeOffset.UtcNow.AddDays(-2);
+
+        var hs = Hotstring.Restore(
+            Guid.NewGuid(), Guid.NewGuid(),
+            new HotstringDefinition("x", "y", null, true, true, false,
+                HotstringKind.DateTime, DateTimeFormat: "MMMM d",
+                DateOffsetAmount: 30, DateOffsetUnit: DateOffsetUnit.Minutes),
+            createdAt, _clock);
+
+        hs.CreatedAt.Should().Be(createdAt);
+        hs.DateTimeFormat.Should().Be("MMMM d");
+        hs.DateOffsetAmount.Should().Be(30);
+        hs.DateOffsetUnit.Should().Be(DateOffsetUnit.Minutes);
+    }
 }

--- a/tests/AHKFlowApp.Infrastructure.Tests/Persistence/HotstringPersistenceTests.cs
+++ b/tests/AHKFlowApp.Infrastructure.Tests/Persistence/HotstringPersistenceTests.cs
@@ -44,4 +44,45 @@ public sealed class HotstringPersistenceTests(SqlContainerFixture sqlFixture)
         reloaded.IsCaseSensitive.Should().BeTrue();
         reloaded.OmitEndingCharacter.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task SaveAndReload_DateTimeFields_RoundTrip()
+    {
+        var csb = new SqlConnectionStringBuilder(sqlFixture.ConnectionString)
+        {
+            InitialCatalog = "HotstringPersistenceTests",
+        };
+        DbContextOptions<AppDbContext> options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlServer(csb.ConnectionString, sql => sql.EnableRetryOnFailure())
+            .Options;
+
+        Hotstring entityWithDateTime = new HotstringBuilder()
+            .WithKind(HotstringKind.DateTime)
+            .WithDateTimeFormat("yyyy-MM-dd")
+            .WithDateOffset(3, DateOffsetUnit.Days)
+            .Build();
+
+        Hotstring entityWithoutDateTime = new HotstringBuilder()
+            .WithKind(HotstringKind.Text)
+            .Build();
+
+        await using (AppDbContext write = new(options))
+        {
+            await write.Database.MigrateAsync();
+            write.Hotstrings.AddRange(entityWithDateTime, entityWithoutDateTime);
+            await write.SaveChangesAsync();
+        }
+
+        await using AppDbContext read = new(options);
+        Hotstring reloadedWithDateTime = await read.Hotstrings.SingleAsync(h => h.Id == entityWithDateTime.Id);
+        Hotstring reloadedWithoutDateTime = await read.Hotstrings.SingleAsync(h => h.Id == entityWithoutDateTime.Id);
+
+        reloadedWithDateTime.DateTimeFormat.Should().Be("yyyy-MM-dd");
+        reloadedWithDateTime.DateOffsetAmount.Should().Be(3);
+        reloadedWithDateTime.DateOffsetUnit.Should().Be(DateOffsetUnit.Days);
+
+        reloadedWithoutDateTime.DateTimeFormat.Should().BeNull();
+        reloadedWithoutDateTime.DateOffsetAmount.Should().BeNull();
+        reloadedWithoutDateTime.DateOffsetUnit.Should().BeNull();
+    }
 }

--- a/tests/AHKFlowApp.TestUtilities/Builders/HotstringBuilder.cs
+++ b/tests/AHKFlowApp.TestUtilities/Builders/HotstringBuilder.cs
@@ -17,6 +17,9 @@ public sealed class HotstringBuilder
     private HotstringKind _kind = HotstringKind.Text;
     private bool _isCaseSensitive;
     private bool _omitEndingCharacter;
+    private string? _dateTimeFormat;
+    private int? _dateOffsetAmount;
+    private DateOffsetUnit? _dateOffsetUnit;
     private TimeProvider _clock = TimeProvider.System;
 
     public HotstringBuilder WithOwner(Guid ownerOid)
@@ -93,6 +96,19 @@ public sealed class HotstringBuilder
         return this;
     }
 
+    public HotstringBuilder WithDateTimeFormat(string format)
+    {
+        _dateTimeFormat = format;
+        return this;
+    }
+
+    public HotstringBuilder WithDateOffset(int amount, DateOffsetUnit unit)
+    {
+        _dateOffsetAmount = amount;
+        _dateOffsetUnit = unit;
+        return this;
+    }
+
     public HotstringBuilder WithCategory(Guid categoryId)
     {
         _categoryIds.Add(categoryId);
@@ -119,7 +135,8 @@ public sealed class HotstringBuilder
             new HotstringDefinition(
                 _trigger, _replacement, _description, _appliesToAllProfiles,
                 _isEndingCharacterRequired, _isTriggerInsideWord,
-                _kind, _isCaseSensitive, _omitEndingCharacter),
+                _kind, _isCaseSensitive, _omitEndingCharacter,
+                _dateTimeFormat, _dateOffsetAmount, _dateOffsetUnit),
             _clock);
 
         foreach (Guid pid in _profileIds)

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -362,6 +362,25 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         item.DateTimeFormat.Should().Be("yyyy-MM-dd");
     }
 
+    [Fact]
+    public async Task SwitchToDateTime_WithNonEmptyReplacement_PromptsConfirmation()
+    {
+        // Mirrors SwitchAwayFromDateTime_WithFormatSet_PromptsConfirmation for the opposite
+        // direction: Text -> DateTime with a non-empty Replacement should prompt for
+        // confirmation and leave the model untouched until it resolves.
+        HotstringEditModel item = new() { Trigger = "btw", Kind = HotstringKind.Text, Replacement = "by the way" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Date & time")).Click();
+
+        // A confirmation MudMessageBox should now be present in the DOM (rendered by the same
+        // MudDialogProvider), and the underlying model must remain untouched until it resolves.
+        provider.WaitForAssertion(() => provider.Markup.Should().Contain("Switching to Date &amp; time"));
+        item.Kind.Should().Be(HotstringKind.Text);
+        item.Replacement.Should().Be("by the way");
+    }
+
     private async Task<IRenderedComponent<MudDialogProvider>> RenderDialogAsync(HotstringEditModel? item = null)
     {
         Render<MudPopoverProvider>();

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -217,4 +217,175 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
             Arg.Is<CreateHotstringDto>(d => d.IsCaseSensitive && d.OmitEndingCharacter),
             Arg.Any<CancellationToken>()));
     }
+
+    [Fact]
+    public async Task KindSelector_Renders()
+    {
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]").Should().NotBeNull());
+    }
+
+    [Fact]
+    public async Task SwitchToDateTime_WithEmptyReplacement_HidesReplacementAndShowsDateTimePanel()
+    {
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Date & time")).Click();
+
+        provider.WaitForAssertion(() =>
+        {
+            provider.FindAll("textarea[data-test=\"replacement-input\"]").Should().BeEmpty();
+            provider.Find("[data-test=\"datetime-format-select\"]").Should().NotBeNull();
+        });
+    }
+
+    [Fact]
+    public async Task SelectingPreset_SetsFormatAndRoundTripsIntoSavedDto()
+    {
+        HotstringDto created = new(Guid.NewGuid(), [], true, "date", "", null, true, true,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        _api.CreateAsync(Arg.Any<CreateHotstringDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringDto>.Ok(created));
+
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Date & time")).Click();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"datetime-format-select\"]"));
+
+        await SelectFormatAsync(provider, "yyyy-MM-dd");
+
+        provider.Find("input[data-test=\"trigger-input\"]").Change("date");
+        provider.Find("button.commit-edit").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).CreateAsync(
+            Arg.Is<CreateHotstringDto>(d => d.Kind == HotstringKind.DateTime
+                && d.DateTimeFormat == "yyyy-MM-dd"
+                && d.Replacement == ""),
+            Arg.Any<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task SelectingCustom_RevealsCustomFormatField()
+    {
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Date & time")).Click();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"datetime-format-select\"]"));
+
+        await SelectFormatAsync(provider, "__custom__");
+
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"datetime-format-custom\"]").Should().NotBeNull());
+    }
+
+    [Fact]
+    public async Task Preview_ShowsFormattedOutputForValidFormat_AndInvalidFormatFallback()
+    {
+        HotstringEditModel item = new() { Trigger = "d", DateTimeFormat = "yyyy", Kind = HotstringKind.DateTime };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"datetime-preview\"]").TextContent.Trim()
+            .Should().Be(DateTime.Now.Year.ToString()));
+
+        item.DateTimeFormat = "yyyy'unterminated";
+        provider.Render();
+
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"datetime-preview\"]").TextContent.Should().Contain("Invalid format"));
+    }
+
+    [Fact]
+    public async Task OffsetSwitch_TogglingOnAndOff_AddsAndRemovesFieldsAndNullsDefaults()
+    {
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Date & time")).Click();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"date-offset-switch\"]"));
+
+        provider.FindAll("[data-test=\"date-offset-amount\"]").Should().BeEmpty();
+
+        provider.Find("input[data-test=\"date-offset-switch\"]").Change(true);
+
+        provider.WaitForAssertion(() =>
+        {
+            provider.Find("input[data-test=\"date-offset-amount\"]").GetAttribute("value").Should().Be("1");
+            provider.Find("[data-test=\"date-offset-unit\"]").Should().NotBeNull();
+        });
+
+        provider.Find("input[data-test=\"date-offset-switch\"]").Change(false);
+
+        provider.WaitForAssertion(() => provider.FindAll("[data-test=\"date-offset-amount\"]").Should().BeEmpty());
+    }
+
+    [Fact]
+    public async Task Save_WithDateTimeKind_PostsDtoWithEmptyReplacement()
+    {
+        HotstringDto created = new(Guid.NewGuid(), [], true, "date", "", null, true, true,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        _api.CreateAsync(Arg.Any<CreateHotstringDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringDto>.Ok(created));
+
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Date & time")).Click();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"datetime-format-select\"]"));
+        await SelectFormatAsync(provider, "yyyy-MM-dd");
+
+        provider.Find("input[data-test=\"trigger-input\"]").Change("date");
+        provider.Find("button.commit-edit").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).CreateAsync(
+            Arg.Is<CreateHotstringDto>(d => d.Kind == HotstringKind.DateTime && d.Replacement == ""),
+            Arg.Any<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task SwitchAwayFromDateTime_WithFormatSet_PromptsConfirmation()
+    {
+        // MudBlazor's IDialogService.ShowMessageBoxAsync opens a MudMessageBox rendered by the
+        // same MudDialogProvider used for the edit dialog itself. bUnit renders it inline, so we
+        // assert on the underlying model state (via a re-render probe) rather than trying to
+        // synchronously await the nested dialog's result from the click handler.
+        HotstringEditModel item = new() { Trigger = "date", Kind = HotstringKind.DateTime, DateTimeFormat = "yyyy-MM-dd" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Trim() == "Text").Click();
+
+        // A confirmation MudMessageBox should now be present in the DOM (rendered by the same
+        // MudDialogProvider), and the underlying model must remain untouched until it resolves.
+        provider.WaitForAssertion(() => provider.Markup.Should().Contain("Switching to Text"));
+        item.Kind.Should().Be(HotstringKind.DateTime);
+        item.DateTimeFormat.Should().Be("yyyy-MM-dd");
+    }
+
+    private async Task<IRenderedComponent<MudDialogProvider>> RenderDialogAsync(HotstringEditModel? item = null)
+    {
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+
+        await provider.InvokeAsync(async () =>
+        {
+            IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+            DialogParameters parameters = new()
+            {
+                [nameof(HotstringEditDialog.Profiles)] = (IReadOnlyList<ProfileDto>)[],
+                [nameof(HotstringEditDialog.Categories)] = (IReadOnlyList<CategoryDto>)[],
+            };
+            if (item is not null)
+                parameters[nameof(HotstringEditDialog.Item)] = item;
+
+            await dialogService.ShowAsync<HotstringEditDialog>("Edit", parameters,
+                new DialogOptions { FullScreen = true, CloseButton = false });
+        });
+
+        return provider;
+    }
+
+    private static Task SelectFormatAsync(IRenderedComponent<MudDialogProvider> provider, string format) =>
+        provider.InvokeAsync(() =>
+            provider.FindComponent<MudSelect<string>>().Instance.ValueChanged.InvokeAsync(format));
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringHistoryDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringHistoryDialogTests.cs
@@ -117,4 +117,36 @@ public sealed class HotstringHistoryDialogTests : BunitContext, IAsyncLifetime
         provider.WaitForAssertion(() =>
             _api.Received(1).RevertAsync(_id, 1, Arg.Any<CancellationToken>()));
     }
+
+    [Fact]
+    public async Task Dialog_SelectDateTimeVersion_RendersFormatSummaryNotBlankReplacement()
+    {
+        HotstringSnapshot snapshot = new(
+            "todaydate",
+            "",
+            null,
+            true,
+            true,
+            true,
+            [],
+            [],
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow,
+            HotstringKind.DateTime,
+            "yyyy-MM-dd",
+            1,
+            DateOffsetUnit.Days);
+        _api.GetHistoryAsync(_id, Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HistoryEntryDto[]>.Ok([new(1, HistoryChangeType.Edit, DateTimeOffset.UtcNow)]));
+        _api.GetHistoryVersionAsync(_id, 1, Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringHistoryVersionDto>.Ok(
+                new HotstringHistoryVersionDto(1, HistoryChangeType.Edit, DateTimeOffset.UtcNow, snapshot)));
+
+        IRenderedComponent<MudDialogProvider> provider = await OpenDialogAsync();
+        provider.WaitForAssertion(() => provider.Markup.Should().Contain("v1"));
+
+        await provider.InvokeAsync(() => provider.Find("button.history-version").Click());
+
+        provider.WaitForAssertion(() => provider.Markup.Should().Contain("yyyy-MM-dd (+1 day)"));
+    }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
@@ -24,6 +24,9 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
     private static HotstringEditModel Item(string trigger = "btw", string replacement = "by the way") =>
         new() { Id = Guid.NewGuid(), Trigger = trigger, Replacement = replacement };
 
+    private static HotstringEditModel DateTimeItem(string trigger = "now", string format = "yyyy-MM-dd") =>
+        new() { Id = Guid.NewGuid(), Trigger = trigger, Replacement = "", Kind = HotstringKind.DateTime, DateTimeFormat = format };
+
     [Fact]
     public void Renders_TriggerAndReplacement_PerRow()
     {
@@ -145,6 +148,34 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
         {
             cut.Markup.Should().Contain("Case:");
             cut.Markup.Should().Contain("Omit end-char:");
+        });
+    }
+
+    [Fact]
+    public void DateTimeRow_ShowsSummaryInReplacementCell()
+    {
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [DateTimeItem()])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        cut.Find("td.replacement-cell").TextContent.Should().Be("yyyy-MM-dd");
+    }
+
+    [Fact]
+    public async Task DateTimeRow_Expanded_ShowsFormatLine_NotReplacementLine()
+    {
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [DateTimeItem()])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        await cut.InvokeAsync(() => cut.Find("tr.mobile-row").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("Format:");
+            cut.Markup.Should().NotContain("Replacement:");
         });
     }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -513,8 +513,28 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         IRenderedComponent<Hotstrings> cut = RenderPage();
         cut.WaitForAssertion(() => cut.Find("[data-test=\"kind-filter\"]"));
 
-        await cut.InvokeAsync(() =>
-            cut.FindComponent<MudSelect<HotstringKind?>>().Instance.ValueChanged.InvokeAsync(HotstringKind.DateTime));
+        IRenderedComponent<MudSelect<HotstringKind?>> desktopKindFilter = cut
+            .FindComponents<MudSelect<HotstringKind?>>()
+            .Single(c => c.Markup.Contains("data-test=\"kind-filter\""));
+        await cut.InvokeAsync(() => desktopKindFilter.Instance.ValueChanged.InvokeAsync(HotstringKind.DateTime));
+
+        cut.WaitForAssertion(() => _api.Received().ListAsync(
+            Arg.Is<HotstringListRequest>(r => r.Kind == HotstringKind.DateTime),
+            Arg.Any<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task Page_MobileKindFilter_ReloadsDataWithSelectedKind()
+    {
+        StubList(Page());
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find("[data-test=\"kind-filter-mobile\"]"));
+
+        IRenderedComponent<MudSelect<HotstringKind?>> mobileKindFilter = cut
+            .FindComponents<MudSelect<HotstringKind?>>()
+            .Single(c => c.Markup.Contains("data-test=\"kind-filter-mobile\""));
+        await cut.InvokeAsync(() => mobileKindFilter.Instance.ValueChanged.InvokeAsync(HotstringKind.DateTime));
 
         cut.WaitForAssertion(() => _api.Received().ListAsync(
             Arg.Is<HotstringListRequest>(r => r.Kind == HotstringKind.DateTime),

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -474,4 +474,50 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
             provider.Find("input[data-test=\"trigger-input\"]").GetAttribute("value").Should().Be("btw"));
         return Task.CompletedTask;
     }
+
+    [Fact]
+    public Task Page_DateTimeRow_ShowsDateTimeSummaryInReplacementColumn()
+    {
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "now", "", null, true, true,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.DateTime,
+            DateTimeFormat: "yyyy-MM-dd");
+        StubList(Page(dto));
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("yyyy-MM-dd"));
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task Page_DateTimeRow_HidesStartEditPencil_TextRowKeepsIt()
+    {
+        var dateTimeDto = new HotstringDto(Guid.NewGuid(), [], true, "now", "", null, true, true,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.DateTime,
+            DateTimeFormat: "yyyy-MM-dd");
+        var textDto = new HotstringDto(Guid.NewGuid(), [], true, "btw", "by the way", null, true, true,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.Text);
+        StubList(Page(dateTimeDto, textDto));
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+
+        cut.WaitForAssertion(() => cut.FindAll("button.start-edit").Count.Should().Be(1));
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Page_KindFilter_ReloadsDataWithSelectedKind()
+    {
+        StubList(Page());
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find("[data-test=\"kind-filter\"]"));
+
+        await cut.InvokeAsync(() =>
+            cut.FindComponent<MudSelect<HotstringKind?>>().Instance.ValueChanged.InvokeAsync(HotstringKind.DateTime));
+
+        cut.WaitForAssertion(() => _api.Received().ListAsync(
+            Arg.Is<HotstringListRequest>(r => r.Kind == HotstringKind.DateTime),
+            Arg.Any<CancellationToken>()));
+    }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Validation/HotstringEditModelTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Validation/HotstringEditModelTests.cs
@@ -157,4 +157,165 @@ public sealed class HotstringEditModelTests
         clone.IsCaseSensitive.Should().BeTrue();
         clone.OmitEndingCharacter.Should().BeTrue();
     }
+
+    [Fact]
+    public void FromDto_AndClone_PreserveDateTimeFields()
+    {
+        HotstringDto dto = new(Guid.NewGuid(), [], true, "now", "", null, true, false,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null,
+            HotstringKind.DateTime, DateTimeFormat: "yyyy-MM-dd", DateOffsetAmount: 3, DateOffsetUnit: DateOffsetUnit.Days);
+
+        HotstringEditModel clone = HotstringEditModel.FromDto(dto).Clone();
+
+        clone.Kind.Should().Be(HotstringKind.DateTime);
+        clone.DateTimeFormat.Should().Be("yyyy-MM-dd");
+        clone.DateOffsetAmount.Should().Be(3);
+        clone.DateOffsetUnit.Should().Be(DateOffsetUnit.Days);
+    }
+
+    [Fact]
+    public void ToCreateDto_And_ToUpdateDto_ThreadDateTimeFields()
+    {
+        HotstringEditModel model = new()
+        {
+            Trigger = "now",
+            Kind = HotstringKind.DateTime,
+            DateTimeFormat = "HH:mm",
+            DateOffsetAmount = -1,
+            DateOffsetUnit = DateOffsetUnit.Hours,
+        };
+
+        CreateHotstringDto createDto = model.ToCreateDto();
+        UpdateHotstringDto updateDto = model.ToUpdateDto();
+
+        createDto.DateTimeFormat.Should().Be("HH:mm");
+        createDto.DateOffsetAmount.Should().Be(-1);
+        createDto.DateOffsetUnit.Should().Be(DateOffsetUnit.Hours);
+        updateDto.DateTimeFormat.Should().Be("HH:mm");
+        updateDto.DateOffsetAmount.Should().Be(-1);
+        updateDto.DateOffsetUnit.Should().Be(DateOffsetUnit.Hours);
+    }
+
+    [Fact]
+    public void ToCreateDto_And_ToUpdateDto_ForceEmptyReplacement_ForDateTimeKind_EvenWithStaleText()
+    {
+        HotstringEditModel model = new()
+        {
+            Trigger = "now",
+            Replacement = "stale leftover text",
+            Kind = HotstringKind.DateTime,
+            DateTimeFormat = "yyyy",
+        };
+
+        CreateHotstringDto createDto = model.ToCreateDto();
+        UpdateHotstringDto updateDto = model.ToUpdateDto();
+
+        createDto.Replacement.Should().BeEmpty();
+        updateDto.Replacement.Should().BeEmpty();
+        // The model's own Replacement is untouched — ToCreateDto/ToUpdateDto must not mutate it.
+        model.Replacement.Should().Be("stale leftover text");
+    }
+
+    [Fact]
+    public void ToCreateDto_DoesNotForceEmptyReplacement_ForTextKind()
+    {
+        HotstringEditModel model = new()
+        {
+            Trigger = "btw",
+            Replacement = "by the way",
+            Kind = HotstringKind.Text,
+        };
+
+        CreateHotstringDto dto = model.ToCreateDto();
+
+        dto.Replacement.Should().Be("by the way");
+    }
+
+    [Theory]
+    [InlineData(HotstringKind.Text, true)]
+    [InlineData(HotstringKind.DateTime, false)]
+    [InlineData(HotstringKind.Macro, false)]
+    [InlineData(HotstringKind.Script, false)]
+    public void IsInlineEditable_OnlyTrueForTextKind(HotstringKind kind, bool expected)
+    {
+        HotstringEditModel model = new() { Kind = kind };
+
+        model.IsInlineEditable.Should().Be(expected);
+    }
+
+    [Fact]
+    public void DateTimeSummary_IsNull_ForNonDateTimeKind()
+    {
+        HotstringEditModel model = new() { Kind = HotstringKind.Text, DateTimeFormat = "yyyy" };
+
+        model.DateTimeSummary.Should().BeNull();
+    }
+
+    [Fact]
+    public void DateTimeSummary_IsEmDash_WhenFormatIsNull()
+    {
+        HotstringEditModel model = new() { Kind = HotstringKind.DateTime, DateTimeFormat = null };
+
+        model.DateTimeSummary.Should().Be("—");
+    }
+
+    [Fact]
+    public void DateTimeSummary_IsRawFormat_WhenNoOffset()
+    {
+        HotstringEditModel model = new() { Kind = HotstringKind.DateTime, DateTimeFormat = "yyyy-MM-dd" };
+
+        model.DateTimeSummary.Should().Be("yyyy-MM-dd");
+    }
+
+    [Theory]
+    [InlineData(1, DateOffsetUnit.Days, "yyyy-MM-dd (+1 day)")]
+    [InlineData(-1, DateOffsetUnit.Days, "yyyy-MM-dd (-1 day)")]
+    [InlineData(3, DateOffsetUnit.Days, "yyyy-MM-dd (+3 days)")]
+    [InlineData(-3, DateOffsetUnit.Hours, "yyyy-MM-dd (-3 hours)")]
+    [InlineData(0, DateOffsetUnit.Minutes, "yyyy-MM-dd (+0 minutes)")]
+    public void DateTimeSummary_FormatsOffset_MatchingCliConvention(int amount, DateOffsetUnit unit, string expected)
+    {
+        HotstringEditModel model = new()
+        {
+            Kind = HotstringKind.DateTime,
+            DateTimeFormat = "yyyy-MM-dd",
+            DateOffsetAmount = amount,
+            DateOffsetUnit = unit,
+        };
+
+        model.DateTimeSummary.Should().Be(expected);
+    }
+
+    [Fact]
+    public void SafePreview_ReturnsEmpty_ForNullOrEmptyFormat()
+    {
+        HotstringEditModel.SafePreview(null).Should().BeEmpty();
+        HotstringEditModel.SafePreview("").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SafePreview_MultiCharFormat_ProducesNonEmptyResult()
+    {
+        string preview = HotstringEditModel.SafePreview("yyyy-MM-dd");
+
+        preview.Should().NotBeNullOrEmpty();
+        preview.Should().NotBe("Invalid format");
+    }
+
+    [Fact]
+    public void SafePreview_SingleCharFormat_UsesCustomSpecifier_NotStandardSpecifier()
+    {
+        string preview = HotstringEditModel.SafePreview("d");
+
+        preview.Should().Be(DateTime.Now.ToString("%d"));
+        preview.Should().NotContain("/");
+    }
+
+    [Fact]
+    public void SafePreview_InvalidFormat_ReturnsInvalidMessage()
+    {
+        string preview = HotstringEditModel.SafePreview("yyyy-QQQQQQ-XY\\");
+
+        preview.Should().Be("Invalid format");
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a **DateTime** hotstring kind: users pick a curated date/time format (12 presets or custom) plus an optional date offset (amount + unit), emitted as `:X*:trig::SendText(FormatTime(A_Now, "..."))` (or with `DateAdd(...)` for offsets) instead of literal replacement text.
- Full stack: Domain/EF migration, AHK emitter, kind-conditional FluentValidation with a format-string security whitelist, DTOs/API/list-query (filter/sort/search by kind and format), history-snapshot round-trip, seed data (`/today`, `/now`), CLI table display, and the full Blazor frontend (edit dialog with kind toggle + format/offset panel + live preview, grid/mobile rendering with kind filter, history dialog).
- Fixes a post-implementation review finding: the mobile list view sent `Kind` in its list request but had no visible control to set it — added a mobile "Type" filter mirroring the desktop one.

## Test plan
- [x] `dotnet build` — 0 errors/warnings
- [x] `dotnet test` — full suite passing (Domain, Application incl. Testcontainers, Infrastructure, API, UI.Blazor incl. bUnit, CLI)
- [x] `dotnet format --verify-no-changes` — clean
- [x] Manual E2E smoke: created a DateTime hotstring via the dialog, downloaded the profile script, confirmed the exact line `:X*:dd::SendText(FormatTime(A_Now, "yyyy-MM-dd"))`; smoked the DateTime panel (kind toggle, presets, custom format, offset, live preview); confirmed Text-row inline edit still works; confirmed the history dialog renders the date/time summary
- [x] Per-task subagent-driven review (13 tasks) plus a final whole-branch review — approved, ready to merge
- [x] Post-implementation local review addressed (mobile kind-filter gap fixed, with new bUnit coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)