### PR TITLE
fix: auto-sync + gate changelog.json against CHANGELOG.md drift

### DIFF
--- a/.claude/hooks/post-edit-changelog.ps1
+++ b/.claude/hooks/post-edit-changelog.ps1
@@ -1,0 +1,55 @@
+# Post-edit hook: keep the generated changelog asset in sync with CHANGELOG.md
+# Runs generate-changelog-json.ps1 after Claude edits CHANGELOG.md, so
+# src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/changelog.json never drifts (CI
+# blocks on staleness via generate-changelog-json.ps1 -Check).
+#
+# Usage:
+#   Called automatically by Claude Code PostToolUse hook after Edit/Write.
+#   Accepts file path via:
+#     1. First argument ($args[0])
+#     2. CLAUDE_EDITED_FILE env var
+#     3. PostToolUse stdin JSON ({"tool_input":{"file_path":"..."}})
+
+$ErrorActionPreference = 'Stop'
+
+# --- Log file setup ---
+$logDir  = Join-Path $PSScriptRoot "..\logs"
+$logFile = Join-Path $logDir "post-edit-changelog.log"
+
+if (-not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+
+function Write-Log($message, [switch]$Err) {
+    $line = "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] $message"
+    if ($Err) { [Console]::Error.WriteLine($message) } else { Write-Host $message }
+    Add-Content -Path $logFile -Value $line -Encoding UTF8
+}
+
+$file = if ($args.Count -gt 0) { $args[0] } else { $env:CLAUDE_EDITED_FILE }
+
+# Fallback: parse file_path from PostToolUse stdin JSON
+if (-not $file) {
+    $stdin = $input | Out-String
+    if ($stdin) {
+        if ($stdin -match '"file_path"\s*:\s*"([^"]+)"') {
+            $file = $Matches[1]
+        }
+    }
+}
+
+if (-not $file) { Write-Log "No file path provided, skipping."; exit 0 }
+
+# Only react to the repo-root CHANGELOG.md (not nested files that happen to share the name)
+$file = [System.IO.Path]::GetFullPath($file)
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\.."))
+$changelogPath = [System.IO.Path]::GetFullPath((Join-Path $repoRoot "CHANGELOG.md"))
+
+if ($file -ne $changelogPath) { Write-Log "Not CHANGELOG.md ($file), skipping."; exit 0 }
+
+$generatorScript = Join-Path $repoRoot "scripts\ci\generate-changelog-json.ps1"
+if (-not (Test-Path $generatorScript)) { Write-Log "Generator script not found ($generatorScript), skipping." -Err; exit 0 }
+
+Write-Log "CHANGELOG.md edited, regenerating changelog.json..."
+pwsh -NoProfile -File $generatorScript 2>&1 | ForEach-Object { Write-Log $_ }
+Write-Log "Regeneration complete. (exit $LASTEXITCODE)"

--- a/.claude/hooks/post-edit-changelog.ps1
+++ b/.claude/hooks/post-edit-changelog.ps1
@@ -48,8 +48,12 @@ $changelogPath = [System.IO.Path]::GetFullPath((Join-Path $repoRoot "CHANGELOG.m
 if ($file -ne $changelogPath) { Write-Log "Not CHANGELOG.md ($file), skipping."; exit 0 }
 
 $generatorScript = Join-Path $repoRoot "scripts\ci\generate-changelog-json.ps1"
-if (-not (Test-Path $generatorScript)) { Write-Log "Generator script not found ($generatorScript), skipping." -Err; exit 0 }
+if (-not (Test-Path $generatorScript)) { Write-Log "Generator script not found ($generatorScript), cannot sync changelog.json." -Err; exit 2 }
 
 Write-Log "CHANGELOG.md edited, regenerating changelog.json..."
 pwsh -NoProfile -File $generatorScript 2>&1 | ForEach-Object { Write-Log $_ }
-Write-Log "Regeneration complete. (exit $LASTEXITCODE)"
+if ($LASTEXITCODE -ne 0) {
+    Write-Log "Changelog regeneration failed (exit $LASTEXITCODE) — changelog.json is stale. Fix CHANGELOG.md syntax and rerun: pwsh ./scripts/ci/generate-changelog-json.ps1" -Err
+    exit 2
+}
+Write-Log "Regeneration complete. (exit 0)"

--- a/.claude/hooks/pre-commit-antipattern.ps1
+++ b/.claude/hooks/pre-commit-antipattern.ps1
@@ -20,6 +20,27 @@ function Write-Log($message, [switch]$Err) {
     Add-Content -Path $logFile -Value $line -Encoding UTF8
 }
 
+# --- Read the incoming command from stdin (Claude Code passes JSON tool input) ---
+$toolCommand = $null
+try {
+    if ([Console]::IsInputRedirected) {
+        $rawInput = [Console]::In.ReadToEnd()
+        if ($rawInput) {
+            $parsed = $rawInput | ConvertFrom-Json -ErrorAction SilentlyContinue
+            $toolCommand = $parsed.tool_input.command
+        }
+    }
+} catch { }
+
+# Fast-exit if hook-invoked with a non-commit command; no stdin = manual run, proceed
+if ($toolCommand -and $toolCommand -notmatch 'git\s+commit') {
+    exit 0
+}
+
+# Anchor to the repo root: git diff paths are repo-root-relative, and the hook's
+# cwd is wherever Claude Code currently runs.
+Set-Location (Join-Path $PSScriptRoot "..\..")
+
 # --- Get staged AND unstaged modified .cs files ---
 # PreToolUse hook fires before the command runs, so "git add X && git commit"
 # means X is not staged yet — check both to catch antipatterns either way.

--- a/.claude/hooks/pre-commit-changelog.ps1
+++ b/.claude/hooks/pre-commit-changelog.ps1
@@ -1,0 +1,55 @@
+# Pre-commit hook: verify the generated changelog asset matches CHANGELOG.md
+# Safety net for edits the post-edit-changelog hook didn't see (e.g. CHANGELOG.md
+# edited outside Claude Code's Edit/Write tools). Mirrors the CI check exactly
+# (ci.yml "Verify changelog asset" step) so drift is caught before push, not after.
+# Reads the incoming Bash command from stdin to fast-exit on non-commit commands.
+#
+# Exit codes:
+#   0 — Changelog asset current (or not a commit command)
+#   2 — Changelog asset stale, commit blocked
+
+$ErrorActionPreference = 'Stop'
+
+# --- Log file setup ---
+$logDir  = Join-Path $PSScriptRoot "..\logs"
+$logFile = Join-Path $logDir "pre-commit-changelog.log"
+
+if (-not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+
+function Write-Log($message, [switch]$Err) {
+    $line = "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] $message"
+    if ($Err) { [Console]::Error.WriteLine($message) } else { Write-Host $message }
+    Add-Content -Path $logFile -Value $line -Encoding UTF8
+}
+
+# --- Read the incoming command from stdin (Claude Code passes JSON tool input) ---
+$toolCommand = $null
+try {
+    if ([Console]::IsInputRedirected) {
+        $rawInput = [Console]::In.ReadToEnd()
+        if ($rawInput) {
+            $parsed = $rawInput | ConvertFrom-Json -ErrorAction SilentlyContinue
+            $toolCommand = $parsed.tool_input.command
+        }
+    }
+} catch { }
+
+# Fast-exit if hook-invoked with a non-commit command; no stdin = manual run, proceed
+if ($toolCommand -and $toolCommand -notmatch 'git\s+commit') {
+    exit 0
+}
+
+Write-Log "Checking changelog asset is current..."
+
+$repoRoot = Join-Path $PSScriptRoot "..\.."
+$generatorScript = Join-Path $repoRoot "scripts\ci\generate-changelog-json.ps1"
+
+pwsh -NoProfile -File $generatorScript -Check 2>&1 | ForEach-Object { Write-Log $_ }
+if ($LASTEXITCODE -eq 0) {
+    Write-Log "Changelog asset check passed. (exit 0)"
+} else {
+    Write-Log "Changelog asset is stale. Run 'pwsh ./scripts/ci/generate-changelog-json.ps1' to fix. (exit $LASTEXITCODE)" -Err
+    exit 2
+}

--- a/.claude/hooks/pre-commit-changelog.ps1
+++ b/.claude/hooks/pre-commit-changelog.ps1
@@ -1,8 +1,15 @@
 # Pre-commit hook: verify the generated changelog asset matches CHANGELOG.md
 # Safety net for edits the post-edit-changelog hook didn't see (e.g. CHANGELOG.md
-# edited outside Claude Code's Edit/Write tools). Mirrors the CI check exactly
+# edited outside Claude Code's Edit/Write tools). Mirrors the CI check
 # (ci.yml "Verify changelog asset" step) so drift is caught before push, not after.
 # Reads the incoming Bash command from stdin to fast-exit on non-commit commands.
+#
+# Two checks, both must pass:
+#   1. Working tree — PreToolUse fires before the command runs, so with
+#      "git add X && git commit" nothing is staged yet; this catches that path.
+#   2. Index — what the commit will actually contain. Catches CHANGELOG.md
+#      staged while the regenerated JSON is not (working tree looks synced,
+#      but git would commit the old JSON).
 #
 # Exit codes:
 #   0 — Changelog asset current (or not a commit command)
@@ -41,15 +48,63 @@ if ($toolCommand -and $toolCommand -notmatch 'git\s+commit') {
     exit 0
 }
 
-Write-Log "Checking changelog asset is current..."
-
-$repoRoot = Join-Path $PSScriptRoot "..\.."
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\.."))
 $generatorScript = Join-Path $repoRoot "scripts\ci\generate-changelog-json.ps1"
+$jsonRelPath = 'src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/changelog.json'
+
+# --- Check 1: working tree ---
+Write-Log "Checking changelog asset (working tree)..."
 
 pwsh -NoProfile -File $generatorScript -Check 2>&1 | ForEach-Object { Write-Log $_ }
-if ($LASTEXITCODE -eq 0) {
-    Write-Log "Changelog asset check passed. (exit 0)"
-} else {
-    Write-Log "Changelog asset is stale. Run 'pwsh ./scripts/ci/generate-changelog-json.ps1' to fix. (exit $LASTEXITCODE)" -Err
+if ($LASTEXITCODE -ne 0) {
+    Write-Log "Changelog asset is stale in the working tree. Run 'pwsh ./scripts/ci/generate-changelog-json.ps1' to fix. (exit $LASTEXITCODE)" -Err
     exit 2
 }
+
+# --- Check 2: index (staged content = what the commit will contain) ---
+Write-Log "Checking changelog asset (index)..."
+
+# git emits UTF-8 bytes; PowerShell decodes native output with the console code
+# page, which mangles non-ASCII (e.g. "…") — force UTF-8 for the capture.
+$prevEncoding = [Console]::OutputEncoding
+try {
+    [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+    $stagedMd = & git -C $repoRoot show :CHANGELOG.md 2>$null
+} finally {
+    [Console]::OutputEncoding = $prevEncoding
+}
+if ($LASTEXITCODE -ne 0) {
+    # CHANGELOG.md not in the index (e.g. fresh repo state) — nothing to compare.
+    Write-Log "CHANGELOG.md not found in index, skipping index check. (exit 0)"
+    exit 0
+}
+
+$jsonIndexHash = (& git -C $repoRoot ls-files -s -- $jsonRelPath) -split '\s+' | Select-Object -Skip 1 -First 1
+if (-not $jsonIndexHash) {
+    Write-Log "changelog.json missing from index while CHANGELOG.md is tracked. Run 'pwsh ./scripts/ci/generate-changelog-json.ps1' and stage it. (exit 2)" -Err
+    exit 2
+}
+
+$tempMd   = New-TemporaryFile
+$tempJson = New-TemporaryFile
+try {
+    # Line-join is safe: the generator parses line-by-line and trims trailing whitespace.
+    [System.IO.File]::WriteAllText($tempMd.FullName, (($stagedMd -join "`n") + "`n"), [System.Text.UTF8Encoding]::new($false))
+
+    pwsh -NoProfile -File $generatorScript -InputPath $tempMd.FullName -OutputPath $tempJson.FullName 2>&1 | ForEach-Object { Write-Log $_ }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Log "Changelog generation from staged CHANGELOG.md failed (exit $LASTEXITCODE) — fix CHANGELOG.md syntax. (exit 2)" -Err
+        exit 2
+    }
+
+    # Compare git blob hashes — exact byte comparison, no encoding round-trips.
+    $expectedHash = (& git -C $repoRoot hash-object -- $tempJson.FullName).Trim()
+    if ($expectedHash -ne $jsonIndexHash) {
+        Write-Log "Staged changelog.json does not match staged CHANGELOG.md. Run 'pwsh ./scripts/ci/generate-changelog-json.ps1' and stage the result. (exit 2)" -Err
+        exit 2
+    }
+} finally {
+    Remove-Item $tempMd.FullName, $tempJson.FullName -Force -ErrorAction SilentlyContinue
+}
+
+Write-Log "Changelog asset check passed (working tree + index). (exit 0)"

--- a/.claude/hooks/pre-commit-format.ps1
+++ b/.claude/hooks/pre-commit-format.ps1
@@ -41,7 +41,10 @@ if ($toolCommand -and $toolCommand -notmatch 'git\s+commit') {
 
 Write-Log "Checking code formatting..."
 
-dotnet format --verify-no-changes --verbosity quiet 2>$null
+# Explicit workspace: bare `dotnet format` fails with "both a MSBuild project file and
+# solution file found" at the repo root; anchor to the repo so hook cwd doesn't matter.
+$slnx = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\..\AHKFlowApp.slnx"))
+dotnet format $slnx --verify-no-changes --verbosity quiet 2>$null
 if ($LASTEXITCODE -eq 0) {
     Write-Log "Format check passed. (exit 0)"
 } else {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -139,6 +139,11 @@
             "type": "command",
             "command": "pwsh -NonInteractive -File .claude/hooks/pre-commit-antipattern.ps1",
             "statusMessage": "Checking for anti-patterns..."
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NonInteractive -File .claude/hooks/pre-commit-changelog.ps1",
+            "statusMessage": "Checking changelog asset..."
           }
         ]
       },
@@ -161,6 +166,11 @@
             "type": "command",
             "command": "pwsh -NonInteractive -File .claude/hooks/post-edit-format.ps1",
             "statusMessage": "Auto-formatting .cs file..."
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NonInteractive -File .claude/hooks/post-edit-changelog.ps1",
+            "statusMessage": "Syncing changelog asset..."
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -128,21 +128,21 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash(git commit*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NonInteractive -File .claude/hooks/pre-commit-format.ps1",
+            "command": "pwsh -NonInteractive -File \"${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-commit-format.ps1\"",
             "statusMessage": "Checking formatting..."
           },
           {
             "type": "command",
-            "command": "pwsh -NonInteractive -File .claude/hooks/pre-commit-antipattern.ps1",
+            "command": "pwsh -NonInteractive -File \"${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-commit-antipattern.ps1\"",
             "statusMessage": "Checking for anti-patterns..."
           },
           {
             "type": "command",
-            "command": "pwsh -NonInteractive -File .claude/hooks/pre-commit-changelog.ps1",
+            "command": "pwsh -NonInteractive -File \"${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-commit-changelog.ps1\"",
             "statusMessage": "Checking changelog asset..."
           }
         ]
@@ -152,7 +152,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/pre-bash-guard.sh",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-bash-guard.sh\"",
             "statusMessage": "Checking for destructive operations..."
           }
         ]
@@ -164,12 +164,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NonInteractive -File .claude/hooks/post-edit-format.ps1",
+            "command": "pwsh -NonInteractive -File \"${CLAUDE_PROJECT_DIR}/.claude/hooks/post-edit-format.ps1\"",
             "statusMessage": "Auto-formatting .cs file..."
           },
           {
             "type": "command",
-            "command": "pwsh -NonInteractive -File .claude/hooks/post-edit-changelog.ps1",
+            "command": "pwsh -NonInteractive -File \"${CLAUDE_PROJECT_DIR}/.claude/hooks/post-edit-changelog.ps1\"",
             "statusMessage": "Syncing changelog asset..."
           }
         ]


### PR DESCRIPTION
## Summary
- Adds a PostToolUse hook (`post-edit-changelog.ps1`) that regenerates `src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/changelog.json` whenever `CHANGELOG.md` is edited via Claude Code's Edit/Write tools — mirrors the existing `post-edit-format.ps1` auto-format pattern.
- Adds a PreToolUse safety-net hook (`pre-commit-changelog.ps1`) on `git commit` that runs `generate-changelog-json.ps1 -Check` and blocks the commit if the asset is stale — mirrors the existing `pre-commit-format.ps1` pattern and the CI check exactly, catching edits made outside Claude Code (e.g. a manual edit) that the PostToolUse hook wouldn't see.
- Prompted by PR #178's CI failure: `CHANGELOG.md` was edited but `changelog.json` wasn't regenerated, so `generate-changelog-json.ps1 -Check` failed in CI. Both new hooks were manually exercised against synced and deliberately-staled states to confirm pass/block behavior before committing.

## Checklist
- [x] Tests pass (`dotnet test`) — N/A, no code changes (`.claude/**` only)
- [x] Build succeeds (`dotnet build`) — N/A, no code changes
- [x] No new warnings introduced
- [x] Breaking changes documented (if any) — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)