### PR TITLE
feat: hotstrings redesign phase 3 — macro kind + preview endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This changelog starts forward-only. Existing releases before this file was intro
 - "Edit details" dialog for hotstrings on desktop.
 - `ahkflow hotstring list` shows a Kind column.
 - DateTime hotstring kind: curated date/time format presets with optional date offset, emitted as `SendText(FormatTime(...))`. Supported in the edit dialog, grid, mobile list, history, and CLI.
+- Macro hotstring kind: replacements can place the cursor and insert key presses (Enter, Tab), emitted as a scripted AutoHotkey sequence. Supported in the edit dialog (insert toolbar, live AutoHotkey preview, and Text-to-Macro suggestion), grid, mobile list, and CLI.
+- "Generated AutoHotkey code" preview panel in the hotstring edit dialog: shows the exact script snippet a hotstring will produce, for every kind.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ This changelog starts forward-only. Existing releases before this file was intro
 - `ahkflow hotstring list` shows a Kind column.
 - DateTime hotstring kind: curated date/time format presets with optional date offset, emitted as `SendText(FormatTime(...))`. Supported in the edit dialog, grid, mobile list, history, and CLI.
 - Macro hotstring kind: replacements can place the cursor and insert key presses (Enter, Tab), emitted as a scripted AutoHotkey sequence. Supported in the edit dialog (insert toolbar, live AutoHotkey preview, and Text-to-Macro suggestion), grid, mobile list, and CLI.
-- "Generated AutoHotkey code" preview panel in the hotstring edit dialog: shows the exact script snippet a hotstring will produce, for every kind.
+- "Generated AutoHotkey code" preview panel in the hotstring edit dialog: shows the exact script snippet a hotstring will produce, for every kind. Updates live while typing, shows an "Updating preview…" indicator, maps validation errors to the Trigger/Replacement fields, and includes a copy button.
+- Macro insert toolbar guards: the Cursor button disables once a cursor token exists, and Enter/Tab insertion behind the cursor is blocked with an inline hint.
 
 ### Changed
 

--- a/docs/superpowers/plans/2026-07-07-hotstrings-redesign-phase1.md
+++ b/docs/superpowers/plans/2026-07-07-hotstrings-redesign-phase1.md
@@ -1,5 +1,7 @@
 # Hotstrings Redesign — Phase 1 (Foundation + Option Toggles) Implementation Plan
 
+> **Status: completed — merged to `main` (PR #173).** Checkboxes below were not ticked during execution; kept as historical reference.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add the `HotstringKind` foundation plus two new option toggles (case-sensitive `C`, omit-ending-character `O`) end-to-end — domain, DB, emitter (always-`T` for Text), API, history, CLI, and UI (badge column + dialog options panel + desktop "Edit details").

--- a/docs/superpowers/plans/2026-07-08-hotstrings-redesign-phase2.md
+++ b/docs/superpowers/plans/2026-07-08-hotstrings-redesign-phase2.md
@@ -1,5 +1,7 @@
 # Hotstrings Redesign — Phase 2: Date & Time Kind
 
+> **Status: completed — merged to `main`.** The worktree branch named below no longer exists; kept as historical reference.
+
 ## Context
 
 Phase 1 of the hotstrings redesign (spec: `docs/superpowers/specs/2026-07-07-hotstrings-redesign-design.md`) merged in PR #173: `HotstringKind` enum, `IsCaseSensitive`/`OmitEndingCharacter` flags, `HotstringDefinition` record, `HotstringEmitter`, grid badge column, dialog option toggles, CLI Kind column. This phase implements **Phase 2 (spec §9)**: the DateTime hotstring kind — users pick a date/time format (curated presets + custom, D3) and optional date offset; the generated script emits `:X:trig::SendText(FormatTime(A_Now, "fmt"))` (with `DateAdd` for offsets). The dialog kind selector appears this phase (D4). Per spec §8, the phase also round-trips the new fields through history snapshots and extends the CLI display.

--- a/docs/superpowers/plans/2026-07-10-hotstrings-redesign-phase3.md
+++ b/docs/superpowers/plans/2026-07-10-hotstrings-redesign-phase3.md
@@ -13,7 +13,7 @@ Branch: `feature/wt-hotstrings-macro-kind` (worktree, clean).
 2. **Strict parser**: any `{{...}}` that isn't exactly a known token → validation error naming the bad token. Single/unmatched braces stay literal. Literal `{{cursor}}` output → use Text kind (document).
 3. **Grouped-runs emission**: consecutive text → one `SendText "..."`; consecutive same keys merged → `Send "{Enter 2}"`; cursor → trailing `Send "{Left N}"` (omitted when N=0). Allman braces, tab-indented.
 4. Preview endpoint: **dedicated request DTO, full validation** via `ValidatingUseCase` → invalid input = 400 ProblemDetails; panel shows first error.
-5. JS interop: **ES module + `IJSObjectReference`** (lazy import; must work in Blazor WASM — `IJSRuntime.InvokeAsync<IJSObjectReference>("import", "./js/macro-editor.js")` is WASM-supported).
+5. JS interop: ES module + `IJSObjectReference` — **superseded during plan review**: MudTextField 9.3.0 has a built-in caret-insertion API, so no custom JS is built (see Dialog design).
 6. CLI shows the **raw replacement as-is** for Macro rows (formatter needs no Macro arm; add a pinning test).
 7. Token lexing: **case-insensitive names, no interior whitespace** (`{{ cursor }}` = error); toolbar inserts canonical lowercase.
 8. Degenerate cursor-only macro **allowed** → empty brace body (valid AHK no-op; user sees it in preview).
@@ -24,7 +24,7 @@ Branch: `feature/wt-hotstrings-macro-kind` (worktree, clean).
 
 ### Token grammar (single source of truth: `MacroTokenParser`)
 - Tokens: `{{cursor}}`, `{{key:Enter}}`, `{{key:Tab}}` — names case-insensitive, no whitespace inside `{{...}}`.
-- New `src/Backend/AHKFlowApp.Application/Services/MacroTokenParser.cs` (internal static). Scans `Replacement`, candidate spans = `\{\{.*?\}\}` (non-greedy); each candidate must match a known token or is reported as an error with its raw text. Everything else = literal text runs.
+- New `src/Backend/AHKFlowApp.Application/Services/MacroTokenParser.cs` (internal static). **Small linear scanner, not a regex** (a non-`Singleline` `\{\{.*?\}\}` silently skips candidates spanning newlines): scan for `{{`; if no closing `}}` follows, the `{{` is literal text; if one does, the span is a token candidate — inner content must match a known token (case-insensitive, no whitespace/newlines) or is reported as an error with its raw text. Everything else = literal text runs.
 - Result model: `MacroParseResult(IReadOnlyList<MacroToken> Tokens, IReadOnlyList<string> Errors)`; `MacroToken` = discriminated by kind (TextRun(string), Key(name canonical "Enter"/"Tab"), Cursor).
 - Used by: validator (parse errors, ≤1 cursor, no keys after cursor), emitter (token stream → statements), preview (indirectly).
 
@@ -34,12 +34,12 @@ Branch: `feature/wt-hotstrings-macro-kind` (worktree, clean).
   ```
   :*:htag::
   {
-  	SendText "<b></b>"
-  	Send "{Enter 2}"
-  	Send "{Left 4}"
+      SendText "<b></b>"
+      Send "{Enter 2}"
+      Send "{Left 4}"
   }
   ```
-  (tab-indented; spec §7 ex. 6 golden). Text runs merge into minimal `SendText` statements (cursor splits a run but emits no text); consecutive identical keys merge to `{Enter N}`; distinct keys = separate `Send` lines.
+  (example shown with spaces; the emitter indents with a tab — spec §7 ex. 6 golden). Text runs merge into minimal `SendText` statements (cursor splits a run but emits no text); consecutive identical keys merge to `{Enter N}`; distinct keys = separate `Send` lines.
 - **Cursor math**: `N` = total character count of text runs *after* the cursor token (`\n` counts 1, per D5); keys after cursor are impossible (validation). `N=0` → no `Send "{Left ...}"` line.
 - **New string-literal escape helper** (distinct from line-level `Escape()`): for AHK v2 double-quoted strings — `` ` `` → ```` `` ````, `"` → `` `" ``, `\n` → `` `n ``, `\r` → `` `r ``, `\t` → `` `t ``. No `;`/brace escaping needed inside quotes.
 - `AhkScriptGenerator` keeps calling `HotstringEmitter.Emit(hs)`; the returned string is now multi-line for macros (verify join/newline style in goldens).
@@ -60,9 +60,10 @@ Branch: `feature/wt-hotstrings-macro-kind` (worktree, clean).
 ### Dialog (`HotstringEditDialog.razor`)
 - Add **Macro** `MudToggleItem` to the kind selector. Kind-switch confirmation (existing `OnKindChangedAsync` message-box pattern): switching away from Macro with tokens present → confirm; Macro→Text keeps Replacement verbatim (tokens become literal text — the confirm text says so).
 - **Macro panel** (`@if Kind == Macro`): keep the multiline Replacement editor, add an **insert toolbar** above it — `Insert: Cursor · Enter · Tab` buttons (`data-test="macro-toolbar"`).
-- **Caret insertion JS**: new `wwwroot/js/macro-editor.js` **ES module**: `insertAtCaret(elementId, text)` — finds the textarea, splices text at selection, restores caret, dispatches `input` event so the Mud binding updates. Small `MacroEditorJs` service (`Services/`) lazily imports via `IJSObjectReference`, implements `IAsyncDisposable`, follows the `dn-use-js-interop` skill. Give the Replacement `MudTextField` a stable input id for lookup.
+- **Caret insertion — no custom JS needed**: MudBlazor 9.3.0 `MudTextField` ships `InsertTextAtCurrentCaretPositionAsync(string)` and `GetCurrentCaretPositionAsync()` (verified via MudMCP). Capture the Replacement field with `@ref="_replacementField"` and call `InsertTextAtCurrentCaretPositionAsync(token)` from the toolbar buttons. Supersedes the earlier `macro-editor.js` ES module + `MacroEditorJs` service + DI registration — none of that is built.
 - **"Use Macro?" suggestion**: when `Kind == Text` and Replacement contains a well-formed known token → dismissible `MudAlert` with a "Switch to Macro" action (`data-test="macro-suggestion"`). Detection via the frontend token helper (below). Dismissal is per-dialog-instance.
 - **Preview panel**: collapsed `MudExpansionPanel` "Generated AutoHotkey code" (`data-test="ahk-preview"`), last panel. While expanded: debounced (400 ms) `PreviewAsync` on any emission-relevant field change + once on expand; renders snippet in a monospace `<pre>`; 400 → show the first validation message instead. No calls while collapsed.
+- **Cancellation + stale-response protection** (ApiClientBase catches only `HttpRequestException` — `OperationCanceledException` propagates to the caller): per-preview `CancellationTokenSource` cancelled and replaced on each new debounced call, on collapse, and in `Dispose`; a monotonically increasing generation id captured per request — responses whose generation isn't current are discarded (out-of-order protection); `OperationCanceledException` swallowed (cancelled previews render nothing, never an error).
 
 ### Frontend plumbing
 - `IHotstringsApiClient`/`HotstringsApiClient`: `PreviewAsync(HotstringPreviewRequestDto, ct)`; mirror request/response DTOs in `UI.Blazor/DTOs/`.
@@ -85,7 +86,7 @@ Branch: `feature/wt-hotstrings-macro-kind` (worktree, clean).
 Commit: `docs: phase 3 plan (macro kind + preview endpoint)`
 
 ### Task 1 — MacroTokenParser (TDD)
-- Tests first: `tests/AHKFlowApp.Application.Tests/Services/MacroTokenParserTests.cs` — plain text (no tokens), each token, case-insensitivity, `{{ cursor }}`/`{{oops}}`/`{{key:Escape}}`/`{{field:name}}` → named errors, unmatched `{{`/single braces literal, adjacent tokens, multiline text runs, token positions for cursor-math.
+- Tests first: `tests/AHKFlowApp.Application.Tests/Services/MacroTokenParserTests.cs` — plain text (no tokens), each token, case-insensitivity, `{{ cursor }}`/`{{oops}}`/`{{key:Escape}}`/`{{field:name}}` → named errors, token candidate spanning a newline (`{{key:\nEnter}}`) → named error, unmatched `{{`/single braces literal, adjacent tokens, multiline text runs, token positions for cursor-math.
 - `src/Backend/AHKFlowApp.Application/Services/MacroTokenParser.cs` + result/token types.
 Commit: `feat: macro token parser ({{cursor}}, {{key:Enter|Tab}})`
 
@@ -97,6 +98,7 @@ Commit: `feat: emit macro hotstrings as AHK brace bodies`
 ### Task 3 — Validation (TDD)
 - Validator tests: widen `Kind_MacroOrScript_Fails` → Script-only; Macro acceptance; parse-error, 2-cursor, key-after-cursor rejections; Macro + date fields → 400 (existing rule, pin it); cursor-only macro passes.
 - `HotstringRules.AddMacroKindRules<T>()`; wire into Create/Update validators; widen kind rule.
+- Update the `Kind` XML comments on `HotstringDto`/`Create`/`Update` (`Application/DTOs/HotstringDto.cs:17`) — Macro becomes API-supported here; only Script stays domain-only.
 Commit: `feat: macro kind validation (strict tokens, cursor rules)`
 
 ### Task 4 — Preview endpoint
@@ -109,15 +111,14 @@ Commit: `feat: stateless hotstring preview endpoint`
 - `tests/AHKFlowApp.UI.Blazor.Tests/Services/HotstringsApiClientTests.cs`: `PreviewAsync` route (`api/v1/hotstrings/preview`) + request payload + 400 ProblemDetails mapping, per existing client test pattern.
 Commit: `feat: preview API client + frontend macro token helper`
 
-### Task 6 — Dialog: Macro panel + toolbar + JS + suggestion
-- `wwwroot/js/macro-editor.js` ES module + `MacroEditorJs` service (lazy import, `IAsyncDisposable`), registered scoped in `Program.cs` (mirror `JsFileSaver` at line 47 — Blazor services are not auto-discovered).
-- Dialog: Macro toggle item, toolbar buttons (insert canonical tokens at caret), kind-switch confirm arms, "Use Macro?" alert with switch action.
-- bUnit tests (JS mocked via bUnit's `JSInterop`): toggle renders, toolbar visible only for Macro, insert calls module with canonical token, suggestion appears for Text+token / dismisses / switches kind, switch-away confirm.
+### Task 6 — Dialog: Macro panel + toolbar + suggestion
+- Dialog: Macro toggle item; toolbar buttons call `_replacementField.InsertTextAtCurrentCaretPositionAsync(token)` on the `@ref`-captured `MudTextField` (no custom JS, no new service/DI — MudBlazor built-in, verified v9.3.0); kind-switch confirm arms; "Use Macro?" alert with switch action.
+- bUnit tests (Mud's internal caret JS mocked via bUnit `JSInterop` loose mode): toggle renders, toolbar visible only for Macro, toolbar click inserts the canonical token into the bound Replacement, suggestion appears for Text+token / dismisses / switches kind, switch-away confirm.
 Commit: `feat: dialog macro panel with insert toolbar and kind suggestion`
 
 ### Task 7 — Dialog preview panel
-- Collapsed expansion panel + 400 ms debounce (only while expanded) + snippet/error rendering.
-- bUnit: expand triggers call, field change while expanded re-calls (debounce advanced via test timer or immediate-flush hook), 400 renders message, collapsed = no calls.
+- Collapsed expansion panel + 400 ms debounce (only while expanded) + snippet/error rendering + per-preview `CancellationTokenSource` + generation-id stale-response guard (design above).
+- bUnit: expand triggers call, field change while expanded re-calls (debounce advanced via test timer or immediate-flush hook), 400 renders message, collapsed = no calls, out-of-order responses ignored (slow gen-1 completing after gen-2 doesn't overwrite), cancellation on collapse/dispose surfaces no error.
 Commit: `feat: generated AHK preview panel in hotstring dialog`
 
 ### Task 8 — Grid + mobile token chips
@@ -131,13 +132,13 @@ Commit: `test: pin macro CLI output and history round-trip`
 ### Task 10 — Verify + changelog
 - `dck-verify` (build, all tests incl. Testcontainers + bUnit, format, diagnostics).
 - Changelog entry + regenerate changelog.json (repo convention).
-- E2E smoke (spec §11): run API + Blazor, create `htag` macro via dialog (toolbar-inserted cursor), expand preview panel and confirm snippet, save, download script, diff against spec §7 ex. 6; verify Text inline edit untouched; `playwright-cli` smoke of Macro panel + preview panel.
+- E2E smoke (spec §11): run API + Blazor, create `htag` macro via dialog (toolbar-inserted cursor), expand preview panel and confirm snippet, save, download script, diff against spec §7 ex. 6; verify Text inline edit untouched; `playwright-cli` smoke of Macro panel + preview panel, including a caret-insertion check (type text, place caret mid-text, click Insert Cursor, assert the token lands at the caret in the bound value — proves the Mud built-in end-to-end, not just a bUnit invocation).
 Commit: `docs: changelog for macro hotstring kind`
 
 Then PR to `main` via `gh`.
 
 ## Edge cases covered
-Strict unknown/malformed token errors; case-insensitive tokens; whitespace-in-token rejected; 2 cursors rejected; key after cursor rejected; cursor-only macro → empty body allowed; cursor at end → no `{Left}`; merged repeated keys; multiline text runs (`` `n ``, counts 1); quote/backtick in macro text; `T` regression (Text keeps it, Macro never); Macro + date fields rejected; preview 400 surface identical to Save; preview panel silent while collapsed; Macro rows excluded from inline edit (existing gate); CLI renders raw tokens; legacy/new snapshots round-trip unchanged.
+Strict unknown/malformed token errors; token spanning newline rejected (scanner, not regex); case-insensitive tokens; whitespace-in-token rejected; stale/out-of-order preview responses discarded; cancelled previews silent; 2 cursors rejected; key after cursor rejected; cursor-only macro → empty body allowed; cursor at end → no `{Left}`; merged repeated keys; multiline text runs (`` `n ``, counts 1); quote/backtick in macro text; `T` regression (Text keeps it, Macro never); Macro + date fields rejected; preview 400 surface identical to Save; preview panel silent while collapsed; Macro rows excluded from inline edit (existing gate); CLI renders raw tokens; legacy/new snapshots round-trip unchanged.
 
 ## Verification
 Per-task: `dotnet build` + targeted `dotnet test` project. End: full `dck-verify` + E2E smoke above.

--- a/docs/superpowers/plans/2026-07-10-hotstrings-redesign-phase3.md
+++ b/docs/superpowers/plans/2026-07-10-hotstrings-redesign-phase3.md
@@ -10,7 +10,7 @@ Branch: `feature/wt-hotstrings-macro-kind` (worktree, clean).
 
 **User-confirmed decisions (grilling, 2026-07-10):**
 1. Key whitelist = **Enter + Tab only** (matches toolbar; extensible later).
-2. **Strict parser**: any `{{...}}` that isn't exactly a known token → validation error naming the bad token. Single/unmatched braces stay literal. Literal `{{cursor}}` output → use Text kind (document).
+2. **Strict parser**: any `{{...}}` that isn't exactly a known token → validation error naming the bad token. Single/unmatched braces stay literal. *(Amended by decision 11 — escaped literals now cover mixed content; plain-literal-only replacements still belong in Text kind.)*
 3. **Grouped-runs emission**: consecutive text → one `SendText "..."`; consecutive same keys merged → `Send "{Enter 2}"`; cursor → trailing `Send "{Left N}"` (omitted when N=0). Allman braces, tab-indented.
 4. Preview endpoint: **dedicated request DTO, full validation** via `ValidatingUseCase` → invalid input = 400 ProblemDetails; panel shows first error.
 5. JS interop: ES module + `IJSObjectReference` — **superseded during plan review**: MudTextField 9.3.0 has a built-in caret-insertion API, so no custom JS is built (see Dialog design).
@@ -19,12 +19,14 @@ Branch: `feature/wt-hotstrings-macro-kind` (worktree, clean).
 8. Degenerate cursor-only macro **allowed** → empty brace body (valid AHK no-op; user sees it in preview).
 9. Preview panel: **calls only while expanded**, 400 ms debounce.
 10. Kind auto-suggestion: **"Use Macro?" alert ships this phase** (detection reuses the token grammar); "Use Script?" waits for Phase 5.
+11. **Escaped literal brace tokens** (plan review, 2026-07-10 — amends decision 2): `{{{{...}}}}` emits literal `{{...}}`, so a mixed macro can contain Jinja/Mustache-style literals alongside real tokens — e.g. `Dear {{{{first_name}}}},{{key:Enter}}{{cursor}}Alex` types `Dear {{first_name}},` + Enter + caret before `Alex`. Real tokens keep their meaning; malformed real tokens (`{{key:Entr}}`) still fail strictly.
 
 ## Design
 
 ### Token grammar (single source of truth: `MacroTokenParser`)
 - Tokens: `{{cursor}}`, `{{key:Enter}}`, `{{key:Tab}}` — names case-insensitive, no whitespace inside `{{...}}`.
-- New `src/Backend/AHKFlowApp.Application/Services/MacroTokenParser.cs` (internal static). **Small linear scanner, not a regex** (a non-`Singleline` `\{\{.*?\}\}` silently skips candidates spanning newlines): scan for `{{`; if no closing `}}` follows, the `{{` is literal text; if one does, the span is a token candidate — inner content must match a known token (case-insensitive, no whitespace/newlines) or is reported as an error with its raw text. Everything else = literal text runs.
+- **Escaped literals** (decision 11): `{{{{...}}}}` is an escape producing the literal text `{{...}}` in the emitted output (any inner content, including whitespace/Mustache names; terminated by the first `}}}}`). Lets one macro mix template literals with real tokens.
+- New `src/Backend/AHKFlowApp.Application/Services/MacroTokenParser.cs` (internal static). **Small linear scanner, not a regex** (a non-`Singleline` `\{\{.*?\}\}` silently skips candidates spanning newlines): scan for `{{`. If it's `{{{{`, seek the first `}}}}` → literal-text token `{{inner}}`; with no `}}}}` closer, the leading `{{` is literal and scanning resumes (an inner `{{oops}}` then still errors strictly). Otherwise, if no closing `}}` follows, the `{{` is literal text; if one does, the span is a token candidate — inner content must match a known token (case-insensitive, no whitespace/newlines) or is reported as an error with its raw text (error message mentions the `{{{{...}}}}` escape for literals). Everything else = literal text runs.
 - Result model: `MacroParseResult(IReadOnlyList<MacroToken> Tokens, IReadOnlyList<string> Errors)`; `MacroToken` = discriminated by kind (TextRun(string), Key(name canonical "Enter"/"Tab"), Cursor).
 - Used by: validator (parse errors, ≤1 cursor, no keys after cursor), emitter (token stream → statements), preview (indirectly).
 
@@ -39,8 +41,8 @@ Branch: `feature/wt-hotstrings-macro-kind` (worktree, clean).
       Send "{Left 4}"
   }
   ```
-  (example shown with spaces; the emitter indents with a tab — spec §7 ex. 6 golden). Text runs merge into minimal `SendText` statements (cursor splits a run but emits no text); consecutive identical keys merge to `{Enter N}`; distinct keys = separate `Send` lines.
-- **Cursor math**: `N` = total character count of text runs *after* the cursor token (`\n` counts 1, per D5); keys after cursor are impossible (validation). `N=0` → no `Send "{Left ...}"` line.
+  (example shown with spaces; the emitter indents with a tab — spec §7 ex. 6 golden). Text runs merge into minimal `SendText` statements (cursor splits a run but emits no text); escaped literals unescape to `{{...}}` and fold into the adjacent text run (`SendText "Dear {{first_name}},"` — safe, `SendText` sends braces literally); consecutive identical keys merge to `{Enter N}`; distinct keys = separate `Send` lines.
+- **Cursor math**: `N` = total character count of text runs *after* the cursor token (`\n` counts 1, per D5); escaped literals count their **emitted** length (`{{{{first_name}}}}` after the cursor counts 14 for `{{first_name}}`); keys after cursor are impossible (validation). `N=0` → no `Send "{Left ...}"` line.
 - **New string-literal escape helper** (distinct from line-level `Escape()`): for AHK v2 double-quoted strings — `` ` `` → ```` `` ````, `"` → `` `" ``, `\n` → `` `n ``, `\r` → `` `r ``, `\t` → `` `t ``. No `;`/brace escaping needed inside quotes.
 - `AhkScriptGenerator` keeps calling `HotstringEmitter.Emit(hs)`; the returned string is now multi-line for macros (verify join/newline style in goldens).
 
@@ -86,28 +88,28 @@ Branch: `feature/wt-hotstrings-macro-kind` (worktree, clean).
 Commit: `docs: phase 3 plan (macro kind + preview endpoint)`
 
 ### Task 1 — MacroTokenParser (TDD)
-- Tests first: `tests/AHKFlowApp.Application.Tests/Services/MacroTokenParserTests.cs` — plain text (no tokens), each token, case-insensitivity, `{{ cursor }}`/`{{oops}}`/`{{key:Escape}}`/`{{field:name}}` → named errors, token candidate spanning a newline (`{{key:\nEnter}}`) → named error, unmatched `{{`/single braces literal, adjacent tokens, multiline text runs, token positions for cursor-math.
+- Tests first: `tests/AHKFlowApp.Application.Tests/Services/MacroTokenParserTests.cs` — plain text (no tokens), each token, case-insensitivity, `{{ cursor }}`/`{{oops}}`/`{{key:Escape}}`/`{{field:name}}` → named errors, token candidate spanning a newline (`{{key:\nEnter}}`) → named error, unmatched `{{`/single braces literal, adjacent tokens, multiline text runs, token positions for cursor-math; escaped literals: `{{{{first_name}}}}` → literal `{{first_name}}`, escape adjacent to real tokens (decision 11 example string), whitespace/newline allowed inside escape, `{{{{` without `}}}}` → leading `{{` literal + inner tokens still scanned, `{{key:Entr}}` still a named error.
 - `src/Backend/AHKFlowApp.Application/Services/MacroTokenParser.cs` + result/token types.
 Commit: `feat: macro token parser ({{cursor}}, {{key:Enter|Tab}})`
 
 ### Task 2 — Emitter macro brace body (goldens first)
-- Goldens in `AhkScriptGeneratorTests.cs`: spec §7 ex. 6 exact (`:*:htag::` + brace body + `{Left 4}`); merged `{Enter 2}`; mixed Enter/Tab; cursor at end → no `{Left}`; cursor-only → empty body; multiline text (`` `n `` inside `SendText`, counts 1 for Left); quote/backtick escaping in `SendText`; **`T` no longer emitted for Macro** (and still emitted for Text — regression golden).
+- Goldens in `AhkScriptGeneratorTests.cs`: spec §7 ex. 6 exact (`:*:htag::` + brace body + `{Left 4}`); merged `{Enter 2}`; mixed Enter/Tab; cursor at end → no `{Left}`; cursor-only → empty body; multiline text (`` `n `` inside `SendText`, counts 1 for Left); quote/backtick escaping in `SendText`; decision 11 example golden (`Dear {{{{first_name}}}},{{key:Enter}}{{cursor}}Alex` → `SendText "Dear {{first_name}},"` + `Send "{Enter}"` + `SendText "Alex"` + `Send "{Left 4}"`); escaped literal after cursor counts emitted length in `{Left N}`; **`T` no longer emitted for Macro** (and still emitted for Text — regression golden).
 - `HotstringEmitter`: `BuildOptions` `T` restricted to `Kind == Text`; `BuildBody` switch + `BuildMacroBody` (grouped runs, merged keys, cursor math) + `EscapeStringLiteral` helper.
 Commit: `feat: emit macro hotstrings as AHK brace bodies`
 
 ### Task 3 — Validation (TDD)
-- Validator tests: widen `Kind_MacroOrScript_Fails` → Script-only; Macro acceptance; parse-error, 2-cursor, key-after-cursor rejections; Macro + date fields → 400 (existing rule, pin it); cursor-only macro passes.
+- Validator tests: widen `Kind_MacroOrScript_Fails` → Script-only; Macro acceptance; parse-error, 2-cursor, key-after-cursor rejections; Macro + date fields → 400 (existing rule, pin it); cursor-only macro passes; escaped-literal macro passes while `{{key:Entr}}` beside it still fails.
 - `HotstringRules.AddMacroKindRules<T>()`; wire into Create/Update validators; widen kind rule.
 - Update the `Kind` XML comments on `HotstringDto`/`Create`/`Update` (`Application/DTOs/HotstringDto.cs:17`) — Macro becomes API-supported here; only Script stays domain-only.
 Commit: `feat: macro kind validation (strict tokens, cursor rules)`
 
 ### Task 4 — Preview endpoint
 - `Application/DTOs/HotstringDto.cs` (or new file): `HotstringPreviewRequestDto`, `HotstringPreviewDto`; `Application/Queries/Hotstrings/GetHotstringPreviewQuery.cs` + validator + handler (transient `Hotstring.Create`, no DbContext); DI registration; controller action `[HttpPost("preview")]` + `ProducesResponseType` annotations.
-- API integration tests (`AHKFlowApp.API.Tests`): Text/DateTime/Macro previews return exact snippets; invalid macro → 400 ProblemDetails with parser message; anonymous → 401 (matches controller auth).
+- API integration tests (`AHKFlowApp.API.Tests`): Text/DateTime/Macro previews return exact snippets (macro case includes an escaped literal); invalid macro → 400 ProblemDetails with parser message; anonymous → 401 (matches controller auth).
 Commit: `feat: stateless hotstring preview endpoint`
 
 ### Task 5 — Frontend plumbing
-- Mirror preview DTOs; `HotstringsApiClient.PreviewAsync`; frontend token helper (`MacroTokens`) + unit tests (detection + splitting).
+- Mirror preview DTOs; `HotstringsApiClient.PreviewAsync`; frontend token helper (`MacroTokens`) + unit tests (detection + splitting, incl. escaped literals: split as literal text `{{...}}`, never a chip, and never trigger the "Use Macro?" suggestion — only real known tokens do).
 - `tests/AHKFlowApp.UI.Blazor.Tests/Services/HotstringsApiClientTests.cs`: `PreviewAsync` route (`api/v1/hotstrings/preview`) + request payload + 400 ProblemDetails mapping, per existing client test pattern.
 Commit: `feat: preview API client + frontend macro token helper`
 
@@ -122,7 +124,7 @@ Commit: `feat: dialog macro panel with insert toolbar and kind suggestion`
 Commit: `feat: generated AHK preview panel in hotstring dialog`
 
 ### Task 8 — Grid + mobile token chips
-- `Hotstrings.razor` + `HotstringMobileList.razor` Macro replacement rendering with chips; bUnit tests.
+- `Hotstrings.razor` + `HotstringMobileList.razor` Macro replacement rendering with chips; bUnit tests (incl. escaped literal shown as plain `{{...}}` text between chips).
 Commit: `feat: macro token chips in grid and mobile list`
 
 ### Task 9 — CLI + history pinning tests
@@ -138,7 +140,7 @@ Commit: `docs: changelog for macro hotstring kind`
 Then PR to `main` via `gh`.
 
 ## Edge cases covered
-Strict unknown/malformed token errors; token spanning newline rejected (scanner, not regex); case-insensitive tokens; whitespace-in-token rejected; stale/out-of-order preview responses discarded; cancelled previews silent; 2 cursors rejected; key after cursor rejected; cursor-only macro → empty body allowed; cursor at end → no `{Left}`; merged repeated keys; multiline text runs (`` `n ``, counts 1); quote/backtick in macro text; `T` regression (Text keeps it, Macro never); Macro + date fields rejected; preview 400 surface identical to Save; preview panel silent while collapsed; Macro rows excluded from inline edit (existing gate); CLI renders raw tokens; legacy/new snapshots round-trip unchanged.
+Strict unknown/malformed token errors; token spanning newline rejected (scanner, not regex); case-insensitive tokens; whitespace-in-token rejected; escaped literals `{{{{...}}}}` pass through (parser, emitter, cursor math, preview, chips) while malformed real tokens beside them still fail; stale/out-of-order preview responses discarded; cancelled previews silent; 2 cursors rejected; key after cursor rejected; cursor-only macro → empty body allowed; cursor at end → no `{Left}`; merged repeated keys; multiline text runs (`` `n ``, counts 1); quote/backtick in macro text; `T` regression (Text keeps it, Macro never); Macro + date fields rejected; preview 400 surface identical to Save; preview panel silent while collapsed; Macro rows excluded from inline edit (existing gate); CLI renders raw tokens; legacy/new snapshots round-trip unchanged.
 
 ## Verification
 Per-task: `dotnet build` + targeted `dotnet test` project. End: full `dck-verify` + E2E smoke above.

--- a/docs/superpowers/plans/2026-07-10-hotstrings-redesign-phase3.md
+++ b/docs/superpowers/plans/2026-07-10-hotstrings-redesign-phase3.md
@@ -1,0 +1,146 @@
+# Hotstrings Redesign — Phase 3: Macro Kind + Preview Endpoint
+
+## Context
+
+Phases 1–2 of the hotstrings redesign (spec: `docs/superpowers/specs/2026-07-07-hotstrings-redesign-design.md`, §9) are merged: kinds enum, option flags, `HotstringEmitter`, DateTime kind, dialog kind selector. This phase implements **Phase 3 (spec §9)**: the Macro kind — replacements with `{{cursor}}` / `{{key:...}}` tokens emitted as an AHK v2 brace body — plus the stateless `POST api/v1/hotstrings/preview` endpoint powering a Generated-AHK preview panel in the dialog (all kinds, zero drift with the real emitter).
+
+Branch: `feature/wt-hotstrings-macro-kind` (worktree, clean).
+
+**Key exploration finding:** macros need **no migration, no new columns, no snapshot/restore/revert changes** — the entire macro payload lives in `Replacement` (already round-trips). The CLI DTO already carries all fields. The spec's per-phase snapshot/CLI boilerplate is a near-no-op this phase.
+
+**User-confirmed decisions (grilling, 2026-07-10):**
+1. Key whitelist = **Enter + Tab only** (matches toolbar; extensible later).
+2. **Strict parser**: any `{{...}}` that isn't exactly a known token → validation error naming the bad token. Single/unmatched braces stay literal. Literal `{{cursor}}` output → use Text kind (document).
+3. **Grouped-runs emission**: consecutive text → one `SendText "..."`; consecutive same keys merged → `Send "{Enter 2}"`; cursor → trailing `Send "{Left N}"` (omitted when N=0). Allman braces, tab-indented.
+4. Preview endpoint: **dedicated request DTO, full validation** via `ValidatingUseCase` → invalid input = 400 ProblemDetails; panel shows first error.
+5. JS interop: **ES module + `IJSObjectReference`** (lazy import; must work in Blazor WASM — `IJSRuntime.InvokeAsync<IJSObjectReference>("import", "./js/macro-editor.js")` is WASM-supported).
+6. CLI shows the **raw replacement as-is** for Macro rows (formatter needs no Macro arm; add a pinning test).
+7. Token lexing: **case-insensitive names, no interior whitespace** (`{{ cursor }}` = error); toolbar inserts canonical lowercase.
+8. Degenerate cursor-only macro **allowed** → empty brace body (valid AHK no-op; user sees it in preview).
+9. Preview panel: **calls only while expanded**, 400 ms debounce.
+10. Kind auto-suggestion: **"Use Macro?" alert ships this phase** (detection reuses the token grammar); "Use Script?" waits for Phase 5.
+
+## Design
+
+### Token grammar (single source of truth: `MacroTokenParser`)
+- Tokens: `{{cursor}}`, `{{key:Enter}}`, `{{key:Tab}}` — names case-insensitive, no whitespace inside `{{...}}`.
+- New `src/Backend/AHKFlowApp.Application/Services/MacroTokenParser.cs` (internal static). Scans `Replacement`, candidate spans = `\{\{.*?\}\}` (non-greedy); each candidate must match a known token or is reported as an error with its raw text. Everything else = literal text runs.
+- Result model: `MacroParseResult(IReadOnlyList<MacroToken> Tokens, IReadOnlyList<string> Errors)`; `MacroToken` = discriminated by kind (TextRun(string), Key(name canonical "Enter"/"Tab"), Cursor).
+- Used by: validator (parse errors, ≤1 cursor, no keys after cursor), emitter (token stream → statements), preview (indirectly).
+
+### Emitter (`HotstringEmitter`)
+- `BuildOptions`: **`T` becomes Text-kind-only** (today it's "non-DateTime" — Macro must not emit `T`; brace-body hotstrings have no auto-replace text). Default macro = `::htag::`, expand-immediately = `:*:htag::`.
+- `BuildBody` ternary → switch; Macro branch returns a multi-line brace body appended after the header line:
+  ```
+  :*:htag::
+  {
+  	SendText "<b></b>"
+  	Send "{Enter 2}"
+  	Send "{Left 4}"
+  }
+  ```
+  (tab-indented; spec §7 ex. 6 golden). Text runs merge into minimal `SendText` statements (cursor splits a run but emits no text); consecutive identical keys merge to `{Enter N}`; distinct keys = separate `Send` lines.
+- **Cursor math**: `N` = total character count of text runs *after* the cursor token (`\n` counts 1, per D5); keys after cursor are impossible (validation). `N=0` → no `Send "{Left ...}"` line.
+- **New string-literal escape helper** (distinct from line-level `Escape()`): for AHK v2 double-quoted strings — `` ` `` → ```` `` ````, `"` → `` `" ``, `\n` → `` `n ``, `\r` → `` `r ``, `\t` → `` `t ``. No `;`/brace escaping needed inside quotes.
+- `AhkScriptGenerator` keeps calling `HotstringEmitter.Emit(hs)`; the returned string is now multi-line for macros (verify join/newline style in goldens).
+
+### Validation (`HotstringRules`)
+- Widen kind rule in Create/Update validators: `Text or DateTime or Macro` (message: "Only Text, Date & time and Macro hotstrings are supported.").
+- New `AddMacroKindRules<T>(...)` extension (mirror `AddDateTimeKindRules` expression style), applied `.When(IsMacro)`:
+  - Replacement parses cleanly (surface first parser error verbatim, e.g. `Unknown token '{{key:Escape}}'. Allowed: {{cursor}}, {{key:Enter}}, {{key:Tab}}.`),
+  - ≤ 1 `{{cursor}}`,
+  - no key tokens after the cursor.
+- Existing rules already cover: Replacement required non-empty for Macro (`When(!IsDateTime)`), date fields must be null when not DateTime.
+
+### Preview endpoint (stateless)
+- `POST api/v1/hotstrings/preview` on `HotstringsController` (model after `ImportPreview`, `HotstringsController.cs:172-180`): `[HttpPost("preview")]`, body = new `HotstringPreviewRequestDto` (emission-relevant fields only: `Kind`, `Trigger`, `Replacement`, `IsCaseSensitive`, `OmitEndingCharacter`, `IsEndingCharacterRequired`, `IsTriggerInsideWord` — match existing DTO property names — plus `DateTimeFormat`, `DateOffsetAmount`, `DateOffsetUnit`). Response: `HotstringPreviewDto(string Snippet)`.
+- `GetHotstringPreviewQuery` + `GetHotstringPreviewQueryValidator` (reuses `HotstringRules`: trigger rules + DateTime rules + Macro rules — identical failure surface to Save) + handler: build a transient `Hotstring.Create(Guid.Empty, definition, timeProvider)` (never persisted, no DbContext) → `HotstringEmitter.Emit` → `Result.Success`.
+- Register in `Application/DependencyInjection.cs` `.AddUseCase<...>()` chain; validator auto-registered.
+
+### Dialog (`HotstringEditDialog.razor`)
+- Add **Macro** `MudToggleItem` to the kind selector. Kind-switch confirmation (existing `OnKindChangedAsync` message-box pattern): switching away from Macro with tokens present → confirm; Macro→Text keeps Replacement verbatim (tokens become literal text — the confirm text says so).
+- **Macro panel** (`@if Kind == Macro`): keep the multiline Replacement editor, add an **insert toolbar** above it — `Insert: Cursor · Enter · Tab` buttons (`data-test="macro-toolbar"`).
+- **Caret insertion JS**: new `wwwroot/js/macro-editor.js` **ES module**: `insertAtCaret(elementId, text)` — finds the textarea, splices text at selection, restores caret, dispatches `input` event so the Mud binding updates. Small `MacroEditorJs` service (`Services/`) lazily imports via `IJSObjectReference`, implements `IAsyncDisposable`, follows the `dn-use-js-interop` skill. Give the Replacement `MudTextField` a stable input id for lookup.
+- **"Use Macro?" suggestion**: when `Kind == Text` and Replacement contains a well-formed known token → dismissible `MudAlert` with a "Switch to Macro" action (`data-test="macro-suggestion"`). Detection via the frontend token helper (below). Dismissal is per-dialog-instance.
+- **Preview panel**: collapsed `MudExpansionPanel` "Generated AutoHotkey code" (`data-test="ahk-preview"`), last panel. While expanded: debounced (400 ms) `PreviewAsync` on any emission-relevant field change + once on expand; renders snippet in a monospace `<pre>`; 400 → show the first validation message instead. No calls while collapsed.
+
+### Frontend plumbing
+- `IHotstringsApiClient`/`HotstringsApiClient`: `PreviewAsync(HotstringPreviewRequestDto, ct)`; mirror request/response DTOs in `UI.Blazor/DTOs/`.
+- Small frontend token helper (`Validation/MacroTokens.cs` or similar): regex-based known-token detection + token splitting for chips — a deliberate lightweight mirror of the backend parser (same pattern as enum mirrors); used by suggestion alert + grid/mobile chip rendering.
+- `HotstringEditModel`: no new fields (macro payload = Replacement). `IsInlineEditable => Kind == Text` already gates macros out of inline editing.
+
+### Grid + mobile
+- `Pages/Hotstrings.razor` Replacement read-mode: Macro rows render text with inline **token chips** (small `MudChip`s: `⌖ cursor`, `Enter`, `Tab`) via the frontend token helper; `HotstringMobileList.razor` same treatment in its replacement cell.
+- Kind filter/sort already handle Macro (enum-driven, Phase 2).
+
+### CLI
+- DTO already complete; formatter falls through to raw replacement (decision 6). Add a pinning test: Macro row renders `Kind=Macro` + raw `<b>{{cursor}}</b>{{key:Enter}}` truncated like Text.
+
+### History
+- No new fields → no snapshot/handler changes. Add one cheap round-trip test: revert of a Macro snapshot restores `Kind=Macro` + token-bearing Replacement intact.
+
+## Tasks (one conventional commit each; TDD for parser, validators, emitter goldens)
+
+### Task 0 — Commit this plan
+Commit: `docs: phase 3 plan (macro kind + preview endpoint)`
+
+### Task 1 — MacroTokenParser (TDD)
+- Tests first: `tests/AHKFlowApp.Application.Tests/Services/MacroTokenParserTests.cs` — plain text (no tokens), each token, case-insensitivity, `{{ cursor }}`/`{{oops}}`/`{{key:Escape}}`/`{{field:name}}` → named errors, unmatched `{{`/single braces literal, adjacent tokens, multiline text runs, token positions for cursor-math.
+- `src/Backend/AHKFlowApp.Application/Services/MacroTokenParser.cs` + result/token types.
+Commit: `feat: macro token parser ({{cursor}}, {{key:Enter|Tab}})`
+
+### Task 2 — Emitter macro brace body (goldens first)
+- Goldens in `AhkScriptGeneratorTests.cs`: spec §7 ex. 6 exact (`:*:htag::` + brace body + `{Left 4}`); merged `{Enter 2}`; mixed Enter/Tab; cursor at end → no `{Left}`; cursor-only → empty body; multiline text (`` `n `` inside `SendText`, counts 1 for Left); quote/backtick escaping in `SendText`; **`T` no longer emitted for Macro** (and still emitted for Text — regression golden).
+- `HotstringEmitter`: `BuildOptions` `T` restricted to `Kind == Text`; `BuildBody` switch + `BuildMacroBody` (grouped runs, merged keys, cursor math) + `EscapeStringLiteral` helper.
+Commit: `feat: emit macro hotstrings as AHK brace bodies`
+
+### Task 3 — Validation (TDD)
+- Validator tests: widen `Kind_MacroOrScript_Fails` → Script-only; Macro acceptance; parse-error, 2-cursor, key-after-cursor rejections; Macro + date fields → 400 (existing rule, pin it); cursor-only macro passes.
+- `HotstringRules.AddMacroKindRules<T>()`; wire into Create/Update validators; widen kind rule.
+Commit: `feat: macro kind validation (strict tokens, cursor rules)`
+
+### Task 4 — Preview endpoint
+- `Application/DTOs/HotstringDto.cs` (or new file): `HotstringPreviewRequestDto`, `HotstringPreviewDto`; `Application/Queries/Hotstrings/GetHotstringPreviewQuery.cs` + validator + handler (transient `Hotstring.Create`, no DbContext); DI registration; controller action `[HttpPost("preview")]` + `ProducesResponseType` annotations.
+- API integration tests (`AHKFlowApp.API.Tests`): Text/DateTime/Macro previews return exact snippets; invalid macro → 400 ProblemDetails with parser message; anonymous → 401 (matches controller auth).
+Commit: `feat: stateless hotstring preview endpoint`
+
+### Task 5 — Frontend plumbing
+- Mirror preview DTOs; `HotstringsApiClient.PreviewAsync`; frontend token helper (`MacroTokens`) + unit tests (detection + splitting).
+Commit: `feat: preview API client + frontend macro token helper`
+
+### Task 6 — Dialog: Macro panel + toolbar + JS + suggestion
+- `wwwroot/js/macro-editor.js` ES module + `MacroEditorJs` service (lazy import, `IAsyncDisposable`).
+- Dialog: Macro toggle item, toolbar buttons (insert canonical tokens at caret), kind-switch confirm arms, "Use Macro?" alert with switch action.
+- bUnit tests (JS mocked via bUnit's `JSInterop`): toggle renders, toolbar visible only for Macro, insert calls module with canonical token, suggestion appears for Text+token / dismisses / switches kind, switch-away confirm.
+Commit: `feat: dialog macro panel with insert toolbar and kind suggestion`
+
+### Task 7 — Dialog preview panel
+- Collapsed expansion panel + 400 ms debounce (only while expanded) + snippet/error rendering.
+- bUnit: expand triggers call, field change while expanded re-calls (debounce advanced via test timer or immediate-flush hook), 400 renders message, collapsed = no calls.
+Commit: `feat: generated AHK preview panel in hotstring dialog`
+
+### Task 8 — Grid + mobile token chips
+- `Hotstrings.razor` + `HotstringMobileList.razor` Macro replacement rendering with chips; bUnit tests.
+Commit: `feat: macro token chips in grid and mobile list`
+
+### Task 9 — CLI + history pinning tests
+- CLI formatter test (raw macro replacement, Macro kind label); history revert/restore round-trip test for a Macro snapshot. No production code expected.
+Commit: `test: pin macro CLI output and history round-trip`
+
+### Task 10 — Verify + changelog
+- `dck-verify` (build, all tests incl. Testcontainers + bUnit, format, diagnostics).
+- Changelog entry + regenerate changelog.json (repo convention).
+- E2E smoke (spec §11): run API + Blazor, create `htag` macro via dialog (toolbar-inserted cursor), expand preview panel and confirm snippet, save, download script, diff against spec §7 ex. 6; verify Text inline edit untouched; `playwright-cli` smoke of Macro panel + preview panel.
+Commit: `docs: changelog for macro hotstring kind`
+
+Then PR to `main` via `gh`.
+
+## Edge cases covered
+Strict unknown/malformed token errors; case-insensitive tokens; whitespace-in-token rejected; 2 cursors rejected; key after cursor rejected; cursor-only macro → empty body allowed; cursor at end → no `{Left}`; merged repeated keys; multiline text runs (`` `n ``, counts 1); quote/backtick in macro text; `T` regression (Text keeps it, Macro never); Macro + date fields rejected; preview 400 surface identical to Save; preview panel silent while collapsed; Macro rows excluded from inline edit (existing gate); CLI renders raw tokens; legacy/new snapshots round-trip unchanged.
+
+## Verification
+Per-task: `dotnet build` + targeted `dotnet test` project. End: full `dck-verify` + E2E smoke above.
+
+## Unresolved questions
+1. Seed a sample Macro hotstring (like Phase 2's `/today`)? Default: no.
+2. Preview snippet in dialog: plain `<pre>` OK, or want copy-button? Default: plain.

--- a/docs/superpowers/plans/2026-07-10-hotstrings-redesign-phase3.md
+++ b/docs/superpowers/plans/2026-07-10-hotstrings-redesign-phase3.md
@@ -106,10 +106,11 @@ Commit: `feat: stateless hotstring preview endpoint`
 
 ### Task 5 — Frontend plumbing
 - Mirror preview DTOs; `HotstringsApiClient.PreviewAsync`; frontend token helper (`MacroTokens`) + unit tests (detection + splitting).
+- `tests/AHKFlowApp.UI.Blazor.Tests/Services/HotstringsApiClientTests.cs`: `PreviewAsync` route (`api/v1/hotstrings/preview`) + request payload + 400 ProblemDetails mapping, per existing client test pattern.
 Commit: `feat: preview API client + frontend macro token helper`
 
 ### Task 6 — Dialog: Macro panel + toolbar + JS + suggestion
-- `wwwroot/js/macro-editor.js` ES module + `MacroEditorJs` service (lazy import, `IAsyncDisposable`).
+- `wwwroot/js/macro-editor.js` ES module + `MacroEditorJs` service (lazy import, `IAsyncDisposable`), registered scoped in `Program.cs` (mirror `JsFileSaver` at line 47 — Blazor services are not auto-discovered).
 - Dialog: Macro toggle item, toolbar buttons (insert canonical tokens at caret), kind-switch confirm arms, "Use Macro?" alert with switch action.
 - bUnit tests (JS mocked via bUnit's `JSInterop`): toggle renders, toolbar visible only for Macro, insert calls module with canonical token, suggestion appears for Text+token / dismisses / switches kind, switch-away confirm.
 Commit: `feat: dialog macro panel with insert toolbar and kind suggestion`

--- a/src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs
@@ -31,7 +31,8 @@ public sealed class HotstringsController(
     IUseCase<RestoreHotstringCommand, Result<HotstringDto>> restoreHotstring,
     IUseCase<PurgeDeletedHotstringCommand, Result> purgeDeletedHotstring,
     IUseCase<PreviewHotstringImportCommand, Result<HotstringImportPreviewDto>> previewImport,
-    IUseCase<ImportHotstringsCommand, Result<HotstringImportResultDto>> importHotstrings) : ControllerBase
+    IUseCase<ImportHotstringsCommand, Result<HotstringImportResultDto>> importHotstrings,
+    IUseCase<GetHotstringPreviewQuery, Result<HotstringPreviewDto>> previewHotstring) : ControllerBase
 {
     /// <summary>List hotstrings for the current user, optionally filtered by profile. Paginated.</summary>
     [HttpGet]
@@ -188,4 +189,13 @@ public sealed class HotstringsController(
         CancellationToken ct) =>
         (await importHotstrings.ExecuteAsync(new ImportHotstringsCommand(dto), ct))
             .ToProblemActionResult(this);
+
+    /// <summary>Preview the AutoHotkey snippet a hotstring definition would generate, without saving it.</summary>
+    [HttpPost("preview")]
+    [ProducesResponseType(typeof(HotstringPreviewDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<HotstringPreviewDto>> Preview(
+        [FromBody] HotstringPreviewRequestDto dto,
+        CancellationToken ct) =>
+        (await previewHotstring.ExecuteAsync(new GetHotstringPreviewQuery(dto), ct)).ToProblemActionResult(this);
 }

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/CreateHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/CreateHotstringCommand.cs
@@ -22,8 +22,8 @@ public sealed class CreateHotstringCommandValidator : AbstractValidator<CreateHo
             .MaximumLength(HotstringRules.DescriptionMaxLength)
             .WithMessage($"Description must be {HotstringRules.DescriptionMaxLength} characters or fewer.");
         RuleFor(x => x.Input.Kind)
-            .Must(k => k is HotstringKind.Text or HotstringKind.DateTime)
-            .WithMessage("Only Text and Date & time hotstrings are supported.");
+            .Must(k => k is HotstringKind.Text or HotstringKind.DateTime or HotstringKind.Macro)
+            .WithMessage("Only Text, Date & time and Macro hotstrings are supported.");
         this.AddProfileAssociationRules(
             x => x.Input.AppliesToAllProfiles,
             x => x.Input.ProfileIds);
@@ -33,6 +33,9 @@ public sealed class CreateHotstringCommandValidator : AbstractValidator<CreateHo
             x => x.Input.DateTimeFormat,
             x => x.Input.DateOffsetAmount,
             x => x.Input.DateOffsetUnit);
+        this.AddMacroKindRules(
+            x => x.Input.Kind,
+            x => x.Input.Replacement);
     }
 }
 

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/UpdateHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/UpdateHotstringCommand.cs
@@ -22,8 +22,8 @@ public sealed class UpdateHotstringCommandValidator : AbstractValidator<UpdateHo
             .MaximumLength(HotstringRules.DescriptionMaxLength)
             .WithMessage($"Description must be {HotstringRules.DescriptionMaxLength} characters or fewer.");
         RuleFor(x => x.Input.Kind)
-            .Must(k => k is HotstringKind.Text or HotstringKind.DateTime)
-            .WithMessage("Only Text and Date & time hotstrings are supported.");
+            .Must(k => k is HotstringKind.Text or HotstringKind.DateTime or HotstringKind.Macro)
+            .WithMessage("Only Text, Date & time and Macro hotstrings are supported.");
         this.AddProfileAssociationRules(
             x => x.Input.AppliesToAllProfiles,
             x => x.Input.ProfileIds);
@@ -33,6 +33,9 @@ public sealed class UpdateHotstringCommandValidator : AbstractValidator<UpdateHo
             x => x.Input.DateTimeFormat,
             x => x.Input.DateOffsetAmount,
             x => x.Input.DateOffsetUnit);
+        this.AddMacroKindRules(
+            x => x.Input.Kind,
+            x => x.Input.Replacement);
     }
 }
 

--- a/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
@@ -14,7 +14,7 @@ namespace AHKFlowApp.Application.DTOs;
 /// <param name="CreatedAt">UTC creation timestamp.</param>
 /// <param name="UpdatedAt">UTC last-update timestamp.</param>
 /// <param name="CategoryIds">Categories assigned to this hotstring.</param>
-/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/> and <see cref="HotstringKind.DateTime"/> are supported via the API; Macro/Script are domain-only.</param>
+/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/>, <see cref="HotstringKind.DateTime"/>, and <see cref="HotstringKind.Macro"/> are supported via the API; Script is domain-only.</param>
 /// <param name="IsCaseSensitive">Controls AutoHotkey's <c>C</c> option.</param>
 /// <param name="OmitEndingCharacter">Controls AutoHotkey's <c>O</c> option.</param>
 /// <param name="DateTimeFormat">Set when <paramref name="Kind"/> is <see cref="HotstringKind.DateTime"/>; a whitelisted AHK/.NET date/time token pattern.</param>
@@ -48,7 +48,7 @@ public sealed record HotstringDto(
 /// <param name="IsTriggerInsideWord">Controls AutoHotkey's <c>?</c> option.</param>
 /// <param name="Description">Optional human-readable note for the hotstring.</param>
 /// <param name="CategoryIds">Categories to assign to the new hotstring.</param>
-/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/> and <see cref="HotstringKind.DateTime"/> are supported via the API; Macro/Script are domain-only.</param>
+/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/>, <see cref="HotstringKind.DateTime"/>, and <see cref="HotstringKind.Macro"/> are supported via the API; Script is domain-only.</param>
 /// <param name="IsCaseSensitive">Controls AutoHotkey's <c>C</c> option.</param>
 /// <param name="OmitEndingCharacter">Controls AutoHotkey's <c>O</c> option.</param>
 /// <param name="DateTimeFormat">Required when <paramref name="Kind"/> is <see cref="HotstringKind.DateTime"/>; a whitelisted AHK/.NET date/time token pattern.</param>
@@ -79,7 +79,7 @@ public sealed record CreateHotstringDto(
 /// <param name="IsTriggerInsideWord">Controls AutoHotkey's <c>?</c> option.</param>
 /// <param name="Description">Optional human-readable note for the hotstring.</param>
 /// <param name="CategoryIds">Replacement category assignment set.</param>
-/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/> and <see cref="HotstringKind.DateTime"/> are supported via the API; Macro/Script are domain-only.</param>
+/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/>, <see cref="HotstringKind.DateTime"/>, and <see cref="HotstringKind.Macro"/> are supported via the API; Script is domain-only.</param>
 /// <param name="IsCaseSensitive">Controls AutoHotkey's <c>C</c> option.</param>
 /// <param name="OmitEndingCharacter">Controls AutoHotkey's <c>O</c> option.</param>
 /// <param name="DateTimeFormat">Required when <paramref name="Kind"/> is <see cref="HotstringKind.DateTime"/>; a whitelisted AHK/.NET date/time token pattern.</param>

--- a/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
@@ -100,3 +100,30 @@ public sealed record UpdateHotstringDto(
     string? DateTimeFormat = null,
     int? DateOffsetAmount = null,
     DateOffsetUnit? DateOffsetUnit = null);
+
+/// <summary>Emission-relevant fields for previewing the AutoHotkey snippet a hotstring definition would generate, without saving it.</summary>
+/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/>, <see cref="HotstringKind.DateTime"/>, and <see cref="HotstringKind.Macro"/> are supported.</param>
+/// <param name="Trigger">Abbreviation that activates the replacement.</param>
+/// <param name="Replacement">Text inserted in place of the trigger.</param>
+/// <param name="IsCaseSensitive">Controls AutoHotkey's <c>C</c> option.</param>
+/// <param name="OmitEndingCharacter">Controls AutoHotkey's <c>O</c> option.</param>
+/// <param name="IsEndingCharacterRequired">Controls AutoHotkey's <c>*</c> option.</param>
+/// <param name="IsTriggerInsideWord">Controls AutoHotkey's <c>?</c> option.</param>
+/// <param name="DateTimeFormat">Required when <paramref name="Kind"/> is <see cref="HotstringKind.DateTime"/>; a whitelisted AHK/.NET date/time token pattern.</param>
+/// <param name="DateOffsetAmount">Optional signed offset applied to the current date/time; requires <paramref name="DateOffsetUnit"/>.</param>
+/// <param name="DateOffsetUnit">Unit for <paramref name="DateOffsetAmount"/>; requires <paramref name="DateOffsetAmount"/>.</param>
+public sealed record HotstringPreviewRequestDto(
+    HotstringKind Kind,
+    string Trigger,
+    string Replacement,
+    bool IsCaseSensitive,
+    bool OmitEndingCharacter,
+    bool IsEndingCharacterRequired,
+    bool IsTriggerInsideWord,
+    string? DateTimeFormat = null,
+    int? DateOffsetAmount = null,
+    DateOffsetUnit? DateOffsetUnit = null);
+
+/// <summary>The AutoHotkey snippet a hotstring definition would generate.</summary>
+/// <param name="Snippet">The exact <c>.ahk</c> line(s) <c>HotstringEmitter.Emit</c> would produce for the given definition.</param>
+public sealed record HotstringPreviewDto(string Snippet);

--- a/src/Backend/AHKFlowApp.Application/DependencyInjection.cs
+++ b/src/Backend/AHKFlowApp.Application/DependencyInjection.cs
@@ -51,6 +51,7 @@ public static class DependencyInjection
             .AddUseCase<SeedHotstringsCommand, Result<PagedList<HotstringDto>>, SeedHotstringsCommandHandler>()
             .AddUseCase<PreviewHotstringImportCommand, Result<HotstringImportPreviewDto>, PreviewHotstringImportCommandHandler>()
             .AddUseCase<ImportHotstringsCommand, Result<HotstringImportResultDto>, ImportHotstringsCommandHandler>()
+            .AddUseCase<GetHotstringPreviewQuery, Result<HotstringPreviewDto>, GetHotstringPreviewQueryHandler>()
             .AddUseCase<CreateHotkeyCommand, Result<HotkeyDto>, CreateHotkeyCommandHandler>()
             .AddUseCase<UpdateHotkeyCommand, Result<HotkeyDto>, UpdateHotkeyCommandHandler>()
             .AddUseCase<DeleteHotkeyCommand, Result, DeleteHotkeyCommandHandler>()

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringPreviewQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringPreviewQuery.cs
@@ -1,0 +1,67 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Services;
+using AHKFlowApp.Application.Validation;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
+using Ardalis.Result;
+using FluentValidation;
+
+namespace AHKFlowApp.Application.Queries.Hotstrings;
+
+public sealed record GetHotstringPreviewQuery(HotstringPreviewRequestDto Input);
+
+public sealed class GetHotstringPreviewQueryValidator : AbstractValidator<GetHotstringPreviewQuery>
+{
+    public GetHotstringPreviewQueryValidator()
+    {
+        RuleFor(x => x.Input.Trigger).ValidTrigger();
+        RuleFor(x => x.Input.Kind)
+            .Must(k => k is HotstringKind.Text or HotstringKind.DateTime or HotstringKind.Macro)
+            .WithMessage("Only Text, Date & time and Macro hotstrings are supported.");
+        this.AddDateTimeKindRules(
+            x => x.Input.Kind,
+            x => x.Input.Replacement,
+            x => x.Input.DateTimeFormat,
+            x => x.Input.DateOffsetAmount,
+            x => x.Input.DateOffsetUnit);
+        this.AddMacroKindRules(
+            x => x.Input.Kind,
+            x => x.Input.Replacement);
+    }
+}
+
+/// <summary>
+/// Computes the exact AutoHotkey snippet a hotstring definition would generate, without
+/// persisting anything. Builds a transient (never-saved) <see cref="Hotstring"/> via
+/// <see cref="Hotstring.Create"/> purely to reuse <see cref="HotstringEmitter"/> — no
+/// <c>IAppDbContext</c> dependency, no side effects.
+/// </summary>
+internal sealed class GetHotstringPreviewQueryHandler(TimeProvider clock)
+    : IUseCaseHandler<GetHotstringPreviewQuery, Result<HotstringPreviewDto>>
+{
+    public Task<Result<HotstringPreviewDto>> ExecuteAsync(GetHotstringPreviewQuery request, CancellationToken ct)
+    {
+        HotstringPreviewRequestDto input = request.Input;
+
+        var hs = Hotstring.Create(
+            Guid.Empty,
+            new HotstringDefinition(
+                input.Trigger,
+                input.Replacement,
+                Description: null,
+                AppliesToAllProfiles: true,
+                input.IsEndingCharacterRequired,
+                input.IsTriggerInsideWord,
+                input.Kind,
+                input.IsCaseSensitive,
+                input.OmitEndingCharacter,
+                input.DateTimeFormat,
+                input.DateOffsetAmount,
+                input.DateOffsetUnit),
+            clock);
+
+        string snippet = HotstringEmitter.Emit(hs);
+        return Task.FromResult(Result.Success(new HotstringPreviewDto(snippet)));
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Services/HotstringEmitter.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/HotstringEmitter.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using AHKFlowApp.Domain.Entities;
 using AHKFlowApp.Domain.Enums;
 
@@ -20,12 +21,17 @@ internal static class HotstringEmitter
         if (hs.IsTriggerInsideWord) options += "?";
         if (hs.IsCaseSensitive) options += "C";
         if (hs.OmitEndingCharacter && hs.IsEndingCharacterRequired) options += "O"; // O is meaningless with *
-        if (!isDateTime) options += "T"; // Text kind always emits literally (WYSIWYG) — resolved decision D1
+        if (hs.Kind == HotstringKind.Text) options += "T"; // Text always emits literally (WYSIWYG) — D1. Brace-body kinds (DateTime/Macro/Script) have no auto-replace text and must never emit T.
         return options;
     }
 
     private static string BuildBody(Hotstring hs) =>
-        hs.Kind == HotstringKind.DateTime ? BuildDateTimeBody(hs) : Escape(hs.Replacement);
+        hs.Kind switch
+        {
+            HotstringKind.DateTime => BuildDateTimeBody(hs),
+            HotstringKind.Macro => BuildMacroBody(hs),
+            _ => Escape(hs.Replacement),
+        };
 
     private static string BuildDateTimeBody(Hotstring hs)
     {
@@ -35,6 +41,73 @@ internal static class HotstringEmitter
             ? $"DateAdd(A_Now, {amount}, \"{unit}\")"
             : "A_Now";
         return $"SendText(FormatTime({nowExpression}, \"{hs.DateTimeFormat}\"))";
+    }
+
+    // Assumes hs.Replacement has already passed Macro validation (parses cleanly, ≤1 cursor,
+    // no keys after cursor) — that invariant is enforced elsewhere (Task 3), not re-checked here.
+    // Produces a tab-indented AHK v2 brace body:
+    //   {
+    //   	SendText "..."
+    //   	Send "{Enter N}"
+    //   	Send "{Left N}"
+    //   }
+    // A Cursor token is transparent for SendText grouping (it emits no keystroke, so text
+    // runs on either side of a bare cursor merge into one SendText call) — only a Key token
+    // forces a break into a new statement. Consecutive identical Key tokens merge into one
+    // "{Name N}" Send line; a differently-named Key starts a new line.
+    private static string BuildMacroBody(Hotstring hs)
+    {
+        IReadOnlyList<MacroToken> tokens = MacroTokenParser.Parse(hs.Replacement).Tokens;
+
+        List<string> lines = [];
+        StringBuilder textAccumulator = new();
+        int cursorIndex = -1;
+
+        void FlushText()
+        {
+            if (textAccumulator.Length == 0) return;
+            lines.Add($"SendText \"{EscapeStringLiteral(textAccumulator.ToString())}\"");
+            textAccumulator.Clear();
+        }
+
+        int i = 0;
+        while (i < tokens.Count)
+        {
+            switch (tokens[i])
+            {
+                case MacroToken.TextRun run:
+                    textAccumulator.Append(run.Text);
+                    i++;
+                    break;
+
+                case MacroToken.Cursor:
+                    cursorIndex = i;
+                    i++;
+                    break;
+
+                case MacroToken.Key key:
+                    FlushText();
+                    int count = 1;
+                    while (i + 1 < tokens.Count && tokens[i + 1] is MacroToken.Key next && next.Name == key.Name)
+                    {
+                        count++;
+                        i++;
+                    }
+                    lines.Add(count == 1 ? $"Send \"{{{key.Name}}}\"" : $"Send \"{{{key.Name} {count}}}\"");
+                    i++;
+                    break;
+            }
+        }
+        FlushText();
+
+        int leftCount = cursorIndex < 0
+            ? 0
+            : tokens.Skip(cursorIndex + 1).OfType<MacroToken.TextRun>().Sum(t => t.Text.Length);
+        if (leftCount > 0)
+            lines.Add($"Send \"{{Left {leftCount}}}\"");
+
+        string body = string.Concat(lines.Select(line => $"\n\t{line}"));
+        return $"\n{{{body}\n}}";
     }
 
     // Keep every hotstring on one physical line and its trigger free of characters
@@ -47,4 +120,16 @@ internal static class HotstringEmitter
             .Replace("\r", "`r")
             .Replace("\t", "`t")
             .Replace(";", "`;");
+
+    // For AHK v2 double-quoted string contents inside a macro's SendText/Send lines.
+    // Unlike Escape() above, no ';' handling is needed (there's no whitespace-preceded-';'
+    // rule inside a quoted string literal). Backtick must be escaped first so later escapes
+    // are not double-escaped.
+    private static string EscapeStringLiteral(string value) =>
+        value
+            .Replace("`", "``")
+            .Replace("\"", "`\"")
+            .Replace("\n", "`n")
+            .Replace("\r", "`r")
+            .Replace("\t", "`t");
 }

--- a/src/Backend/AHKFlowApp.Application/Services/MacroTokenParser.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/MacroTokenParser.cs
@@ -1,0 +1,137 @@
+using System.Text;
+
+namespace AHKFlowApp.Application.Services;
+
+/// <summary>
+/// A single lexical unit produced by <see cref="MacroTokenParser"/>: a run of literal text,
+/// a key-press token, or the caret placement marker. Closed hierarchy — the private
+/// constructor restricts derivation to the nested records below.
+/// </summary>
+internal abstract record MacroToken
+{
+    private MacroToken() { }
+
+    /// <summary>A run of literal text emitted verbatim (includes unescaped <c>{{{{...}}}}</c> content).</summary>
+    internal sealed record TextRun(string Text) : MacroToken;
+
+    /// <summary>A key-press token. <see cref="Name"/> is canonical casing ("Enter" or "Tab").</summary>
+    internal sealed record Key(string Name) : MacroToken;
+
+    /// <summary>The caret placement marker (<c>{{cursor}}</c>).</summary>
+    internal sealed record Cursor : MacroToken;
+}
+
+/// <summary>
+/// Outcome of <see cref="MacroTokenParser.Parse"/>: the recognized token stream plus any
+/// strict parse errors. Consumers (validator, emitter) treat a non-empty <see cref="Errors"/>
+/// list as "this Replacement is not a valid Macro" regardless of what partial tokens exist.
+/// </summary>
+internal sealed record MacroParseResult(IReadOnlyList<MacroToken> Tokens, IReadOnlyList<string> Errors);
+
+/// <summary>
+/// Lexes a Macro hotstring's Replacement text into a stream of <see cref="MacroToken"/>s.
+/// Recognizes <c>{{cursor}}</c>, <c>{{key:Enter}}</c>, <c>{{key:Tab}}</c> (case-insensitive
+/// token names, no interior whitespace) and the <c>{{{{...}}}}</c> escaped-literal form — any
+/// inner content, including whitespace/newlines, terminated by the first <c>}}}}</c> — which
+/// emits literal <c>{{...}}</c> text (decision 11).
+///
+/// Deliberately a small linear character-by-character scanner, not regex-based: a non-Singleline
+/// <c>\{\{.*?\}\}</c> would silently skip token candidates that span a newline instead of
+/// raising the strict error this parser must report for them.
+/// </summary>
+internal static class MacroTokenParser
+{
+    private const string AllowedTokensMessage = "Allowed: {{cursor}}, {{key:Enter}}, {{key:Tab}}.";
+
+    public static MacroParseResult Parse(string replacement)
+    {
+        ArgumentNullException.ThrowIfNull(replacement);
+
+        List<MacroToken> tokens = [];
+        List<string> errors = [];
+        StringBuilder text = new();
+        int i = 0;
+
+        while (i < replacement.Length)
+        {
+            if (!IsDoubleOpenBrace(replacement, i))
+            {
+                text.Append(replacement[i]);
+                i++;
+                continue;
+            }
+
+            if (IsEscapeOpen(replacement, i))
+            {
+                int closeAt = replacement.IndexOf("}}}}", i + 4, StringComparison.Ordinal);
+                if (closeAt >= 0)
+                {
+                    text.Append("{{").Append(replacement, i + 4, closeAt - (i + 4)).Append("}}");
+                    i = closeAt + 4;
+                    continue;
+                }
+
+                // No "}}}}" closer anywhere ahead — only the leading "{{" is literal text;
+                // resume scanning right after it, so a following "{{...}}" is still evaluated
+                // as a real token candidate (and reports its own strict error if malformed).
+                text.Append("{{");
+                i += 2;
+                continue;
+            }
+
+            int close = replacement.IndexOf("}}", i + 2, StringComparison.Ordinal);
+            if (close < 0)
+            {
+                // No closing "}}" anywhere ahead — the "{{" is literal text; keep scanning.
+                text.Append("{{");
+                i += 2;
+                continue;
+            }
+
+            string candidate = replacement[(i + 2)..close];
+            string raw = replacement[i..(close + 2)];
+            MacroToken? token = ResolveToken(candidate);
+
+            if (token is not null)
+            {
+                FlushText(text, tokens);
+                tokens.Add(token);
+            }
+            else
+            {
+                errors.Add($"Unknown token '{raw}'. {AllowedTokensMessage}");
+            }
+
+            i = close + 2;
+        }
+
+        FlushText(text, tokens);
+        return new MacroParseResult(tokens, errors);
+    }
+
+    private static bool IsDoubleOpenBrace(string s, int i) =>
+        s[i] == '{' && i + 1 < s.Length && s[i + 1] == '{';
+
+    private static bool IsEscapeOpen(string s, int i) =>
+        i + 3 < s.Length && s[i + 2] == '{' && s[i + 3] == '{';
+
+    // Exact (non-trimmed) comparisons are what make interior whitespace a strict error —
+    // "{{ cursor }}" candidate is " cursor ", which matches none of these.
+    private static MacroToken? ResolveToken(string candidate) =>
+        candidate switch
+        {
+            _ when candidate.Equals("cursor", StringComparison.OrdinalIgnoreCase) => new MacroToken.Cursor(),
+            _ when candidate.Equals("key:enter", StringComparison.OrdinalIgnoreCase) => new MacroToken.Key("Enter"),
+            _ when candidate.Equals("key:tab", StringComparison.OrdinalIgnoreCase) => new MacroToken.Key("Tab"),
+            _ => null,
+        };
+
+    private static void FlushText(StringBuilder text, List<MacroToken> tokens)
+    {
+        if (text.Length == 0)
+            return;
+
+        tokens.Add(new MacroToken.TextRun(text.ToString()));
+        text.Clear();
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
+++ b/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;
+using AHKFlowApp.Application.Services;
 using AHKFlowApp.Domain.Enums;
 using FluentValidation;
 
@@ -146,6 +147,60 @@ internal static partial class HotstringRules
         validator.RuleFor(dateOffsetUnit)
             .IsInEnum()
             .When(x => IsDateTime(x) && BothOffsetsSet(x));
+    }
+
+    /// <summary>
+    /// Adds kind-conditional validation for Macro hotstrings.
+    /// When <paramref name="kind"/> is <see cref="HotstringKind.Macro"/>, <paramref name="replacement"/> must:
+    /// (1) parse cleanly via <see cref="MacroTokenParser"/> — the first parser error is surfaced verbatim,
+    /// (2) contain at most one <c>{{cursor}}</c> token, and (3) contain no <c>{{key:...}}</c> tokens after the
+    /// cursor. Rules 2 and 3 only run when the replacement parsed without errors — a malformed replacement's
+    /// token stream isn't meaningful to evaluate further.
+    /// The Replacement-required and date-field-null rules for Macro are already covered by
+    /// <see cref="AddDateTimeKindRules{T}"/> (Macro is not DateTime, so it falls into that method's "otherwise"
+    /// branches) and are not duplicated here.
+    /// </summary>
+    public static void AddMacroKindRules<T>(
+        this AbstractValidator<T> validator,
+        Expression<Func<T, HotstringKind>> kind,
+        Expression<Func<T, string>> replacement)
+    {
+        Func<T, HotstringKind> kindFn = kind.Compile();
+
+        bool IsMacro(T x) => kindFn(x) == HotstringKind.Macro;
+
+        validator.RuleFor(replacement)
+            .Custom((value, context) =>
+            {
+                MacroParseResult parsed = MacroTokenParser.Parse(value);
+
+                if (parsed.Errors.Count > 0)
+                {
+                    context.AddFailure(parsed.Errors[0]);
+                    return;
+                }
+
+                int cursorCount = 0;
+                bool keyAfterCursor = false;
+
+                foreach (MacroToken token in parsed.Tokens)
+                {
+                    if (token is MacroToken.Cursor)
+                        cursorCount++;
+                    else if (token is MacroToken.Key && cursorCount > 0)
+                        keyAfterCursor = true;
+                }
+
+                if (cursorCount > 1)
+                {
+                    context.AddFailure("Macro replacement must contain at most one {{cursor}} token.");
+                    return;
+                }
+
+                if (keyAfterCursor)
+                    context.AddFailure("Macro replacement must not contain {{key:...}} tokens after {{cursor}}.");
+            })
+            .When(IsMacro);
     }
 
     [GeneratedRegex(@"^(?=.*[yMdHhmst])[yMdHhmst0-9 \-./:,()]+$")]

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Common/MacroReplacementDisplay.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Common/MacroReplacementDisplay.razor
@@ -1,0 +1,28 @@
+@namespace AHKFlowApp.UI.Blazor.Components.Common
+@using AHKFlowApp.UI.Blazor.Helpers
+
+@foreach (MacroTextPiece piece in Pieces)
+{
+    if (piece is MacroTextPiece.Text text)
+    {
+        @text.Value
+    }
+    else if (piece is MacroTextPiece.Token token)
+    {
+        <MudChip T="string" Size="Size.Small" Class="macro-token-chip">@LabelFor(token.Kind)</MudChip>
+    }
+}
+
+@code {
+    [Parameter, EditorRequired] public string Replacement { get; set; } = "";
+
+    private IReadOnlyList<MacroTextPiece> Pieces => MacroTokens.Split(Replacement);
+
+    private static string LabelFor(MacroTokenKind kind) => kind switch
+    {
+        MacroTokenKind.Cursor => "⌖ cursor",
+        MacroTokenKind.Enter => "Enter",
+        MacroTokenKind.Tab => "Tab",
+        _ => kind.ToString(),
+    };
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -125,6 +125,19 @@
             {
                 <MudAlert Severity="Severity.Error">@_error</MudAlert>
             }
+
+            <MudExpansionPanels UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "ahk-preview" })">
+                <MudExpansionPanel Text="Generated AutoHotkey code" Expanded="_previewExpanded" ExpandedChanged="OnPreviewExpandedChangedAsync">
+                    @if (_previewError is not null)
+                    {
+                        <MudText Color="Color.Error">@_previewError</MudText>
+                    }
+                    else
+                    {
+                        <pre>@_previewSnippet</pre>
+                    }
+                </MudExpansionPanel>
+            </MudExpansionPanels>
         </MudStack>
         </MudForm>
     </DialogContent>
@@ -168,6 +181,12 @@
     private string _selectedFormatOption = CustomFormatSentinel;
     private MudTextField<string> _replacementField = default!;
     private bool _macroSuggestionDismissed;
+    private bool _previewExpanded;
+    private string? _previewSnippet;
+    private string? _previewError;
+    private PreviewSnapshot? _lastPreviewSnapshot;
+    private CancellationTokenSource? _previewCts;
+    private int _previewGeneration;
 
     protected override void OnParametersSet()
     {
@@ -182,6 +201,21 @@
                 ? Item.DateTimeFormat
                 : CustomFormatSentinel;
         }
+    }
+
+    protected override Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_previewExpanded)
+        {
+            PreviewSnapshot current = PreviewSnapshot.From(Item);
+            if (_lastPreviewSnapshot is null || _lastPreviewSnapshot != current)
+            {
+                _lastPreviewSnapshot = current;
+                SchedulePreview(debounce: true);
+            }
+        }
+
+        return Task.CompletedTask;
     }
 
     private void Cancel() => Dialog.Cancel();
@@ -317,5 +351,97 @@
         }
     }
 
-    public void Dispose() { _cts.Cancel(); _cts.Dispose(); }
+    private Task OnPreviewExpandedChangedAsync(bool expanded)
+    {
+        _previewExpanded = expanded;
+        if (expanded)
+        {
+            _lastPreviewSnapshot = PreviewSnapshot.From(Item);
+            SchedulePreview(debounce: false);
+        }
+        else
+        {
+            CancelPendingPreview();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void SchedulePreview(bool debounce)
+    {
+        CancelPendingPreview();
+        CancellationTokenSource cts = new();
+        _previewCts = cts;
+        int generation = ++_previewGeneration;
+        _ = RunPreviewAsync(cts.Token, generation, debounce);
+    }
+
+    private void CancelPendingPreview()
+    {
+        _previewCts?.Cancel();
+        _previewCts?.Dispose();
+        _previewCts = null;
+    }
+
+    private async Task RunPreviewAsync(CancellationToken ct, int generation, bool debounce)
+    {
+        try
+        {
+            if (debounce)
+                await Task.Delay(400, ct);
+
+            HotstringPreviewRequestDto request = new(Item.Kind, Item.Trigger, Item.Replacement, Item.IsCaseSensitive,
+                Item.OmitEndingCharacter, Item.IsEndingCharacterRequired, Item.IsTriggerInsideWord,
+                Item.DateTimeFormat, Item.DateOffsetAmount, Item.DateOffsetUnit);
+
+            ApiResult<HotstringPreviewDto> result = await Api.PreviewAsync(request, ct);
+
+            if (generation != _previewGeneration)
+                return;
+
+            if (result.IsSuccess)
+            {
+                _previewSnippet = result.Value!.Snippet;
+                _previewError = null;
+            }
+            else
+            {
+                _previewError = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+                _previewSnippet = null;
+            }
+
+            StateHasChanged();
+        }
+        catch (OperationCanceledException)
+        {
+            // A cancelled preview (superseded input, panel collapsed, dialog disposed) is
+            // silently ignored — never surfaced as an error.
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
+        CancelPendingPreview();
+    }
+
+    /// <summary>Emission-relevant fields that affect the generated AutoHotkey snippet.</summary>
+    private sealed record PreviewSnapshot(
+        HotstringKind Kind,
+        string Trigger,
+        string Replacement,
+        bool IsCaseSensitive,
+        bool OmitEndingCharacter,
+        bool IsEndingCharacterRequired,
+        bool IsTriggerInsideWord,
+        string? DateTimeFormat,
+        int? DateOffsetAmount,
+        DateOffsetUnit? DateOffsetUnit)
+    {
+        public static PreviewSnapshot From(HotstringEditModel item) => new(
+            item.Kind, item.Trigger, item.Replacement, item.IsCaseSensitive, item.OmitEndingCharacter,
+            item.IsEndingCharacterRequired, item.IsTriggerInsideWord, item.DateTimeFormat,
+            item.DateOffsetAmount, item.DateOffsetUnit);
+    }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -223,34 +223,8 @@
         }
     }
 
-    private string PreviewWithOffset()
-    {
-        if (string.IsNullOrEmpty(Item.DateTimeFormat))
-            return "";
-
-        DateTime moment = DateTime.Now;
-        if (Item.DateOffsetAmount is { } amount && Item.DateOffsetUnit is { } unit)
-        {
-            moment = unit switch
-            {
-                DateOffsetUnit.Seconds => moment.AddSeconds(amount),
-                DateOffsetUnit.Minutes => moment.AddMinutes(amount),
-                DateOffsetUnit.Hours => moment.AddHours(amount),
-                DateOffsetUnit.Days => moment.AddDays(amount),
-                _ => moment,
-            };
-        }
-
-        try
-        {
-            string actualFormat = Item.DateTimeFormat.Length == 1 ? "%" + Item.DateTimeFormat : Item.DateTimeFormat;
-            return moment.ToString(actualFormat);
-        }
-        catch (FormatException)
-        {
-            return "Invalid format";
-        }
-    }
+    private string PreviewWithOffset() =>
+        HotstringEditModel.SafePreview(Item.DateTimeFormat, Item.DateOffsetAmount, Item.DateOffsetUnit);
 
     private async Task SaveAsync()
     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -2,13 +2,16 @@
 @using AHKFlowApp.UI.Blazor.Helpers
 @using AHKFlowApp.UI.Blazor.Services
 @using AHKFlowApp.UI.Blazor.Validation
+@using Microsoft.Extensions.Logging
+@using Microsoft.JSInterop
 @using MudBlazor
 @implements IDisposable
 
 <MudDialog Class="hotstring-edit-dialog">
     <TitleContent>
         <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="flex-grow-1">
-            <MudIconButton Class="cancel-edit" Icon="@Icons.Material.Filled.ArrowBack" OnClick="Cancel" />
+            <MudIconButton Class="cancel-edit" Icon="@Icons.Material.Filled.ArrowBack" OnClick="Cancel"
+                           UserAttributes="@(new Dictionary<string, object?> { ["aria-label"] = "Close without saving" })" />
             <MudText Typo="Typo.h6">@(Item.Id is null ? "New hotstring" : "Edit hotstring")</MudText>
             <MudButton Class="commit-edit" Color="Color.Primary" Variant="Variant.Filled" OnClick="SaveAsync" Disabled="@_saving">Save</MudButton>
         </MudStack>
@@ -23,10 +26,37 @@
                 <MudToggleItem Value="HotstringKind.Macro" Text="Macro" />
             </MudToggleGroup>
 
-            <MudTextField T="string" Label="Trigger" @bind-Value="Item.Trigger"
+            <MudTextField T="string" Label="Trigger" @bind-Value="Item.Trigger" Immediate="true"
                           Required="true" RequiredError="Trigger is required" MaxLength="50"
-                          Error="@(_triggerError is not null)" ErrorText="@_triggerError"
+                          Error="@(TriggerErrorText is not null)" ErrorText="@TriggerErrorText"
                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "trigger-input" })" />
+            @if (Item.Kind == HotstringKind.Macro)
+            {
+                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap"
+                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "macro-toolbar" })">
+                    <MudText Typo="Typo.body2">Insert:</MudText>
+                    <MudButton Variant="Variant.Outlined" Size="Size.Small" Disabled="@HasCursorToken"
+                               OnClick="@(() => InsertTokenAsync(CursorToken))">Cursor</MudButton>
+                    <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="@(() => InsertTokenAsync("{{key:Enter}}"))">Enter</MudButton>
+                    <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="@(() => InsertTokenAsync("{{key:Tab}}"))">Tab</MudButton>
+                </MudStack>
+                @if (_macroInsertHint is not null)
+                {
+                    <MudText Typo="Typo.caption" Color="Color.Warning"
+                             UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "macro-insert-hint", ["role"] = "status" })">
+                        @_macroInsertHint
+                    </MudText>
+                }
+            }
+            @if (Item.Kind != HotstringKind.DateTime)
+            {
+                <MudTextField T="string" Label="Replacement" @bind-Value="Item.Replacement" @ref="_replacementField"
+                              Immediate="true"
+                              Lines="3" Required="true" RequiredError="Replacement is required" MaxLength="4000"
+                              Error="@(_previewReplacementError is not null)" ErrorText="@_previewReplacementError"
+                              HelperText="@(Item.Kind == HotstringKind.Macro ? MacroHelperText : null)"
+                              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "replacement-input" })" />
+            }
             @if (Item.Kind == HotstringKind.Text && !_macroSuggestionDismissed && MacroTokens.ContainsKnownToken(Item.Replacement))
             {
                 <MudAlert Severity="Severity.Info" UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "macro-suggestion" })">
@@ -34,24 +64,12 @@
                         <MudText Typo="Typo.body2">This replacement looks like it contains macro tokens.</MudText>
                         <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
                             <MudButton Size="Size.Small" OnClick="SwitchToMacroFromSuggestion">Switch to Macro</MudButton>
-                            <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small" OnClick="@(() => _macroSuggestionDismissed = true)" />
+                            <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small"
+                                           OnClick="@(() => _macroSuggestionDismissed = true)"
+                                           UserAttributes="@(new Dictionary<string, object?> { ["aria-label"] = "Dismiss macro suggestion" })" />
                         </MudStack>
                     </MudStack>
                 </MudAlert>
-            }
-            @if (Item.Kind != HotstringKind.DateTime)
-            {
-                <MudTextField T="string" Label="Replacement" @bind-Value="Item.Replacement" @ref="_replacementField"
-                              Lines="3" Required="@(Item.Kind != HotstringKind.DateTime)" RequiredError="Replacement is required" MaxLength="4000"
-                              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "replacement-input" })" />
-            }
-            @if (Item.Kind == HotstringKind.Macro)
-            {
-                <MudStack Row="true" Spacing="1" UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "macro-toolbar" })">
-                    <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="@(() => InsertTokenAsync("{{cursor}}"))">Cursor</MudButton>
-                    <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="@(() => InsertTokenAsync("{{key:Enter}}"))">Enter</MudButton>
-                    <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="@(() => InsertTokenAsync("{{key:Tab}}"))">Tab</MudButton>
-                </MudStack>
             }
             @if (Item.Kind == HotstringKind.DateTime)
             {
@@ -66,7 +84,7 @@
                 </MudSelect>
                 @if (_selectedFormatOption == CustomFormatSentinel)
                 {
-                    <MudTextField T="string" Label="Custom format" @bind-Value="Item.DateTimeFormat" MaxLength="50"
+                    <MudTextField T="string" Label="Custom format" @bind-Value="Item.DateTimeFormat" MaxLength="50" Immediate="true"
                                   UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "datetime-format-custom" })" />
                 }
 
@@ -91,6 +109,38 @@
                     @PreviewWithOffset()
                 </MudText>
             }
+
+            <MudExpansionPanels UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "ahk-preview" })">
+                <MudExpansionPanel Text="Generated AutoHotkey code" Expanded="_previewExpanded" ExpandedChanged="OnPreviewExpandedChangedAsync">
+                    @if (_previewPending)
+                    {
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-1"
+                                  UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "preview-pending" })">
+                            <MudProgressCircular Size="Size.Small" Indeterminate="true" />
+                            <MudText Typo="Typo.caption">Updating preview…</MudText>
+                        </MudStack>
+                    }
+                    @if (_previewError is not null)
+                    {
+                        <MudText Color="Color.Error" Class="@(_previewPending ? "preview-stale" : null)"
+                                 UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "preview-error" })">
+                            @_previewError
+                        </MudText>
+                    }
+                    else if (_previewSnippet is not null)
+                    {
+                        <div class="preview-snippet-container">
+                            <MudIconButton Icon="@Icons.Material.Filled.ContentCopy" Size="Size.Small"
+                                           Class="preview-copy" Disabled="@_previewPending"
+                                           OnClick="CopyPreviewAsync"
+                                           UserAttributes="@(new Dictionary<string, object?> { ["aria-label"] = "Copy generated AutoHotkey code", ["data-test"] = "preview-copy" })" />
+                            <pre class="@($"preview-snippet{(_previewPending ? " preview-stale" : "")}")"
+                                 data-test="preview-snippet">@_previewSnippet</pre>
+                        </div>
+                    }
+                </MudExpansionPanel>
+            </MudExpansionPanels>
+
             <MudTextField T="string" Label="Description" @bind-Value="Item.Description"
                           MaxLength="200"
                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "description-input" })" />
@@ -125,19 +175,6 @@
             {
                 <MudAlert Severity="Severity.Error">@_error</MudAlert>
             }
-
-            <MudExpansionPanels UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "ahk-preview" })">
-                <MudExpansionPanel Text="Generated AutoHotkey code" Expanded="_previewExpanded" ExpandedChanged="OnPreviewExpandedChangedAsync">
-                    @if (_previewError is not null)
-                    {
-                        <MudText Color="Color.Error">@_previewError</MudText>
-                    }
-                    else
-                    {
-                        <pre>@_previewSnippet</pre>
-                    }
-                </MudExpansionPanel>
-            </MudExpansionPanels>
         </MudStack>
         </MudForm>
     </DialogContent>
@@ -145,6 +182,9 @@
 
 @code {
     private const string CustomFormatSentinel = "__custom__";
+    private const string CursorToken = "{{cursor}}";
+    private const string MacroHelperText =
+        "One {{cursor}} token allowed; Enter/Tab must come before it. Write {{{{...}}}} for literal {{...}} text.";
 
     private static readonly (string Label, string Format)[] DateTimeFormatPresets =
     [
@@ -165,10 +205,16 @@
     [CascadingParameter] private IMudDialogInstance Dialog { get; set; } = default!;
     [Inject] private IHotstringsApiClient Api { get; set; } = default!;
     [Inject] private IDialogService DialogService { get; set; } = default!;
+    [Inject] private ISnackbar Snackbar { get; set; } = default!;
+    [Inject] private IJSRuntime JS { get; set; } = default!;
+    [Inject] private ILogger<HotstringEditDialog> Logger { get; set; } = default!;
 
     [Parameter] public HotstringEditModel Item { get; set; } = new();
     [Parameter] public IReadOnlyList<ProfileDto> Profiles { get; set; } = [];
     [Parameter] public IReadOnlyList<CategoryDto> Categories { get; set; } = [];
+
+    /// <summary>Debounce applied to preview refreshes after a field change. Test seam.</summary>
+    internal TimeSpan PreviewDebounce { get; set; } = TimeSpan.FromMilliseconds(400);
 
     private string? _error;
     private string? _triggerError;
@@ -181,13 +227,21 @@
     private string _selectedFormatOption = CustomFormatSentinel;
     private MudTextField<string> _replacementField = default!;
     private bool _macroSuggestionDismissed;
+    private string? _macroInsertHint;
     private bool _previewExpanded;
+    private bool _previewPending;
     private string? _previewSnippet;
     private string? _previewError;
-    private PreviewSnapshot? _lastPreviewSnapshot;
+    private string? _previewTriggerError;
+    private string? _previewReplacementError;
+    private HotstringPreviewRequestDto? _lastPreviewRequest;
     private CancellationTokenSource? _previewCts;
     private int _previewGeneration;
     private bool _disposed;
+
+    private string? TriggerErrorText => _triggerError ?? _previewTriggerError;
+
+    private bool HasCursorToken => MacroTokens.CursorTokenStart(Item.Replacement) is not null;
 
     protected override void OnParametersSet()
     {
@@ -208,11 +262,11 @@
     {
         if (_previewExpanded)
         {
-            PreviewSnapshot current = PreviewSnapshot.From(Item);
-            if (_lastPreviewSnapshot is null || _lastPreviewSnapshot != current)
+            HotstringPreviewRequestDto current = BuildPreviewRequest();
+            if (_lastPreviewRequest != current)
             {
-                _lastPreviewSnapshot = current;
-                SchedulePreview(debounce: true);
+                _lastPreviewRequest = current;
+                SchedulePreview(current, debounce: true);
             }
         }
 
@@ -282,8 +336,33 @@
         }
     }
 
-    private async Task InsertTokenAsync(string token) =>
+    private async Task InsertTokenAsync(string token)
+    {
+        _macroInsertHint = null;
+
+        int? cursorStart = MacroTokens.CursorTokenStart(Item.Replacement);
+        if (token == CursorToken)
+        {
+            // The button is disabled once a cursor token exists; this guard covers paths
+            // where the bound value is newer than the last render.
+            if (cursorStart is not null)
+            {
+                _macroInsertHint = "Only one {{cursor}} token is allowed.";
+                return;
+            }
+        }
+        else if (cursorStart is { } start)
+        {
+            int caret = await _replacementField.GetCurrentCaretPositionAsync();
+            if (caret > start)
+            {
+                _macroInsertHint = "Enter and Tab can only be inserted before the {{cursor}} token.";
+                return;
+            }
+        }
+
         await _replacementField.InsertTextAtCurrentCaretPositionAsync(token);
+    }
 
     private Task SwitchToMacroFromSuggestion() => OnKindChangedAsync(HotstringKind.Macro);
 
@@ -352,65 +431,90 @@
         }
     }
 
+    private async Task CopyPreviewAsync()
+    {
+        if (_previewSnippet is null)
+            return;
+
+        try
+        {
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", _previewSnippet);
+            Snackbar.Add("Generated code copied.", Severity.Success);
+        }
+        catch (JSException)
+        {
+            Snackbar.Add("Copy to clipboard failed.", Severity.Warning);
+        }
+    }
+
     private Task OnPreviewExpandedChangedAsync(bool expanded)
     {
         _previewExpanded = expanded;
         if (expanded)
         {
-            _lastPreviewSnapshot = PreviewSnapshot.From(Item);
-            SchedulePreview(debounce: false);
+            HotstringPreviewRequestDto request = BuildPreviewRequest();
+            _lastPreviewRequest = request;
+            SchedulePreview(request, debounce: false);
         }
         else
         {
             CancelPendingPreview();
+            _previewTriggerError = null;
+            _previewReplacementError = null;
         }
 
         return Task.CompletedTask;
     }
 
-    private void SchedulePreview(bool debounce)
+    private HotstringPreviewRequestDto BuildPreviewRequest() => new(
+        Item.Kind, Item.Trigger, Item.Replacement, Item.IsCaseSensitive,
+        Item.OmitEndingCharacter, Item.IsEndingCharacterRequired, Item.IsTriggerInsideWord,
+        Item.DateTimeFormat, Item.DateOffsetAmount, Item.DateOffsetUnit);
+
+    private void SchedulePreview(HotstringPreviewRequestDto request, bool debounce)
     {
         CancelPendingPreview();
         CancellationTokenSource cts = new();
         _previewCts = cts;
         int generation = ++_previewGeneration;
-        _ = RunPreviewAsync(cts.Token, generation, debounce);
+        _previewPending = true;
+
+        // Fire-and-forget with the fault path observed: cancellations are handled inside
+        // RunPreviewAsync; anything else is a bug that must be logged, not lost as an
+        // unobserved task exception.
+        Task previewTask = RunPreviewAsync(request, cts.Token, generation, debounce);
+        _ = previewTask.ContinueWith(
+            t => Logger.LogError(t.Exception, "Hotstring preview failed unexpectedly."),
+            CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Current);
+
+        StateHasChanged();
     }
 
     private void CancelPendingPreview()
     {
+        // Bumping the generation (not just cancelling) also discards in-flight responses
+        // whose transport ignores cancellation and completes successfully afterwards.
+        _previewGeneration++;
+        _previewPending = false;
         _previewCts?.Cancel();
         _previewCts?.Dispose();
         _previewCts = null;
     }
 
-    private async Task RunPreviewAsync(CancellationToken ct, int generation, bool debounce)
+    private async Task RunPreviewAsync(HotstringPreviewRequestDto request, CancellationToken ct, int generation, bool debounce)
     {
         try
         {
-            if (debounce)
-                await Task.Delay(400, ct);
-
-            HotstringPreviewRequestDto request = new(Item.Kind, Item.Trigger, Item.Replacement, Item.IsCaseSensitive,
-                Item.OmitEndingCharacter, Item.IsEndingCharacterRequired, Item.IsTriggerInsideWord,
-                Item.DateTimeFormat, Item.DateOffsetAmount, Item.DateOffsetUnit);
+            if (debounce && PreviewDebounce > TimeSpan.Zero)
+                await Task.Delay(PreviewDebounce, ct);
 
             ApiResult<HotstringPreviewDto> result = await Api.PreviewAsync(request, ct);
 
             if (generation != _previewGeneration || _disposed)
                 return;
 
-            if (result.IsSuccess)
-            {
-                _previewSnippet = result.Value!.Snippet;
-                _previewError = null;
-            }
-            else
-            {
-                _previewError = ApiErrorMessageFactory.Build(result.Status, result.Problem);
-                _previewSnippet = null;
-            }
-
+            _previewPending = false;
+            ApplyPreviewResult(result);
             StateHasChanged();
         }
         catch (OperationCanceledException)
@@ -420,30 +524,49 @@
         }
     }
 
+    private void ApplyPreviewResult(ApiResult<HotstringPreviewDto> result)
+    {
+        _previewTriggerError = null;
+        _previewReplacementError = null;
+
+        if (result.IsSuccess)
+        {
+            _previewSnippet = result.Value!.Snippet;
+            _previewError = null;
+            return;
+        }
+
+        _previewSnippet = null;
+
+        if (result.Status == ApiResultStatus.Validation && result.Problem?.Errors is { Count: > 0 } errors)
+        {
+            foreach ((string key, string[] messages) in errors)
+            {
+                if (messages.FirstOrDefault() is not { } message)
+                    continue;
+
+                // Property paths arrive as e.g. "Input.Replacement" — the last dotted part
+                // is the field name.
+                string field = key[(key.LastIndexOf('.') + 1)..];
+                if (field.Equals(nameof(Item.Trigger), StringComparison.OrdinalIgnoreCase))
+                    _previewTriggerError ??= message;
+                else if (field.Equals(nameof(Item.Replacement), StringComparison.OrdinalIgnoreCase))
+                    _previewReplacementError ??= message;
+            }
+
+            _previewError = errors.SelectMany(kv => kv.Value).FirstOrDefault() ?? "The request was invalid.";
+        }
+        else
+        {
+            _previewError = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+        }
+    }
+
     public void Dispose()
     {
         _disposed = true;
         _cts.Cancel();
         _cts.Dispose();
         CancelPendingPreview();
-    }
-
-    /// <summary>Emission-relevant fields that affect the generated AutoHotkey snippet.</summary>
-    private sealed record PreviewSnapshot(
-        HotstringKind Kind,
-        string Trigger,
-        string Replacement,
-        bool IsCaseSensitive,
-        bool OmitEndingCharacter,
-        bool IsEndingCharacterRequired,
-        bool IsTriggerInsideWord,
-        string? DateTimeFormat,
-        int? DateOffsetAmount,
-        DateOffsetUnit? DateOffsetUnit)
-    {
-        public static PreviewSnapshot From(HotstringEditModel item) => new(
-            item.Kind, item.Trigger, item.Replacement, item.IsCaseSensitive, item.OmitEndingCharacter,
-            item.IsEndingCharacterRequired, item.IsTriggerInsideWord, item.DateTimeFormat,
-            item.DateOffsetAmount, item.DateOffsetUnit);
     }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -1,4 +1,5 @@
 @using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Helpers
 @using AHKFlowApp.UI.Blazor.Services
 @using AHKFlowApp.UI.Blazor.Validation
 @using MudBlazor
@@ -19,17 +20,38 @@
                              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "kind-selector" })">
                 <MudToggleItem Value="HotstringKind.Text" Text="Text" />
                 <MudToggleItem Value="HotstringKind.DateTime" Text="Date & time" />
+                <MudToggleItem Value="HotstringKind.Macro" Text="Macro" />
             </MudToggleGroup>
 
             <MudTextField T="string" Label="Trigger" @bind-Value="Item.Trigger"
                           Required="true" RequiredError="Trigger is required" MaxLength="50"
                           Error="@(_triggerError is not null)" ErrorText="@_triggerError"
                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "trigger-input" })" />
+            @if (Item.Kind == HotstringKind.Text && !_macroSuggestionDismissed && MacroTokens.ContainsKnownToken(Item.Replacement))
+            {
+                <MudAlert Severity="Severity.Info" UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "macro-suggestion" })">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="flex-grow-1">
+                        <MudText Typo="Typo.body2">This replacement looks like it contains macro tokens.</MudText>
+                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                            <MudButton Size="Size.Small" OnClick="SwitchToMacroFromSuggestion">Switch to Macro</MudButton>
+                            <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small" OnClick="@(() => _macroSuggestionDismissed = true)" />
+                        </MudStack>
+                    </MudStack>
+                </MudAlert>
+            }
             @if (Item.Kind != HotstringKind.DateTime)
             {
-                <MudTextField T="string" Label="Replacement" @bind-Value="Item.Replacement"
+                <MudTextField T="string" Label="Replacement" @bind-Value="Item.Replacement" @ref="_replacementField"
                               Lines="3" Required="@(Item.Kind != HotstringKind.DateTime)" RequiredError="Replacement is required" MaxLength="4000"
                               UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "replacement-input" })" />
+            }
+            @if (Item.Kind == HotstringKind.Macro)
+            {
+                <MudStack Row="true" Spacing="1" UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "macro-toolbar" })">
+                    <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="@(() => InsertTokenAsync("{{cursor}}"))">Cursor</MudButton>
+                    <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="@(() => InsertTokenAsync("{{key:Enter}}"))">Enter</MudButton>
+                    <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="@(() => InsertTokenAsync("{{key:Tab}}"))">Tab</MudButton>
+                </MudStack>
             }
             @if (Item.Kind == HotstringKind.DateTime)
             {
@@ -144,6 +166,8 @@
     private IReadOnlyList<EntityOption> _categoryOptions = [];
     private HotstringEditModel? _lastItem;
     private string _selectedFormatOption = CustomFormatSentinel;
+    private MudTextField<string> _replacementField = default!;
+    private bool _macroSuggestionDismissed;
 
     protected override void OnParametersSet()
     {
@@ -191,13 +215,42 @@
                     yesText: "Switch", cancelText: "Cancel");
                 if (confirm != true) return;
             }
+            else if (Item.Kind == HotstringKind.Macro && MacroTokens.ContainsKnownToken(Item.Replacement))
+            {
+                bool? confirm = await DialogService.ShowMessageBoxAsync(
+                    title: "Switch to Text?",
+                    message: "Switching to Text will treat any {{...}} tokens in the replacement as literal text instead of macro commands. Continue?",
+                    yesText: "Switch", cancelText: "Cancel");
+                if (confirm != true) return;
+            }
 
             Item.DateTimeFormat = null;
             Item.DateOffsetAmount = null;
             Item.DateOffsetUnit = null;
             Item.Kind = HotstringKind.Text;
         }
+        else if (newKind == HotstringKind.Macro)
+        {
+            if (Item.DateTimeFormat is not null)
+            {
+                bool? confirm = await DialogService.ShowMessageBoxAsync(
+                    title: "Switch to Macro?",
+                    message: "Switching to Macro will clear the date/time format and offset. Continue?",
+                    yesText: "Switch", cancelText: "Cancel");
+                if (confirm != true) return;
+            }
+
+            Item.DateTimeFormat = null;
+            Item.DateOffsetAmount = null;
+            Item.DateOffsetUnit = null;
+            Item.Kind = HotstringKind.Macro;
+        }
     }
+
+    private async Task InsertTokenAsync(string token) =>
+        await _replacementField.InsertTextAtCurrentCaretPositionAsync(token);
+
+    private Task SwitchToMacroFromSuggestion() => OnKindChangedAsync(HotstringKind.Macro);
 
     private void OnFormatOptionChanged(string option)
     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -478,14 +478,12 @@
         _previewCts = cts;
         int generation = ++_previewGeneration;
         _previewPending = true;
+        _previewTriggerError = null;
+        _previewReplacementError = null;
 
-        // Fire-and-forget with the fault path observed: cancellations are handled inside
-        // RunPreviewAsync; anything else is a bug that must be logged, not lost as an
-        // unobserved task exception.
-        Task previewTask = RunPreviewAsync(request, cts.Token, generation, debounce);
-        _ = previewTask.ContinueWith(
-            t => Logger.LogError(t.Exception, "Hotstring preview failed unexpectedly."),
-            CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Current);
+        // Fire-and-forget: RunPreviewAsync handles every exception it can raise (including
+        // unexpected ones), so the task never faults.
+        _ = RunPreviewAsync(request, cts.Token, generation, debounce);
 
         StateHasChanged();
     }
@@ -522,6 +520,22 @@
             // A cancelled preview (superseded input, panel collapsed, dialog disposed) is
             // silently ignored — never surfaced as an error.
         }
+        catch (Exception ex)
+        {
+            // Boundary for a fire-and-forget background task: successful-response
+            // deserialization (or anything else) can throw after ApiClientBase's
+            // HttpRequestException handling. Log it and surface a friendly message instead
+            // of leaving the "Updating preview…" spinner stuck forever.
+            Logger.LogError(ex, "Hotstring preview failed unexpectedly.");
+
+            if (generation != _previewGeneration || _disposed)
+                return;
+
+            _previewPending = false;
+            _previewSnippet = null;
+            _previewError = "Something went wrong generating the preview. Try again.";
+            StateHasChanged();
+        }
     }
 
     private void ApplyPreviewResult(ApiResult<HotstringPreviewDto> result)
@@ -540,6 +554,10 @@
 
         if (result.Status == ApiResultStatus.Validation && result.Problem?.Errors is { Count: > 0 } errors)
         {
+            // Errors mapped onto Trigger/Replacement show inline only; the panel is
+            // reserved for anything that isn't shown next to a field, so the same message
+            // never appears twice.
+            List<string> unmapped = [];
             foreach ((string key, string[] messages) in errors)
             {
                 if (messages.FirstOrDefault() is not { } message)
@@ -552,9 +570,11 @@
                     _previewTriggerError ??= message;
                 else if (field.Equals(nameof(Item.Replacement), StringComparison.OrdinalIgnoreCase))
                     _previewReplacementError ??= message;
+                else
+                    unmapped.Add(message);
             }
 
-            _previewError = errors.SelectMany(kv => kv.Value).FirstOrDefault() ?? "The request was invalid.";
+            _previewError = unmapped.FirstOrDefault();
         }
         else
         {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -187,6 +187,7 @@
     private PreviewSnapshot? _lastPreviewSnapshot;
     private CancellationTokenSource? _previewCts;
     private int _previewGeneration;
+    private bool _disposed;
 
     protected override void OnParametersSet()
     {
@@ -396,7 +397,7 @@
 
             ApiResult<HotstringPreviewDto> result = await Api.PreviewAsync(request, ct);
 
-            if (generation != _previewGeneration)
+            if (generation != _previewGeneration || _disposed)
                 return;
 
             if (result.IsSuccess)
@@ -421,6 +422,7 @@
 
     public void Dispose()
     {
+        _disposed = true;
         _cts.Cancel();
         _cts.Dispose();
         CancelPendingPreview();

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor.css
@@ -1,0 +1,24 @@
+.preview-snippet-container {
+    position: relative;
+    max-width: 100%;
+}
+
+.preview-snippet {
+    margin: 0;
+    padding: 8px 40px 8px 12px;
+    font-size: 0.85rem;
+    background: var(--mud-palette-background-grey);
+    border-radius: 4px;
+    overflow-x: auto;
+    max-width: 100%;
+}
+
+.preview-snippet-container ::deep .preview-copy {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+}
+
+.preview-stale {
+    opacity: 0.5;
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
@@ -132,10 +132,11 @@
         _categoryOptions = [.. Categories.Select(c => new EntityOption(c.Id, c.Name))];
     }
 
+    // Collapsed rows keep a single ellipsized line for list density — Macro rows show the
+    // raw replacement text here; the token-chip rendering lives in the expanded details.
     private RenderFragment RenderReplacementCell(HotstringEditModel item) => item.Kind switch
     {
         HotstringKind.DateTime => @<text>@item.DateTimeSummary</text>,
-        HotstringKind.Macro => @<MacroReplacementDisplay Replacement="@item.Replacement" />,
         _ => @<text>@item.Replacement</text>,
     };
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
@@ -42,7 +42,7 @@
                             </td>
                         }
                         <td class="trigger-cell"><code>@item.Trigger</code></td>
-                        <td class="replacement-cell">@(item.Kind == HotstringKind.DateTime ? item.DateTimeSummary : item.Replacement)</td>
+                        <td class="replacement-cell">@RenderReplacementCell(item)</td>
                         <td class="chevron-cell">@(expanded ? "▾" : "▸")</td>
                     </tr>
                     @if (expanded)
@@ -54,6 +54,12 @@
                                     {
                                         <MudText Typo="Typo.body2" Style="white-space: pre-wrap">
                                             <strong>Format:</strong> @item.DateTimeSummary
+                                        </MudText>
+                                    }
+                                    else if (item.Kind == HotstringKind.Macro)
+                                    {
+                                        <MudText Typo="Typo.body2" Style="white-space: pre-wrap">
+                                            <strong>Replacement:</strong> <MacroReplacementDisplay Replacement="@item.Replacement" />
                                         </MudText>
                                     }
                                     else
@@ -125,6 +131,13 @@
         _profileOptions = [.. Profiles.Select(p => new EntityOption(p.Id, p.Name))];
         _categoryOptions = [.. Categories.Select(c => new EntityOption(c.Id, c.Name))];
     }
+
+    private RenderFragment RenderReplacementCell(HotstringEditModel item) => item.Kind switch
+    {
+        HotstringKind.DateTime => @<text>@item.DateTimeSummary</text>,
+        HotstringKind.Macro => @<MacroReplacementDisplay Replacement="@item.Replacement" />,
+        _ => @<text>@item.Replacement</text>,
+    };
 
     private void OnRowClick(HotstringEditModel item)
     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HotstringPreviewDtos.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HotstringPreviewDtos.cs
@@ -1,0 +1,15 @@
+namespace AHKFlowApp.UI.Blazor.DTOs;
+
+public sealed record HotstringPreviewRequestDto(
+    HotstringKind Kind,
+    string Trigger,
+    string Replacement,
+    bool IsCaseSensitive,
+    bool OmitEndingCharacter,
+    bool IsEndingCharacterRequired,
+    bool IsTriggerInsideWord,
+    string? DateTimeFormat = null,
+    int? DateOffsetAmount = null,
+    DateOffsetUnit? DateOffsetUnit = null);
+
+public sealed record HotstringPreviewDto(string Snippet);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/MacroTokens.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/MacroTokens.cs
@@ -42,16 +42,19 @@ public abstract record MacroTextPiece
 /// <c>{{...}}</c> text).
 ///
 /// Unlike the backend parser, this helper never validates or rejects malformed input —
-/// it exists only to drive UI hints (the "Use Macro?" suggestion) and chip rendering.
-/// An unrecognized <c>{{...}}</c> candidate is treated as plain text rather than reported
-/// as an error; the backend remains the sole source of truth for Macro validation.
+/// it exists only to drive UI hints (the "Use Macro?" suggestion, toolbar insertion guards)
+/// and chip rendering. An unrecognized <c>{{...}}</c> candidate is treated as plain text
+/// rather than reported as an error; the backend remains the sole source of truth for
+/// Macro validation.
 ///
-/// Deliberately a small linear character scan, not regex-based, matching the backend's
-/// rationale: a non-Singleline <c>\{\{.*?\}\}</c> would silently skip token candidates that
-/// span a newline. Since this helper's worst-case failure is a missed suggestion or a chip
-/// falling back to plain text (not a data-integrity issue), a regex-based rewrite would be
-/// an acceptable simplification later if needed — this scan just keeps behavior aligned
-/// with the backend today.
+/// Deliberately a small linear character scan, not regex-based. A regex rewrite was
+/// evaluated (2026-07-10) and rejected: an alternation such as
+/// <c>\{\{\{\{.*?\}\}\}\}|\{\{.*?\}\}</c> cannot reproduce the scanner's
+/// resume-after-orphan-escape rule — e.g. <c>{{{{cursor}}</c> (escape opener with no
+/// <c>}}}}</c> closer) must yield literal <c>{{</c> followed by a real cursor token, while
+/// the regex consumes <c>{{{{cursor}}</c> as one unknown candidate and misses the token.
+/// Patching that with lookaheads ends up longer and less clear than the scan, and any
+/// divergence here desynchronizes the "Use Macro?" hint from backend validation.
 /// </summary>
 public static class MacroTokens
 {
@@ -61,8 +64,11 @@ public static class MacroTokens
     /// content looks like a token name (e.g. <c>{{{{cursor}}}}</c> unescapes to the literal
     /// text <c>{{cursor}}</c>, which is not a real token).
     /// </summary>
-    public static bool ContainsKnownToken(string text) =>
-        Split(text).Any(piece => piece is MacroTextPiece.Token);
+    public static bool ContainsKnownToken(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return Scan(text).Any(segment => segment.Token is not null);
+    }
 
     /// <summary>
     /// Splits <paramref name="text"/> into an ordered sequence of plain-text and token
@@ -75,13 +81,54 @@ public static class MacroTokens
 
         List<MacroTextPiece> pieces = [];
         StringBuilder plain = new();
+
+        foreach (Segment segment in Scan(text))
+        {
+            if (segment.Token is { } kind)
+            {
+                FlushText(plain, pieces);
+                pieces.Add(new MacroTextPiece.Token(kind));
+            }
+            else
+            {
+                plain.Append(segment.Text);
+            }
+        }
+
+        FlushText(plain, pieces);
+        return pieces;
+    }
+
+    /// <summary>
+    /// Raw character index of the first real <c>{{cursor}}</c> token, or null when the text
+    /// has none. Escaped literals never match. Drives the dialog toolbar guards (block a
+    /// second cursor, block Enter/Tab insertion behind the cursor).
+    /// </summary>
+    public static int? CursorTokenStart(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        foreach (Segment segment in Scan(text))
+        {
+            if (segment.Token == MacroTokenKind.Cursor)
+                return segment.Start;
+        }
+
+        return null;
+    }
+
+    /// <summary>One scanned stretch of the raw text: a token (Text empty) or literal text.</summary>
+    private readonly record struct Segment(int Start, string Text, MacroTokenKind? Token);
+
+    private static IEnumerable<Segment> Scan(string text)
+    {
         int i = 0;
+        int runStart = 0;
 
         while (i < text.Length)
         {
             if (!IsDoubleOpenBrace(text, i))
             {
-                plain.Append(text[i]);
                 i++;
                 continue;
             }
@@ -91,15 +138,18 @@ public static class MacroTokens
                 int closeAt = text.IndexOf("}}}}", i + 4, StringComparison.Ordinal);
                 if (closeAt >= 0)
                 {
-                    plain.Append("{{").Append(text, i + 4, closeAt - (i + 4)).Append("}}");
+                    if (i > runStart)
+                        yield return new Segment(runStart, text[runStart..i], null);
+
+                    yield return new Segment(i, $"{{{{{text[(i + 4)..closeAt]}}}}}", null);
                     i = closeAt + 4;
+                    runStart = i;
                     continue;
                 }
 
                 // No "}}}}" closer anywhere ahead — only the leading "{{" is literal text;
                 // resume right after it so a following "{{...}}" is still evaluated as a
                 // token candidate.
-                plain.Append("{{");
                 i += 2;
                 continue;
             }
@@ -107,32 +157,28 @@ public static class MacroTokens
             int close = text.IndexOf("}}", i + 2, StringComparison.Ordinal);
             if (close < 0)
             {
-                // No closing "}}" anywhere ahead — treat the "{{" as literal text.
-                plain.Append("{{");
+                // No closing "}}" anywhere ahead — the "{{" stays literal text.
                 i += 2;
                 continue;
             }
 
-            string candidate = text[(i + 2)..close];
-            MacroTokenKind? kind = ResolveToken(candidate);
-
+            MacroTokenKind? kind = ResolveToken(text[(i + 2)..close]);
             if (kind is { } resolvedKind)
             {
-                FlushText(plain, pieces);
-                pieces.Add(new MacroTextPiece.Token(resolvedKind));
+                if (i > runStart)
+                    yield return new Segment(runStart, text[runStart..i], null);
+
+                yield return new Segment(i, "", resolvedKind);
+                runStart = close + 2;
             }
-            else
-            {
-                // Unrecognized "{{...}}" candidate — not the backend's job here, keep it
-                // as plain text rather than reporting an error.
-                plain.Append(text, i, close + 2 - i);
-            }
+            // Unrecognized "{{...}}" candidate — not the backend's job here, it stays part
+            // of the surrounding literal run.
 
             i = close + 2;
         }
 
-        FlushText(plain, pieces);
-        return pieces;
+        if (text.Length > runStart)
+            yield return new Segment(runStart, text[runStart..], null);
     }
 
     private static bool IsDoubleOpenBrace(string s, int i) =>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/MacroTokens.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/MacroTokens.cs
@@ -1,0 +1,163 @@
+using System.Text;
+
+namespace AHKFlowApp.UI.Blazor.Helpers;
+
+/// <summary>The kind of macro token a <see cref="MacroTextPiece.Token"/> piece represents.</summary>
+public enum MacroTokenKind
+{
+    /// <summary><c>{{cursor}}</c> — the caret placement marker.</summary>
+    Cursor,
+
+    /// <summary><c>{{key:Enter}}</c>.</summary>
+    Enter,
+
+    /// <summary><c>{{key:Tab}}</c>.</summary>
+    Tab,
+}
+
+/// <summary>
+/// A single piece of a split macro replacement string: either a run of plain text
+/// (including unescaped <c>{{{{...}}}}</c> content) or a recognized token. Closed
+/// hierarchy — the private constructor restricts derivation to the nested records below.
+/// A Razor component can iterate a <see cref="MacroTokens.Split"/> result and render each
+/// piece as either an inline text span (<see cref="Text"/>) or a chip (<see cref="Token"/>).
+/// </summary>
+public abstract record MacroTextPiece
+{
+    private MacroTextPiece() { }
+
+    /// <summary>A run of plain text.</summary>
+    public sealed record Text(string Value) : MacroTextPiece;
+
+    /// <summary>A recognized macro token.</summary>
+    public sealed record Token(MacroTokenKind Kind) : MacroTextPiece;
+}
+
+/// <summary>
+/// Lightweight frontend mirror of the backend grammar in
+/// <c>AHKFlowApp.Application.Services.MacroTokenParser</c>. Recognizes the same three real
+/// tokens (<c>{{cursor}}</c>, <c>{{key:Enter}}</c>, <c>{{key:Tab}}</c> — case-insensitive
+/// token names, no interior whitespace) and the <c>{{{{...}}}}</c> escaped-literal form
+/// (any inner content terminated by the first <c>}}}}</c>, unescaped to literal
+/// <c>{{...}}</c> text).
+///
+/// Unlike the backend parser, this helper never validates or rejects malformed input —
+/// it exists only to drive UI hints (the "Use Macro?" suggestion) and chip rendering.
+/// An unrecognized <c>{{...}}</c> candidate is treated as plain text rather than reported
+/// as an error; the backend remains the sole source of truth for Macro validation.
+///
+/// Deliberately a small linear character scan, not regex-based, matching the backend's
+/// rationale: a non-Singleline <c>\{\{.*?\}\}</c> would silently skip token candidates that
+/// span a newline. Since this helper's worst-case failure is a missed suggestion or a chip
+/// falling back to plain text (not a data-integrity issue), a regex-based rewrite would be
+/// an acceptable simplification later if needed — this scan just keeps behavior aligned
+/// with the backend today.
+/// </summary>
+public static class MacroTokens
+{
+    /// <summary>
+    /// True if <paramref name="text"/> contains at least one well-formed, unescaped known
+    /// token. An escaped-literal <c>{{{{...}}}}</c> never counts, even when its unescaped
+    /// content looks like a token name (e.g. <c>{{{{cursor}}}}</c> unescapes to the literal
+    /// text <c>{{cursor}}</c>, which is not a real token).
+    /// </summary>
+    public static bool ContainsKnownToken(string text) =>
+        Split(text).Any(piece => piece is MacroTextPiece.Token);
+
+    /// <summary>
+    /// Splits <paramref name="text"/> into an ordered sequence of plain-text and token
+    /// pieces for chip rendering. Escaped literals split out as a plain-text piece
+    /// containing their unescaped content, never as a token piece.
+    /// </summary>
+    public static IReadOnlyList<MacroTextPiece> Split(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        List<MacroTextPiece> pieces = [];
+        StringBuilder plain = new();
+        int i = 0;
+
+        while (i < text.Length)
+        {
+            if (!IsDoubleOpenBrace(text, i))
+            {
+                plain.Append(text[i]);
+                i++;
+                continue;
+            }
+
+            if (IsEscapeOpen(text, i))
+            {
+                int closeAt = text.IndexOf("}}}}", i + 4, StringComparison.Ordinal);
+                if (closeAt >= 0)
+                {
+                    plain.Append("{{").Append(text, i + 4, closeAt - (i + 4)).Append("}}");
+                    i = closeAt + 4;
+                    continue;
+                }
+
+                // No "}}}}" closer anywhere ahead — only the leading "{{" is literal text;
+                // resume right after it so a following "{{...}}" is still evaluated as a
+                // token candidate.
+                plain.Append("{{");
+                i += 2;
+                continue;
+            }
+
+            int close = text.IndexOf("}}", i + 2, StringComparison.Ordinal);
+            if (close < 0)
+            {
+                // No closing "}}" anywhere ahead — treat the "{{" as literal text.
+                plain.Append("{{");
+                i += 2;
+                continue;
+            }
+
+            string candidate = text[(i + 2)..close];
+            MacroTokenKind? kind = ResolveToken(candidate);
+
+            if (kind is { } resolvedKind)
+            {
+                FlushText(plain, pieces);
+                pieces.Add(new MacroTextPiece.Token(resolvedKind));
+            }
+            else
+            {
+                // Unrecognized "{{...}}" candidate — not the backend's job here, keep it
+                // as plain text rather than reporting an error.
+                plain.Append(text, i, close + 2 - i);
+            }
+
+            i = close + 2;
+        }
+
+        FlushText(plain, pieces);
+        return pieces;
+    }
+
+    private static bool IsDoubleOpenBrace(string s, int i) =>
+        s[i] == '{' && i + 1 < s.Length && s[i + 1] == '{';
+
+    private static bool IsEscapeOpen(string s, int i) =>
+        i + 3 < s.Length && s[i + 2] == '{' && s[i + 3] == '{';
+
+    // Exact (non-trimmed) comparisons are what make interior whitespace not count as a
+    // known token — "{{ cursor }}" candidate is " cursor ", which matches none of these.
+    private static MacroTokenKind? ResolveToken(string candidate) =>
+        candidate switch
+        {
+            _ when candidate.Equals("cursor", StringComparison.OrdinalIgnoreCase) => MacroTokenKind.Cursor,
+            _ when candidate.Equals("key:enter", StringComparison.OrdinalIgnoreCase) => MacroTokenKind.Enter,
+            _ when candidate.Equals("key:tab", StringComparison.OrdinalIgnoreCase) => MacroTokenKind.Tab,
+            _ => null,
+        };
+
+    private static void FlushText(StringBuilder plain, List<MacroTextPiece> pieces)
+    {
+        if (plain.Length == 0)
+            return;
+
+        pieces.Add(new MacroTextPiece.Text(plain.ToString()));
+        plain.Clear();
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -103,9 +103,17 @@
                                               Immediate="true" MaxLength="4000"
                                               UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "replacement-input" })" />
                             }
+                            else if (context.Item.Kind == HotstringKind.DateTime)
+                            {
+                                <span style="white-space: pre-wrap">@context.Item.DateTimeSummary</span>
+                            }
+                            else if (context.Item.Kind == HotstringKind.Macro)
+                            {
+                                <span style="white-space: pre-wrap"><MacroReplacementDisplay Replacement="@context.Item.Replacement" /></span>
+                            }
                             else
                             {
-                                <span style="white-space: pre-wrap">@(context.Item.Kind == HotstringKind.DateTime ? context.Item.DateTimeSummary : context.Item.Replacement)</span>
+                                <span style="white-space: pre-wrap">@context.Item.Replacement</span>
                             }
                         </CellTemplate>
                     </PropertyColumn>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/HotstringsApiClient.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/HotstringsApiClient.cs
@@ -79,6 +79,9 @@ public sealed class HotstringsApiClient(HttpClient httpClient) : ApiClientBase(h
     public Task<ApiResult> PurgeDeletedAsync(Guid id, CancellationToken ct = default) =>
         SendNoContentAsync(HttpMethod.Delete, $"{BasePath}/deleted/{id}", ct);
 
+    public Task<ApiResult<HotstringPreviewDto>> PreviewAsync(HotstringPreviewRequestDto request, CancellationToken ct = default) =>
+        SendAsync<HotstringPreviewDto>(HttpMethod.Post, $"{BasePath}/preview", JsonContent.Create(request), ct);
+
     public Task<ApiResult<HotstringImportPreviewDto>> PreviewImportAsync(string script, CancellationToken ct = default) =>
         SendAsync<HotstringImportPreviewDto>(
             HttpMethod.Post,

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/IHotstringsApiClient.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/IHotstringsApiClient.cs
@@ -19,6 +19,7 @@ public interface IHotstringsApiClient
     Task<ApiResult<DeletedHotstringDto[]>> ListDeletedAsync(CancellationToken ct = default);
     Task<ApiResult<HotstringDto>> RestoreAsync(Guid id, CancellationToken ct = default);
     Task<ApiResult> PurgeDeletedAsync(Guid id, CancellationToken ct = default);
+    Task<ApiResult<HotstringPreviewDto>> PreviewAsync(HotstringPreviewRequestDto request, CancellationToken ct = default);
     Task<ApiResult<HotstringImportPreviewDto>> PreviewImportAsync(string script, CancellationToken ct = default);
     Task<ApiResult<HotstringImportResultDto>> ImportAsync(ImportHotstringsRequestDto request, CancellationToken ct = default);
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Validation/HotstringEditModel.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Validation/HotstringEditModel.cs
@@ -116,20 +116,33 @@ public sealed class HotstringEditModel
     }
 
     /// <summary>
-    /// Previews what <paramref name="format"/> would produce for the current moment, without
-    /// throwing on invalid or partial input while the user is typing. Offset-free — a raw format
-    /// preview only (Task 10 owns any offset preview on top of this).
+    /// Previews what <paramref name="format"/> would produce for the current moment (optionally
+    /// offset by <paramref name="offsetAmount"/>/<paramref name="offsetUnit"/>), without throwing
+    /// on invalid or partial input while the user is typing.
     /// </summary>
-    public static string SafePreview(string? format)
+    public static string SafePreview(string? format, int? offsetAmount = null, DateOffsetUnit? offsetUnit = null, TimeProvider? clock = null)
     {
         if (string.IsNullOrEmpty(format)) return "";
+
+        DateTime moment = (clock ?? TimeProvider.System).GetLocalNow().DateTime;
+        if (offsetAmount is { } amount && offsetUnit is { } unit)
+        {
+            moment = unit switch
+            {
+                DTOs.DateOffsetUnit.Seconds => moment.AddSeconds(amount),
+                DTOs.DateOffsetUnit.Minutes => moment.AddMinutes(amount),
+                DTOs.DateOffsetUnit.Hours => moment.AddHours(amount),
+                DTOs.DateOffsetUnit.Days => moment.AddDays(amount),
+                _ => moment,
+            };
+        }
 
         try
         {
             // A single-character custom format specifier (e.g. "d") is ambiguous with .NET's
             // standard format specifiers. Prefixing with '%' forces custom-specifier interpretation.
             string actualFormat = format.Length == 1 ? "%" + format : format;
-            return DateTime.Now.ToString(actualFormat);
+            return moment.ToString(actualFormat);
         }
         catch (FormatException)
         {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/changelog.json
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/changelog.json
@@ -14,7 +14,9 @@
             "Type/Options badge column in the hotstrings grid (replaces the two option checkbox columns).",
             "\"Edit details\" dialog for hotstrings on desktop.",
             "`ahkflow hotstring list` shows a Kind column.",
-            "DateTime hotstring kind: curated date/time format presets with optional date offset, emitted as `SendText(FormatTime(...))`. Supported in the edit dialog, grid, mobile list, history, and CLI."
+            "DateTime hotstring kind: curated date/time format presets with optional date offset, emitted as `SendText(FormatTime(...))`. Supported in the edit dialog, grid, mobile list, history, and CLI.",
+            "Macro hotstring kind: replacements can place the cursor and insert key presses (Enter, Tab), emitted as a scripted AutoHotkey sequence. Supported in the edit dialog (insert toolbar, live AutoHotkey preview, and Text-to-Macro suggestion), grid, mobile list, and CLI.",
+            "\"Generated AutoHotkey code\" preview panel in the hotstring edit dialog: shows the exact script snippet a hotstring will produce, for every kind."
           ]
         },
         {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/changelog.json
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/changelog.json
@@ -16,7 +16,8 @@
             "`ahkflow hotstring list` shows a Kind column.",
             "DateTime hotstring kind: curated date/time format presets with optional date offset, emitted as `SendText(FormatTime(...))`. Supported in the edit dialog, grid, mobile list, history, and CLI.",
             "Macro hotstring kind: replacements can place the cursor and insert key presses (Enter, Tab), emitted as a scripted AutoHotkey sequence. Supported in the edit dialog (insert toolbar, live AutoHotkey preview, and Text-to-Macro suggestion), grid, mobile list, and CLI.",
-            "\"Generated AutoHotkey code\" preview panel in the hotstring edit dialog: shows the exact script snippet a hotstring will produce, for every kind."
+            "\"Generated AutoHotkey code\" preview panel in the hotstring edit dialog: shows the exact script snippet a hotstring will produce, for every kind. Updates live while typing, shows an \"Updating preview…\" indicator, maps validation errors to the Trigger/Replacement fields, and includes a copy button.",
+            "Macro insert toolbar guards: the Cursor button disables once a cursor token exists, and Enter/Tab insertion behind the cursor is blocked with an inline hint."
           ]
         },
         {

--- a/tests/AHKFlowApp.API.Tests/Hotstrings/HotstringPreviewEndpointsTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Hotstrings/HotstringPreviewEndpointsTests.cs
@@ -1,0 +1,160 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Enums;
+using AHKFlowApp.TestUtilities.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.API.Tests.Hotstrings;
+
+[Collection("WebApi")]
+public sealed class HotstringPreviewEndpointsTests(ApiTestFixture fixture)
+{
+    private readonly CustomWebApplicationFactory _factory = fixture.Factory;
+
+    private HttpClient CreateAuthed(Guid? oid = null) =>
+        _factory.CreateAuthenticatedClient(b => b.WithOid(oid ?? Guid.NewGuid()));
+
+    [Fact]
+    public async Task Preview_TextKind_ReturnsExactSnippet()
+    {
+        using HttpClient client = CreateAuthed();
+        var dto = new HotstringPreviewRequestDto(
+            HotstringKind.Text,
+            "btw",
+            "by the way",
+            IsCaseSensitive: false,
+            OmitEndingCharacter: false,
+            IsEndingCharacterRequired: true,
+            IsTriggerInsideWord: false);
+
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/v1/hotstrings/preview", dto);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        HotstringPreviewDto? body = await response.Content.ReadFromJsonAsync<HotstringPreviewDto>();
+        body!.Snippet.Should().Be(":T:btw::by the way");
+    }
+
+    [Fact]
+    public async Task Preview_DateTimeKind_ReturnsExactSnippet()
+    {
+        using HttpClient client = CreateAuthed();
+        var dto = new HotstringPreviewRequestDto(
+            HotstringKind.DateTime,
+            "ddate",
+            string.Empty,
+            IsCaseSensitive: false,
+            OmitEndingCharacter: false,
+            IsEndingCharacterRequired: true,
+            IsTriggerInsideWord: false,
+            DateTimeFormat: "yyyy-MM-dd");
+
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/v1/hotstrings/preview", dto);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        HotstringPreviewDto? body = await response.Content.ReadFromJsonAsync<HotstringPreviewDto>();
+        body!.Snippet.Should().Be(":X:ddate::SendText(FormatTime(A_Now, \"yyyy-MM-dd\"))");
+    }
+
+    [Fact]
+    public async Task Preview_MacroKind_WithEscapedLiteralAndTokens_ReturnsExactSnippet()
+    {
+        using HttpClient client = CreateAuthed();
+        var dto = new HotstringPreviewRequestDto(
+            HotstringKind.Macro,
+            "mgreet",
+            "Hi {{{{first_name}}}},{{key:Enter}}{{cursor}}",
+            IsCaseSensitive: false,
+            OmitEndingCharacter: false,
+            IsEndingCharacterRequired: true,
+            IsTriggerInsideWord: false);
+
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/v1/hotstrings/preview", dto);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        HotstringPreviewDto? body = await response.Content.ReadFromJsonAsync<HotstringPreviewDto>();
+        body!.Snippet.Should().Be(
+            "::mgreet::\n{\n\tSendText \"Hi {{first_name}},\"\n\tSend \"{Enter}\"\n}");
+    }
+
+    [Fact]
+    public async Task Preview_InvalidMacroToken_Returns400WithParserMessage()
+    {
+        using HttpClient client = CreateAuthed();
+        var dto = new HotstringPreviewRequestDto(
+            HotstringKind.Macro,
+            "mbad",
+            "{{key:Escape}}",
+            IsCaseSensitive: false,
+            OmitEndingCharacter: false,
+            IsEndingCharacterRequired: true,
+            IsTriggerInsideWord: false);
+
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/v1/hotstrings/preview", dto);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("title").GetString().Should().Be("Validation failed");
+        JsonElement errors = root.GetProperty("errors");
+        errors.TryGetProperty("Input.Replacement", out JsonElement replacementErrors).Should().BeTrue();
+        replacementErrors.EnumerateArray().Select(e => e.GetString()).Should().Contain(
+            "Unknown token '{{key:Escape}}'. Allowed: {{cursor}}, {{key:Enter}}, {{key:Tab}}.");
+    }
+
+    [Fact]
+    public async Task Preview_InvalidMacroToken_MatchesCreateEndpointErrorMessage()
+    {
+        using HttpClient client = CreateAuthed();
+        const string invalidReplacement = "{{key:Escape}}";
+
+        HttpResponseMessage previewResponse = await client.PostAsJsonAsync(
+            "/api/v1/hotstrings/preview",
+            new HotstringPreviewRequestDto(
+                HotstringKind.Macro,
+                "mbad2",
+                invalidReplacement,
+                IsCaseSensitive: false,
+                OmitEndingCharacter: false,
+                IsEndingCharacterRequired: true,
+                IsTriggerInsideWord: false));
+        HttpResponseMessage createResponse = await client.PostAsJsonAsync(
+            "/api/v1/hotstrings",
+            new CreateHotstringDto("mbad2", invalidReplacement, Kind: HotstringKind.Macro));
+
+        previewResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        using var previewDoc = JsonDocument.Parse(await previewResponse.Content.ReadAsStringAsync());
+        using var createDoc = JsonDocument.Parse(await createResponse.Content.ReadAsStringAsync());
+
+        string? previewMessage = previewDoc.RootElement.GetProperty("errors")
+            .GetProperty("Input.Replacement")[0].GetString();
+        string? createMessage = createDoc.RootElement.GetProperty("errors")
+            .GetProperty("Input.Replacement")[0].GetString();
+
+        previewMessage.Should().Be(createMessage);
+    }
+
+    [Fact]
+    public async Task Preview_Unauthenticated_Returns401()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/v1/hotstrings/preview",
+            new HotstringPreviewRequestDto(
+                HotstringKind.Text,
+                "btw",
+                "by the way",
+                IsCaseSensitive: false,
+                OmitEndingCharacter: false,
+                IsEndingCharacterRequired: true,
+                IsTriggerInsideWord: false));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/History/HotstringNewFieldHistoryTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/History/HotstringNewFieldHistoryTests.cs
@@ -174,4 +174,46 @@ public sealed class HotstringNewFieldHistoryTests(HistoryDbFixture fx)
         result.Value.DateOffsetAmount.Should().Be(-2);
         result.Value.DateOffsetUnit.Should().Be(DateOffsetUnit.Hours);
     }
+
+    [Fact]
+    public async Task RevertHotstring_RestoresMacroKindAndTokenReplacement()
+    {
+        var owner = Guid.NewGuid();
+        const string macroReplacement = "Dear {{cursor}}Alex";
+        Hotstring entity = new HotstringBuilder()
+            .WithOwner(owner).WithTrigger("macro1").WithReplacement(macroReplacement)
+            .WithKind(HotstringKind.Macro)
+            .Build();
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotstrings.Add(entity);
+            await seed.SaveChangesAsync();
+        }
+
+        // Update switches the hotstring to Text kind with a plain replacement — the before-image
+        // snapshot must carry the original Macro kind and token-bearing replacement intact.
+        await using (AppDbContext db = fx.CreateContext())
+        {
+            UpdateHotstringCommandHandler update = new(
+                db, CurrentUserHelper.For(owner), TimeProvider.System,
+                new EntityHistoryRecorder(db, TimeProvider.System));
+            Result<HotstringDto> updated = await update.ExecuteAsync(
+                new UpdateHotstringCommand(entity.Id,
+                    new UpdateHotstringDto("macro1", "plain text", null, true, true, true, null)), default);
+            updated.IsSuccess.Should().BeTrue();
+            updated.Value.Kind.Should().Be(HotstringKind.Text);
+        }
+
+        await using AppDbContext revertDb = fx.CreateContext();
+        RevertHotstringCommandHandler revert = new(
+            revertDb, CurrentUserHelper.For(owner), TimeProvider.System,
+            new EntityHistoryRecorder(revertDb, TimeProvider.System));
+        Result<HotstringDto> result = await revert.ExecuteAsync(
+            new RevertHotstringCommand(entity.Id, 1), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Kind.Should().Be(HotstringKind.Macro);
+        result.Value.Replacement.Should().Be(macroReplacement);
+    }
 }

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
@@ -257,16 +257,111 @@ public sealed class CreateHotstringCommandValidatorTests
         result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
     }
 
-    [Theory]
-    [InlineData(HotstringKind.Macro)]
-    [InlineData(HotstringKind.Script)]
-    public void Kind_MacroOrScript_Fails(HotstringKind kind)
+    [Fact]
+    public void Kind_Script_Fails()
     {
-        ValidationResult result = _sut.Validate(Cmd(kind: kind));
+        ValidationResult result = _sut.Validate(Cmd(kind: HotstringKind.Script));
 
         result.Errors.Should().Contain(e =>
             e.PropertyName == "Input.Kind" &&
-            e.ErrorMessage == "Only Text and Date & time hotstrings are supported.");
+            e.ErrorMessage == "Only Text, Date & time and Macro hotstrings are supported.");
+    }
+
+    [Fact]
+    public void Kind_Macro_Passes()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "Dear {{cursor}},"));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Kind");
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
+    }
+
+    [Fact]
+    public void MacroKind_MalformedToken_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "{{key:Escape}}"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Replacement" &&
+            e.ErrorMessage == "Unknown token '{{key:Escape}}'. Allowed: {{cursor}}, {{key:Enter}}, {{key:Tab}}.");
+    }
+
+    [Fact]
+    public void MacroKind_TwoCursors_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "{{cursor}}{{cursor}}"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Replacement" &&
+            e.ErrorMessage == "Macro replacement must contain at most one {{cursor}} token.");
+    }
+
+    [Fact]
+    public void MacroKind_KeyAfterCursor_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "{{cursor}}{{key:Enter}}"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Replacement" &&
+            e.ErrorMessage == "Macro replacement must not contain {{key:...}} tokens after {{cursor}}.");
+    }
+
+    [Fact]
+    public void MacroKind_WithNonNullDateTimeFormat_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "Dear {{cursor}},",
+            dateTimeFormat: "yyyy-MM-dd"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.DateTimeFormat" &&
+            e.ErrorMessage == "DateTimeFormat must be null unless Kind is Date & time.");
+    }
+
+    [Fact]
+    public void MacroKind_CursorOnly_Passes()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "{{cursor}}"));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
+    }
+
+    [Fact]
+    public void MacroKind_EscapedLiteralOnly_Passes()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "{{{{first_name}}}}"));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
+    }
+
+    [Fact]
+    public void MacroKind_EscapedLiteralWithMalformedToken_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "{{{{first_name}}}} {{key:Entr}}"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Replacement" &&
+            e.ErrorMessage == "Unknown token '{{key:Entr}}'. Allowed: {{cursor}}, {{key:Enter}}, {{key:Tab}}.");
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/UpdateHotstringCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/UpdateHotstringCommandValidatorTests.cs
@@ -245,16 +245,111 @@ public sealed class UpdateHotstringCommandValidatorTests
         result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
     }
 
-    [Theory]
-    [InlineData(HotstringKind.Macro)]
-    [InlineData(HotstringKind.Script)]
-    public void Kind_MacroOrScript_Fails(HotstringKind kind)
+    [Fact]
+    public void Kind_Script_Fails()
     {
-        ValidationResult result = _sut.Validate(Cmd(kind: kind));
+        ValidationResult result = _sut.Validate(Cmd(kind: HotstringKind.Script));
 
         result.Errors.Should().Contain(e =>
             e.PropertyName == "Input.Kind" &&
-            e.ErrorMessage == "Only Text and Date & time hotstrings are supported.");
+            e.ErrorMessage == "Only Text, Date & time and Macro hotstrings are supported.");
+    }
+
+    [Fact]
+    public void Kind_Macro_Passes()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "Dear {{cursor}},"));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Kind");
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
+    }
+
+    [Fact]
+    public void MacroKind_MalformedToken_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "{{key:Escape}}"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Replacement" &&
+            e.ErrorMessage == "Unknown token '{{key:Escape}}'. Allowed: {{cursor}}, {{key:Enter}}, {{key:Tab}}.");
+    }
+
+    [Fact]
+    public void MacroKind_TwoCursors_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "{{cursor}}{{cursor}}"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Replacement" &&
+            e.ErrorMessage == "Macro replacement must contain at most one {{cursor}} token.");
+    }
+
+    [Fact]
+    public void MacroKind_KeyAfterCursor_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "{{cursor}}{{key:Enter}}"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Replacement" &&
+            e.ErrorMessage == "Macro replacement must not contain {{key:...}} tokens after {{cursor}}.");
+    }
+
+    [Fact]
+    public void MacroKind_WithNonNullDateTimeFormat_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "Dear {{cursor}},",
+            dateTimeFormat: "yyyy-MM-dd"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.DateTimeFormat" &&
+            e.ErrorMessage == "DateTimeFormat must be null unless Kind is Date & time.");
+    }
+
+    [Fact]
+    public void MacroKind_CursorOnly_Passes()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "{{cursor}}"));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
+    }
+
+    [Fact]
+    public void MacroKind_EscapedLiteralOnly_Passes()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "{{{{first_name}}}}"));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
+    }
+
+    [Fact]
+    public void MacroKind_EscapedLiteralWithMalformedToken_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Macro,
+            replacement: "{{{{first_name}}}} {{key:Entr}}"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Replacement" &&
+            e.ErrorMessage == "Unknown token '{{key:Entr}}'. Allowed: {{cursor}}, {{key:Enter}}, {{key:Tab}}.");
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs
@@ -404,6 +404,211 @@ public sealed class AhkScriptGeneratorTests
         output.Should().Contain(expectedLine);
     }
 
+    [Fact]
+    public void Generate_MacroHotstring_MergesTextAcrossCursorAndConsecutiveEnterKeys_MatchesSpecExample6()
+    {
+        // Reconstructed input: spec §7 ex. 6 (`<b>{{cursor}}</b>`) extended with two Enter
+        // key tokens so this single golden also proves consecutive-same-key merging.
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("htag")
+            .WithKind(HotstringKind.Macro)
+            .WithReplacement("<b>{{cursor}}</b>{{key:Enter}}{{key:Enter}}")
+            .WithEndingCharacterRequired(false)
+            .WithTriggerInsideWord(false)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain(
+            ":*:htag::\n" +
+            "{\n" +
+            "\tSendText \"<b></b>\"\n" +
+            "\tSend \"{Enter 2}\"\n" +
+            "\tSend \"{Left 4}\"\n" +
+            "}");
+    }
+
+    [Fact]
+    public void Generate_MacroHotstring_MergesConsecutiveIdenticalTabKeys()
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("m")
+            .WithKind(HotstringKind.Macro)
+            .WithReplacement("{{key:Tab}}{{key:Tab}}{{key:Tab}}")
+            .WithEndingCharacterRequired(false)
+            .WithTriggerInsideWord(false)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain(
+            ":*:m::\n" +
+            "{\n" +
+            "\tSend \"{Tab 3}\"\n" +
+            "}");
+    }
+
+    [Fact]
+    public void Generate_MacroHotstring_MixedEnterThenTab_EmitsTwoSeparateSendLinesInOrder()
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("m")
+            .WithKind(HotstringKind.Macro)
+            .WithReplacement("{{key:Enter}}{{key:Tab}}")
+            .WithEndingCharacterRequired(false)
+            .WithTriggerInsideWord(false)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain(
+            ":*:m::\n" +
+            "{\n" +
+            "\tSend \"{Enter}\"\n" +
+            "\tSend \"{Tab}\"\n" +
+            "}");
+    }
+
+    [Fact]
+    public void Generate_MacroHotstring_CursorAtEnd_OmitsTrailingLeftLine()
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("m")
+            .WithKind(HotstringKind.Macro)
+            .WithReplacement("abc{{cursor}}")
+            .WithEndingCharacterRequired(false)
+            .WithTriggerInsideWord(false)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain(
+            ":*:m::\n" +
+            "{\n" +
+            "\tSendText \"abc\"\n" +
+            "}");
+        output.Should().NotContain("Left");
+    }
+
+    [Fact]
+    public void Generate_MacroHotstring_CursorOnly_EmitsEmptyBraceBody()
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("m")
+            .WithKind(HotstringKind.Macro)
+            .WithReplacement("{{cursor}}")
+            .WithEndingCharacterRequired(false)
+            .WithTriggerInsideWord(false)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain(":*:m::\n{\n}");
+    }
+
+    [Fact]
+    public void Generate_MacroHotstring_MultilineTextRunAfterCursor_EscapesNewlineAndCountsAsOneCharInLeft()
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("m")
+            .WithKind(HotstringKind.Macro)
+            .WithReplacement("{{cursor}}line1\nline2")
+            .WithEndingCharacterRequired(false)
+            .WithTriggerInsideWord(false)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain(
+            ":*:m::\n" +
+            "{\n" +
+            "\tSendText \"line1`nline2\"\n" +
+            "\tSend \"{Left 11}\"\n" +
+            "}");
+    }
+
+    [Fact]
+    public void Generate_MacroHotstring_EscapesBacktickBeforeQuote_InSendTextString()
+    {
+        // Escaping quote first would produce a stray "`\"" that a later backtick-escape
+        // pass would then double — locking backtick-first ordering in this golden.
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("m")
+            .WithKind(HotstringKind.Macro)
+            .WithReplacement("a`b\"c")
+            .WithEndingCharacterRequired(false)
+            .WithTriggerInsideWord(false)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain("SendText \"a``b`\"c\"");
+    }
+
+    [Fact]
+    public void Generate_MacroHotstring_Decision11EscapedLiteralExample_MatchesGolden()
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("m")
+            .WithKind(HotstringKind.Macro)
+            .WithReplacement("Dear {{{{first_name}}}},{{key:Enter}}{{cursor}}Alex")
+            .WithEndingCharacterRequired(false)
+            .WithTriggerInsideWord(false)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain(
+            ":*:m::\n" +
+            "{\n" +
+            "\tSendText \"Dear {{first_name}},\"\n" +
+            "\tSend \"{Enter}\"\n" +
+            "\tSendText \"Alex\"\n" +
+            "\tSend \"{Left 4}\"\n" +
+            "}");
+    }
+
+    [Fact]
+    public void Generate_TextHotstring_StillEmitsTOption_NoRegression()
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("btw")
+            .WithKind(HotstringKind.Text)
+            .WithReplacement("by the way")
+            .WithTriggerInsideWord(false)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain(":T:btw::by the way");
+    }
+
+    [Fact]
+    public void Generate_MacroHotstring_NeverEmitsTOption()
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("m")
+            .WithKind(HotstringKind.Macro)
+            .WithReplacement("{{cursor}}")
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        int lineEnd = output.IndexOf("::", StringComparison.Ordinal);
+        string optionsSegment = output[..lineEnd];
+        optionsSegment.Should().NotContain("T");
+    }
+
     private static AhkScriptGenerator TokenSut(string version = "1.2.3")
     {
         IAppVersionProvider ver = Substitute.For<IAppVersionProvider>();

--- a/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs
@@ -577,6 +577,30 @@ public sealed class AhkScriptGeneratorTests
     }
 
     [Fact]
+    public void Generate_MacroHotstring_EscapedLiteralAfterCursor_CountsEmittedLengthInLeft()
+    {
+        // {{{{first_name}}}} unescapes to the 14-char literal "{{first_name}}" — Left must
+        // count that emitted length, not the raw pre-unescape token text.
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder()
+            .WithTrigger("m")
+            .WithKind(HotstringKind.Macro)
+            .WithReplacement("{{cursor}}{{{{first_name}}}}")
+            .WithEndingCharacterRequired(false)
+            .WithTriggerInsideWord(false)
+            .Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Contain(
+            ":*:m::\n" +
+            "{\n" +
+            "\tSendText \"{{first_name}}\"\n" +
+            "\tSend \"{Left 14}\"\n" +
+            "}");
+    }
+
+    [Fact]
     public void Generate_TextHotstring_StillEmitsTOption_NoRegression()
     {
         Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();

--- a/tests/AHKFlowApp.Application.Tests/Services/MacroTokenParserTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/MacroTokenParserTests.cs
@@ -1,0 +1,224 @@
+using AHKFlowApp.Application.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Services;
+
+public sealed class MacroTokenParserTests
+{
+    // Cross-task contract (Task 3 validator surfaces this verbatim) — keep in sync with the
+    // plan's example message (docs/superpowers/plans/2026-07-10-hotstrings-redesign-phase3.md).
+    private const string Allowed = "Allowed: {{cursor}}, {{key:Enter}}, {{key:Tab}}.";
+
+    private static MacroToken.TextRun Text(string s) => new(s);
+    private static MacroToken.Key Key(string name) => new(name);
+    private static MacroToken.Cursor Cursor() => new();
+
+    private static string UnknownToken(string raw) => $"Unknown token '{raw}'. {Allowed}";
+
+    [Fact]
+    public void PlainText_NoTokens_SingleTextRun_NoErrors()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("hello world");
+
+        result.Tokens.Should().Equal(Text("hello world"));
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CursorToken_ParsedAlone()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("{{cursor}}");
+
+        result.Tokens.Should().Equal(Cursor());
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void KeyEnterToken_ParsedAlone()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("{{key:Enter}}");
+
+        result.Tokens.Should().Equal(Key("Enter"));
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void KeyTabToken_ParsedAlone()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("{{key:Tab}}");
+
+        result.Tokens.Should().Equal(Key("Tab"));
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("{{CURSOR}}")]
+    [InlineData("{{Cursor}}")]
+    [InlineData("{{cUrSoR}}")]
+    public void CursorToken_CaseInsensitive(string input)
+    {
+        MacroTokenParser.Parse(input).Tokens.Should().Equal(Cursor());
+    }
+
+    [Theory]
+    [InlineData("{{Key:enter}}", "Enter")]
+    [InlineData("{{KEY:ENTER}}", "Enter")]
+    [InlineData("{{key:TAB}}", "Tab")]
+    [InlineData("{{KEY:tab}}", "Tab")]
+    public void KeyToken_CaseInsensitive_CanonicalName(string input, string expectedName)
+    {
+        MacroTokenParser.Parse(input).Tokens.Should().Equal(Key(expectedName));
+    }
+
+    [Fact]
+    public void InteriorWhitespace_IsStrictError()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("{{ cursor }}");
+
+        result.Errors.Should().Equal(UnknownToken("{{ cursor }}"));
+        result.Tokens.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void UnknownTokenName_IsStrictError()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("{{oops}}");
+
+        result.Errors.Should().Equal(UnknownToken("{{oops}}"));
+    }
+
+    [Fact]
+    public void UnknownKeyName_IsStrictError()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("{{key:Escape}}");
+
+        result.Errors.Should().Equal(UnknownToken("{{key:Escape}}"));
+    }
+
+    [Fact]
+    public void UnknownFieldStyleToken_IsStrictError()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("{{field:name}}");
+
+        result.Errors.Should().Equal(UnknownToken("{{field:name}}"));
+    }
+
+    [Fact]
+    public void TokenCandidateSpanningNewline_IsStrictError()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("{{key:\nEnter}}");
+
+        result.Errors.Should().Equal(UnknownToken("{{key:\nEnter}}"));
+    }
+
+    [Fact]
+    public void UnmatchedOpenBraces_NoClosingPair_TreatedAsLiteralText()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("a{{b no closer here");
+
+        result.Tokens.Should().Equal(Text("a{{b no closer here"));
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SingleUnpairedBraces_TreatedAsLiteralText()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("a{b}c");
+
+        result.Tokens.Should().Equal(Text("a{b}c"));
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AdjacentTokens_NoTextBetween_NoEmptyTextRun()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("{{key:Enter}}{{key:Tab}}{{cursor}}");
+
+        result.Tokens.Should().Equal(Key("Enter"), Key("Tab"), Cursor());
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MultilineTextRun_PreservedVerbatim_WhenNoTokens()
+    {
+        string input = "Line1\nLine2\r\nLine3";
+
+        MacroTokenParser.Parse(input).Tokens.Should().Equal(Text(input));
+    }
+
+    [Fact]
+    public void TokenStream_PreservesOrdering_ForLaterCursorMath()
+    {
+        // The parser doesn't compute offsets itself (Task 2's job) — but the token stream's
+        // order and TextRun contents must give a later consumer everything it needs to derive
+        // "characters after cursor" by simple summation.
+        MacroParseResult result = MacroTokenParser.Parse("abc{{cursor}}def");
+
+        result.Tokens.Should().Equal(Text("abc"), Cursor(), Text("def"));
+    }
+
+    [Fact]
+    public void EscapedLiteral_EmitsDoubledBraceText()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("{{{{first_name}}}}");
+
+        result.Tokens.Should().Equal(Text("{{first_name}}"));
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EscapedLiteral_AdjacentToRealTokens_Decision11Example()
+    {
+        MacroParseResult result = MacroTokenParser.Parse(
+            "Dear {{{{first_name}}}},{{key:Enter}}{{cursor}}Alex");
+
+        result.Tokens.Should().Equal(
+            Text("Dear {{first_name}},"),
+            Key("Enter"),
+            Cursor(),
+            Text("Alex"));
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EscapedLiteral_AllowsWhitespaceAndNewlinesInsideInnerContent()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("{{{{ some \n mustache var }}}}");
+
+        result.Tokens.Should().Equal(Text("{{ some \n mustache var }}"));
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void UnclosedEscape_NoClosingQuadBrace_LeadingPairIsLiteral_InnerTokenStillScanned()
+    {
+        // "{{{{" with no "}}}}" anywhere ahead: only the leading "{{" is literal; scanning
+        // resumes right after it, so the remaining "{{oops}}" is evaluated as a real token
+        // candidate (and fails strictly, since it isn't a known token).
+        MacroParseResult result = MacroTokenParser.Parse("{{{{oops}}");
+
+        result.Tokens.Should().Equal(Text("{{"));
+        result.Errors.Should().Equal(UnknownToken("{{oops}}"));
+    }
+
+    [Fact]
+    public void UnclosedEscape_ContainingMalformedRealToken_StillSurfacesStrictError()
+    {
+        // Decision-11 edge case from the plan: unclosed escape wrapping a typo'd real token —
+        // the leading "{{" is literal, and "{{key:Entr}}" still raises its own strict error.
+        MacroParseResult result = MacroTokenParser.Parse("{{{{key:Entr}}");
+
+        result.Tokens.Should().Equal(Text("{{"));
+        result.Errors.Should().Equal(UnknownToken("{{key:Entr}}"));
+    }
+
+    [Fact]
+    public void TypoKeyToken_StillErrors_EvenNextToAValidEscape()
+    {
+        MacroParseResult result = MacroTokenParser.Parse("{{{{first_name}}}}{{key:Entr}}");
+
+        result.Tokens.Should().Equal(Text("{{first_name}}"));
+        result.Errors.Should().Equal(UnknownToken("{{key:Entr}}"));
+    }
+}

--- a/tests/AHKFlowApp.CLI.Tests/Output/HotstringTableFormatterTests.cs
+++ b/tests/AHKFlowApp.CLI.Tests/Output/HotstringTableFormatterTests.cs
@@ -281,4 +281,25 @@ public sealed class HotstringTableFormatterTests
 
         sw.ToString().Should().Contain($"3 {expected}");
     }
+
+    [Fact]
+    public void Write_MacroRow_RendersKindLabelAndRawTruncatedTokenReplacement()
+    {
+        // Pinning test: Macro kind has no special formatter handling — it falls through to the
+        // same raw Truncate(...) path as Text (FormatReplacementColumn only special-cases DateTime).
+        // The 41-char input exceeds ReplacementWidth (40), so Truncate cuts to 39 chars + "…".
+        const string macroReplacement = "<b>{{cursor}}</b>{{key:Enter}}{{key:Tab}}";
+        const string expectedTruncated = "<b>{{cursor}}</b>{{key:Enter}}{{key:Tab…";
+        StringWriter sw = new();
+        PagedList<HotstringDto> page = new(
+            [Hotstring(trigger: "htag", replacement: macroReplacement) with { Kind = HotstringKind.Macro }],
+            1, 50, 1);
+
+        HotstringTableFormatter.Write(sw, page, EmptyNames);
+
+        string output = sw.ToString();
+        output.Should().Contain("Macro");
+        output.Should().Contain(expectedTruncated);
+        output.Should().NotContain(macroReplacement);
+    }
 }

--- a/tests/AHKFlowApp.E2E.Tests/MacroHotstringFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/MacroHotstringFlowTests.cs
@@ -1,0 +1,86 @@
+using AHKFlowApp.E2E.Tests.Fixtures;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace AHKFlowApp.E2E.Tests;
+
+[Collection(E2ETestCollection.Name)]
+public sealed class MacroHotstringFlowTests(StackFixture fixture) : IAsyncLifetime
+{
+    private static readonly BrowserNewContextOptions PhoneViewport = new()
+    {
+        ViewportSize = new ViewportSize { Width = 375, Height = 812 },
+    };
+
+    private sealed class OverflowMetrics
+    {
+        public int BodyOverflow { get; init; }
+
+        public int DocumentOverflow { get; init; }
+    }
+
+    public Task InitializeAsync() =>
+        fixture.ResetDataAsync();
+
+    public Task DisposeAsync() =>
+        Task.CompletedTask;
+
+    [Fact]
+    public async Task CreateMacroViaDialog_CaretInsertion_PreviewAndSave()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        Task<IResponse> profilesLoaded = page.WaitForResponseAsync(response =>
+            response.Url.Contains("/api/v1/profiles", StringComparison.OrdinalIgnoreCase) &&
+            response.Status == 200);
+        Task<IResponse> categoriesLoaded = page.WaitForResponseAsync(response =>
+            response.Url.Contains("/api/v1/categories", StringComparison.OrdinalIgnoreCase) &&
+            response.Status == 200);
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotstrings");
+        await page.WaitForSelectorAsync("button.add-hotstring-fab");
+        await Task.WhenAll(profilesLoaded, categoriesLoaded);
+
+        await page.ClickAsync("button.add-hotstring-fab");
+        await page.WaitForSelectorAsync(".hotstring-edit-dialog");
+
+        await page.ClickAsync(".hotstring-edit-dialog .mud-toggle-item:has-text('Macro')");
+        await page.WaitForSelectorAsync("[data-test=\"macro-toolbar\"]");
+
+        await page.FillAsync("input[data-test=\"trigger-input\"]", "htag");
+
+        ILocator replacement = page.Locator("textarea[data-test=\"replacement-input\"]");
+        await replacement.FillAsync("<b></b>");
+        // Place the caret between the tags, then insert the cursor token via the toolbar.
+        await replacement.EvaluateAsync("el => { el.focus(); el.setSelectionRange(3, 3); }");
+        await page.ClickAsync("[data-test=\"macro-toolbar\"] button:has-text('Cursor')");
+
+        ILocator cursorButton = page.Locator("[data-test=\"macro-toolbar\"] button:has-text('Cursor')");
+        await Assertions.Expect(replacement).ToHaveValueAsync("<b>{{cursor}}</b>");
+        // The Cursor button disables once the bound model contains a cursor token — this
+        // proves the insertion flowed through Blazor's binding, not just the DOM.
+        await Assertions.Expect(cursorButton).ToBeDisabledAsync();
+
+        await page.ClickAsync("[data-test=\"ahk-preview\"] .mud-expand-panel-header");
+        await page.WaitForSelectorAsync("[data-test=\"preview-snippet\"]");
+
+        ILocator snippet = page.Locator("[data-test=\"preview-snippet\"]");
+        // ":?:" — the dialog's defaults include trigger-inside-word, emitted as the ? option.
+        await Assertions.Expect(snippet).ToContainTextAsync(":?:htag::");
+        await Assertions.Expect(snippet).ToContainTextAsync("SendText \"<b></b>\"");
+        await Assertions.Expect(snippet).ToContainTextAsync("Send \"{Left 4}\"");
+
+        OverflowMetrics metrics = await page.EvaluateAsync<OverflowMetrics>(
+            "() => ({ BodyOverflow: document.body.scrollWidth - window.innerWidth, DocumentOverflow: document.documentElement.scrollWidth - window.innerWidth })");
+        Assert.True(metrics.BodyOverflow <= 0, $"Body overflowed by {metrics.BodyOverflow}px with the preview expanded.");
+        Assert.True(metrics.DocumentOverflow <= 0, $"Document overflowed by {metrics.DocumentOverflow}px with the preview expanded.");
+
+        await page.ClickAsync("button.commit-edit");
+        await page.WaitForSelectorAsync("text=Hotstring created.");
+
+        await page.WaitForSelectorAsync("tr.mobile-row:has-text(\"htag\")");
+        ILocator replacementCell = page.Locator("tr.mobile-row:has-text(\"htag\") td.replacement-cell");
+        await Assertions.Expect(replacementCell).ToHaveTextAsync("<b>{{cursor}}</b>");
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/AHKFlowApp.UI.Blazor.Tests.csproj
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/AHKFlowApp.UI.Blazor.Tests.csproj
@@ -14,6 +14,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MudBlazor" />
     <PackageReference Include="NSubstitute" />

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -381,6 +381,149 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         item.Replacement.Should().Be("by the way");
     }
 
+    [Fact]
+    public async Task KindSelector_HasThreeItemsIncludingMacro()
+    {
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+
+        provider.WaitForAssertion(() =>
+        {
+            IReadOnlyList<AngleSharp.Dom.IElement> items = provider.FindAll(".mud-toggle-item");
+            items.Should().HaveCount(3);
+            items.Select(e => e.TextContent.Trim()).Should().Contain("Macro");
+        });
+    }
+
+    [Fact]
+    public async Task MacroToolbar_HiddenForTextAndDateTime_VisibleForMacro()
+    {
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+
+        provider.FindAll("[data-test=\"macro-toolbar\"]").Should().BeEmpty();
+
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Date & time")).Click();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"datetime-format-select\"]"));
+        provider.FindAll("[data-test=\"macro-toolbar\"]").Should().BeEmpty();
+
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Trim() == "Macro").Click();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"macro-toolbar\"]").Should().NotBeNull());
+    }
+
+    [Theory]
+    [InlineData("Cursor", "{{cursor}}")]
+    [InlineData("Enter", "{{key:Enter}}")]
+    [InlineData("Tab", "{{key:Tab}}")]
+    public async Task MacroToolbar_ClickInsertButton_InvokesCaretInsertionWithCanonicalToken(string buttonLabel, string expectedToken)
+    {
+        // MudTextField.InsertTextAtCurrentCaretPositionAsync mutates the real DOM element via JS interop
+        // and relies on a browser "oninput" event to flow the change back into @bind-Value. bUnit's
+        // JSInterop.Mode = Loose accepts the call but never mutates the DOM or raises that event, so
+        // Item.Replacement can never observably change in this test environment. Instead, verify the
+        // toolbar button triggers the caret-insertion JS interop call with the correct token.
+        HotstringEditModel item = new() { Trigger = "sig", Kind = HotstringKind.Macro, Replacement = "" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"macro-toolbar\"]"));
+
+        provider.FindAll("[data-test=\"macro-toolbar\"] button").First(b => b.TextContent.Contains(buttonLabel)).Click();
+
+        provider.WaitForAssertion(() =>
+        {
+            Bunit.JSRuntimeInvocation invocation = JSInterop.VerifyInvoke("mudInput.insertAtCurrentCaretPosition");
+            invocation.Arguments.Should().Contain(expectedToken);
+        });
+    }
+
+    [Fact]
+    public async Task MacroSuggestion_AppearsForTextWithToken_DismissesAndSwitches()
+    {
+        HotstringEditModel item = new() { Trigger = "sig", Kind = HotstringKind.Text, Replacement = "Hi {{cursor}} bye" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"macro-suggestion\"]").Should().NotBeNull());
+
+        // Switching to Macro directly via the suggestion button (no confirm expected)
+        provider.Find("[data-test=\"macro-suggestion\"] button").Click();
+
+        provider.WaitForAssertion(() => item.Kind.Should().Be(HotstringKind.Macro));
+    }
+
+    [Fact]
+    public async Task MacroSuggestion_DoesNotAppearWithoutToken()
+    {
+        HotstringEditModel item = new() { Trigger = "sig", Kind = HotstringKind.Text, Replacement = "plain text" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+
+        provider.FindAll("[data-test=\"macro-suggestion\"]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MacroSuggestion_DismissButton_HidesAlert()
+    {
+        HotstringEditModel item = new() { Trigger = "sig", Kind = HotstringKind.Text, Replacement = "Hi {{cursor}} bye" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"macro-suggestion\"]"));
+
+        provider.Find("[data-test=\"macro-suggestion\"] button.mud-icon-button").Click();
+
+        provider.WaitForAssertion(() => provider.FindAll("[data-test=\"macro-suggestion\"]").Should().BeEmpty());
+    }
+
+    [Fact]
+    public async Task SwitchFromMacroWithToken_ToText_PromptsConfirmation()
+    {
+        HotstringEditModel item = new() { Trigger = "sig", Kind = HotstringKind.Macro, Replacement = "Hi {{cursor}} bye" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Trim() == "Text").Click();
+
+        provider.WaitForAssertion(() => provider.Markup.Should().Contain("Switch to Text"));
+        item.Kind.Should().Be(HotstringKind.Macro);
+        item.Replacement.Should().Be("Hi {{cursor}} bye");
+    }
+
+    [Fact]
+    public async Task SwitchFromMacroWithoutToken_ToText_NoConfirmationNeeded()
+    {
+        HotstringEditModel item = new() { Trigger = "sig", Kind = HotstringKind.Macro, Replacement = "plain text" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Trim() == "Text").Click();
+
+        provider.WaitForAssertion(() => item.Kind.Should().Be(HotstringKind.Text));
+        item.Replacement.Should().Be("plain text");
+    }
+
+    [Fact]
+    public async Task SwitchFromDateTime_ToMacro_WithFormatSet_PromptsConfirmation()
+    {
+        HotstringEditModel item = new() { Trigger = "date", Kind = HotstringKind.DateTime, DateTimeFormat = "yyyy-MM-dd" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Trim() == "Macro").Click();
+
+        provider.WaitForAssertion(() => provider.Markup.Should().Contain("Switch to Macro"));
+        item.Kind.Should().Be(HotstringKind.DateTime);
+        item.DateTimeFormat.Should().Be("yyyy-MM-dd");
+    }
+
+    [Fact]
+    public async Task SwitchFromText_ToMacro_NoConfirmationNeeded()
+    {
+        HotstringEditModel item = new() { Trigger = "sig", Kind = HotstringKind.Text, Replacement = "plain text" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Trim() == "Macro").Click();
+
+        provider.WaitForAssertion(() => item.Kind.Should().Be(HotstringKind.Macro));
+        item.Replacement.Should().Be("plain text");
+    }
+
     private async Task<IRenderedComponent<MudDialogProvider>> RenderDialogAsync(HotstringEditModel? item = null)
     {
         Render<MudPopoverProvider>();

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -546,12 +546,11 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
     public async Task PreviewPanel_Collapsed_NeverCallsPreviewEvenAfterFieldChanges()
     {
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        DisablePreviewDebounce(provider);
         provider.WaitForAssertion(() => provider.Find("input[data-test=\"trigger-input\"]"));
 
         provider.Find("input[data-test=\"trigger-input\"]").Input("btw");
         provider.Find("textarea[data-test=\"replacement-input\"]").Input("by the way");
-
-        await Task.Delay(600);
         provider.Render();
 
         _ = _api.DidNotReceive().PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>());
@@ -607,6 +606,7 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
 
         HotstringEditModel item = new() { Trigger = "one", Replacement = "text" };
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        DisablePreviewDebounce(provider);
         provider.WaitForAssertion(() => provider.Find("[data-test=\"ahk-preview\"]"));
         provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
 
@@ -615,12 +615,8 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
 
         provider.Find("input[data-test=\"trigger-input\"]").Input("two");
 
-        // The debounced call to the mock doesn't trigger a re-render (it's still awaiting the
-        // pending tcs2 task), so WaitForAssertion has no render event to re-poll on — wait out
-        // the real 400ms debounce window directly instead.
-        await Task.Delay(600);
-        _ = _api.Received(1).PreviewAsync(
-            Arg.Is<HotstringPreviewRequestDto>(r => r.Trigger == "two"), Arg.Any<CancellationToken>());
+        provider.WaitForAssertion(() => _api.Received(1).PreviewAsync(
+            Arg.Is<HotstringPreviewRequestDto>(r => r.Trigger == "two"), Arg.Any<CancellationToken>()));
 
         // Resolve the newer (generation 2) response first, then the stale (generation 1) response.
         // The stale response must never overwrite the newer result.
@@ -764,6 +760,24 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public async Task PreviewPanel_UnexpectedFault_ClearsPendingAndShowsFriendlyError()
+    {
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns<ApiResult<HotstringPreviewDto>>(_ => throw new InvalidOperationException("boom - e.g. a deserialization failure"));
+
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        DisablePreviewDebounce(provider);
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() =>
+        {
+            provider.FindAll("[data-test=\"preview-pending\"]").Should().BeEmpty(
+                "an unexpected fault must not leave the spinner stuck forever");
+            provider.Find("[data-test=\"preview-error\"]").TextContent.Should().NotBeNullOrWhiteSpace();
+        });
+    }
+
+    [Fact]
     public async Task PreviewPanel_WhileRefreshing_KeepsPreviousSnippetVisiblyDimmed()
     {
         TaskCompletionSource<ApiResult<HotstringPreviewDto>> tcs2 = new();
@@ -832,7 +846,7 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public async Task PreviewPanel_ValidationError_ShowsFriendlyMessageWithoutPropertyPath_AndMapsToReplacementField()
+    public async Task PreviewPanel_ValidationError_MapsToReplacementFieldOnly_NoPanelDuplicate()
     {
         const string parserMessage = "Unknown token '{{key:Escape}}'. Allowed: {{cursor}}, {{key:Enter}}, {{key:Tab}}.";
         _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
@@ -847,13 +861,41 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
 
         provider.WaitForAssertion(() =>
         {
-            string panelError = provider.Find("[data-test=\"preview-error\"]").TextContent.Trim();
-            panelError.Should().Be(parserMessage, "the DTO property-path prefix must be stripped");
-
             MudTextField<string> replacementField = provider.FindComponents<MudTextField<string>>()
                 .Single(f => f.Instance.Label == "Replacement").Instance;
-            replacementField.GetState(x => x.ErrorText).Should().Be(parserMessage);
+            replacementField.GetState(x => x.ErrorText).Should().Be(parserMessage, "the DTO property-path prefix must be stripped");
+
+            provider.FindAll("[data-test=\"preview-error\"]").Should().BeEmpty(
+                "a field-mapped error shows inline only, never duplicated in the panel");
         });
+    }
+
+    [Fact]
+    public async Task PreviewPanel_FieldError_ClearsImmediatelyWhenSchedulingNextPreview()
+    {
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringPreviewDto>.Failure(ApiResultStatus.Validation,
+                new ApiProblemDetails(null, "Bad Request", 400, null, null,
+                    new Dictionary<string, string[]> { ["Replacement"] = ["Replacement is required."] })));
+
+        HotstringEditModel item = new() { Trigger = "btw", Replacement = "" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        DisablePreviewDebounce(provider);
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() =>
+            provider.FindComponents<MudTextField<string>>().Single(f => f.Instance.Label == "Replacement")
+                .Instance.GetState(x => x.ErrorText).Should().Be("Replacement is required."));
+
+        TaskCompletionSource<ApiResult<HotstringPreviewDto>> pending = new();
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>()).Returns(pending.Task);
+
+        provider.Find("textarea[data-test=\"replacement-input\"]").Input("fixed");
+
+        provider.WaitForAssertion(() =>
+            provider.FindComponents<MudTextField<string>>().Single(f => f.Instance.Label == "Replacement")
+                .Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty(
+                    "the stale field error must not linger while a corrected value awaits its next preview"));
     }
 
     [Fact]

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -524,6 +524,163 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         item.Replacement.Should().Be("plain text");
     }
 
+    [Fact]
+    public async Task PreviewPanel_Expand_TriggersExactlyOnePreviewCall()
+    {
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringPreviewDto>.Ok(new HotstringPreviewDto("::btw::by the way")));
+
+        HotstringEditModel item = new() { Trigger = "btw", Replacement = "by the way" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"ahk-preview\"]"));
+
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() => provider.Markup.Should().Contain("::btw::by the way"));
+        _ = _api.Received(1).PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PreviewPanel_Collapsed_NeverCallsPreviewEvenAfterFieldChanges()
+    {
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        provider.WaitForAssertion(() => provider.Find("input[data-test=\"trigger-input\"]"));
+
+        provider.Find("input[data-test=\"trigger-input\"]").Change("btw");
+        provider.Find("textarea[data-test=\"replacement-input\"]").Change("by the way");
+
+        await Task.Delay(600);
+        provider.Render();
+
+        _ = _api.DidNotReceive().PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PreviewPanel_FieldChangeWhileExpanded_RecallsAfterDebounceWithUpdatedValues()
+    {
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringPreviewDto>.Ok(new HotstringPreviewDto("snippet")));
+
+        HotstringEditModel item = new() { Trigger = "btw", Replacement = "by the way" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"ahk-preview\"]"));
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).PreviewAsync(
+            Arg.Is<HotstringPreviewRequestDto>(r => r.Replacement == "by the way"), Arg.Any<CancellationToken>()));
+
+        provider.Find("textarea[data-test=\"replacement-input\"]").Change("by the way!");
+
+        provider.WaitForAssertion(() => _api.Received(1).PreviewAsync(
+            Arg.Is<HotstringPreviewRequestDto>(r => r.Replacement == "by the way!"), Arg.Any<CancellationToken>()),
+            timeout: TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task PreviewPanel_ValidationFailure_ShowsErrorMessageInsteadOfSnippet()
+    {
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringPreviewDto>.Failure(ApiResultStatus.Validation,
+                new ApiProblemDetails(null, "Bad Request", 400, null, null,
+                    new Dictionary<string, string[]> { ["Replacement"] = ["Replacement is required."] })));
+
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"ahk-preview\"]"));
+
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() => provider.Markup.Should().Contain("Replacement is required."));
+    }
+
+    [Fact]
+    public async Task PreviewPanel_OutOfOrderResponses_LaterGenerationWins()
+    {
+        TaskCompletionSource<ApiResult<HotstringPreviewDto>> tcs1 = new();
+        TaskCompletionSource<ApiResult<HotstringPreviewDto>> tcs2 = new();
+
+        _api.PreviewAsync(Arg.Is<HotstringPreviewRequestDto>(r => r.Trigger == "one"), Arg.Any<CancellationToken>())
+            .Returns(tcs1.Task);
+        _api.PreviewAsync(Arg.Is<HotstringPreviewRequestDto>(r => r.Trigger == "two"), Arg.Any<CancellationToken>())
+            .Returns(tcs2.Task);
+
+        HotstringEditModel item = new() { Trigger = "one", Replacement = "text" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"ahk-preview\"]"));
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).PreviewAsync(
+            Arg.Is<HotstringPreviewRequestDto>(r => r.Trigger == "one"), Arg.Any<CancellationToken>()));
+
+        provider.Find("input[data-test=\"trigger-input\"]").Change("two");
+
+        // The debounced call to the mock doesn't trigger a re-render (it's still awaiting the
+        // pending tcs2 task), so WaitForAssertion has no render event to re-poll on — wait out
+        // the real 400ms debounce window directly instead.
+        await Task.Delay(600);
+        _ = _api.Received(1).PreviewAsync(
+            Arg.Is<HotstringPreviewRequestDto>(r => r.Trigger == "two"), Arg.Any<CancellationToken>());
+
+        // Resolve the newer (generation 2) response first, then the stale (generation 1) response.
+        // The stale response must never overwrite the newer result.
+        tcs2.SetResult(ApiResult<HotstringPreviewDto>.Ok(new HotstringPreviewDto("snippet-two")));
+        provider.WaitForAssertion(() => provider.Markup.Should().Contain("snippet-two"));
+
+        tcs1.SetResult(ApiResult<HotstringPreviewDto>.Ok(new HotstringPreviewDto("snippet-one")));
+        await Task.Delay(150);
+        provider.Render();
+
+        provider.Markup.Should().Contain("snippet-two");
+        provider.Markup.Should().NotContain("snippet-one");
+    }
+
+    [Fact]
+    public async Task PreviewPanel_CollapseCancelsPendingPreview_NoErrorSurfaced()
+    {
+        TaskCompletionSource<ApiResult<HotstringPreviewDto>> tcs = new();
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(tcs.Task);
+
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"ahk-preview\"]"));
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>()));
+
+        // Collapse while the preview call is still pending.
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        tcs.SetException(new OperationCanceledException());
+
+        await Task.Delay(150);
+        provider.Render();
+
+        provider.FindAll(".mud-alert").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PreviewPanel_DisposeCancelsPendingPreview_NoUnhandledException()
+    {
+        TaskCompletionSource<ApiResult<HotstringPreviewDto>> tcs = new();
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(tcs.Task);
+
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"ahk-preview\"]"));
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>()));
+
+        await DisposeAsync();
+
+        Func<Task> act = async () =>
+        {
+            tcs.SetException(new OperationCanceledException());
+            await Task.Delay(150);
+        };
+
+        await act.Should().NotThrowAsync();
+    }
+
     private async Task<IRenderedComponent<MudDialogProvider>> RenderDialogAsync(HotstringEditModel? item = null)
     {
         Render<MudPopoverProvider>();

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -6,6 +6,7 @@ using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
+using MudBlazor.Extensions;
 using MudBlazor.Services;
 using NSubstitute;
 using Xunit;
@@ -15,11 +16,12 @@ namespace AHKFlowApp.UI.Blazor.Tests.Components.Hotstrings;
 public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
 {
     private readonly IHotstringsApiClient _api = Substitute.For<IHotstringsApiClient>();
+    private readonly ISnackbar _snackbar = Substitute.For<ISnackbar>();
 
     public HotstringEditDialogTests()
     {
         Services.AddSingleton(_api);
-        Services.AddSingleton(Substitute.For<ISnackbar>());
+        Services.AddSingleton(_snackbar);
         Services.AddMudServices();
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
@@ -104,8 +106,8 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         });
 
         provider.WaitForAssertion(() => provider.Find("input[data-test=\"trigger-input\"]"));
-        provider.Find("input[data-test=\"trigger-input\"]").Change("btw");
-        provider.Find("textarea[data-test=\"replacement-input\"]").Change("by the way");
+        provider.Find("input[data-test=\"trigger-input\"]").Input("btw");
+        provider.Find("textarea[data-test=\"replacement-input\"]").Input("by the way");
         provider.Find("button.commit-edit").Click();
 
         provider.WaitForAssertion(() => _api.Received(1).CreateAsync(
@@ -143,7 +145,7 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         });
 
         provider.WaitForAssertion(() => provider.Find("textarea[data-test=\"replacement-input\"]"));
-        provider.Find("textarea[data-test=\"replacement-input\"]").Change("by the way!");
+        provider.Find("textarea[data-test=\"replacement-input\"]").Input("by the way!");
         provider.Find("button.commit-edit").Click();
 
         provider.WaitForAssertion(() => _api.Received(1).UpdateAsync(
@@ -175,8 +177,8 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         });
 
         provider.WaitForAssertion(() => provider.Find("input[data-test=\"trigger-input\"]"));
-        provider.Find("input[data-test=\"trigger-input\"]").Change("btw");
-        provider.Find("textarea[data-test=\"replacement-input\"]").Change("by the way");
+        provider.Find("input[data-test=\"trigger-input\"]").Input("btw");
+        provider.Find("textarea[data-test=\"replacement-input\"]").Input("by the way");
         provider.Find("button.commit-edit").Click();
 
         provider.WaitForAssertion(() => provider.Markup.Should().Contain("Trigger already exists"));
@@ -207,8 +209,8 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         });
 
         provider.WaitForAssertion(() => provider.Find("input[data-test=\"trigger-input\"]"));
-        provider.Find("input[data-test=\"trigger-input\"]").Change("btw");
-        provider.Find("textarea[data-test=\"replacement-input\"]").Change("by the way");
+        provider.Find("input[data-test=\"trigger-input\"]").Input("btw");
+        provider.Find("textarea[data-test=\"replacement-input\"]").Input("by the way");
         provider.Find("input[data-test=\"case-sensitive-checkbox\"]").Change(true);
         provider.Find("input[data-test=\"omit-ending-checkbox\"]").Change(true);
         provider.Find("button.commit-edit").Click();
@@ -257,7 +259,7 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
 
         await SelectFormatAsync(provider, "yyyy-MM-dd");
 
-        provider.Find("input[data-test=\"trigger-input\"]").Change("date");
+        provider.Find("input[data-test=\"trigger-input\"]").Input("date");
         provider.Find("button.commit-edit").Click();
 
         provider.WaitForAssertion(() => _api.Received(1).CreateAsync(
@@ -334,7 +336,7 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         provider.WaitForAssertion(() => provider.Find("[data-test=\"datetime-format-select\"]"));
         await SelectFormatAsync(provider, "yyyy-MM-dd");
 
-        provider.Find("input[data-test=\"trigger-input\"]").Change("date");
+        provider.Find("input[data-test=\"trigger-input\"]").Input("date");
         provider.Find("button.commit-edit").Click();
 
         provider.WaitForAssertion(() => _api.Received(1).CreateAsync(
@@ -546,8 +548,8 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
         provider.WaitForAssertion(() => provider.Find("input[data-test=\"trigger-input\"]"));
 
-        provider.Find("input[data-test=\"trigger-input\"]").Change("btw");
-        provider.Find("textarea[data-test=\"replacement-input\"]").Change("by the way");
+        provider.Find("input[data-test=\"trigger-input\"]").Input("btw");
+        provider.Find("textarea[data-test=\"replacement-input\"]").Input("by the way");
 
         await Task.Delay(600);
         provider.Render();
@@ -569,7 +571,7 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         provider.WaitForAssertion(() => _api.Received(1).PreviewAsync(
             Arg.Is<HotstringPreviewRequestDto>(r => r.Replacement == "by the way"), Arg.Any<CancellationToken>()));
 
-        provider.Find("textarea[data-test=\"replacement-input\"]").Change("by the way!");
+        provider.Find("textarea[data-test=\"replacement-input\"]").Input("by the way!");
 
         provider.WaitForAssertion(() => _api.Received(1).PreviewAsync(
             Arg.Is<HotstringPreviewRequestDto>(r => r.Replacement == "by the way!"), Arg.Any<CancellationToken>()),
@@ -611,7 +613,7 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         provider.WaitForAssertion(() => _api.Received(1).PreviewAsync(
             Arg.Is<HotstringPreviewRequestDto>(r => r.Trigger == "one"), Arg.Any<CancellationToken>()));
 
-        provider.Find("input[data-test=\"trigger-input\"]").Change("two");
+        provider.Find("input[data-test=\"trigger-input\"]").Input("two");
 
         // The debounced call to the mock doesn't trigger a re-render (it's still awaiting the
         // pending tcs2 task), so WaitForAssertion has no render event to re-poll on — wait out
@@ -680,6 +682,265 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
 
         await act.Should().NotThrowAsync();
     }
+
+    [Fact]
+    public async Task PreviewPanel_TypingWithoutBlur_SendsUpdatedValueToPreview()
+    {
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringPreviewDto>.Ok(new HotstringPreviewDto("snippet")));
+
+        HotstringEditModel item = new() { Trigger = "btw", Replacement = "by the way" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        DisablePreviewDebounce(provider);
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).PreviewAsync(
+            Arg.Is<HotstringPreviewRequestDto>(r => r.Replacement == "by the way"), Arg.Any<CancellationToken>()));
+
+        // Raise input events only — the field never blurs, so a change-on-blur binding
+        // would keep sending the stale value.
+        provider.Find("textarea[data-test=\"replacement-input\"]").Input("by the way!!");
+
+        provider.WaitForAssertion(() => _api.Received(1).PreviewAsync(
+            Arg.Is<HotstringPreviewRequestDto>(r => r.Replacement == "by the way!!"), Arg.Any<CancellationToken>()));
+
+        provider.Find("input[data-test=\"trigger-input\"]").Input("btw2");
+
+        provider.WaitForAssertion(() => _api.Received(1).PreviewAsync(
+            Arg.Is<HotstringPreviewRequestDto>(r => r.Trigger == "btw2"), Arg.Any<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task PreviewPanel_LateResponseIgnoringCancellation_NeverSurfacesEvenAfterReopen()
+    {
+        TaskCompletionSource<ApiResult<HotstringPreviewDto>> tcs1 = new();
+        TaskCompletionSource<ApiResult<HotstringPreviewDto>> tcs2 = new();
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(tcs1.Task, tcs2.Task);
+
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        DisablePreviewDebounce(provider);
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>()));
+
+        // Collapse, then let the first transport "ignore" cancellation and complete successfully.
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+        tcs1.SetResult(ApiResult<HotstringPreviewDto>.Ok(new HotstringPreviewDto("sneaky-snippet")));
+
+        await Task.Delay(100);
+        provider.Render();
+        provider.Markup.Should().NotContain("sneaky-snippet");
+
+        // Reopen: a fresh preview call starts (tcs2, still pending) — the stale response
+        // must not have been stashed in hidden state.
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+        provider.WaitForAssertion(() => _api.Received(2).PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>()));
+
+        provider.Markup.Should().NotContain("sneaky-snippet");
+    }
+
+    [Fact]
+    public async Task PreviewPanel_WhilePending_ShowsUpdatingIndicator_ThenSnippet()
+    {
+        TaskCompletionSource<ApiResult<HotstringPreviewDto>> tcs = new();
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(tcs.Task);
+
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
+        DisablePreviewDebounce(provider);
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"preview-pending\"]").TextContent.Should().Contain("Updating preview"));
+
+        tcs.SetResult(ApiResult<HotstringPreviewDto>.Ok(new HotstringPreviewDto("snippet-x")));
+
+        provider.WaitForAssertion(() =>
+        {
+            provider.FindAll("[data-test=\"preview-pending\"]").Should().BeEmpty();
+            provider.Find("[data-test=\"preview-snippet\"]").TextContent.Should().Contain("snippet-x");
+            provider.Find("[data-test=\"preview-snippet\"]").ClassList.Should().NotContain("preview-stale");
+        });
+    }
+
+    [Fact]
+    public async Task PreviewPanel_WhileRefreshing_KeepsPreviousSnippetVisiblyDimmed()
+    {
+        TaskCompletionSource<ApiResult<HotstringPreviewDto>> tcs2 = new();
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(ApiResult<HotstringPreviewDto>.Ok(new HotstringPreviewDto("snippet-one"))), tcs2.Task);
+
+        HotstringEditModel item = new() { Trigger = "btw", Replacement = "one" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        DisablePreviewDebounce(provider);
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"preview-snippet\"]").TextContent.Should().Contain("snippet-one"));
+
+        provider.Find("textarea[data-test=\"replacement-input\"]").Input("two");
+
+        // The previous snippet stays visible but is explicitly marked stale while the
+        // refresh is in flight — never presented as current.
+        provider.WaitForAssertion(() =>
+        {
+            provider.Find("[data-test=\"preview-pending\"]").TextContent.Should().Contain("Updating preview");
+            provider.Find("[data-test=\"preview-snippet\"]").ClassList.Should().Contain("preview-stale");
+            provider.Find("[data-test=\"preview-snippet\"]").TextContent.Should().Contain("snippet-one");
+            provider.Find("[data-test=\"preview-copy\"]").HasAttribute("disabled").Should().BeTrue();
+        });
+    }
+
+    [Fact]
+    public async Task PreviewPanel_CopyButton_CopiesSnippetAndShowsSnackbar()
+    {
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringPreviewDto>.Ok(new HotstringPreviewDto("::btw::by the way")));
+
+        HotstringEditModel item = new() { Trigger = "btw", Replacement = "by the way" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        DisablePreviewDebounce(provider);
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"preview-copy\"]"));
+        provider.Find("[data-test=\"preview-copy\"]").GetAttribute("aria-label").Should().NotBeNullOrEmpty();
+        provider.Find("[data-test=\"preview-copy\"]").Click();
+
+        provider.WaitForAssertion(() =>
+        {
+            Bunit.JSRuntimeInvocation invocation = JSInterop.VerifyInvoke("navigator.clipboard.writeText");
+            invocation.Arguments.Should().Contain("::btw::by the way");
+            _snackbar.Received(1).Add("Generated code copied.", Severity.Success, Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>());
+        });
+    }
+
+    [Fact]
+    public async Task PreviewPanel_RendersDirectlyAfterEditor_BeforeDescription()
+    {
+        HotstringEditModel item = new() { Trigger = "sig", Kind = HotstringKind.Macro, Replacement = "x" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"ahk-preview\"]"));
+
+        string markup = provider.Markup;
+        int toolbar = markup.IndexOf("data-test=\"macro-toolbar\"", StringComparison.Ordinal);
+        int replacement = markup.IndexOf("data-test=\"replacement-input\"", StringComparison.Ordinal);
+        int preview = markup.IndexOf("data-test=\"ahk-preview\"", StringComparison.Ordinal);
+        int description = markup.IndexOf("data-test=\"description-input\"", StringComparison.Ordinal);
+
+        toolbar.Should().BePositive().And.BeLessThan(replacement, "the insert toolbar sits above the Replacement editor");
+        replacement.Should().BeLessThan(preview, "the preview panel sits directly below the editor");
+        preview.Should().BeLessThan(description, "the preview panel comes before Description");
+    }
+
+    [Fact]
+    public async Task PreviewPanel_ValidationError_ShowsFriendlyMessageWithoutPropertyPath_AndMapsToReplacementField()
+    {
+        const string parserMessage = "Unknown token '{{key:Escape}}'. Allowed: {{cursor}}, {{key:Enter}}, {{key:Tab}}.";
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringPreviewDto>.Failure(ApiResultStatus.Validation,
+                new ApiProblemDetails(null, "Bad Request", 400, null, null,
+                    new Dictionary<string, string[]> { ["Input.Replacement"] = [parserMessage] })));
+
+        HotstringEditModel item = new() { Trigger = "sig", Kind = HotstringKind.Macro, Replacement = "{{key:Escape}}" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        DisablePreviewDebounce(provider);
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() =>
+        {
+            string panelError = provider.Find("[data-test=\"preview-error\"]").TextContent.Trim();
+            panelError.Should().Be(parserMessage, "the DTO property-path prefix must be stripped");
+
+            MudTextField<string> replacementField = provider.FindComponents<MudTextField<string>>()
+                .Single(f => f.Instance.Label == "Replacement").Instance;
+            replacementField.GetState(x => x.ErrorText).Should().Be(parserMessage);
+        });
+    }
+
+    [Fact]
+    public async Task PreviewPanel_TriggerValidationError_MapsToTriggerField()
+    {
+        const string triggerMessage = "Trigger is required.";
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringPreviewDto>.Failure(ApiResultStatus.Validation,
+                new ApiProblemDetails(null, "Bad Request", 400, null, null,
+                    new Dictionary<string, string[]> { ["Input.Trigger"] = [triggerMessage] })));
+
+        HotstringEditModel item = new() { Trigger = "", Replacement = "by the way" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        DisablePreviewDebounce(provider);
+        provider.Find("[data-test=\"ahk-preview\"] .mud-expand-panel-header").Click();
+
+        provider.WaitForAssertion(() =>
+        {
+            MudTextField<string> triggerField = provider.FindComponents<MudTextField<string>>()
+                .Single(f => f.Instance.Label == "Trigger").Instance;
+            triggerField.GetState(x => x.ErrorText).Should().Be(triggerMessage);
+        });
+    }
+
+    [Fact]
+    public async Task MacroToolbar_ShowsInsertLabelAndHelperText()
+    {
+        HotstringEditModel item = new() { Trigger = "sig", Kind = HotstringKind.Macro, Replacement = "" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+
+        provider.WaitForAssertion(() =>
+        {
+            provider.Find("[data-test=\"macro-toolbar\"]").TextContent.Should().Contain("Insert:");
+            provider.Markup.Should().Contain("Enter/Tab must come before it");
+        });
+    }
+
+    [Fact]
+    public async Task MacroToolbar_CursorButton_DisabledWhenCursorTokenPresent()
+    {
+        HotstringEditModel item = new() { Trigger = "sig", Kind = HotstringKind.Macro, Replacement = "Hi {{cursor}}" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"macro-toolbar\"]"));
+
+        AngleSharp.Dom.IElement cursorButton = provider.FindAll("[data-test=\"macro-toolbar\"] button")
+            .First(b => b.TextContent.Contains("Cursor"));
+
+        cursorButton.HasAttribute("disabled").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task MacroToolbar_EnterAfterCursor_BlockedWithInlineHint()
+    {
+        JSInterop.Setup<int>("mudInput.getCaretPosition", _ => true).SetResult(12);
+
+        HotstringEditModel item = new() { Trigger = "sig", Kind = HotstringKind.Macro, Replacement = "{{cursor}}tail" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"macro-toolbar\"]"));
+
+        provider.FindAll("[data-test=\"macro-toolbar\"] button").First(b => b.TextContent.Contains("Enter")).Click();
+
+        provider.WaitForAssertion(() =>
+            provider.Find("[data-test=\"macro-insert-hint\"]").TextContent.Should().Contain("before the {{cursor}} token"));
+        JSInterop.Invocations.Should().NotContain(i => i.Identifier == "mudInput.insertAtCurrentCaretPosition");
+    }
+
+    [Fact]
+    public async Task MacroToolbar_EnterBeforeCursor_InsertsToken()
+    {
+        JSInterop.Setup<int>("mudInput.getCaretPosition", _ => true).SetResult(0);
+
+        HotstringEditModel item = new() { Trigger = "sig", Kind = HotstringKind.Macro, Replacement = "abc{{cursor}}" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"macro-toolbar\"]"));
+
+        provider.FindAll("[data-test=\"macro-toolbar\"] button").First(b => b.TextContent.Contains("Enter")).Click();
+
+        provider.WaitForAssertion(() =>
+        {
+            Bunit.JSRuntimeInvocation invocation = JSInterop.VerifyInvoke("mudInput.insertAtCurrentCaretPosition");
+            invocation.Arguments.Should().Contain("{{key:Enter}}");
+        });
+        provider.FindAll("[data-test=\"macro-insert-hint\"]").Should().BeEmpty();
+    }
+
+    private static void DisablePreviewDebounce(IRenderedComponent<MudDialogProvider> provider) =>
+        provider.FindComponent<HotstringEditDialog>().Instance.PreviewDebounce = TimeSpan.Zero;
 
     private async Task<IRenderedComponent<MudDialogProvider>> RenderDialogAsync(HotstringEditModel? item = null)
     {

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
@@ -27,6 +27,9 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
     private static HotstringEditModel DateTimeItem(string trigger = "now", string format = "yyyy-MM-dd") =>
         new() { Id = Guid.NewGuid(), Trigger = trigger, Replacement = "", Kind = HotstringKind.DateTime, DateTimeFormat = format };
 
+    private static HotstringEditModel MacroItem(string trigger = "greet", string replacement = "Dear {{{{first_name}}}},{{key:Enter}}{{cursor}}Alex") =>
+        new() { Id = Guid.NewGuid(), Trigger = trigger, Replacement = replacement, Kind = HotstringKind.Macro };
+
     [Fact]
     public void Renders_TriggerAndReplacement_PerRow()
     {
@@ -177,5 +180,65 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
             cut.Markup.Should().Contain("Format:");
             cut.Markup.Should().NotContain("Replacement:");
         });
+    }
+
+    [Fact]
+    public void MacroRow_CollapsedCell_RendersTokenChipsNotRawSyntax()
+    {
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [MacroItem()])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        string cellMarkup = cut.Find("td.replacement-cell").InnerHtml;
+        cellMarkup.Should().NotContain("{{key:Enter}}");
+        cellMarkup.Should().NotContain("{{cursor}}");
+        cellMarkup.Should().Contain("{{first_name}}");
+        cut.Find("td.replacement-cell").TextContent.Should().Contain("Enter").And.Contain("⌖ cursor");
+        cut.FindAll("td.replacement-cell .macro-token-chip").Count.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task MacroRow_Expanded_ShowsChipsInReplacementLine()
+    {
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [MacroItem()])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        await cut.InvokeAsync(() => cut.Find("tr.mobile-row").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("Replacement:");
+            cut.Markup.Should().NotContain("{{key:Enter}}");
+            cut.Markup.Should().NotContain("{{cursor}}");
+            cut.Markup.Should().Contain("{{first_name}}");
+            cut.FindAll("tr.mobile-row-expanded .macro-token-chip").Count.Should().Be(2);
+        });
+    }
+
+    [Fact]
+    public void EscapedLiteralOnlyMacro_RendersPlainTextNoChip()
+    {
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [MacroItem("esc", "{{{{first_name}}}}")])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        cut.Find("td.replacement-cell").TextContent.Should().Be("{{first_name}}");
+        cut.FindAll("td.replacement-cell .macro-token-chip").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TextRow_CollapsedCell_HasNoMacroChips()
+    {
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [Item("btw", "by the way")])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        cut.Find("td.replacement-cell").TextContent.Should().Be("by the way");
+        cut.FindAll("td.replacement-cell .macro-token-chip").Should().BeEmpty();
     }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
@@ -183,19 +183,18 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public void MacroRow_CollapsedCell_RendersTokenChipsNotRawSyntax()
+    public void MacroRow_CollapsedCell_RendersRawReplacementWithoutChips()
     {
+        // Collapsed rows stay a single ellipsized text line for list density; the
+        // token-chip rendering is reserved for the expanded details.
         IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
             .Add(c => c.Items, [MacroItem()])
             .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
             .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
 
-        string cellMarkup = cut.Find("td.replacement-cell").InnerHtml;
-        cellMarkup.Should().NotContain("{{key:Enter}}");
-        cellMarkup.Should().NotContain("{{cursor}}");
-        cellMarkup.Should().Contain("{{first_name}}");
-        cut.Find("td.replacement-cell").TextContent.Should().Contain("Enter").And.Contain("⌖ cursor");
-        cut.FindAll("td.replacement-cell .macro-token-chip").Count.Should().Be(2);
+        cut.Find("td.replacement-cell").TextContent
+            .Should().Be("Dear {{{{first_name}}}},{{key:Enter}}{{cursor}}Alex");
+        cut.FindAll("td.replacement-cell .macro-token-chip").Should().BeEmpty();
     }
 
     [Fact]
@@ -210,24 +209,30 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
 
         cut.WaitForAssertion(() =>
         {
-            cut.Markup.Should().Contain("Replacement:");
-            cut.Markup.Should().NotContain("{{key:Enter}}");
-            cut.Markup.Should().NotContain("{{cursor}}");
-            cut.Markup.Should().Contain("{{first_name}}");
+            string expanded = cut.Find("tr.mobile-row-expanded").TextContent;
+            expanded.Should().Contain("Replacement:");
+            expanded.Should().NotContain("{{key:Enter}}");
+            expanded.Should().NotContain("{{cursor}}");
+            expanded.Should().Contain("{{first_name}}");
             cut.FindAll("tr.mobile-row-expanded .macro-token-chip").Count.Should().Be(2);
         });
     }
 
     [Fact]
-    public void EscapedLiteralOnlyMacro_RendersPlainTextNoChip()
+    public async Task EscapedLiteralOnlyMacro_Expanded_RendersUnescapedTextNoChip()
     {
         IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
             .Add(c => c.Items, [MacroItem("esc", "{{{{first_name}}}}")])
             .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
             .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
 
-        cut.Find("td.replacement-cell").TextContent.Should().Be("{{first_name}}");
-        cut.FindAll("td.replacement-cell .macro-token-chip").Should().BeEmpty();
+        await cut.InvokeAsync(() => cut.Find("tr.mobile-row").Click());
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("tr.mobile-row-expanded").TextContent.Should().Contain("{{first_name}}");
+            cut.FindAll("tr.mobile-row-expanded .macro-token-chip").Should().BeEmpty();
+        });
     }
 
     [Fact]

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/MacroTokensTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/MacroTokensTests.cs
@@ -75,4 +75,31 @@ public sealed class MacroTokensTests
         pieces[2].Should().BeOfType<MacroTextPiece.Token>().Which.Kind.Should().Be(MacroTokenKind.Cursor);
         pieces[3].Should().BeOfType<MacroTextPiece.Text>().Which.Value.Should().Be("Alex");
     }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Dear customer")]
+    [InlineData("{{key:Enter}}")]
+    [InlineData("{{key:Tab}}")]
+    [InlineData("{{oops}}")]
+    [InlineData("{{ cursor }}")]
+    public void CursorTokenStart_no_real_cursor_token_returns_null(string text) =>
+        MacroTokens.CursorTokenStart(text).Should().BeNull();
+
+    [Theory]
+    [InlineData("{{cursor}}", 0)]
+    [InlineData("{{CURSOR}}", 0)]
+    [InlineData("{{Cursor}}", 0)]
+    [InlineData("abc{{cursor}}", 3)]
+    [InlineData("Dear {{cursor}} name", 5)]
+    public void CursorTokenStart_real_cursor_token_returns_start_index(string text, int expectedStart) =>
+        MacroTokens.CursorTokenStart(text).Should().Be(expectedStart);
+
+    [Fact]
+    public void CursorTokenStart_escaped_cursor_literal_returns_null() =>
+        MacroTokens.CursorTokenStart("{{{{cursor}}}}").Should().BeNull();
+
+    [Fact]
+    public void CursorTokenStart_orphan_escape_without_closer_returns_nested_cursor_position() =>
+        MacroTokens.CursorTokenStart("{{{{cursor}}").Should().Be(2);
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/MacroTokensTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/MacroTokensTests.cs
@@ -1,0 +1,78 @@
+using AHKFlowApp.UI.Blazor.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Helpers;
+
+public sealed class MacroTokensTests
+{
+    [Theory]
+    [InlineData("Dear customer")]
+    [InlineData("")]
+    [InlineData("{{ cursor }}")]
+    [InlineData("{{key:enter }}")]
+    public void ContainsKnownToken_no_real_token_returns_false(string text) =>
+        MacroTokens.ContainsKnownToken(text).Should().BeFalse();
+
+    [Theory]
+    [InlineData("{{cursor}}")]
+    [InlineData("{{CURSOR}}")]
+    [InlineData("{{key:Enter}}")]
+    [InlineData("{{KEY:ENTER}}")]
+    [InlineData("{{key:enter}}")]
+    [InlineData("{{key:Tab}}")]
+    [InlineData("{{KEY:TAB}}")]
+    [InlineData("Dear {{cursor}} name")]
+    public void ContainsKnownToken_real_token_returns_true(string text) =>
+        MacroTokens.ContainsKnownToken(text).Should().BeTrue();
+
+    [Fact]
+    public void ContainsKnownToken_escaped_literal_alone_returns_false() =>
+        MacroTokens.ContainsKnownToken("{{{{cursor}}}}").Should().BeFalse();
+
+    [Fact]
+    public void ContainsKnownToken_escaped_literal_alongside_real_token_returns_true() =>
+        MacroTokens.ContainsKnownToken("{{{{cursor}}}}{{key:Enter}}").Should().BeTrue();
+
+    [Fact]
+    public void Split_plain_text_returns_single_text_piece()
+    {
+        IReadOnlyList<MacroTextPiece> pieces = MacroTokens.Split("Dear customer");
+
+        pieces.Should().ContainSingle().Which.Should().BeOfType<MacroTextPiece.Text>()
+            .Which.Value.Should().Be("Dear customer");
+    }
+
+    [Fact]
+    public void Split_real_token_returns_alternating_pieces()
+    {
+        IReadOnlyList<MacroTextPiece> pieces = MacroTokens.Split("Dear {{cursor}}Alex");
+
+        pieces.Should().HaveCount(3);
+        pieces[0].Should().BeOfType<MacroTextPiece.Text>().Which.Value.Should().Be("Dear ");
+        pieces[1].Should().BeOfType<MacroTextPiece.Token>().Which.Kind.Should().Be(MacroTokenKind.Cursor);
+        pieces[2].Should().BeOfType<MacroTextPiece.Text>().Which.Value.Should().Be("Alex");
+    }
+
+    [Fact]
+    public void Split_escaped_literal_returns_single_unescaped_text_piece()
+    {
+        IReadOnlyList<MacroTextPiece> pieces = MacroTokens.Split("{{{{first_name}}}}");
+
+        pieces.Should().ContainSingle().Which.Should().BeOfType<MacroTextPiece.Text>()
+            .Which.Value.Should().Be("{{first_name}}");
+    }
+
+    [Fact]
+    public void Split_mixed_example_produces_expected_piece_sequence()
+    {
+        IReadOnlyList<MacroTextPiece> pieces =
+            MacroTokens.Split("Dear {{{{first_name}}}},{{key:Enter}}{{cursor}}Alex");
+
+        pieces.Should().HaveCount(4);
+        pieces[0].Should().BeOfType<MacroTextPiece.Text>().Which.Value.Should().Be("Dear {{first_name}},");
+        pieces[1].Should().BeOfType<MacroTextPiece.Token>().Which.Kind.Should().Be(MacroTokenKind.Enter);
+        pieces[2].Should().BeOfType<MacroTextPiece.Token>().Which.Kind.Should().Be(MacroTokenKind.Cursor);
+        pieces[3].Should().BeOfType<MacroTextPiece.Text>().Which.Value.Should().Be("Alex");
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -490,6 +490,61 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public Task Page_MacroRow_RendersTokenChipsNotRawSyntax()
+    {
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "greet", "Dear {{{{first_name}}}},{{key:Enter}}{{cursor}}Alex",
+            null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.Macro);
+        StubList(Page(dto));
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().NotContain("{{key:Enter}}");
+            cut.Markup.Should().NotContain("{{cursor}}");
+            cut.Markup.Should().Contain("{{first_name}}");
+            cut.Markup.Should().Contain("Enter");
+            cut.Markup.Should().Contain("⌖ cursor");
+            cut.FindAll(".hotstrings-grid .macro-token-chip").Count.Should().Be(2);
+        });
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task Page_MacroRow_EscapedLiteralOnly_RendersPlainTextNoChip()
+    {
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "esc", "{{{{first_name}}}}",
+            null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.Macro);
+        StubList(Page(dto));
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("{{first_name}}");
+            cut.FindAll(".hotstrings-grid .macro-token-chip").Should().BeEmpty();
+        });
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task Page_TextRow_ReplacementCell_HasNoMacroChips()
+    {
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "btw", "by the way",
+            null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.Text);
+        StubList(Page(dto));
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("by the way");
+            cut.FindAll(".hotstrings-grid .macro-token-chip").Should().BeEmpty();
+        });
+        return Task.CompletedTask;
+    }
+
+    [Fact]
     public Task Page_DateTimeRow_HidesStartEditPencil_TextRowKeepsIt()
     {
         var dateTimeDto = new HotstringDto(Guid.NewGuid(), [], true, "now", "", null, true, true,

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -500,11 +500,14 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
 
         cut.WaitForAssertion(() =>
         {
-            cut.Markup.Should().NotContain("{{key:Enter}}");
-            cut.Markup.Should().NotContain("{{cursor}}");
-            cut.Markup.Should().Contain("{{first_name}}");
-            cut.Markup.Should().Contain("Enter");
-            cut.Markup.Should().Contain("⌖ cursor");
+            // Scoped to the desktop grid: the mobile branch is also in the DOM (hidden by
+            // CSS) and intentionally renders the raw macro text in its collapsed rows.
+            string grid = cut.Find(".hotstrings-grid").TextContent;
+            grid.Should().NotContain("{{key:Enter}}");
+            grid.Should().NotContain("{{cursor}}");
+            grid.Should().Contain("{{first_name}}");
+            grid.Should().Contain("Enter");
+            grid.Should().Contain("⌖ cursor");
             cut.FindAll(".hotstrings-grid .macro-token-chip").Count.Should().Be(2);
         });
         return Task.CompletedTask;

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Services/HotstringsApiClientTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Services/HotstringsApiClientTests.cs
@@ -206,6 +206,52 @@ public sealed class HotstringsApiClientTests
         handler.LastRequest.RequestUri!.ToString().Should().Be("http://localhost/api/v1/hotstrings/import");
     }
 
+    [Fact]
+    public async Task PreviewAsync_PostsRequestToPreviewRoute()
+    {
+        HotstringPreviewDto dto = new("::btw::by the way");
+        var handler = StubHttpMessageHandler.JsonResponse(HttpStatusCode.OK, dto);
+        var request = new HotstringPreviewRequestDto(
+            HotstringKind.Macro,
+            "btw",
+            "Dear {{cursor}}",
+            IsCaseSensitive: false,
+            OmitEndingCharacter: false,
+            IsEndingCharacterRequired: true,
+            IsTriggerInsideWord: true);
+
+        ApiResult<HotstringPreviewDto> result = await ClientWith(handler).PreviewAsync(request);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Snippet.Should().Be("::btw::by the way");
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.ToString().Should().Be("http://localhost/api/v1/hotstrings/preview");
+        handler.LastRequestBody.Should().Contain("\"trigger\":\"btw\"");
+        handler.LastRequestBody.Should().Contain("\"replacement\":\"Dear {{cursor}}\"");
+        handler.LastRequestBody.Should().Contain("\"kind\":2");
+    }
+
+    [Fact]
+    public async Task PreviewAsync_OnValidationError_ReturnsValidationResultWithProblemDetails()
+    {
+        var problem = new ApiProblemDetails(null, "Validation failed", 400, "Trigger is required.", "/api/v1/hotstrings/preview", null);
+        var handler = StubHttpMessageHandler.JsonResponse(HttpStatusCode.BadRequest, problem);
+        var request = new HotstringPreviewRequestDto(
+            HotstringKind.Text,
+            string.Empty,
+            "by the way",
+            IsCaseSensitive: false,
+            OmitEndingCharacter: false,
+            IsEndingCharacterRequired: true,
+            IsTriggerInsideWord: true);
+
+        ApiResult<HotstringPreviewDto> result = await ClientWith(handler).PreviewAsync(request);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ApiResultStatus.Validation);
+        result.Problem!.Detail.Should().Contain("Trigger is required");
+    }
+
     private sealed class StubHttpMessageHandler : HttpMessageHandler
     {
         public HttpRequestMessage? LastRequest { get; private set; }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Validation/HotstringEditModelTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Validation/HotstringEditModelTests.cs
@@ -1,6 +1,7 @@
 using AHKFlowApp.UI.Blazor.DTOs;
 using AHKFlowApp.UI.Blazor.Validation;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace AHKFlowApp.UI.Blazor.Tests.Validation;
@@ -317,5 +318,24 @@ public sealed class HotstringEditModelTests
         string preview = HotstringEditModel.SafePreview("yyyy-QQQQQQ-XY\\");
 
         preview.Should().Be("Invalid format");
+    }
+
+    [Fact]
+    public void SafePreview_WithClock_IsDeterministic()
+    {
+        FakeTimeProvider clock = new(DateTimeOffset.Parse("2026-07-10T08:30:00Z"));
+        clock.SetLocalTimeZone(TimeZoneInfo.Utc);
+
+        HotstringEditModel.SafePreview("yyyy-MM-dd HH:mm", clock: clock).Should().Be("2026-07-10 08:30");
+    }
+
+    [Fact]
+    public void SafePreview_WithOffset_AppliesOffsetToClock()
+    {
+        FakeTimeProvider clock = new(DateTimeOffset.Parse("2026-07-10T08:30:00Z"));
+        clock.SetLocalTimeZone(TimeZoneInfo.Utc);
+
+        HotstringEditModel.SafePreview("yyyy-MM-dd", 7, DateOffsetUnit.Days, clock).Should().Be("2026-07-17");
+        HotstringEditModel.SafePreview("HH:mm", -2, DateOffsetUnit.Hours, clock).Should().Be("06:30");
     }
 }


### PR DESCRIPTION
## Summary
- Adds the **Macro** hotstring kind: `{{cursor}}` / `{{key:Enter|Tab}}` tokens (plus `{{{{...}}}}` escaped literals) parsed by a new backend `MacroTokenParser` and emitted as AHK v2 brace bodies.
- Adds a stateless `POST api/v1/hotstrings/preview` endpoint and a live Generated-AHK preview panel in the dialog (debounced, cancellable, stale-response-safe) covering all three kinds.
- Adds the macro insert toolbar (MudBlazor built-in caret insertion, no custom JS), a "Use Macro?" suggestion for Text replacements containing tokens, and token chips in the grid/mobile list.
- CLI and history round-trip macros unchanged (no schema/migration needed — Macro payload lives entirely in `Replacement`).
- Follow-up commit addresses a local code review pass: an unexpected (non-cancellation) preview fault no longer leaves the "Updating preview…" spinner stuck forever; field-mapped validation errors show inline only instead of being duplicated in the panel and clear immediately when a corrected value is re-previewed; adds direct `CursorTokenStart` test coverage; trims a couple of real-time test sleeps via the existing debounce test seam.

Design doc: `docs/superpowers/plans/2026-07-10-hotstrings-redesign-phase3.md`

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] Blazor test suite (bUnit) — 369/369 passing
- [x] Macro E2E (Playwright) — caret insertion, live preview, save, mobile overflow
- [x] Manual: create a Macro hotstring via the dialog, expand the preview panel, verify snippet, save, download script

🤖 Generated with [Claude Code](https://claude.com/claude-code)