### PR TITLE
fix: no-auth by default in worktrees for local dev

### DIFF
--- a/.agents/worktrees/SKILL.md
+++ b/.agents/worktrees/SKILL.md
@@ -19,6 +19,8 @@ pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name>
 
 It creates the branch, places the worktree under `.claude/worktrees/<name>/`, copies `.worktreeinclude` entries, runs local-dev isolation setup, and prints the worktree path on success.
 
+**Branch naming:** worktree branches insert `wt-` after the type prefix — `fix/wt-<topic>`, `feature/wt-NNN-<topic>` (see AGENTS.md Git Workflow). Pass it explicitly (`-BranchName fix/wt-<topic>`) or name the worktree so the derived branch matches.
+
 **Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
 
 ### Cleanup of merged worktrees on create

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,6 +10,8 @@ Be concise in all interactions. Optimize for readability when writing documentat
 
 At the end of each plan, give me a list of unresolved questions to answer, if any. Make the questions extremely concise. Sacrifice grammar for the sake of concision.
 
+When finalizing a plan or spec (in plan mode: right before calling ExitPlanMode), save it in the repo as `docs/superpowers/plans/YYYY-MM-DD-<topic>-plan.md` or `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` — never only in a local plans folder outside the repo.
+
 Only commit plans/specs to `docs/superpowers/` when they relate to project improvements — code, features, infra, deployment, tests, repo tooling that affects contributors. Skip writing (or keep out-of-repo) plans for Claude Code optimization, personal workflow tuning, agent housekeeping, or one-off context/config cleanups.
 
 ## Workflow Preferences

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
           ./tests/WorktreePowerShellHost.Tests.ps1
           ./tests/WorktreeMergedCleanup.Tests.ps1
           ./tests/WorktreeRemoveHook.Tests.ps1
+          ./tests/WorktreeLocalDevSetup.Tests.ps1
 
   bicep-lint:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,7 @@ running `deploy.ps1`.
 
 GitHub Flow — feature branches from `main`, PR required for all merges.
 Branch naming: `feature/NNN-short-description`, `fix/short-description`, `hotfix/issueid-short-description`
+Branches created in agent git worktrees insert `wt-` after the type prefix: `fix/wt-<topic>`, `feature/wt-NNN-<topic>` — marks worktree-born branches for grepping/cleanup.
 Conventional commits: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:` — body explains "why", not "what".
 Atomic commits: one logical change per commit; feature + its tests = one commit. Don't bundle unrelated changes.
 Never force-push to main/master. Run `dotnet build` + `dotnet test` before creating a PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,12 @@ Azure resources are provisioned per-environment using `.\scripts\deploy.ps1`. Ea
 - API: `http://localhost:5600` (single port for all backend scenarios: VS, docker-compose, Docker-only)
 - Frontend: `http://localhost:5601`
 
+**Local auth:** the main checkout runs real MSAL (Azure AD) by default. Agent git worktrees run
+**no-auth** (test provider, always signed in as "Test User") automatically — `setup-worktree-local-dev.ps1`
+writes both `appsettings.Development.json` files with `Auth:UseTestProvider=true`, so Playwright/E2E get
+full CRUD with no login. Humans in the main checkout opt into no-auth via the `http (No Auth)` frontend
+and `Docker SQL (No Auth)` backend launch profiles.
+
 App Service and SQL Server names include a short deterministic suffix (e.g. `ahkflowapp-api-test-ab12cd`)
 to avoid Azure's global-name collisions. Exact names/URLs are saved to `scripts/.env.<env>` after
 running `deploy.ps1`.

--- a/docs/superpowers/plans/2026-07-09-worktree-noauth-local-dev-plan.md
+++ b/docs/superpowers/plans/2026-07-09-worktree-noauth-local-dev-plan.md
@@ -1,0 +1,64 @@
+# Local No-Auth Mode: Default for Agent Worktrees + Launch Profile + Tests
+
+## Context
+
+Running `dotnet run` in this worktree shows "You are not signed in." and a disabled Add button. The branch code is innocent — the diff touches only hotstring feature files. The real cause: the no-auth toggle `Auth:UseTestProvider` lives in gitignored `appsettings.Development.json` files that worktrees don't inherit. `scripts/setup-worktree-local-dev.ps1` copies the **frontend** dev config from the main checkout (with real Azure AD IDs, no `Auth` key) but has **no backend equivalent**, so a worktree backend always runs real MSAL JWT validation while the frontend either has no signed-in user or (after hand-editing) sends no bearer tokens → 401s.
+
+Goal: AI agents in worktrees get no-auth mode automatically (full CRUD via Playwright, no login); regular users in the main checkout keep MSAL by default with an explicit opt-in profile; tests keep both working.
+
+Design decisions (grilled & confirmed):
+- Worktrees default to no-auth, no opt-out switch (escape hatch: hand-edit generated configs).
+- Script **writes** deterministic minimal configs for both tiers — stops copying MSAL values from main checkout.
+- Human opt-in via new committed `NoAuth` frontend environment + backend launch profile env var.
+- Protection: E2E smoke test + Pester assertions on the setup script (E2E alone wouldn't have caught this bug).
+
+## Key mechanics (verified)
+
+- Frontend `src/Frontend/AHKFlowApp.UI.Blazor/Program.cs:24` — `Auth:UseTestProvider` → `TestAuthenticationProvider` (always authenticated) + all API clients `useAuth:false`; config comes from `wwwroot/appsettings.json` + `appsettings.{Environment}.json` fetched by the browser (env vars can't reach WASM).
+- Backend `src/Backend/AHKFlowApp.API/Program.cs:114–135` — same key → `TestAuthenticationHandler`; guard throws if `true` outside `Development` (keep profiles in Development).
+- Existing committed patterns to mirror: `wwwroot/appsettings.Local.json`, `appsettings.E2E.json` (both `UseTestProvider: true`).
+- E2E fixtures `tests/AHKFlowApp.E2E.Tests/Fixtures/SpaHost.cs` + `ApiFactory.cs` already boot the full stack in test-auth mode.
+- Pester tests live in `tests/Worktree*.Tests.ps1`, run in `.github/workflows/ci.yml`.
+- Worktree creation auto-runs `scripts/new-worktree.ps1` → `setup-worktree-local-dev.ps1` via the `WorktreeCreate` hook — so the script change makes no-auth fully automatic for agents.
+
+## Changes
+
+### 1. `scripts/setup-worktree-local-dev.ps1` — write both dev configs
+- Replace `Write-FrontendWorktreeDevelopmentConfig` (copies main's file, lines ~524–552) with a deterministic write of `src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.Development.json`:
+  `{ "Auth": { "UseTestProvider": true }, "ApiHttpClient": { "BaseAddress": "http://localhost:<worktreeApiPort>" } }`
+- Add `Write-BackendWorktreeDevelopmentConfig` writing `src/Backend/AHKFlowApp.API/appsettings.Development.json` with `{ "Auth": { "UseTestProvider": true } }` (CORS/connection string stay in the existing `Write-BackendWorktreeAppSettings` patching).
+- No real Azure AD IDs ever land in worktrees; both tiers written by one script so they can't disagree.
+
+### 2. Launch profiles for the main checkout (human opt-in)
+- **Frontend:** commit `wwwroot/appsettings.NoAuth.json` — `{ "Auth": { "UseTestProvider": true }, "ApiHttpClient": { "BaseAddress": "http://localhost:5600" } }`. Add profile `"http (No Auth)"` to `src/Frontend/AHKFlowApp.UI.Blazor/Properties/launchSettings.json` with `ASPNETCORE_ENVIRONMENT=NoAuth` (WASM then loads that file; the Development cache-bust overlay at Program.cs:18 is correctly skipped).
+- **Backend:** add profile `"Docker SQL (No Auth)"` to `src/Backend/AHKFlowApp.API/Properties/launchSettings.json` — clone of "Docker SQL (Recommended)" plus `Auth__UseTestProvider=true`; stays `ASPNETCORE_ENVIRONMENT=Development` so the outside-Development guard and dev CORS keep working. Keep it **after** the existing first profile so plain `dotnet run` defaults stay unchanged (MSAL for humans).
+
+### 3. E2E smoke test — `tests/AHKFlowApp.E2E.Tests/LocalAuthModeFlowTests.cs`
+Reuse `SpaHost`/`ApiFactory` fixtures (pattern: `HotkeysMobileFlowTests.cs`):
+1. Assert top bar shows "Test User" and Log out is disabled (local-install-mode signature, `Shared/LoginDisplay.razor`).
+2. Hotstrings page: Add button enabled → create a hotstring → appears in the grid.
+
+### 4. Pester test — `tests/WorktreeLocalDevSetup.Tests.ps1` (or extend an existing Worktree test file if a better fit)
+- After running the setup script against a temp worktree fixture: both `appsettings.Development.json` files exist, both have `Auth.UseTestProvider = true`, frontend `BaseAddress` matches the allocated API port.
+- Register the file in the `ci.yml` Pester step alongside the existing three.
+
+### 5. Docs
+- `AGENTS.md`: short note — worktrees run no-auth (test provider) by default; main checkout uses MSAL; "No Auth" launch profiles for opt-in.
+- `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md` Local Setup section: mention the no-auth path (currently only documents the MSAL copy-example flow).
+- `scripts/README.md`: document the new backend config writer.
+- Spec doc per user prefs: `docs/superpowers/specs/2026-07-09-local-noauth-mode-design.md` (this design, condensed).
+
+### 6. Unbreak this worktree immediately
+Run the updated `setup-worktree-local-dev.ps1` (or write the two dev config files directly) so `dotnet run` works here today with ports from `scripts/.env.worktree` (API 5606 / UI 5607).
+
+## Verification
+
+1. `dotnet build` + `dotnet test` (includes new E2E test; E2E uses Testcontainers SQL).
+2. Run the new Pester test locally: `pwsh -NoProfile -File tests/WorktreeLocalDevSetup.Tests.ps1` (Invoke-Pester).
+3. End-to-end in this worktree: `dotnet run` API + UI, then `playwright-cli` skill — verify signed in as "Test User", add a hotstring without login, no 401s in network log.
+4. Main checkout sanity: plain `dotnet run` still boots the MSAL branch (no behavior change); `dotnet run --launch-profile "http (No Auth)"` + backend "Docker SQL (No Auth)" gives full no-login CRUD.
+
+## Resolved
+
+- Branch: implement in a **new worktree + branch** (e.g. `fix/worktree-noauth-local-dev`) — separate concern from `feature/hotstrings-datetime-kind`. Still write the gitignored dev configs into THIS worktree for immediate relief (step 6; gitignored, doesn't dirty the branch).
+- E2E test stays focused — no sibling-page "not signed in" assertions.

--- a/docs/superpowers/plans/2026-07-09-worktree-noauth-local-dev-plan.md
+++ b/docs/superpowers/plans/2026-07-09-worktree-noauth-local-dev-plan.md
@@ -35,12 +35,15 @@ Design decisions (grilled & confirmed):
 
 ### 3. E2E smoke test — `tests/AHKFlowApp.E2E.Tests/LocalAuthModeFlowTests.cs`
 Reuse `SpaHost`/`ApiFactory` fixtures (pattern: `HotkeysMobileFlowTests.cs`):
-1. Assert top bar shows "Test User" and Log out is disabled (local-install-mode signature, `Shared/LoginDisplay.razor`).
+1. Assert the local-install-mode signature: a **disabled Log out button** (`Shared/LoginDisplay.razor`, only rendered in the Authorized + test-auth branch). Note: `Identity.Name` is null for the synthetic user — no `nameType` on the `TestAuthenticationProvider` claims — so "Test User" does **not** render as text; assert the disabled button, not the name.
 2. Hotstrings page: Add button enabled → create a hotstring → appears in the grid.
 
-### 4. Pester test — `tests/WorktreeLocalDevSetup.Tests.ps1` (or extend an existing Worktree test file if a better fit)
+**Scope:** this E2E only proves UI CRUD under synthetic auth — `SpaHost` injects `Auth:UseTestProvider=true` for every appsettings request and `ApiFactory` registers its own test auth handler, so it does **not** exercise the generated backend/frontend dev configs or the No Auth launch profiles. The real guard for that wiring is the script test in step 4 (asserts the setup script writes both dev configs with `Auth:UseTestProvider=true`); the profiles are covered by the manual check in Verification step 4.
+
+### 4. Script regression test — `tests/WorktreeLocalDevSetup.Tests.ps1`
+Follow the repo convention: a self-running assert-style `.ps1` with local `Assert-*` helpers that CI runs directly (like the existing `Worktree*.Tests.ps1`) — **not** Pester / `Invoke-Pester`.
 - After running the setup script against a temp worktree fixture: both `appsettings.Development.json` files exist, both have `Auth.UseTestProvider = true`, frontend `BaseAddress` matches the allocated API port.
-- Register the file in the `ci.yml` Pester step alongside the existing three.
+- Register the file in the `ci.yml` worktree-PowerShell test step alongside the existing three.
 
 ### 5. Docs
 - `AGENTS.md`: short note — worktrees run no-auth (test provider) by default; main checkout uses MSAL; "No Auth" launch profiles for opt-in.
@@ -49,12 +52,12 @@ Reuse `SpaHost`/`ApiFactory` fixtures (pattern: `HotkeysMobileFlowTests.cs`):
 - Spec doc per user prefs: `docs/superpowers/specs/2026-07-09-local-noauth-mode-design.md` (this design, condensed).
 
 ### 6. Unbreak this worktree immediately
-Run the updated `setup-worktree-local-dev.ps1` (or write the two dev config files directly) so `dotnet run` works here today with ports from `scripts/.env.worktree` (API 5606 / UI 5607).
+Run the updated `setup-worktree-local-dev.ps1` (or write the two dev config files directly) so `dotnet run` works here today. If writing directly, read the current ports from `scripts/.env.worktree` (`AHKFLOW_API_PORT` / `AHKFLOW_UI_PORT`) — don't hard-code them, they vary per worktree.
 
 ## Verification
 
 1. `dotnet build` + `dotnet test` (includes new E2E test; E2E uses Testcontainers SQL).
-2. Run the new Pester test locally: `pwsh -NoProfile -File tests/WorktreeLocalDevSetup.Tests.ps1` (Invoke-Pester).
+2. Run the new script regression test locally: `pwsh -NoProfile -File tests/WorktreeLocalDevSetup.Tests.ps1` (self-running assert-style, no Pester).
 3. End-to-end in this worktree: `dotnet run` API + UI, then `playwright-cli` skill — verify signed in as "Test User", add a hotstring without login, no 401s in network log.
 4. Main checkout sanity: plain `dotnet run` still boots the MSAL branch (no behavior change); `dotnet run --launch-profile "http (No Auth)"` + backend "Docker SQL (No Auth)" gives full no-login CRUD.
 

--- a/docs/superpowers/specs/2026-07-09-local-noauth-mode-design.md
+++ b/docs/superpowers/specs/2026-07-09-local-noauth-mode-design.md
@@ -34,11 +34,16 @@ MSAL JWT validation → 401s.
    `Docker SQL (No Auth)` (clone of the recommended profile + `Auth__UseTestProvider=true`, still
    `ASPNETCORE_ENVIRONMENT=Development`). The default (first) profiles are unchanged → plain
    `dotnet run` stays MSAL.
-3. **Protection:**
+3. **Worktree SQL isolation for all Docker SQL profiles:** the setup script patches compose project,
+   SQL port, and connection string on every launch profile marked `AHKFLOW_START_DOCKER_SQL=true`
+   (not just the recommended one), so running `Docker SQL (No Auth)` inside a worktree can't hit
+   the main checkout's SQL container on 1433.
+4. **Protection:**
    - E2E `LocalAuthModeFlowTests` — app boots as "Test User", Log out disabled, create-hotstring works.
    - Pester `WorktreeLocalDevSetup.Tests.ps1` — runs the setup script against a temp worktree fixture;
      asserts both dev configs exist, both have `Auth.UseTestProvider=true`, frontend `BaseAddress`
-     matches the allocated API port, and no `AzureAd` section leaks in. Registered in `ci.yml`.
+     matches the allocated API port, both Docker SQL launch profiles get the worktree SQL port/compose
+     project, and no `AzureAd` section leaks in. Registered in `ci.yml`.
 
 ## Decisions
 

--- a/docs/superpowers/specs/2026-07-09-local-noauth-mode-design.md
+++ b/docs/superpowers/specs/2026-07-09-local-noauth-mode-design.md
@@ -1,0 +1,47 @@
+# Local No-Auth Mode — Design
+
+## Problem
+
+Agent worktrees showed "You are not signed in." with a disabled Add button. Root cause: the
+no-auth toggle `Auth:UseTestProvider` lives in gitignored `appsettings.Development.json` files that
+worktrees don't inherit. The setup script copied the **frontend** dev config from the main checkout
+(real Azure AD IDs, no `Auth` key) and had **no backend equivalent**, so a worktree backend ran real
+MSAL JWT validation → 401s.
+
+## Goals
+
+- Agent worktrees get no-auth mode automatically (full CRUD via Playwright, no login).
+- Main checkout keeps MSAL by default, with an explicit human opt-in.
+- Tests keep both paths working.
+
+## Mechanics
+
+- Key `Auth:UseTestProvider=true` → frontend `TestAuthenticationProvider` (always authenticated) +
+  API clients `useAuth:false`; backend `TestAuthenticationHandler`. Backend guard throws if the key
+  is true outside `Development`, so all no-auth profiles stay in `Development`.
+- Frontend config is fetched by the browser from `wwwroot/appsettings*.json`; env vars can't reach
+  WASM. The `Development` cache-bust overlay (`Program.cs`) is correctly skipped under a custom
+  environment such as `NoAuth`.
+
+## Design
+
+1. **`setup-worktree-local-dev.ps1`** deterministically **writes** both dev configs (stops copying
+   from the main checkout): frontend `{ Auth.UseTestProvider=true, ApiHttpClient.BaseAddress=<worktree
+   API port> }` and backend `{ Auth.UseTestProvider=true }`. One script writes both, so they can't
+   disagree, and no real Azure AD IDs ever land in a worktree. Both files are gitignored.
+2. **Human opt-in (main checkout):** committed `wwwroot/appsettings.NoAuth.json`; frontend launch
+   profile `http (No Auth)` (`ASPNETCORE_ENVIRONMENT=NoAuth`); backend launch profile
+   `Docker SQL (No Auth)` (clone of the recommended profile + `Auth__UseTestProvider=true`, still
+   `ASPNETCORE_ENVIRONMENT=Development`). The default (first) profiles are unchanged → plain
+   `dotnet run` stays MSAL.
+3. **Protection:**
+   - E2E `LocalAuthModeFlowTests` — app boots as "Test User", Log out disabled, create-hotstring works.
+   - Pester `WorktreeLocalDevSetup.Tests.ps1` — runs the setup script against a temp worktree fixture;
+     asserts both dev configs exist, both have `Auth.UseTestProvider=true`, frontend `BaseAddress`
+     matches the allocated API port, and no `AzureAd` section leaks in. Registered in `ci.yml`.
+
+## Decisions
+
+- Worktrees default to no-auth with no opt-out switch (escape hatch: hand-edit the generated configs).
+- E2E alone wouldn't have caught the original bug (its SpaHost forces test auth regardless), hence the
+  Pester assertions on the script are the primary regression guard.

--- a/plugins/ahkflowapp/skills/worktrees/SKILL.md
+++ b/plugins/ahkflowapp/skills/worktrees/SKILL.md
@@ -19,6 +19,8 @@ pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name>
 
 It creates the branch, places the worktree under `.claude/worktrees/<name>/`, copies `.worktreeinclude` entries, runs local-dev isolation setup, and prints the worktree path on success.
 
+**Branch naming:** worktree branches insert `wt-` after the type prefix — `fix/wt-<topic>`, `feature/wt-NNN-<topic>` (see AGENTS.md Git Workflow). Pass it explicitly (`-BranchName fix/wt-<topic>`) or name the worktree so the derived branch matches.
+
 **Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
 
 ### Cleanup of merged worktrees on create

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,7 +51,7 @@ These form one contract: change them together or not at all. They stay flat in
 
 | File | Purpose |
 | --- | --- |
-| `setup-worktree-local-dev.ps1` | Assigns deterministic localhost ports and writes worktree-local config. |
+| `setup-worktree-local-dev.ps1` | Assigns deterministic localhost ports and writes worktree-local config, including deterministic no-auth `appsettings.Development.json` for both the frontend (`Auth:UseTestProvider=true` + worktree API base address) and backend (`Auth:UseTestProvider=true`), so worktrees never inherit the main checkout's Azure AD IDs. |
 | `remove-worktree-local-dev.ps1` | WorktreeRemove hook: removes the worktree + branch only when the branch is merged into `main` AND the tree is clean (detached HEAD is never eligible); otherwise preserves it and logs manual-cleanup guidance. `AHKFLOW_WORKTREE_FORCE_REMOVE=1` bypasses the gate. |
 | `cleanup-merged-worktrees.ps1` | Detects worktrees merged into `main` and removes the clean ones on opt-in (`-Cleanup`, `AHKFLOW_WORKTREE_CLEANUP=1` for Claude CLI native worktree creation, or the interactive prompt); invoked by `new-worktree.ps1` before it creates a worktree. |
 | `prune-worktree-databases.ps1` | Drops orphaned per-worktree databases with no live git worktree. |

--- a/scripts/setup-worktree-local-dev.ps1
+++ b/scripts/setup-worktree-local-dev.ps1
@@ -40,6 +40,7 @@ $RootKey = "${EnvVarPrefix}ROOT"
 $BackendAppSettingsRelativePath = 'src/Backend/AHKFlowApp.API/appsettings.json'
 $FrontendAppSettingsRelativePath = 'src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.json'
 $FrontendDevelopmentConfigRelativePath = 'src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.Development.json'
+$BackendDevelopmentConfigRelativePath = 'src/Backend/AHKFlowApp.API/appsettings.Development.json'
 $BackendLaunchSettingsRelativePath = 'src/Backend/AHKFlowApp.API/Properties/launchSettings.json'
 $VsCodeLaunchSettingsRelativePath = '.vscode/launch.json'
 $FrontendLaunchSettingsRelativePath = 'src/Frontend/AHKFlowApp.UI.Blazor/Properties/launchSettings.json'
@@ -517,14 +518,13 @@ function Write-FrontendWorktreeAppSettings {
     }
 }
 
-# The frontend's gitignored appsettings.Development.json (local dev config such as auth) is
-# not checked out into a fresh worktree. Copy the main checkout's copy so the worktree app
-# starts, then point its API base address at the worktree. In Development this file is loaded
-# after appsettings.json, so its BaseAddress wins -- which is why the rebase here is required.
+# The frontend's gitignored appsettings.Development.json (local dev config such as auth) is not
+# checked out into a fresh worktree. Write a deterministic no-auth config so agent worktrees get
+# full CRUD via the test auth provider without ever inheriting the main checkout's real Azure AD
+# IDs. In Development this file loads after appsettings.json, so its BaseAddress/Auth win.
 function Write-FrontendWorktreeDevelopmentConfig {
     param(
         [string] $Root,
-        [string] $ConfigRoot,
         [string] $ApiUrl
     )
 
@@ -532,23 +532,30 @@ function Write-FrontendWorktreeDevelopmentConfig {
         return
     }
 
+    # The file is gitignored, so it is written directly (no skip-worktree bookkeeping needed).
     $worktreePath = Join-Path $Root ($FrontendDevelopmentConfigRelativePath -replace '/', '\')
-    $mainPath = Join-Path $ConfigRoot ($FrontendDevelopmentConfigRelativePath -replace '/', '\')
+    Write-JsonFile $worktreePath ([pscustomobject]@{
+        Auth = [pscustomobject]@{ UseTestProvider = $true }
+        ApiHttpClient = [pscustomobject]@{ BaseAddress = $ApiUrl }
+    })
+}
 
-    if (-not (Test-Path -LiteralPath $worktreePath) -and (Test-Path -LiteralPath $mainPath)) {
-        New-Item -ItemType Directory -Path (Split-Path -Parent $worktreePath) -Force | Out-Null
-        Copy-Item -LiteralPath $mainPath -Destination $worktreePath -Force
-    }
+# The backend's gitignored appsettings.Development.json is likewise absent in a fresh worktree, so
+# without this the worktree API runs real MSAL JWT validation and rejects the frontend's test-auth
+# calls (401). Write the no-auth toggle; CORS + connection string stay in Write-BackendWorktreeAppSettings.
+function Write-BackendWorktreeDevelopmentConfig {
+    param(
+        [string] $Root
+    )
 
-    if (-not (Test-Path -LiteralPath $worktreePath)) {
+    if (-not (Test-LinkedWorktree $Root)) {
         return
     }
 
-    # The file is gitignored, so it is written directly (no skip-worktree bookkeeping needed).
-    $config = ConvertFrom-Jsonc (Get-Content -LiteralPath $worktreePath -Raw)
-    Set-JsonSectionValue $config 'ApiHttpClient' 'BaseAddress' $ApiUrl
-    $json = Format-Json ($config | ConvertTo-Json -Depth 16)
-    [System.IO.File]::WriteAllText($worktreePath, $json + [Environment]::NewLine, [System.Text.Encoding]::UTF8)
+    $worktreePath = Join-Path $Root ($BackendDevelopmentConfigRelativePath -replace '/', '\')
+    Write-JsonFile $worktreePath ([pscustomobject]@{
+        Auth = [pscustomobject]@{ UseTestProvider = $true }
+    })
 }
 
 . (Join-Path $PSScriptRoot 'worktree-database.common.ps1')
@@ -662,8 +669,9 @@ function Write-WorktreeConfig {
     # binds and talks to its own ports/DB without any Program.cs wiring in the target.
     Write-BackendWorktreeLaunchSettings $Root $apiUrl
     Write-BackendWorktreeAppSettings $Root $uiUrl $connectionString
+    Write-BackendWorktreeDevelopmentConfig $Root
     Write-FrontendWorktreeAppSettings $Root $apiUrl
-    Write-FrontendWorktreeDevelopmentConfig $Root $ConfigRoot $apiUrl
+    Write-FrontendWorktreeDevelopmentConfig $Root $apiUrl
     Write-FrontendWorktreeLaunchSettings $Root $uiUrl
     Write-VsCodeWorktreeLaunchConfig $Root $apiUrl $uiUrl
     Write-BackendWorktreeDockerProfile $Root $SqlPort $ComposeProject

--- a/scripts/setup-worktree-local-dev.ps1
+++ b/scripts/setup-worktree-local-dev.ps1
@@ -33,9 +33,10 @@ $SqlPortRangeEnd = 14399
 $ReservedSqlPort = 1433
 $SqlPortKey = "${EnvVarPrefix}SQL_PORT"
 $ComposeProjectKey = "${EnvVarPrefix}COMPOSE_PROJECT"
-# The launch profile whose Docker SQL env vars (compose project + SQL port) are patched per
-# worktree. The exporter rebases this literal to the adopting repo's profile name.
-$DockerSqlProfileName = 'Docker SQL (Recommended)'
+# Marker env var identifying launch profiles that boot Docker SQL; every profile carrying it
+# with value 'true' gets its Docker SQL env vars (compose project + SQL port) patched per
+# worktree, so variants like "Docker SQL (No Auth)" stay isolated too.
+$DockerSqlStartFlag = 'AHKFLOW_START_DOCKER_SQL'
 $RootKey = "${EnvVarPrefix}ROOT"
 $BackendAppSettingsRelativePath = 'src/Backend/AHKFlowApp.API/appsettings.json'
 $FrontendAppSettingsRelativePath = 'src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.json'
@@ -625,26 +626,33 @@ function Write-BackendWorktreeDockerProfile {
         param([object] $LaunchSettings)
 
         $profiles = $LaunchSettings.profiles
-        if (($profiles.PSObject.Properties.Name) -notcontains $DockerSqlProfileName) {
-            if ($composeIntended) {
-                Write-Host "WARNING: found docker-compose.yml but no '$DockerSqlProfileName' launch profile; Docker SQL per-worktree isolation was not applied. Add that profile, or set DockerSqlProfileName when exporting the isolation kit."
+        $patched = 0
+
+        foreach ($profileName in $profiles.PSObject.Properties.Name) {
+            $launchProfile = $profiles.$profileName
+            if (($launchProfile.PSObject.Properties.Name) -notcontains 'environmentVariables') {
+                continue
             }
-            return
+
+            $env = $launchProfile.environmentVariables
+            if (($env.PSObject.Properties.Name) -notcontains $DockerSqlStartFlag -or
+                [string] $env.$DockerSqlStartFlag -ne 'true') {
+                continue
+            }
+
+            Set-NoteProperty $env 'COMPOSE_PROJECT_NAME' $ComposeProject
+            Set-NoteProperty $env 'AHKFLOW_SQL_PORT' ([string] $SqlPort)
+
+            if (($env.PSObject.Properties.Name) -contains 'ConnectionStrings__DefaultConnection') {
+                $builder = New-Object System.Data.SqlClient.SqlConnectionStringBuilder([string] $env.'ConnectionStrings__DefaultConnection')
+                $builder['Data Source'] = "localhost,$SqlPort"
+                $env.'ConnectionStrings__DefaultConnection' = $builder.ConnectionString
+            }
+            $patched++
         }
 
-        $env = $profiles.$DockerSqlProfileName.environmentVariables
-        if (-not $env) {
-            Write-Host "WARNING: launch profile '$DockerSqlProfileName' has no environmentVariables block; Docker SQL per-worktree isolation (compose project + SQL port) was not applied."
-            return
-        }
-
-        Set-NoteProperty $env 'COMPOSE_PROJECT_NAME' $ComposeProject
-        Set-NoteProperty $env 'AHKFLOW_SQL_PORT' ([string] $SqlPort)
-
-        if (($env.PSObject.Properties.Name) -contains 'ConnectionStrings__DefaultConnection') {
-            $builder = New-Object System.Data.SqlClient.SqlConnectionStringBuilder([string] $env.'ConnectionStrings__DefaultConnection')
-            $builder['Data Source'] = "localhost,$SqlPort"
-            $env.'ConnectionStrings__DefaultConnection' = $builder.ConnectionString
+        if ($patched -eq 0 -and $composeIntended) {
+            Write-Host "WARNING: found docker-compose.yml but no launch profile with $DockerSqlStartFlag=true; Docker SQL per-worktree isolation (compose project + SQL port) was not applied."
         }
     }
 }

--- a/src/Backend/AHKFlowApp.API/Properties/launchSettings.json
+++ b/src/Backend/AHKFlowApp.API/Properties/launchSettings.json
@@ -14,6 +14,20 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5600"
     },
+    "Docker SQL (No Auth)": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "AHKFLOW_START_DOCKER_SQL": "true",
+        "COMPOSE_PROJECT_NAME": "ahkflowapp",
+        "ConnectionStrings__DefaultConnection": "Server=localhost,1433;Database=AHKFlowAppDb;User Id=sa;Password=Dev!LocalOnly_2026;TrustServerCertificate=True;MultipleActiveResultSets=true",
+        "Auth__UseTestProvider": "true"
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5600"
+    },
     "LocalDB SQL": {
       "commandName": "Project",
       "launchBrowser": true,

--- a/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
@@ -27,11 +27,18 @@ params. The server is optional and configured locally (per-developer MCP setup).
 
 ## Local Setup
 
-`wwwroot/appsettings.Development.json` is gitignored. Copy the example and fill in your Azure AD values:
+`wwwroot/appsettings.Development.json` is gitignored. Two paths:
+
+**MSAL (real Azure AD):** copy the example and fill in your Azure AD values:
 
 ```bash
 cp wwwroot/appsettings.Development.json.example wwwroot/appsettings.Development.json
 ```
+
+**No-auth (test provider, always signed in):** run with the `http (No Auth)` launch profile
+(`ASPNETCORE_ENVIRONMENT=NoAuth` → loads committed `wwwroot/appsettings.NoAuth.json` with
+`Auth:UseTestProvider=true`), paired with the API's `Docker SQL (No Auth)` profile. Git worktrees
+get this automatically via `setup-worktree-local-dev.ps1` (no example copy needed).
 
 ## Adding a Page
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Properties/launchSettings.json
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Properties/launchSettings.json
@@ -10,6 +10,16 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "http (No Auth)": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "applicationUrl": "http://localhost:5601",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "NoAuth"
+      }
     }
   }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.NoAuth.json
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.NoAuth.json
@@ -1,0 +1,4 @@
+{
+  "Auth": { "UseTestProvider": true },
+  "ApiHttpClient": { "BaseAddress": "http://localhost:5600" }
+}

--- a/tests/AHKFlowApp.E2E.Tests/LocalAuthModeFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/LocalAuthModeFlowTests.cs
@@ -1,0 +1,44 @@
+using AHKFlowApp.E2E.Tests.Fixtures;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace AHKFlowApp.E2E.Tests;
+
+// Guards the local no-auth (test provider) mode agent worktrees and the "No Auth" launch profiles
+// rely on: the app boots already signed in as the synthetic user and full CRUD works with no login.
+[Collection(E2ETestCollection.Name)]
+public sealed class LocalAuthModeFlowTests(StackFixture fixture) : IAsyncLifetime
+{
+    public Task InitializeAsync() =>
+        fixture.ResetDataAsync();
+
+    public Task DisposeAsync() =>
+        Task.CompletedTask;
+
+    [Fact]
+    public async Task LocalInstallMode_SignsInSyntheticUserAndAllowsCrud()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync();
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotstrings");
+        await page.WaitForSelectorAsync("button.add-hotstring");
+
+        // Local-install-mode signature (Shared/LoginDisplay.razor): a *disabled* Log out button only
+        // renders in the Authorized + test-auth branch, so it proves both "signed in" and no-auth mode.
+        // The app bar sits behind an async AuthorizeView, so wait for it rather than snapshotting.
+        ILocator logOut = page.Locator("button:has-text(\"Log out\")");
+        await logOut.WaitForAsync();
+        Assert.True(await logOut.IsDisabledAsync());
+
+        // Full CRUD works without any login step.
+        await page.ClickAsync("button.add-hotstring");
+        await page.WaitForSelectorAsync("tr.draft-row");
+        await page.FillAsync("input[data-test=\"trigger-input\"]", "btw");
+        await page.FillAsync("textarea[data-test=\"replacement-input\"]", "by the way");
+        await page.ClickAsync("button.commit-edit");
+
+        await page.WaitForSelectorAsync("text=Hotstring created.");
+        await page.WaitForSelectorAsync("tbody tr:has-text(\"btw\")");
+    }
+}

--- a/tests/WorktreeLocalDevSetup.Tests.ps1
+++ b/tests/WorktreeLocalDevSetup.Tests.ps1
@@ -54,6 +54,50 @@ function New-TempMainCheckout {
     } | ConvertTo-Json -Depth 8
     Set-Content -LiteralPath (Join-Path $backendDir 'appsettings.json') -Value $appsettings -Encoding utf8
 
+    # Mirror the real backend launchSettings: two Docker SQL profiles (marker
+    # AHKFLOW_START_DOCKER_SQL=true) that must both get per-worktree SQL isolation, and a
+    # LocalDB profile that must stay untouched.
+    $launchSettingsDir = Join-Path $backendDir 'Properties'
+    New-Item -ItemType Directory -Path $launchSettingsDir -Force | Out-Null
+    $connection = 'Server=localhost,1433;Database=AHKFlowAppDb;User Id=sa;Password=Dev!LocalOnly_2026;TrustServerCertificate=True;MultipleActiveResultSets=true'
+    $launchSettings = @{
+        profiles = @{
+            'Docker SQL (Recommended)' = @{
+                commandName = 'Project'
+                environmentVariables = @{
+                    ASPNETCORE_ENVIRONMENT = 'Development'
+                    AHKFLOW_START_DOCKER_SQL = 'true'
+                    COMPOSE_PROJECT_NAME = 'ahkflowapp'
+                    ConnectionStrings__DefaultConnection = $connection
+                }
+                applicationUrl = 'http://localhost:5600'
+            }
+            'Docker SQL (No Auth)' = @{
+                commandName = 'Project'
+                environmentVariables = @{
+                    ASPNETCORE_ENVIRONMENT = 'Development'
+                    AHKFLOW_START_DOCKER_SQL = 'true'
+                    COMPOSE_PROJECT_NAME = 'ahkflowapp'
+                    ConnectionStrings__DefaultConnection = $connection
+                    Auth__UseTestProvider = 'true'
+                }
+                applicationUrl = 'http://localhost:5600'
+            }
+            'LocalDB SQL' = @{
+                commandName = 'Project'
+                environmentVariables = @{
+                    ASPNETCORE_ENVIRONMENT = 'Development'
+                    AHKFLOW_START_DOCKER_SQL = 'false'
+                }
+                applicationUrl = 'http://localhost:5600'
+            }
+        }
+    } | ConvertTo-Json -Depth 8
+    Set-Content -LiteralPath (Join-Path $launchSettingsDir 'launchSettings.json') -Value $launchSettings -Encoding utf8
+
+    # Compose file marks the repo as a Docker SQL adopter so profile patching is expected.
+    Set-Content -LiteralPath (Join-Path $repo 'docker-compose.yml') -Value "services: {}" -Encoding utf8
+
     Invoke-TestGit $repo @('add', '-A') | Out-Null
     Invoke-TestGit $repo @('commit', '-m', 'seed') | Out-Null
 
@@ -107,6 +151,24 @@ try {
 
     $apiPort = Get-ManifestPort (Join-Path $wtPath 'scripts\.env.worktree') 'AHKFLOW_API_PORT'
     Assert-Equal "http://localhost:$apiPort" $frontend.ApiHttpClient.BaseAddress 'Frontend BaseAddress must match the allocated API port.'
+
+    # Regression guard: every Docker SQL profile (marker AHKFLOW_START_DOCKER_SQL=true) must get
+    # per-worktree SQL isolation — originally only "Docker SQL (Recommended)" was patched, so
+    # "Docker SQL (No Auth)" kept pointing at the main checkout's SQL container on 1433.
+    $sqlPort = Get-ManifestPort (Join-Path $wtPath 'scripts\.env.worktree') 'AHKFLOW_SQL_PORT'
+    $composeProject = Get-ManifestPort (Join-Path $wtPath 'scripts\.env.worktree') 'AHKFLOW_COMPOSE_PROJECT'
+    $launchSettingsPath = Join-Path $wtPath 'src\Backend\AHKFlowApp.API\Properties\launchSettings.json'
+    $launch = Get-Content -Raw -LiteralPath $launchSettingsPath | ConvertFrom-Json
+
+    foreach ($profileName in @('Docker SQL (Recommended)', 'Docker SQL (No Auth)')) {
+        $profileEnv = $launch.profiles.$profileName.environmentVariables
+        Assert-Equal $composeProject $profileEnv.COMPOSE_PROJECT_NAME "'$profileName' must use the worktree compose project."
+        Assert-Equal $sqlPort $profileEnv.AHKFLOW_SQL_PORT "'$profileName' must use the worktree SQL port."
+        Assert-True ($profileEnv.ConnectionStrings__DefaultConnection -match [regex]::Escape("localhost,$sqlPort")) "'$profileName' connection string must target the worktree SQL port."
+    }
+
+    $localDbEnv = $launch.profiles.'LocalDB SQL'.environmentVariables
+    Assert-True (($localDbEnv.PSObject.Properties.Name) -notcontains 'COMPOSE_PROJECT_NAME') 'Non-Docker profile must not be patched with a compose project.'
 } finally {
     Remove-TempTree $repo
 }

--- a/tests/WorktreeLocalDevSetup.Tests.ps1
+++ b/tests/WorktreeLocalDevSetup.Tests.ps1
@@ -1,0 +1,114 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+$setupScript = Join-Path $repoRoot 'scripts\setup-worktree-local-dev.ps1'
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { throw $Message }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string] $Message)
+    if (-not [string]::Equals([string] $Expected, [string] $Actual, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "$Message (expected '$Expected', got '$Actual')"
+    }
+}
+
+function Invoke-TestGit {
+    param([string] $RepoDir, [string[]] $GitArgs)
+    $out = & git -C $RepoDir @GitArgs 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($GitArgs -join ' ') failed: $out"
+    }
+    return $out
+}
+
+# Fresh main-checkout repo seeded with just the tracked backend appsettings the setup script reads
+# to derive the per-worktree database (Get-WorktreeDatabaseConfig). Worktrees are created as
+# siblings, matching the harness in the other Worktree*.Tests.ps1 files.
+function New-TempMainCheckout {
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ('wtsetup-' + [guid]::NewGuid().ToString('N').Substring(0, 8))
+    $repo = Join-Path $root 'repo'
+    $backendDir = Join-Path $repo 'src\Backend\AHKFlowApp.API'
+    New-Item -ItemType Directory -Path $backendDir -Force | Out-Null
+
+    & git -C $repo init *> $null
+    & git -C $repo symbolic-ref HEAD refs/heads/main *> $null
+    & git -C $repo config user.email 'test@example.com' *> $null
+    & git -C $repo config user.name 'Worktree Setup Test' *> $null
+
+    # Mirror the real backend appsettings sections the setup script patches (Cors, ConnectionStrings)
+    # so per-worktree overrides take the in-place update path rather than creating empty sections.
+    $appsettings = @{
+        Cors = @{ AllowedOrigins = @('http://localhost:5601') }
+        ConnectionStrings = @{
+            DefaultConnection = 'Server=localhost,1433;Database=AHKFlowAppDb;User Id=sa;Password=Dev!LocalOnly_2026;TrustServerCertificate=True;MultipleActiveResultSets=true'
+        }
+    } | ConvertTo-Json -Depth 8
+    Set-Content -LiteralPath (Join-Path $backendDir 'appsettings.json') -Value $appsettings -Encoding utf8
+
+    Invoke-TestGit $repo @('add', '-A') | Out-Null
+    Invoke-TestGit $repo @('commit', '-m', 'seed') | Out-Null
+
+    return (Resolve-Path -LiteralPath $repo).Path
+}
+
+function Add-TestWorktree {
+    param([string] $RepoDir, [string] $BranchName)
+    $wtPath = Join-Path (Split-Path -Parent $RepoDir) ('wt-' + $BranchName)
+    Invoke-TestGit $RepoDir @('worktree', 'add', '-b', $BranchName, $wtPath, 'main') | Out-Null
+    return (Resolve-Path -LiteralPath $wtPath).Path
+}
+
+function Remove-TempTree {
+    param([string] $RepoDir)
+    $root = Split-Path -Parent $RepoDir
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+function Get-ManifestPort {
+    param([string] $ManifestPath, [string] $Key)
+    foreach ($line in Get-Content -LiteralPath $ManifestPath) {
+        if ($line -match "^\s*$([regex]::Escape($Key))\s*=\s*(.+?)\s*$") { return $matches[1] }
+    }
+    throw "Manifest '$ManifestPath' has no key '$Key'."
+}
+
+# --- Test: setup writes both no-auth dev configs, frontend points at the allocated API port ---
+$repo = New-TempMainCheckout
+try {
+    $wtPath = Add-TestWorktree -RepoDir $repo -BranchName 'feat-noauth'
+
+    & $setupScript -RepoRoot $wtPath -Quiet
+    Assert-True ($LASTEXITCODE -eq 0 -or $null -eq $LASTEXITCODE) 'Setup script should succeed.'
+
+    $backendDev = Join-Path $wtPath 'src\Backend\AHKFlowApp.API\appsettings.Development.json'
+    $frontendDev = Join-Path $wtPath 'src\Frontend\AHKFlowApp.UI.Blazor\wwwroot\appsettings.Development.json'
+
+    Assert-True (Test-Path -LiteralPath $backendDev) "Backend dev config should be written at $backendDev."
+    Assert-True (Test-Path -LiteralPath $frontendDev) "Frontend dev config should be written at $frontendDev."
+
+    $backend = Get-Content -Raw -LiteralPath $backendDev | ConvertFrom-Json
+    Assert-True ([bool] $backend.Auth.UseTestProvider) 'Backend dev config must enable the test auth provider.'
+
+    $frontend = Get-Content -Raw -LiteralPath $frontendDev | ConvertFrom-Json
+    Assert-True ([bool] $frontend.Auth.UseTestProvider) 'Frontend dev config must enable the test auth provider.'
+
+    # Regression guard: the old copy-from-main behavior leaked the main checkout's real Azure AD IDs
+    # into worktrees. The deterministic writer must not emit an AzureAd section.
+    Assert-True (($frontend.PSObject.Properties.Name) -notcontains 'AzureAd') 'Frontend dev config must not carry Azure AD IDs.'
+
+    $apiPort = Get-ManifestPort (Join-Path $wtPath 'scripts\.env.worktree') 'AHKFLOW_API_PORT'
+    Assert-Equal "http://localhost:$apiPort" $frontend.ApiHttpClient.BaseAddress 'Frontend BaseAddress must match the allocated API port.'
+} finally {
+    Remove-TempTree $repo
+}
+
+Write-Host 'Worktree local-dev setup no-auth tests passed.'


### PR DESCRIPTION
## Summary
- Worktrees now run in no-auth mode (synthetic `TestAuthenticationProvider`/`TestAuthenticationHandler`) by default, generated deterministically by `setup-worktree-local-dev.ps1` for both frontend and backend, instead of copying MSAL config from the main checkout.
- Adds committed `"http (No Auth)"` frontend / `"Docker SQL (No Auth)"` backend launch profiles as an explicit opt-in for humans in the main checkout (plain `dotnet run` keeps MSAL).
- Patches all Docker SQL launch profiles for correct per-worktree port isolation.
- Adds regression coverage: `tests/WorktreeLocalDevSetup.Tests.ps1` (setup script writes both dev configs) and `tests/AHKFlowApp.E2E.Tests/LocalAuthModeFlowTests.cs` (synthetic sign-in + hotstring CRUD).

## Test plan
- [x] `dotnet build` — clean, 0 warnings/errors
- [x] `dotnet test` — all 8 projects pass (1,358 tests), including new `LocalAuthModeFlowTests`
- [x] `pwsh -NoProfile -File tests/WorktreeLocalDevSetup.Tests.ps1` — passes
- [x] Live check in this worktree via playwright-cli: disabled "Log out" button (no-login signature), created a hotstring end-to-end, zero console errors/401s
- [x] Plan doc: `docs/superpowers/plans/2026-07-09-worktree-noauth-local-dev-plan.md`; spec: `docs/superpowers/specs/2026-07-09-local-noauth-mode-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)