### PR TITLE
feat: Raw hotstring kind (replaces Script)

### DIFF
--- a/docs/cli/hotstrings.md
+++ b/docs/cli/hotstrings.md
@@ -5,11 +5,15 @@ actual CLI surface and how each hotstring kind renders in `list` output.
 
 ## Commands
 
-- `ahkflow hotstring new` — creates a **Text** hotstring only. `--trigger`/`-t` and
-  `--replacement`/`-r` are required; `--profile`/`-p` is repeatable; `--no-ending-char` and
-  `--no-inside-word` flip the two boolean options (both default to their "on" behavior).
-  Advanced kinds (Date & time, Macro, Script) cannot be created via the CLI yet — create them
-  in the web UI, then they show up (display-only) in `ahkflow hotstring list`.
+- `ahkflow hotstring new` — creates a **Text** hotstring, or a **Raw** hotstring with `--raw`.
+  - **Text:** `--trigger`/`-t` and `--replacement`/`-r`; `--profile`/`-p` is repeatable;
+    `--no-ending-char` and `--no-inside-word` flip the two boolean options (both default to their
+    "on" behavior).
+  - **Raw:** `--raw "<definition>"` sends the entire verbatim AHK v2 definition (e.g.
+    `:K1000 SE*:ftw::for the win`); the server derives the trigger and validates it. `--raw` is
+    **mutually exclusive** with `--trigger`/`--replacement`. `--profile` still applies.
+  - Date & time and Macro kinds cannot be created via the CLI yet — create them in the web UI,
+    then they show up (display-only) in `ahkflow hotstring list`.
 - `ahkflow hotstring list` — lists hotstrings of **all** kinds. Supports `--profile`/`-p`,
   `--search`/`-s`/`-g`, `--page`, `--page-size`, and `--json`. There is **no** `--kind` filter
   and **no** `hotstring update` command in the CLI today.
@@ -19,7 +23,7 @@ actual CLI surface and how each hotstring kind renders in `list` output.
 | Column | Contents |
 |---|---|
 | Trigger | The abbreviation, truncated to 20 chars. |
-| Kind | `Text`, `DateTime`, `Macro`, or `Script`. |
+| Kind | `Text`, `DateTime`, `Macro`, or `Raw`. |
 | Replacement | Per-kind summary — see below. |
 | Profiles | Resolved profile names, or `all`. |
 | Context | Window-context summary (`exe:`/`class:`/`title:` prefix), blank when global. |
@@ -36,17 +40,28 @@ actual CLI surface and how each hotstring kind renders in `list` output.
   complexity, and remains a possible follow-up. Advanced-kind rows are otherwise
   read-only/display-only until their own CLI create/edit support lands (see the redesign
   spec's D6).
-- **Script** — only the **first line** of the raw AutoHotkey body, truncated to 40 chars. A
-  multi-line script shows just its opening line so the table stays one row per hotstring; use
-  the web UI to see (or edit) the full body.
+- **Raw** — only the **first line** of the verbatim definition (the `:options:trigger::` line),
+  truncated to 40 chars. A multi-line brace-body definition shows just its opening line so the
+  table stays one row per hotstring; use the web UI to see (or edit) the full definition.
 
-## Script validation limitations
+## Raw validation limitations
 
-Script bodies are validated (in the web UI, where they are created) by two naive rules: no
-line may start with `#` (directive lines corrupt the generated `#HotIf` grouping), and braces
-must balance. Brace counting is **string- and comment-unaware** — a `{` inside a quoted string
-(e.g. `SendText "{"`) counts toward the balance and is falsely rejected. This is a deliberate
-limitation, not a bug; work around it by splitting the line or wrapping the brace differently.
+A Raw definition is the entire verbatim AHK v2 hotstring, validated (server-side) against a
+deliberately **restricted subset** of AHK v2:
+
+- The first non-blank line must be a `:options:trigger::` definition, and the paste must contain
+  exactly **one** definition.
+- The derived trigger must be non-empty, ≤ 40 characters (AHK's own abbreviation limit), and free
+  of line breaks/tabs — so a trigger using escaped tab/newline (`` `t ``/`` `n ``) is rejected.
+- Every option flag must be a known AHK v2 flag; `X0` and other undocumented off-forms are rejected.
+- No line may start with `#` (directive lines corrupt the generated `#HotIf` grouping).
+- A bare `::` first line requires a `{` brace body on its own line, with balanced braces and no
+  content after the closing `}`. Brace counting is **string- and comment-unaware** — a `{` inside a
+  quoted string (e.g. `SendText "{"`) counts toward the balance and is falsely rejected. Inline
+  replacements are exempt from the brace check.
+- **OTB** brace placement (`::btw:: {`) and **continuation sections** (`(` … `)`) are rejected with
+  actionable messages. These are deliberate limitations, not bugs; supporting them is a possible
+  follow-up.
 
 ## Example
 
@@ -56,5 +71,5 @@ Trigger               Kind      Replacement                               Profil
 btw                   Text      by the way                                all                                               2026-07-11 09:00:00
 dd                    DateTime  yyyy-MM-dd (+7 days)                      all                                               2026-07-11 09:00:00
 htag                  Macro     <b>{{cursor}}</b>                         all                                               2026-07-11 09:00:00
-~ver                  Script    MsgBox A_AhkVersion                       all                                               2026-07-11 09:00:00
+ftw                   Raw       :K1000 SE*:ftw::for the win               all                                               2026-07-11 09:00:00
 ```

--- a/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-implementation-plan.md
+++ b/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-implementation-plan.md
@@ -3,7 +3,7 @@
 **Date:** 2026-07-13
 **Spec:** [2026-07-13-raw-hotstring-kind-design.md](../specs/2026-07-13-raw-hotstring-kind-design.md)
 **Tracker:** [2026-07-13-raw-hotstring-kind-plan.md](2026-07-13-raw-hotstring-kind-plan.md)
-**Status:** Ready to implement; awaiting user go-ahead on pacing
+**Status:** Implemented on `worktree-feature-wt-raw-hotstring-kind` (P0–P14, commits `02f363f`…`d2be1d3`); review findings fixed in follow-up (`2c33830`). Build/tests/format green.
 
 File-level, dependency-ordered tasks. TDD where the spec marks it (parser,
 validators, composer). Each phase is a candidate atomic commit (feature + its tests).

--- a/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-implementation-plan.md
+++ b/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-implementation-plan.md
@@ -1,0 +1,144 @@
+# Plan: Raw hotstring kind — implementation
+
+**Date:** 2026-07-13
+**Spec:** [2026-07-13-raw-hotstring-kind-design.md](../specs/2026-07-13-raw-hotstring-kind-design.md)
+**Tracker:** [2026-07-13-raw-hotstring-kind-plan.md](2026-07-13-raw-hotstring-kind-plan.md)
+**Status:** Ready to implement; awaiting user go-ahead on pacing
+
+File-level, dependency-ordered tasks. TDD where the spec marks it (parser,
+validators, composer). Each phase is a candidate atomic commit (feature + its tests).
+
+## Dependency order
+
+```
+P0 enum/domain
+  └─ P1 parser ──┬─ P2 validation
+                 └─ P3 shared composer ─┬─ P4 emitter
+                                        ├─ P6 migration
+                                        └─ P7 history
+P2+P4 ─ P5 commands/queries ─ P8 DTOs ─ P9 dialog ─ P10 promote ─ P11 lists
+P5 ─ P12 CLI
+P5/P9 ─ P13 docs/OpenAPI ─ P14 E2E + verify
+```
+
+## P0 — Enum & domain (no tests; compile gate)
+
+- `Domain/Enums/HotstringKind.cs`: add `Raw = 4`; mark `Script = 3` `[Obsolete("Legacy; accepted only when deserializing history snapshots")]`.
+- `Domain/Entities/Hotstring*` (`HotstringDefinition`): XML-doc the kind-dependent meaning of `Replacement` (verbatim definition for Raw).
+- Constants in `Validation/HotstringRules.cs`: add `RawDefinitionMaxLength = 4200`, `RawTriggerMaxLength = 40`.
+
+## P1 — RawHotstringDefinitionParser (TDD)
+
+- **Test first:** `tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs`
+  - structure split (`:opts:trigger::` + optional brace body), option tokenization incl. `K1000 SE*`
+  - longest-match goldens `SE*` / `S0` / `SI` / `SP`, case-insensitivity, `K-1`, `P9`
+  - multi-definition detection, brace bodies, escaped-trigger decode (`` `; ``)
+  - unknown-token capture (`X0`)
+- **Impl:** `src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs`
+  - `internal static class`, pure; `RawParseResult Parse(string)` → `IsValid, Trigger, string[] OptionTokens, string[] UnknownOptionTokens, string? Error`
+  - known-option set + longest-match tokenizer; cite `autohotkey.com/docs/v2/Hotstrings.htm` in a comment.
+
+## P2 — Validation: AddRawKindRules (TDD)
+
+- **Test first:** extend `CreateHotstringCommandValidatorTests`, `UpdateHotstringCommandValidatorTests`, `GetHotstringPreviewQueryValidatorTests` — all 8 rules; `X0` rejected; OTB + continuation-section rejection; 41-char trigger rejected; empty client trigger passes for Raw.
+- **Impl:** `Validation/HotstringRules.cs`
+  - add `AddRawKindRules<T>(kind, replacement)` (rules 1-8 from spec §Validation), XML-doc the restricted-subset limits.
+  - **remove** `AddScriptKindRules` from active use (keep method or delete — no live caller after P5).
+  - **Gate `ValidTrigger()`**: in the three validators wrap `RuleFor(x => x.Input.Trigger).ValidTrigger()` in `.When(x => x.Input.Kind != HotstringKind.Raw)`.
+  - Update the `Kind` allow-list `Must(...)` to `Text/DateTime/Macro/Raw` (drop `Script`), message reworded.
+
+## P3 — Shared Script→Raw composer (TDD, golden fixtures)
+
+The Script→Raw transform lives in **one** place, reused by migration SQL parity test, history composer, and dialog compose.
+
+- **Fixtures:** `tests/AHKFlowApp.TestUtilities/` — shared golden set: option matrix × triggers with backtick/`;`, CRLF bodies, blank-edged bodies, 4,000-char body.
+- **Test first:** `ScriptToRawComposerTests` asserting each fixture → expected verbatim definition (byte-identical to today's emitter output).
+- **Impl:** `Application/Services/ScriptToRawComposer.cs` — compose `:opts:trigger::\n{\n<body>\n}` mirroring `HotstringEmitter.BuildOptions` (X/*/?/C/O) + `HotstringEmitter.Escape` on trigger. Pure, static.
+
+## P4 — Emitter Raw branch + save normalization
+
+- `Application/Services/HotstringEmitter.cs`
+  - `BuildBody` switch: `HotstringKind.Raw => hs.Replacement` (verbatim; no options, no escape, no wrap). Note the whole `Emit` for Raw returns `hs.Replacement` — confirm `Emit` shape returns raw string, not `:opts:trigger::body` re-wrap. (Raw already carries the full definition; emit must **not** re-prefix.)
+  - Keep `Script` branch for legacy-snapshot emission path? No — snapshots convert at restore/revert (P7); emitter never sees `Kind=Script`. Remove `BuildScriptBody`.
+- Save-time normalization (CRLF→LF, trim leading/trailing blank lines + per-line trailing WS): apply in create/update handlers (P5) before persisting Raw `Replacement`.
+- **Test:** `AhkScriptGeneratorTests` — verbatim emission + `#HotIf` wrap; round-trip paste→save→generate byte-identical.
+
+## P5 — Commands / queries wiring
+
+- `Commands/Hotstrings/CreateHotstringCommand.cs` & `UpdateHotstringCommand.cs` handlers:
+  - when `Kind == Raw`: parse via `RawHotstringDefinitionParser`, **derive+decode trigger**, normalize `Replacement`, use derived trigger for the duplicate check + `HotstringDefinition` construction.
+  - validators: swap `AddScriptKindRules` → `AddRawKindRules`; gate `ValidTrigger` (P2).
+- `Queries/Hotstrings/GetHotstringPreviewQuery.cs`:
+  - validator: same swap + gate.
+  - handler: for Raw, parse to derive trigger before building the transient `Hotstring`; populate `RawSummary` (P8).
+- **Test:** `CreateHotstringCommandHandlerTests`, `UpdateHotstringCommandHandlerTests`, preview handler — Raw payload with empty client trigger derives server-side; duplicate detection on derived trigger; normalization applied.
+
+## P6 — Migration (schema + data)
+
+- `dotnet ef migrations add RawHotstringKind` (Infrastructure project).
+- Schema: `Replacement` `nvarchar(4000)` → `nvarchar(max)`; update `HotstringConfiguration` + snapshot.
+- Data: raw SQL rewriting `Kind=3` → `Kind=4`, `Replacement` = emitted form (mirror `BuildOptions` + `Escape`). No down-migration (documented).
+- **Test:** `Infrastructure.Tests` Testcontainers — seed Script rows from shared fixtures; assert generated scripts byte-identical pre/post migration; include 4,000-char body row (proves no truncation).
+
+## P7 — History restore/revert legacy conversion
+
+- `Commands/Hotstrings/RestoreHotstringCommand.cs` & `RevertHotstringCommand.cs`:
+  - after deserializing snapshot, if `snapshot.Kind == HotstringKind.Script`: compose Raw definition via `ScriptToRawComposer`, set `Kind = Raw`, derived trigger, composed `Replacement`; else use snapshot as-is.
+- **Test:** restore + revert of a legacy `Kind=3` snapshot → valid Raw row (composed definition, derived trigger); post-change `Kind=4` snapshot round-trips unchanged. Keep `HotstringSnapshotCompatibilityTests` green.
+
+## P8 — DTOs (preview RawSummary)
+
+- `Application/DTOs/HotstringPreviewDto` (+ Blazor `DTOs/HotstringPreviewDtos.cs`): add optional `RawSummary(string Trigger, string[] OptionTokens)`, populated for Raw only.
+- Ensure serialization parity backend ↔ Blazor.
+
+## P9 — UI edit dialog
+
+- `Components/Hotstrings/HotstringEditDialog.razor`
+  - kind toggle `Script` → `Raw`.
+  - Raw selected: monospace 8-line textarea "Raw definition", placeholder `:K1000 SE*:ftw::for the win`; hide Trigger field + 4 option checkboxes; keep description/profiles/categories/context.
+  - parsed summary from `RawSummary` via existing debounced preview; errors via existing preview error path.
+  - multi-def paste error under textarea (no Import referral).
+  - kind switch: →Raw composes via shared composer; Raw→other confirms discard of unexpressible options, then moves trigger+body into fields.
+  - Text "looks like AHK code" hint → "Switch to Raw".
+- **Test (bUnit):** `HotstringEditDialogTests` — textarea, hidden fields, summary, multi-def error, kind-switch compose/decompose + confirm.
+
+## P10 — UI promote inline row → dialog
+
+- Desktop grid component: add third inline action (`Tune` icon, "More options / change type") next to ✓/✗.
+- Promote carries typed values into `HotstringEditDialog`; draft cancel restores inline draft; existing-row cancel restores in-row values. Add still defaults to inline Text draft.
+- **Test (bUnit):** promote from draft + existing row; cancel restores.
+
+## P11 — UI lists
+
+- Desktop grid + mobile list: Trigger column via derived trigger.
+- Mobile list: "Raw" kind chip; suppress the 4 option checkmarks for Raw rows.
+
+## P12 — CLI
+
+- `Tools/AHKFlowApp.CLI/Services/IHotstringsApiClient.cs`: enum `Raw = 4`, drop `Script`; `CreateHotstringDto` gains `Kind`; table/JSON labels.
+- `Commands/Hotstrings/NewHotstringCommand.cs`: add `--raw "<definition>"`, mutually exclusive with `--trigger`/`--replacement`; sends `Kind=Raw`, definition as `Replacement`; relays ProblemDetails.
+- **Test:** `NewHotstringCommandTests` — `--raw` happy path, mutual-exclusion error, server-error relay.
+
+## P13 — Docs & OpenAPI
+
+- `docs/cli/hotstrings.md`: `new` gains `--raw`; Kind/Replacement-summary column Script→Raw (summary = first line, ≤40 chars); rewrite "Script validation limitations" → Raw restricted subset.
+- `API/OpenApi/Examples/HotstringExamples.cs`: history example Script→Raw.
+- `HotstringKind` XML docs: `Script = 3` = rejected legacy (deserialize-only).
+- **Test:** CLI docs example output regression; example serialization.
+
+## P14 — E2E + final verify
+
+- `tests/AHKFlowApp.E2E.Tests`: rename `ScriptHotstringFlowTests` → `RawHotstringFlowTests` — paste `:K1000 SE*:ftw::for the win`, verify summary, save, downloaded script contains exact line; add promote-flow coverage.
+- `dotnet build` + `dotnet test` full; `dotnet format`; `dck-verify`.
+
+## Verification checklist
+
+- All 6 review findings covered: overflow (P6), enum compat (P0/P7), trigger gating (P2/P5), restricted-subset docs (P2), no-Import-referral + discard-confirm (P9), CLI `--raw` (P12).
+- Shared composer single-sourced across P3/P6/P7/P9.
+- No live caller of `AddScriptKindRules` / `BuildScriptBody` after P4/P5.
+
+## Open questions
+
+1. Delete `AddScriptKindRules`/`BuildScriptBody` outright, or keep `[Obsolete]` for a release?
+2. Composer home: `Application/Services` (shared w/ migration test) vs `TestUtilities` — SQL migration itself can't call C#; confirm parity is test-enforced only.
+3. `Emit(Raw)` — confirm it returns `hs.Replacement` with **no** `:opts:trigger::` re-wrap (definition already complete).

--- a/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-implementation-plan.md
+++ b/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-implementation-plan.md
@@ -43,7 +43,7 @@ P5/P9 ─ P13 docs/OpenAPI ─ P14 E2E + verify
 - **Test first:** extend `CreateHotstringCommandValidatorTests`, `UpdateHotstringCommandValidatorTests`, `GetHotstringPreviewQueryValidatorTests` — all 8 rules; `X0` rejected; OTB + continuation-section rejection; 41-char trigger rejected; empty client trigger passes for Raw.
 - **Impl:** `Validation/HotstringRules.cs`
   - add `AddRawKindRules<T>(kind, replacement)` (rules 1-8 from spec §Validation), XML-doc the restricted-subset limits.
-  - **remove** `AddScriptKindRules` from active use (keep method or delete — no live caller after P5).
+  - **Delete `AddScriptKindRules` outright** — no `[Obsolete]`; its only callers are the three validators, all swapped to `AddRawKindRules` in P5.
   - **Gate `ValidTrigger()`**: in the three validators wrap `RuleFor(x => x.Input.Trigger).ValidTrigger()` in `.When(x => x.Input.Kind != HotstringKind.Raw)`.
   - Update the `Kind` allow-list `Must(...)` to `Text/DateTime/Macro/Raw` (drop `Script`), message reworded.
 
@@ -53,13 +53,20 @@ The Script→Raw transform lives in **one** place, reused by migration SQL parit
 
 - **Fixtures:** `tests/AHKFlowApp.TestUtilities/` — shared golden set: option matrix × triggers with backtick/`;`, CRLF bodies, blank-edged bodies, 4,000-char body.
 - **Test first:** `ScriptToRawComposerTests` asserting each fixture → expected verbatim definition (byte-identical to today's emitter output).
-- **Impl:** `Application/Services/ScriptToRawComposer.cs` — compose `:opts:trigger::\n{\n<body>\n}` mirroring `HotstringEmitter.BuildOptions` (X/*/?/C/O) + `HotstringEmitter.Escape` on trigger. Pure, static.
+- **Impl:** `Application/Services/ScriptToRawComposer.cs` — compose `:opts:trigger::\n{\n<body>\n}` mirroring `HotstringEmitter.BuildOptions` (X/*/?/C/O) + `HotstringEmitter.Escape` on trigger. Pure, static. Lives in `Application` (not `TestUtilities`) so P7 restore/revert and P9 dialog can call it directly. The migration SQL (P6) is a **separate hand-written T-SQL copy** — SQL can't call C#; the P6 parity test is what enforces they agree.
 
 ## P4 — Emitter Raw branch + save normalization
 
 - `Application/Services/HotstringEmitter.cs`
-  - `BuildBody` switch: `HotstringKind.Raw => hs.Replacement` (verbatim; no options, no escape, no wrap). Note the whole `Emit` for Raw returns `hs.Replacement` — confirm `Emit` shape returns raw string, not `:opts:trigger::body` re-wrap. (Raw already carries the full definition; emit must **not** re-prefix.)
-  - Keep `Script` branch for legacy-snapshot emission path? No — snapshots convert at restore/revert (P7); emitter never sees `Kind=Script`. Remove `BuildScriptBody`.
+  - **`Emit()` top-level guard** (not a `BuildBody` change): Raw returns `hs.Replacement` verbatim, bypassing the `:{options}:{trigger}::{body}` template entirely — Raw's `Replacement` already contains the full `:opts:trigger::` definition, so re-prefixing would double it. `BuildOptions`/`Escape`/`BuildBody` are never reached for Raw.
+    ```csharp
+    public static string Emit(Hotstring hs) =>
+        hs.Kind == HotstringKind.Raw
+            ? hs.Replacement
+            : $":{BuildOptions(hs)}:{Escape(hs.Trigger)}::{BuildBody(hs)}";
+    ```
+    (Safe: `AhkScriptGenerator` adds each `Emit` result to a line list joined with `\n`, so a multi-line verbatim definition slots in as multiple physical lines.)
+  - Emitter never sees `Kind=Script` (snapshots convert at restore/revert, P7). **Delete `BuildScriptBody`** and its `Script` switch arm outright — no `[Obsolete]`.
 - Save-time normalization (CRLF→LF, trim leading/trailing blank lines + per-line trailing WS): apply in create/update handlers (P5) before persisting Raw `Replacement`.
 - **Test:** `AhkScriptGeneratorTests` — verbatim emission + `#HotIf` wrap; round-trip paste→save→generate byte-identical.
 
@@ -137,8 +144,8 @@ The Script→Raw transform lives in **one** place, reused by migration SQL parit
 - Shared composer single-sourced across P3/P6/P7/P9.
 - No live caller of `AddScriptKindRules` / `BuildScriptBody` after P4/P5.
 
-## Open questions
+## Resolved decisions (grilling, 2026-07-13)
 
-1. Delete `AddScriptKindRules`/`BuildScriptBody` outright, or keep `[Obsolete]` for a release?
-2. Composer home: `Application/Services` (shared w/ migration test) vs `TestUtilities` — SQL migration itself can't call C#; confirm parity is test-enforced only.
-3. `Emit(Raw)` — confirm it returns `hs.Replacement` with **no** `:opts:trigger::` re-wrap (definition already complete).
+1. **Delete `AddScriptKindRules` + `BuildScriptBody` outright** — no `[Obsolete]`. Internal-only, zero live callers after P4/P5; git history preserves them.
+2. **Composer in `Application/Services`**, called by P7/P9. Migration SQL is a separate T-SQL copy; P6 Testcontainers parity test enforces agreement (raw-SQL path, not a C#-driven data migration).
+3. **`Emit()` top-level guard returns `hs.Replacement` verbatim for Raw** — no `:opts:trigger::` re-wrap. Template pieces never reached for Raw.

--- a/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-plan.md
+++ b/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-plan.md
@@ -21,18 +21,18 @@ can't express. Full design in the spec above.
 
 ## Approved decision checklist (spec must keep capturing these)
 
-1. Raw **replaces** Script — enum value 3 renamed, wire-compatible (enums serialize as numbers)
-2. Storage: `Replacement` = verbatim definition; `Trigger` server-derived; option flag columns ignored for Raw; window context stays active
-3. Data-only EF migration rewrites `Kind=3` rows to emitted form; byte-identical generated scripts; no down-migration
+1. Raw **replaces** Script — new enum value 4; `Script = 3` retired (legacy snapshot conversion only)
+2. Storage: `Replacement` = verbatim definition (column → `nvarchar(max)`); `Trigger` server-derived (client-trigger validation gated to non-Raw kinds); option flag columns ignored for Raw; window context stays active
+3. EF migration: widen `Replacement` + rewrite `Kind=3` rows to emitted form with `Kind=4`; byte-identical generated scripts; no down-migration; 4,000-char-body test
 4. New pure `RawHotstringDefinitionParser` (Application/Services)
-5. `AddRawKindRules` (8 structural rules incl. single-definition → Import referral) + option flags validated against known AHK v2 set; verify `S`/`S0` against official docs during impl
+5. `AddRawKindRules` (8 structural rules; multi-definition → "paste one at a time", no Import referral) + option flags validated against known AHK v2 set incl. `S`/`S0`; documented restricted subset (naive brace count on brace bodies only, no escaped tab/newline triggers)
 6. Emitter Raw branch returns `Replacement` verbatim; save-time trim + CRLF→LF only; `#HotIf` grouping and preview pipeline unchanged
-7. Dialog: Raw = monospace textarea + server-authoritative parsed summary (`HotstringPreviewDto.RawSummary`); trigger/options fields hidden; kind-switch compose/decompose; "Switch to Raw" suggestion
-8. Lists: derived trigger fills columns; mobile shows "Raw" chip, suppresses option checkmarks; CLI follows rename
+7. Dialog: Raw = monospace textarea + server-authoritative parsed summary (`HotstringPreviewDto.RawSummary`); trigger/options fields hidden; kind-switch compose/decompose with discard-options confirmation; "Switch to Raw" suggestion
+8. Lists: derived trigger fills columns; mobile shows "Raw" chip, suppresses option checkmarks; CLI changed explicitly (own enum) + minimal `--raw` creation
 9. Desktop grid: promote inline draft/edit row to full dialog via `Tune` action button; cancel restores inline state; Add still defaults to inline Text draft
-10. Errors: existing ValidatingUseCase → ProblemDetails; conflict handling unchanged; history snapshots compatible
-11. Tests: TDD parser/validator; emitter round-trip; migration equivalence (Testcontainers); API integration; bUnit dialog + promote; E2E `RawHotstringFlowTests`
-12. Out of scope: Raw in bulk Import (follow-up backlog), CLI Raw UX, semantic AHK validation
+10. Errors: existing ValidatingUseCase → ProblemDetails; conflict handling unchanged; restore/revert convert legacy `Kind=3` snapshots via shared composer
+11. Tests: TDD parser/validator; emitter round-trip; migration equivalence + max-length row (Testcontainers); legacy-snapshot restore/revert; API integration; bUnit dialog + promote; E2E `RawHotstringFlowTests`
+12. Out of scope: Raw in bulk Import (follow-up backlog), CLI Raw UX beyond `--raw` create, semantic AHK validation / full lexer
 
 ## Verification
 

--- a/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-plan.md
+++ b/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-plan.md
@@ -1,0 +1,40 @@
+# Plan: Raw hotstring kind — spec finalization & next steps
+
+**Date:** 2026-07-13
+**Spec:** [2026-07-13-raw-hotstring-kind-design.md](../specs/2026-07-13-raw-hotstring-kind-design.md)
+**Status:** Spec written; awaiting user review, then detailed implementation plan (superpowers:writing-plans)
+
+## Context
+
+Brainstorming session concluded: replace the Script hotstring kind with a **Raw** kind
+that stores an entire AHK v2 hotstring definition verbatim (e.g.
+`:K1000 SE*:ftw::for the win`), preserving exotic option flags the structured fields
+can't express. Full design in the spec above.
+
+## Steps
+
+1. ~~Write spec to `docs/superpowers/specs/`~~ — done, self-reviewed
+2. Create branch `feature/raw-hotstring-kind` from `main`
+3. Commit spec + this plan: `docs: raw hotstring kind design spec`
+4. User reviews spec (review gate)
+5. Invoke superpowers:writing-plans for the detailed implementation plan
+
+## Approved decision checklist (spec must keep capturing these)
+
+1. Raw **replaces** Script — enum value 3 renamed, wire-compatible (enums serialize as numbers)
+2. Storage: `Replacement` = verbatim definition; `Trigger` server-derived; option flag columns ignored for Raw; window context stays active
+3. Data-only EF migration rewrites `Kind=3` rows to emitted form; byte-identical generated scripts; no down-migration
+4. New pure `RawHotstringDefinitionParser` (Application/Services)
+5. `AddRawKindRules` (8 structural rules incl. single-definition → Import referral) + option flags validated against known AHK v2 set; verify `S`/`S0` against official docs during impl
+6. Emitter Raw branch returns `Replacement` verbatim; save-time trim + CRLF→LF only; `#HotIf` grouping and preview pipeline unchanged
+7. Dialog: Raw = monospace textarea + server-authoritative parsed summary (`HotstringPreviewDto.RawSummary`); trigger/options fields hidden; kind-switch compose/decompose; "Switch to Raw" suggestion
+8. Lists: derived trigger fills columns; mobile shows "Raw" chip, suppresses option checkmarks; CLI follows rename
+9. Desktop grid: promote inline draft/edit row to full dialog via `Tune` action button; cancel restores inline state; Add still defaults to inline Text draft
+10. Errors: existing ValidatingUseCase → ProblemDetails; conflict handling unchanged; history snapshots compatible
+11. Tests: TDD parser/validator; emitter round-trip; migration equivalence (Testcontainers); API integration; bUnit dialog + promote; E2E `RawHotstringFlowTests`
+12. Out of scope: Raw in bulk Import (follow-up backlog), CLI Raw UX, semantic AHK validation
+
+## Verification
+
+- Spec + plan committed on `feature/raw-hotstring-kind`
+- Spec content matches every item in the checklist above

--- a/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-plan.md
+++ b/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-plan.md
@@ -14,27 +14,32 @@ can't express. Full design in the spec above.
 ## Steps
 
 1. ~~Write spec to `docs/superpowers/specs/`~~ — done, self-reviewed
-2. Create branch `feature/raw-hotstring-kind` from `main`
-3. Commit spec + this plan: `docs: raw hotstring kind design spec`
+2. ~~Create branch~~ — done: work lives on the worktree branch
+   `worktree-feature-wt-raw-hotstring-kind` (PR branch per `feature/wt-` convention at
+   PR time)
+3. ~~Commit spec + this plan~~ — done (`5f4da7b`, review fixes in follow-up commits)
 4. User reviews spec (review gate)
-5. Invoke superpowers:writing-plans for the detailed implementation plan
+5. Invoke superpowers:writing-plans for the detailed implementation plan (file-level
+   tasks, dependency order — this document is the spec-finalization tracker, not that
+   plan)
 
 ## Approved decision checklist (spec must keep capturing these)
 
 1. Raw **replaces** Script — new enum value 4; `Script = 3` retired (legacy snapshot conversion only)
 2. Storage: `Replacement` = verbatim definition (column → `nvarchar(max)`); `Trigger` server-derived (client-trigger validation gated to non-Raw kinds); option flag columns ignored for Raw; window context stays active
-3. EF migration: widen `Replacement` + rewrite `Kind=3` rows to emitted form with `Kind=4`; byte-identical generated scripts; no down-migration; 4,000-char-body test
+3. EF migration: widen `Replacement` + rewrite `Kind=3` rows to emitted form with `Kind=4`; SQL mirrors option building **and** trigger escaping; byte-identical generated scripts; no down-migration; shared golden fixtures (option matrix, backtick/`;` triggers, CRLF/blank-edged bodies, 4,000-char body) guard migration + history composer + dialog compose
 4. New pure `RawHotstringDefinitionParser` (Application/Services)
-5. `AddRawKindRules` (8 structural rules; multi-definition → "paste one at a time", no Import referral) + option flags validated against known AHK v2 set incl. `S`/`S0`; documented restricted subset (naive brace count on brace bodies only, no escaped tab/newline triggers)
+5. `AddRawKindRules` (8 structural rules; multi-definition → "paste one at a time", no Import referral) + option flags validated against known AHK v2 set incl. `S`/`S0` but **not** `X0` (no documented off-form); longest-match goldens `SE*`/`S0`/`SI`/`SP`; Raw trigger ≤ 40 (AHK's limit; structured kinds keep 50); documented restricted subset (naive brace count on brace bodies only, no escaped tab/newline triggers, OTB braces and continuation sections rejected with actionable messages)
 6. Emitter Raw branch returns `Replacement` verbatim; save-time trim + CRLF→LF only; `#HotIf` grouping and preview pipeline unchanged
 7. Dialog: Raw = monospace textarea + server-authoritative parsed summary (`HotstringPreviewDto.RawSummary`); trigger/options fields hidden; kind-switch compose/decompose with discard-options confirmation; "Switch to Raw" suggestion
 8. Lists: derived trigger fills columns; mobile shows "Raw" chip, suppresses option checkmarks; CLI changed explicitly (own enum) + minimal `--raw` creation
 9. Desktop grid: promote inline draft/edit row to full dialog via `Tune` action button; cancel restores inline state; Add still defaults to inline Text draft
 10. Errors: existing ValidatingUseCase → ProblemDetails; conflict handling unchanged; restore/revert convert legacy `Kind=3` snapshots via shared composer
-11. Tests: TDD parser/validator; emitter round-trip; migration equivalence + max-length row (Testcontainers); legacy-snapshot restore/revert; API integration; bUnit dialog + promote; E2E `RawHotstringFlowTests`
-12. Out of scope: Raw in bulk Import (follow-up backlog), CLI Raw UX beyond `--raw` create, semantic AHK validation / full lexer
+11. Tests: TDD parser/validator; emitter round-trip; migration equivalence via shared golden fixtures + max-length row (Testcontainers); legacy-snapshot restore/revert; API integration; bUnit dialog + promote; E2E `RawHotstringFlowTests`
+12. Docs & API contract: `docs/cli/hotstrings.md` rewritten for `--raw` + Raw kind; OpenAPI history example Script→Raw; `Script = 3` XML-documented as rejected legacy
+13. Out of scope: Raw in bulk Import (follow-up backlog), CLI Raw UX beyond `--raw` create, semantic AHK validation / full lexer, OTB/continuation-section support
 
 ## Verification
 
-- Spec + plan committed on `feature/raw-hotstring-kind`
+- Spec + plan committed on `worktree-feature-wt-raw-hotstring-kind`
 - Spec content matches every item in the checklist above

--- a/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-plan.md
+++ b/docs/superpowers/plans/2026-07-13-raw-hotstring-kind-plan.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-13
 **Spec:** [2026-07-13-raw-hotstring-kind-design.md](../specs/2026-07-13-raw-hotstring-kind-design.md)
-**Status:** Spec written; awaiting user review, then detailed implementation plan (superpowers:writing-plans)
+**Status:** Implemented. Spec finalized → [implementation plan](2026-07-13-raw-hotstring-kind-implementation-plan.md) executed (P0–P14) on `worktree-feature-wt-raw-hotstring-kind`; review findings fixed in follow-up (`2c33830`).
 
 ## Context
 
@@ -18,10 +18,10 @@ can't express. Full design in the spec above.
    `worktree-feature-wt-raw-hotstring-kind` (PR branch per `feature/wt-` convention at
    PR time)
 3. ~~Commit spec + this plan~~ — done (`5f4da7b`, review fixes in follow-up commits)
-4. User reviews spec (review gate)
-5. Invoke superpowers:writing-plans for the detailed implementation plan (file-level
-   tasks, dependency order — this document is the spec-finalization tracker, not that
-   plan)
+4. ~~User reviews spec (review gate)~~ — done
+5. ~~Invoke superpowers:writing-plans for the detailed implementation plan~~ — done
+   ([implementation plan](2026-07-13-raw-hotstring-kind-implementation-plan.md)), then
+   executed P0–P14
 
 ## Approved decision checklist (spec must keep capturing these)
 

--- a/docs/superpowers/specs/2026-07-13-raw-hotstring-kind-design.md
+++ b/docs/superpowers/specs/2026-07-13-raw-hotstring-kind-design.md
@@ -1,0 +1,206 @@
+# Raw Hotstring Kind — Design
+
+**Date:** 2026-07-13
+**Status:** Approved (brainstorming session)
+**Replaces:** the `Script` hotstring kind
+
+## Problem
+
+Experienced AHK users can't enter a hotstring definition verbatim. The Script kind
+manages trigger and options through app fields, so definitions with exotic options
+(e.g. `:K1000 SE*:ftw::for the win`) can't be expressed — `K1000` and `SE` have no
+field and are silently unrepresentable. Import preserves the text expansion but drops
+those flags with a warning. The primary audience knows AHK syntax; let them paste the
+whole definition.
+
+## Decision summary
+
+| Decision | Choice |
+|---|---|
+| Script kind | **Replaced** by Raw (enum value 3 renamed, wire-compatible) |
+| Entry granularity | Single hotstring per entry; multi-definition paste → error referring to Import |
+| Window context | Kept — Raw participates in app-managed `#HotIf` grouping |
+| Edit UX | Monospace textarea + live parsed summary (trigger, options) |
+| Validation | Structural rules block save; option flags validated against known AHK v2 set |
+| Bulk Import | Unchanged; importing exotic/code-body lines as Raw is a follow-up backlog item |
+| Storage | `Replacement` holds the verbatim definition; `Trigger` derived server-side |
+
+## Domain & storage
+
+- `HotstringKind.Script` → `HotstringKind.Raw`, keeping value `3`. Enums serialize as
+  numbers everywhere (no `JsonStringEnumConverter`), so the API contract and stored
+  history snapshots stay compatible. Only C# identifiers change (backend, Blazor DTOs,
+  CLI, tests).
+- For Raw rows, `Replacement` stores the **entire verbatim definition** — first line
+  `:options:trigger::…`, optional brace body below. Document the kind-dependent meaning
+  on the entity.
+- `Trigger` is **server-derived** for Raw: create/update handlers parse it from the raw
+  text and ignore the client-sent value. Escaped characters in the trigger (e.g. `` `; ``)
+  are decoded for storage, matching import. Per-owner uniqueness and duplicate
+  detection work unchanged.
+- Option flag columns (`IsCaseSensitive`, `IsEndingCharacterRequired`,
+  `IsTriggerInsideWord`, `OmitEndingCharacter`) are ignored for Raw (left at defaults);
+  the raw text is the single source of truth. Same pattern as `DateTimeFormat` being
+  null for non-DateTime kinds.
+- `ContextMatchType` / `ContextValue` stay active for Raw.
+
+## Migration (data-only, no schema change)
+
+EF migration rewrites `Kind = 3` rows: `Replacement` becomes the exact text today's
+emitter produces for that row, e.g. `Send String(Random(1, 100))` with `*` set →
+
+```
+:*:rng::
+{
+Send String(Random(1, 100))
+}
+```
+
+Implemented as raw SQL mirroring `HotstringEmitter.BuildOptions` (X/*/?/C/O logic; no
+`T` for brace-body kinds) so generated scripts are **byte-identical** before and after
+migration. Down-migration unsupported (documented in the migration).
+
+## Parsing
+
+New `RawHotstringDefinitionParser` (Application/Services, static, pure — sibling of
+`AhkHotstringParser`, intentionally simpler: no Send-body conversion, no v1 rescue, no
+normalization):
+
+```csharp
+internal static class RawHotstringDefinitionParser
+{
+    public static RawParseResult Parse(string rawDefinition);
+}
+// RawParseResult: IsValid, Trigger, string[] OptionTokens,
+//                 string[] UnknownOptionTokens, string? Error
+```
+
+Responsibilities: split options/trigger/body structurally, tokenize the options block,
+count definitions in the paste.
+
+## Validation
+
+`HotstringRules.AddRawKindRules` replaces `AddScriptKindRules` in
+`CreateHotstringCommand`, `UpdateHotstringCommand`, and `GetHotstringPreviewQuery`.
+All rules `When(Kind == Raw)`:
+
+| # | Rule | Message |
+|---|---|---|
+| 1 | First non-blank line matches `:options:trigger::` | "Not a valid hotstring definition — expected `:options:trigger::replacement`." |
+| 2 | Exactly one definition in the paste | "Multiple hotstrings detected — use the Import feature for bulk pasting." |
+| 3 | Parsed trigger non-empty, ≤ `TriggerMaxLength`, no line breaks/tabs | existing trigger messages |
+| 4 | Every option token in the known AHK v2 set | "Unknown hotstring option '{token}'." |
+| 5 | No line starting with `#` | carried over from Script rules |
+| 6 | Balanced braces | carried over from Script rules |
+| 7 | Bare `::trigger::` first line requires a `{` brace body; no content after the closing `}` | "Raw definition has content after the closing brace." |
+| 8 | Total length ≤ `ReplacementMaxLength` (4000) | existing message |
+
+**Known AHK v2 option set (rule 4):** `*`/`*0`, `?`/`?0`, `B`/`B0`, `C`/`C0`/`C1`,
+`K<n>` (incl. `K-1`), `O`/`O0`, `P<n>`, `R`/`R0`, `SI`/`SP`/`SE`, `T`/`T0`, `X`/`X0`,
+`Z`/`Z0`. Case-insensitive; whitespace between tokens allowed. Verify the final set
+(notably whether bare `S`/`S0` suspend-exempt exists for v2 hotstrings) against
+<https://www.autohotkey.com/docs/v2/Hotstrings.htm> during implementation and cite the
+URL in a code comment.
+
+## Emission & preview
+
+- `HotstringEmitter.Emit()` gains a Raw branch returning `hs.Replacement` **verbatim**
+  — no option building, no escaping, no wrapping. `AhkScriptGenerator` joins entries
+  with `\n`, so multi-line definitions drop in unchanged.
+- Save-time normalization (the only mutation): CRLF→LF, trim leading/trailing blank
+  lines and trailing whitespace. Interior lines and indentation preserved exactly.
+- `#HotIf` context grouping in `AhkScriptGenerator` unchanged — Raw rows group by
+  `(ContextMatchType, ContextValue)` like every kind. Trigger-ordinal sorting works via
+  the derived `Trigger`.
+- Preview pipeline works as-is: `GetHotstringPreviewQueryHandler` → `Emit()` echoes the
+  raw text plus the `#HotIf` wrap when a context is set. The dialog keeps its
+  "Generated AutoHotkey code" panel for Raw.
+
+## UI — edit dialog
+
+- Kind toggle item `Script` → `Raw`.
+- Raw selected: monospace (`ahk-mono`) 8-line textarea labeled **"Raw definition"**,
+  placeholder `:K1000 SE*:ftw::for the win`. Trigger field and the four trigger-option
+  checkboxes hidden. Description, profiles, categories, window context stay.
+- **Parsed summary** below the textarea (`Trigger: ftw` / `Options: K1000 SE *`),
+  server-authoritative: extend `HotstringPreviewDto` with optional
+  `RawSummary(Trigger, OptionTokens)` populated for Raw; the client renders it from the
+  existing debounced preview call. Validation failures surface through the existing
+  preview error path.
+- Multi-definition paste: rule-2 error rendered under the textarea with an inline link
+  that closes the dialog and opens the Import dialog.
+- Kind switching mid-edit: **→ Raw** composes a starting definition from current fields
+  (same shape as the migration); **Raw → other** moves the parsed trigger into the
+  Trigger field and the body (brace content or inline replacement) into Replacement;
+  option checkboxes reset to defaults.
+- The Text-kind "looks like AHK code" suggestion becomes **"Switch to Raw"** using the
+  compose behavior.
+
+## UI — promote inline row to full editor
+
+Desktop grid only (mobile FAB already opens the full dialog):
+
+- While a row is inline-editing (new draft or existing row), a third action button
+  (`Tune` icon, tooltip "More options / change type") appears next to ✓ commit and
+  ✗ cancel.
+- Clicking promotes the row to `HotstringEditDialog`, carrying over everything typed
+  (trigger, replacement, description). The kind toggle is immediately available.
+- **Draft row:** create dialog seeded with draft values; inline draft removed; dialog
+  cancel **restores the inline draft with its values**.
+- **Existing row:** edit dialog seeded with current in-row (possibly modified) values;
+  cancel returns to the inline edit state with those values intact.
+- Save follows the dialog's normal create/update path. **Add** still defaults to an
+  inline Text draft.
+
+## UI — lists & CLI
+
+- Trigger column works via derived trigger (desktop grid + mobile list).
+- Mobile list: show kind chip "Raw"; suppress the four option checkmarks
+  (`End-char / In-word / Case / Omit end-char`) for Raw rows — they're meaningless.
+- CLI table/JSON kind naming follows the enum rename automatically.
+
+## Error handling
+
+- Raw validation runs server-side via the existing `ValidatingUseCase` decorator →
+  `Result.Invalid` → RFC 9457 ProblemDetails.
+- Duplicate derived trigger → existing unique-constraint conflict handling.
+- History: snapshots store `Kind=3` + verbatim `Replacement`; restore/revert unchanged.
+  Reverting a pre-migration Script snapshot re-validates under Raw rules; a failing
+  revert surfaces the standard validation error.
+
+## Security notes
+
+- The app never executes AHK; it generates text the owner downloads. Raw adds no new
+  code-execution surface (Script already emitted arbitrary AHK verbatim).
+- Structural rules 2/5/6/7 prevent a paste from smuggling extra definitions or
+  directives that would corrupt `#HotIf` grouping or the script structure.
+- Blazor auto-encodes output; never render raw content via `MarkupString`.
+- If sharing between users is ever added, revisit the threat model (applies to all
+  kinds, not just Raw).
+
+## Testing
+
+- **TDD first:** `RawHotstringDefinitionParser` unit tests (structure, flag
+  tokenization incl. `K1000 SE*`, multi-definition detection, brace bodies, escaped
+  triggers); `AddRawKindRules` validator tests (all 8 rules; flag edge cases `K-1`,
+  `P9`, case-insensitivity, `*0`).
+- **Emitter:** verbatim emission + context wrapping in `AhkScriptGeneratorTests`;
+  round-trip test — paste → save → generate → byte-identical line.
+- **Migration:** Testcontainers integration test asserting a seeded Script row's
+  generated script is byte-identical before/after migration.
+- **API integration:** create/update/preview with Raw payloads (valid,
+  multi-definition, unknown flag, directive line).
+- **bUnit:** dialog Raw mode (textarea, hidden fields, parsed summary, import-referral
+  error, kind-switch compose/decompose); grid promote action (draft + existing row,
+  cancel restores).
+- **E2E:** rewrite `ScriptHotstringFlowTests` → `RawHotstringFlowTests` (paste
+  `:K1000 SE*:ftw::for the win`, verify summary, save, download contains the exact
+  line); add promote-flow coverage.
+- Existing suites (`HotstringSnapshotCompatibilityTests`, import tests) stay green —
+  Import behavior intentionally untouched.
+
+## Out of scope
+
+- Raw rows in bulk Import (follow-up backlog item).
+- CLI create/update UX for Raw beyond what shared DTOs give for free.
+- Semantic validation of the AHK body — only structure and option flags are checked.

--- a/docs/superpowers/specs/2026-07-13-raw-hotstring-kind-design.md
+++ b/docs/superpowers/specs/2026-07-13-raw-hotstring-kind-design.md
@@ -17,37 +17,55 @@ whole definition.
 
 | Decision | Choice |
 |---|---|
-| Script kind | **Replaced** by Raw (enum value 3 renamed, wire-compatible) |
-| Entry granularity | Single hotstring per entry; multi-definition paste → error referring to Import |
+| Script kind | **Replaced** by Raw (new enum value 4; `Script = 3` retired, kept for legacy snapshot conversion) |
+| Entry granularity | Single hotstring per entry; multi-definition paste → error telling the user to paste one definition at a time |
 | Window context | Kept — Raw participates in app-managed `#HotIf` grouping |
 | Edit UX | Monospace textarea + live parsed summary (trigger, options) |
-| Validation | Structural rules block save; option flags validated against known AHK v2 set |
+| Validation | Structural rules block save; option flags validated against known AHK v2 set; **restricted subset** (see Validation limits) |
 | Bulk Import | Unchanged; importing exotic/code-body lines as Raw is a follow-up backlog item |
-| Storage | `Replacement` holds the verbatim definition; `Trigger` derived server-side |
+| Storage | `Replacement` holds the verbatim definition (column widened to `nvarchar(max)`); `Trigger` derived server-side |
+| CLI | Explicit changes required (own enum); minimal Raw creation via `--raw` |
 
 ## Domain & storage
 
-- `HotstringKind.Script` → `HotstringKind.Raw`, keeping value `3`. Enums serialize as
-  numbers everywhere (no `JsonStringEnumConverter`), so the API contract and stored
-  history snapshots stay compatible. Only C# identifiers change (backend, Blazor DTOs,
-  CLI, tests).
+- `HotstringKind.Raw = 4` is a **new** enum value; `Script = 3` is retired but kept in
+  the enum (marked `[Obsolete]`, rejected by validators) so historical snapshots with
+  `Kind = 3` still deserialize. Reusing value 3 is not wire- or history-compatible:
+  old clients read 3 as a body-only Script while the new API would read it as a
+  complete definition, and restore/revert apply snapshots without a validation pass —
+  a body-only snapshot persisted as Raw would emit its body as top-level script text.
+  Backend, Blazor DTOs, CLI, and tests all change explicitly (the CLI has its own
+  enum copy — see UI — lists & CLI).
 - For Raw rows, `Replacement` stores the **entire verbatim definition** — first line
   `:options:trigger::…`, optional brace body below. Document the kind-dependent meaning
   on the entity.
 - `Trigger` is **server-derived** for Raw: create/update handlers parse it from the raw
-  text and ignore the client-sent value. Escaped characters in the trigger (e.g. `` `; ``)
-  are decoded for storage, matching import. Per-owner uniqueness and duplicate
-  detection work unchanged.
+  text and ignore the client-sent value. Because FluentValidation runs before handlers
+  (`ValidatingUseCase`), the client-trigger rules (`ValidTrigger()`) in
+  `CreateHotstringCommand`, `UpdateHotstringCommand`, and `GetHotstringPreviewQuery`
+  are **gated to non-Raw kinds** (`When(Kind != Raw)`) — otherwise a Raw payload with
+  the trigger field hidden would be rejected before reaching the handler. The parsed
+  trigger is validated by rule 3 instead, and handlers parse/canonicalize it **before**
+  the duplicate check, entity construction, and preview emission. Escaped characters in
+  the trigger (e.g. `` `; ``) are decoded for storage, matching import. Per-owner
+  uniqueness and duplicate detection work unchanged.
 - Option flag columns (`IsCaseSensitive`, `IsEndingCharacterRequired`,
   `IsTriggerInsideWord`, `OmitEndingCharacter`) are ignored for Raw (left at defaults);
   the raw text is the single source of truth. Same pattern as `DateTimeFormat` being
   null for non-DateTime kinds.
 - `ContextMatchType` / `ContextValue` stay active for Raw.
 
-## Migration (data-only, no schema change)
+## Migration (schema + data)
 
-EF migration rewrites `Kind = 3` rows: `Replacement` becomes the exact text today's
-emitter produces for that row, e.g. `Send String(Random(1, 100))` with `*` set →
+**Schema:** `Replacement` widens from `nvarchar(4000)` to `nvarchar(max)` (not indexed,
+so no index rebuild). Required for losslessness: a 4,000-character Script body grows by
+the trigger line and braces when embedded in a complete definition, which would
+overflow the old column for near-limit rows. Validation limits (rule 8) keep user input
+bounded; the column change only removes the hard truncation point.
+
+**Data:** the same migration rewrites `Kind = 3` rows to `Kind = 4` and sets
+`Replacement` to the exact text today's emitter produces for that row, e.g.
+`Send String(Random(1, 100))` with `*` set →
 
 ```
 :*:rng::
@@ -58,7 +76,8 @@ Send String(Random(1, 100))
 
 Implemented as raw SQL mirroring `HotstringEmitter.BuildOptions` (X/*/?/C/O logic; no
 `T` for brace-body kinds) so generated scripts are **byte-identical** before and after
-migration. Down-migration unsupported (documented in the migration).
+migration. Down-migration unsupported (documented in the migration). Migration test
+must include a row with a 4,000-character body (the old max) to prove no truncation.
 
 ## Parsing
 
@@ -87,20 +106,38 @@ All rules `When(Kind == Raw)`:
 | # | Rule | Message |
 |---|---|---|
 | 1 | First non-blank line matches `:options:trigger::` | "Not a valid hotstring definition — expected `:options:trigger::replacement`." |
-| 2 | Exactly one definition in the paste | "Multiple hotstrings detected — use the Import feature for bulk pasting." |
+| 2 | Exactly one definition in the paste | "Multiple hotstrings detected — paste one definition at a time." |
 | 3 | Parsed trigger non-empty, ≤ `TriggerMaxLength`, no line breaks/tabs | existing trigger messages |
 | 4 | Every option token in the known AHK v2 set | "Unknown hotstring option '{token}'." |
 | 5 | No line starting with `#` | carried over from Script rules |
-| 6 | Balanced braces | carried over from Script rules |
-| 7 | Bare `::trigger::` first line requires a `{` brace body; no content after the closing `}` | "Raw definition has content after the closing brace." |
-| 8 | Total length ≤ `ReplacementMaxLength` (4000) | existing message |
+| 6 | Brace body (when present) has balanced braces — **not** applied to inline replacements | "Raw definition must have balanced braces." |
+| 7 | First line ending in bare `::` (no inline replacement) requires a `{` brace body; inline replacement forbids further lines; no content after the closing `}` | "Raw definition has content after the closing brace." |
+| 8 | Total length ≤ `RawDefinitionMaxLength` (4200) | new message |
+
+Rule 8 uses a Raw-specific constant (4,200 = 4,000 body + trigger, options, and brace
+overhead) so migrated near-limit Script rows remain editable; other kinds keep
+`ReplacementMaxLength` (4000).
 
 **Known AHK v2 option set (rule 4):** `*`/`*0`, `?`/`?0`, `B`/`B0`, `C`/`C0`/`C1`,
-`K<n>` (incl. `K-1`), `O`/`O0`, `P<n>`, `R`/`R0`, `SI`/`SP`/`SE`, `T`/`T0`, `X`/`X0`,
-`Z`/`Z0`. Case-insensitive; whitespace between tokens allowed. Verify the final set
-(notably whether bare `S`/`S0` suspend-exempt exists for v2 hotstrings) against
-<https://www.autohotkey.com/docs/v2/Hotstrings.htm> during implementation and cite the
-URL in a code comment.
+`K<n>` (incl. `K-1`), `O`/`O0`, `P<n>`, `R`/`R0`, `S`/`S0`, `SI`/`SP`/`SE`, `T`/`T0`,
+`X`/`X0`, `Z`/`Z0`. Case-insensitive; whitespace between tokens allowed. `S`/`S0`
+(suspend-exempt) are confirmed valid per the official v2 docs. Re-verify the final set
+against <https://www.autohotkey.com/docs/v2/Hotstrings.htm> during implementation and
+cite the URL in a code comment.
+
+**Validation limits — Raw supports a restricted subset of AHK v2 (deliberate):**
+
+- Rule 6 counts `{`/`}` characters in the brace body with no string-literal, comment,
+  or continuation-section awareness — the same D12 limitation as the old Script rules.
+  A brace inside a quoted string or comment can false-positive reject a valid body.
+  Restricting the check to brace bodies (rule 6) already accepts inline definitions
+  like `:*:brace::{{}` that pure character counting would reject.
+- Triggers containing escaped tab/newline (`` `t ``/`` `n ``, valid per the AHK docs)
+  are rejected by rule 3 — the `Trigger` column and duplicate detection assume
+  single-line triggers.
+- These limits are documented in the code (`AddRawKindRules` XML docs) and in the edit
+  dialog's help text; lifting them (a real lexer for strings/comments/continuation
+  sections) is explicitly out of scope.
 
 ## Emission & preview
 
@@ -127,10 +164,14 @@ URL in a code comment.
   `RawSummary(Trigger, OptionTokens)` populated for Raw; the client renders it from the
   existing debounced preview call. Validation failures surface through the existing
   preview error path.
-- Multi-definition paste: rule-2 error rendered under the textarea with an inline link
-  that closes the dialog and opens the Import dialog.
+- Multi-definition paste: rule-2 error rendered under the textarea, telling the user to
+  paste one definition at a time. **No Import referral** — Import drops the exotic
+  flags Raw exists to preserve; a link there would silently lose data. Revisit once
+  Raw-aware import ships (backlog follow-up).
 - Kind switching mid-edit: **→ Raw** composes a starting definition from current fields
-  (same shape as the migration); **Raw → other** moves the parsed trigger into the
+  (same shape as the migration); **Raw → other** shows a confirmation first when the
+  definition carries option flags the structured fields can't express ("Options
+  `K1000 SE` will be discarded — continue?"), then moves the parsed trigger into the
   Trigger field and the body (brace content or inline replacement) into Replacement;
   option checkboxes reset to defaults.
 - The Text-kind "looks like AHK code" suggestion becomes **"Switch to Raw"** using the
@@ -157,16 +198,27 @@ Desktop grid only (mobile FAB already opens the full dialog):
 - Trigger column works via derived trigger (desktop grid + mobile list).
 - Mobile list: show kind chip "Raw"; suppress the four option checkmarks
   (`End-char / In-word / Case / Omit end-char`) for Raw rows — they're meaningless.
-- CLI table/JSON kind naming follows the enum rename automatically.
+- **CLI requires explicit changes** — it has its own `HotstringKind` copy and table
+  labels (`IHotstringsApiClient.cs`), and its `CreateHotstringDto` has no `Kind`:
+  - Mirror the enum change (`Raw = 4`, drop `Script`) and table/JSON label.
+  - Minimal Raw creation: `ahkflow hotstrings new --raw "<definition>"` — mutually
+    exclusive with `--trigger`/`--replacement`; sends `Kind = Raw` with the definition
+    as `Replacement` (CLI `CreateHotstringDto` gains `Kind`); server does all parsing
+    and validation, CLI just relays ProblemDetails errors. Keeps the first-class CLI
+    at feature parity for create; richer Raw UX (edit, summary) stays out of scope.
 
 ## Error handling
 
 - Raw validation runs server-side via the existing `ValidatingUseCase` decorator →
   `Result.Invalid` → RFC 9457 ProblemDetails.
 - Duplicate derived trigger → existing unique-constraint conflict handling.
-- History: snapshots store `Kind=3` + verbatim `Replacement`; restore/revert unchanged.
-  Reverting a pre-migration Script snapshot re-validates under Raw rules; a failing
-  revert surfaces the standard validation error.
+- History: existing snapshots keep `Kind=3` (body-only `Replacement`) — they are
+  **not** rewritten. Restore/revert handlers apply snapshots without a validation
+  pass, so they gain a **legacy conversion step**: on deserializing a snapshot with
+  `Kind == Script`, compose the full Raw definition from the snapshot's body + option
+  flags (same transform as the migration, shared composer) and persist it as
+  `Kind = Raw`. Snapshots written after the change store `Kind=4` + verbatim
+  `Replacement` and restore as-is.
 
 ## Security notes
 
@@ -187,9 +239,13 @@ Desktop grid only (mobile FAB already opens the full dialog):
 - **Emitter:** verbatim emission + context wrapping in `AhkScriptGeneratorTests`;
   round-trip test — paste → save → generate → byte-identical line.
 - **Migration:** Testcontainers integration test asserting a seeded Script row's
-  generated script is byte-identical before/after migration.
+  generated script is byte-identical before/after migration — including a row with a
+  4,000-character body (old column max) proving no truncation after the widen.
+- **History:** restore/revert of a legacy `Kind=3` snapshot converts to a valid Raw
+  row (composed definition, derived trigger); post-change snapshots round-trip as-is.
 - **API integration:** create/update/preview with Raw payloads (valid,
-  multi-definition, unknown flag, directive line).
+  multi-definition, unknown flag, directive line, empty client trigger — must pass
+  validation and derive server-side).
 - **bUnit:** dialog Raw mode (textarea, hidden fields, parsed summary, import-referral
   error, kind-switch compose/decompose); grid promote action (draft + existing row,
   cancel restores).
@@ -202,5 +258,6 @@ Desktop grid only (mobile FAB already opens the full dialog):
 ## Out of scope
 
 - Raw rows in bulk Import (follow-up backlog item).
-- CLI create/update UX for Raw beyond what shared DTOs give for free.
-- Semantic validation of the AHK body — only structure and option flags are checked.
+- CLI Raw UX beyond minimal `--raw` creation (edit, parsed summary, listing details).
+- Semantic validation of the AHK body — only structure and option flags are checked;
+  a string/comment/continuation-aware lexer (see Validation limits) is likewise out.

--- a/docs/superpowers/specs/2026-07-13-raw-hotstring-kind-design.md
+++ b/docs/superpowers/specs/2026-07-13-raw-hotstring-kind-design.md
@@ -74,10 +74,18 @@ Send String(Random(1, 100))
 }
 ```
 
-Implemented as raw SQL mirroring `HotstringEmitter.BuildOptions` (X/*/?/C/O logic; no
-`T` for brace-body kinds) so generated scripts are **byte-identical** before and after
-migration. Down-migration unsupported (documented in the migration). Migration test
-must include a row with a 4,000-character body (the old max) to prove no truncation.
+Implemented as raw SQL mirroring **both** `HotstringEmitter.BuildOptions` (X/*/?/C/O
+logic; no `T` for brace-body kinds) **and** `HotstringEmitter.Escape` on the trigger
+(backtick first, then `` `n ``/`` `r ``/`` `t ``/`` `; ``) so generated scripts are
+**byte-identical** before and after migration. Down-migration unsupported (documented
+in the migration).
+
+This Script→Raw transform exists **three times** — the SQL migration, the history
+legacy-snapshot composer, and the dialog's kind-switch compose (see UI — edit dialog).
+One **shared golden-fixture set** guards all three against drift: the option-flag
+matrix crossed with triggers containing backticks and semicolons, CRLF bodies,
+leading/trailing blank body lines, and a 4,000-character body (the old column max,
+proving no truncation).
 
 ## Parsing
 
@@ -107,7 +115,7 @@ All rules `When(Kind == Raw)`:
 |---|---|---|
 | 1 | First non-blank line matches `:options:trigger::` | "Not a valid hotstring definition — expected `:options:trigger::replacement`." |
 | 2 | Exactly one definition in the paste | "Multiple hotstrings detected — paste one definition at a time." |
-| 3 | Parsed trigger non-empty, ≤ `TriggerMaxLength`, no line breaks/tabs | existing trigger messages |
+| 3 | Parsed trigger non-empty, ≤ 40 chars, no line breaks/tabs | existing trigger messages (40-char variant) |
 | 4 | Every option token in the known AHK v2 set | "Unknown hotstring option '{token}'." |
 | 5 | No line starting with `#` | carried over from Script rules |
 | 6 | Brace body (when present) has balanced braces — **not** applied to inline replacements | "Raw definition must have balanced braces." |
@@ -118,12 +126,20 @@ Rule 8 uses a Raw-specific constant (4,200 = 4,000 body + trigger, options, and 
 overhead) so migrated near-limit Script rows remain editable; other kinds keep
 `ReplacementMaxLength` (4000).
 
+Rule 3 uses a Raw-specific `RawTriggerMaxLength = 40` — AHK's own documented
+abbreviation limit ("no more than 40 characters"), so Raw never accepts a definition
+AHK itself rejects. Structured kinds keep `TriggerMaxLength` (50), an app-level limit
+that predates Raw; tightening them is out of scope.
+
 **Known AHK v2 option set (rule 4):** `*`/`*0`, `?`/`?0`, `B`/`B0`, `C`/`C0`/`C1`,
 `K<n>` (incl. `K-1`), `O`/`O0`, `P<n>`, `R`/`R0`, `S`/`S0`, `SI`/`SP`/`SE`, `T`/`T0`,
-`X`/`X0`, `Z`/`Z0`. Case-insensitive; whitespace between tokens allowed. `S`/`S0`
-(suspend-exempt) are confirmed valid per the official v2 docs. Re-verify the final set
-against <https://www.autohotkey.com/docs/v2/Hotstrings.htm> during implementation and
-cite the URL in a code comment.
+`X`, `Z`/`Z0`. Case-insensitive; whitespace between tokens allowed. `S`/`S0`
+(suspend-exempt) are confirmed valid per the official v2 docs; `X`, `K<n>`, `P<n>`,
+and `SI`/`SP`/`SE` have **no documented `0` off-form** — `X0` is rejected as unknown
+(verified against the official v2 docs). Tokenization is longest-match first (`SE`
+before `S` and `*`, `S0` before `S`); parser grammar goldens must cover `SE*`, `S0`,
+`SI`, `SP`. Cite <https://www.autohotkey.com/docs/v2/Hotstrings.htm> in a code
+comment.
 
 **Validation limits — Raw supports a restricted subset of AHK v2 (deliberate):**
 
@@ -135,6 +151,13 @@ cite the URL in a code comment.
 - Triggers containing escaped tab/newline (`` `t ``/`` `n ``, valid per the AHK docs)
   are rejected by rule 3 — the `Trigger` column and duplicate detection assume
   single-line triggers.
+- OTB brace placement (`::btw:: {` — opening brace on the definition line, valid v2
+  per the docs) is **rejected** by rule 7 with an actionable message ("Put `{` on its
+  own line below the trigger.").
+- Continuation sections (`(`…`)` blocks, valid v2 for long replacements) are
+  **rejected** — a bare-`::` first line requires a `{` brace body (rule 7). Both
+  rejections get dedicated tests; supporting them is a possible follow-up, not in
+  scope.
 - These limits are documented in the code (`AddRawKindRules` XML docs) and in the edit
   dialog's help text; lifting them (a real lexer for strings/comments/continuation
   sections) is explicitly out of scope.
@@ -145,7 +168,10 @@ cite the URL in a code comment.
   — no option building, no escaping, no wrapping. `AhkScriptGenerator` joins entries
   with `\n`, so multi-line definitions drop in unchanged.
 - Save-time normalization (the only mutation): CRLF→LF, trim leading/trailing blank
-  lines and trailing whitespace. Interior lines and indentation preserved exactly.
+  lines and per-line trailing whitespace. Interior lines and indentation preserved
+  exactly. The trim is behavior-neutral: AHK ignores literal trailing spaces/tabs on
+  script lines — the docs require the `` `s ``/`` `t `` escapes for a meaningful
+  trailing space in a replacement, and those survive the trim untouched.
 - `#HotIf` context grouping in `AhkScriptGenerator` unchanged — Raw rows group by
   `(ContextMatchType, ContextValue)` like every kind. Trigger-ordinal sorting works via
   the derived `Trigger`.
@@ -207,6 +233,19 @@ Desktop grid only (mobile FAB already opens the full dialog):
     and validation, CLI just relays ProblemDetails errors. Keeps the first-class CLI
     at feature parity for create; richer Raw UX (edit, summary) stays out of scope.
 
+## Docs & API contract
+
+- `docs/cli/hotstrings.md`: the `new` command section gains `--raw`; the Kind column
+  and per-kind Replacement summary replace `Script` with `Raw` (summary: first line of
+  the definition, truncated to 40 chars); the "Script validation limitations" section
+  is rewritten for the Raw restricted subset (Validation limits above).
+- OpenAPI examples: `HotstringHistoryVersionDtoExample` (currently a Script snapshot)
+  becomes a Raw example (`HotstringExamples.cs`).
+- `HotstringKind` XML docs mark `Script = 3` as rejected legacy — accepted only when
+  deserializing stored history snapshots, never in new payloads — so the OpenAPI
+  schema explains why the value exists. Regression tests cover the CLI docs example
+  output and the updated examples.
+
 ## Error handling
 
 - Raw validation runs server-side via the existing `ValidatingUseCase` decorator →
@@ -233,14 +272,18 @@ Desktop grid only (mobile FAB already opens the full dialog):
 ## Testing
 
 - **TDD first:** `RawHotstringDefinitionParser` unit tests (structure, flag
-  tokenization incl. `K1000 SE*`, multi-definition detection, brace bodies, escaped
-  triggers); `AddRawKindRules` validator tests (all 8 rules; flag edge cases `K-1`,
-  `P9`, case-insensitivity, `*0`).
+  tokenization incl. `K1000 SE*`, longest-match goldens `SE*`/`S0`/`SI`/`SP`,
+  multi-definition detection, brace bodies, escaped triggers); `AddRawKindRules`
+  validator tests (all 8 rules; flag edge cases `K-1`, `P9`, case-insensitivity,
+  `*0`, `X0` rejected; OTB brace and continuation-section rejections; 41-char
+  trigger rejected).
 - **Emitter:** verbatim emission + context wrapping in `AhkScriptGeneratorTests`;
   round-trip test — paste → save → generate → byte-identical line.
-- **Migration:** Testcontainers integration test asserting a seeded Script row's
-  generated script is byte-identical before/after migration — including a row with a
-  4,000-character body (old column max) proving no truncation after the widen.
+- **Migration:** Testcontainers integration test asserting seeded Script rows'
+  generated scripts are byte-identical before/after migration, driven by the shared
+  golden-fixture set (option matrix, backtick/semicolon triggers, CRLF bodies,
+  blank-edged bodies, 4,000-character body — see Migration). The same fixtures run
+  against the history composer and the dialog compose logic.
 - **History:** restore/revert of a legacy `Kind=3` snapshot converts to a valid Raw
   row (composed definition, derived trigger); post-change snapshots round-trip as-is.
 - **API integration:** create/update/preview with Raw payloads (valid,

--- a/src/Backend/AHKFlowApp.API/OpenApi/Examples/HotstringExamples.cs
+++ b/src/Backend/AHKFlowApp.API/OpenApi/Examples/HotstringExamples.cs
@@ -79,11 +79,11 @@ internal sealed class HotstringPreviewDtoExample : IExamplesProvider<HotstringPr
         Snippet: "#HotIf WinActive(\"ahk_exe outlook.exe\")\n:T:sig::Best regards,`nJohn Doe`nSales Team\n#HotIf");
 }
 
-// Script kind (spec §7 ex. 7): `~ver` / `MsgBox A_AhkVersion`. Targets HotstringHistoryVersionDto
-// — the actual response type on HotstringsController's history-version endpoint — rather than
-// HotstringSnapshot (nested inside it; Swashbuckle.AspNetCore.Filters only annotates examples on
-// operation-level request/response types, not nested property types, so an example on the
-// nested type alone never surfaces in swagger.json) or HotstringDto/CreateHotstringDto/
+// Raw kind: `~ver` with a brace body, stored verbatim in Replacement. Targets
+// HotstringHistoryVersionDto — the actual response type on HotstringsController's history-version
+// endpoint — rather than HotstringSnapshot (nested inside it; Swashbuckle.AspNetCore.Filters only
+// annotates examples on operation-level request/response types, not nested property types, so an
+// example on the nested type alone never surfaces in swagger.json) or HotstringDto/CreateHotstringDto/
 // UpdateHotstringDto/HotstringPreviewRequestDto/HotstringPreviewDto (all already covered above,
 // per the same one-provider-per-type trap documented there). HotstringHistoryVersionDto had no
 // example yet, making it a clean, unused vehicle for this scenario.
@@ -95,7 +95,7 @@ internal sealed class HotstringHistoryVersionDtoExample : IExamplesProvider<Hots
         CapturedAt: DateTimeOffset.Parse("2026-07-11T09:00:00Z"),
         Snapshot: new HotstringSnapshot(
             Trigger: "~ver",
-            Replacement: "MsgBox A_AhkVersion",
+            Replacement: ":*:~ver::\n{\nMsgBox A_AhkVersion\n}",
             Description: "Show the running AutoHotkey version",
             AppliesToAllProfiles: true,
             IsEndingCharacterRequired: false,
@@ -104,5 +104,5 @@ internal sealed class HotstringHistoryVersionDtoExample : IExamplesProvider<Hots
             CategoryIds: [],
             CreatedAt: DateTimeOffset.Parse("2026-07-11T09:00:00Z"),
             UpdatedAt: DateTimeOffset.Parse("2026-07-11T09:00:00Z"),
-            Kind: HotstringKind.Script));
+            Kind: HotstringKind.Raw));
 }

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/CreateHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/CreateHotstringCommand.cs
@@ -2,6 +2,7 @@ using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.Common;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Application.Mapping;
+using AHKFlowApp.Application.Services;
 using AHKFlowApp.Application.Validation;
 using AHKFlowApp.Domain.Entities;
 using AHKFlowApp.Domain.Enums;
@@ -17,13 +18,16 @@ public sealed class CreateHotstringCommandValidator : AbstractValidator<CreateHo
 {
     public CreateHotstringCommandValidator()
     {
-        RuleFor(x => x.Input.Trigger).ValidTrigger();
+        // Raw derives its trigger server-side (the client field is hidden), so the client-trigger
+        // rules are gated off for Raw — the parsed trigger is validated by AddRawKindRules instead.
+        RuleFor(x => x.Input.Trigger).ValidTrigger()
+            .When(x => x.Input.Kind != HotstringKind.Raw);
         RuleFor(x => x.Input.Description)
             .MaximumLength(HotstringRules.DescriptionMaxLength)
             .WithMessage($"Description must be {HotstringRules.DescriptionMaxLength} characters or fewer.");
         RuleFor(x => x.Input.Kind)
-            .Must(k => k is HotstringKind.Text or HotstringKind.DateTime or HotstringKind.Macro or HotstringKind.Script)
-            .WithMessage("Only Text, Date & time, Macro and Script hotstrings are supported.");
+            .Must(k => k is HotstringKind.Text or HotstringKind.DateTime or HotstringKind.Macro or HotstringKind.Raw)
+            .WithMessage("Only Text, Date & time, Macro and Raw hotstrings are supported.");
         this.AddProfileAssociationRules(
             x => x.Input.AppliesToAllProfiles,
             x => x.Input.ProfileIds);
@@ -36,7 +40,7 @@ public sealed class CreateHotstringCommandValidator : AbstractValidator<CreateHo
         this.AddMacroKindRules(
             x => x.Input.Kind,
             x => x.Input.Replacement);
-        this.AddScriptKindRules(
+        this.AddRawKindRules(
             x => x.Input.Kind,
             x => x.Input.Replacement);
         this.AddWindowContextRules(
@@ -58,9 +62,20 @@ internal sealed class CreateHotstringCommandHandler(
 
         CreateHotstringDto input = request.Input;
 
+        // Raw stores the verbatim definition and derives its trigger server-side; the client-sent
+        // Trigger is ignored. Normalize first, then parse — the parsed trigger drives the duplicate
+        // check and entity construction. Validation (ValidatingUseCase) already guaranteed a valid Raw.
+        string trigger = input.Trigger;
+        string replacement = input.Replacement;
+        if (input.Kind == HotstringKind.Raw)
+        {
+            replacement = RawHotstringDefinitionParser.Normalize(input.Replacement);
+            trigger = RawHotstringDefinitionParser.Parse(replacement).Trigger;
+        }
+
         bool duplicate = await db.Hotstrings.AnyAsync(
             h => h.OwnerOid == ownerOid
-                && h.Trigger == input.Trigger
+                && h.Trigger == trigger
                 && h.ContextMatchType == input.ContextMatchType
                 && h.ContextValue == input.ContextValue, ct);
         if (duplicate)
@@ -88,8 +103,8 @@ internal sealed class CreateHotstringCommandHandler(
         var entity = Hotstring.Create(
             ownerOid,
             new HotstringDefinition(
-                input.Trigger,
-                input.Replacement,
+                trigger,
+                replacement,
                 description,
                 input.AppliesToAllProfiles,
                 input.IsEndingCharacterRequired,

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/RestoreHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/RestoreHotstringCommand.cs
@@ -3,6 +3,7 @@ using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.Common;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Application.Mapping;
+using AHKFlowApp.Application.Services;
 using AHKFlowApp.Domain.Entities;
 using AHKFlowApp.Domain.Enums;
 using Ardalis.Result;
@@ -54,24 +55,12 @@ internal sealed class RestoreHotstringCommandHandler(
             .Select(c => c.Id)
             .ToArrayAsync(ct);
 
+        // A legacy Kind=Script snapshot is composed into an equivalent Raw definition; other
+        // kinds apply as-is. Restore/revert bypass validation, so this is where the conversion runs.
         var entity = Hotstring.Restore(
             request.Id,
             ownerOid,
-            new HotstringDefinition(
-                snapshot.Trigger,
-                snapshot.Replacement,
-                snapshot.Description,
-                snapshot.AppliesToAllProfiles,
-                snapshot.IsEndingCharacterRequired,
-                snapshot.IsTriggerInsideWord,
-                snapshot.Kind,
-                snapshot.IsCaseSensitive,
-                snapshot.OmitEndingCharacter,
-                snapshot.DateTimeFormat,
-                snapshot.DateOffsetAmount,
-                snapshot.DateOffsetUnit,
-                snapshot.ContextMatchType,
-                snapshot.ContextValue),
+            ScriptToRawComposer.ToDefinition(snapshot),
             snapshot.CreatedAt,
             clock);
 

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/RevertHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/RevertHotstringCommand.cs
@@ -3,6 +3,7 @@ using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.Common;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Application.Mapping;
+using AHKFlowApp.Application.Services;
 using AHKFlowApp.Domain.Entities;
 using AHKFlowApp.Domain.Enums;
 using Ardalis.Result;
@@ -57,23 +58,9 @@ internal sealed class RevertHotstringCommandHandler(
             .Select(c => c.Id)
             .ToArrayAsync(ct);
 
-        entity.Update(
-            new HotstringDefinition(
-                snapshot.Trigger,
-                snapshot.Replacement,
-                snapshot.Description,
-                snapshot.AppliesToAllProfiles,
-                snapshot.IsEndingCharacterRequired,
-                snapshot.IsTriggerInsideWord,
-                snapshot.Kind,
-                snapshot.IsCaseSensitive,
-                snapshot.OmitEndingCharacter,
-                snapshot.DateTimeFormat,
-                snapshot.DateOffsetAmount,
-                snapshot.DateOffsetUnit,
-                snapshot.ContextMatchType,
-                snapshot.ContextValue),
-            clock);
+        // A legacy Kind=Script snapshot is composed into an equivalent Raw definition; other
+        // kinds apply as-is. Revert bypasses validation, so this is where the conversion runs.
+        entity.Update(ScriptToRawComposer.ToDefinition(snapshot), clock);
 
         db.HotstringProfiles.RemoveRange(entity.Profiles);
         entity.Profiles.Clear();

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/UpdateHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/UpdateHotstringCommand.cs
@@ -2,6 +2,7 @@ using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.Common;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Application.Mapping;
+using AHKFlowApp.Application.Services;
 using AHKFlowApp.Application.Validation;
 using AHKFlowApp.Domain.Entities;
 using AHKFlowApp.Domain.Enums;
@@ -17,13 +18,16 @@ public sealed class UpdateHotstringCommandValidator : AbstractValidator<UpdateHo
 {
     public UpdateHotstringCommandValidator()
     {
-        RuleFor(x => x.Input.Trigger).ValidTrigger();
+        // Raw derives its trigger server-side (the client field is hidden), so the client-trigger
+        // rules are gated off for Raw — the parsed trigger is validated by AddRawKindRules instead.
+        RuleFor(x => x.Input.Trigger).ValidTrigger()
+            .When(x => x.Input.Kind != HotstringKind.Raw);
         RuleFor(x => x.Input.Description)
             .MaximumLength(HotstringRules.DescriptionMaxLength)
             .WithMessage($"Description must be {HotstringRules.DescriptionMaxLength} characters or fewer.");
         RuleFor(x => x.Input.Kind)
-            .Must(k => k is HotstringKind.Text or HotstringKind.DateTime or HotstringKind.Macro or HotstringKind.Script)
-            .WithMessage("Only Text, Date & time, Macro and Script hotstrings are supported.");
+            .Must(k => k is HotstringKind.Text or HotstringKind.DateTime or HotstringKind.Macro or HotstringKind.Raw)
+            .WithMessage("Only Text, Date & time, Macro and Raw hotstrings are supported.");
         this.AddProfileAssociationRules(
             x => x.Input.AppliesToAllProfiles,
             x => x.Input.ProfileIds);
@@ -36,7 +40,7 @@ public sealed class UpdateHotstringCommandValidator : AbstractValidator<UpdateHo
         this.AddMacroKindRules(
             x => x.Input.Kind,
             x => x.Input.Replacement);
-        this.AddScriptKindRules(
+        this.AddRawKindRules(
             x => x.Input.Kind,
             x => x.Input.Replacement);
         this.AddWindowContextRules(
@@ -67,6 +71,16 @@ internal sealed class UpdateHotstringCommandHandler(
 
         UpdateHotstringDto input = request.Input;
 
+        // Raw stores the verbatim definition and derives its trigger server-side; the client-sent
+        // Trigger is ignored. Normalize first, then parse. Validation already guaranteed a valid Raw.
+        string trigger = input.Trigger;
+        string replacement = input.Replacement;
+        if (input.Kind == HotstringKind.Raw)
+        {
+            replacement = RawHotstringDefinitionParser.Normalize(input.Replacement);
+            trigger = RawHotstringDefinitionParser.Parse(replacement).Trigger;
+        }
+
         Guid[] distinctProfileIds = input.ProfileIds?.Distinct().ToArray() ?? [];
         if (!input.AppliesToAllProfiles)
         {
@@ -90,8 +104,8 @@ internal sealed class UpdateHotstringCommandHandler(
 
         entity.Update(
             new HotstringDefinition(
-                input.Trigger,
-                input.Replacement,
+                trigger,
+                replacement,
                 description,
                 input.AppliesToAllProfiles,
                 input.IsEndingCharacterRequired,

--- a/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
@@ -14,7 +14,7 @@ namespace AHKFlowApp.Application.DTOs;
 /// <param name="CreatedAt">UTC creation timestamp.</param>
 /// <param name="UpdatedAt">UTC last-update timestamp.</param>
 /// <param name="CategoryIds">Categories assigned to this hotstring.</param>
-/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/>, <see cref="HotstringKind.DateTime"/>, <see cref="HotstringKind.Macro"/>, and <see cref="HotstringKind.Script"/> are all supported via the API.</param>
+/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/>, <see cref="HotstringKind.DateTime"/>, <see cref="HotstringKind.Macro"/>, and <see cref="HotstringKind.Raw"/> are all supported via the API.</param>
 /// <param name="IsCaseSensitive">Controls AutoHotkey's <c>C</c> option.</param>
 /// <param name="OmitEndingCharacter">Controls AutoHotkey's <c>O</c> option.</param>
 /// <param name="DateTimeFormat">Set when <paramref name="Kind"/> is <see cref="HotstringKind.DateTime"/>; a whitelisted AHK/.NET date/time token pattern.</param>
@@ -52,7 +52,7 @@ public sealed record HotstringDto(
 /// <param name="IsTriggerInsideWord">Controls AutoHotkey's <c>?</c> option.</param>
 /// <param name="Description">Optional human-readable note for the hotstring.</param>
 /// <param name="CategoryIds">Categories to assign to the new hotstring.</param>
-/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/>, <see cref="HotstringKind.DateTime"/>, <see cref="HotstringKind.Macro"/>, and <see cref="HotstringKind.Script"/> are all supported via the API.</param>
+/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/>, <see cref="HotstringKind.DateTime"/>, <see cref="HotstringKind.Macro"/>, and <see cref="HotstringKind.Raw"/> are all supported via the API.</param>
 /// <param name="IsCaseSensitive">Controls AutoHotkey's <c>C</c> option.</param>
 /// <param name="OmitEndingCharacter">Controls AutoHotkey's <c>O</c> option.</param>
 /// <param name="DateTimeFormat">Required when <paramref name="Kind"/> is <see cref="HotstringKind.DateTime"/>; a whitelisted AHK/.NET date/time token pattern.</param>
@@ -87,7 +87,7 @@ public sealed record CreateHotstringDto(
 /// <param name="IsTriggerInsideWord">Controls AutoHotkey's <c>?</c> option.</param>
 /// <param name="Description">Optional human-readable note for the hotstring.</param>
 /// <param name="CategoryIds">Replacement category assignment set.</param>
-/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/>, <see cref="HotstringKind.DateTime"/>, <see cref="HotstringKind.Macro"/>, and <see cref="HotstringKind.Script"/> are all supported via the API.</param>
+/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/>, <see cref="HotstringKind.DateTime"/>, <see cref="HotstringKind.Macro"/>, and <see cref="HotstringKind.Raw"/> are all supported via the API.</param>
 /// <param name="IsCaseSensitive">Controls AutoHotkey's <c>C</c> option.</param>
 /// <param name="OmitEndingCharacter">Controls AutoHotkey's <c>O</c> option.</param>
 /// <param name="DateTimeFormat">Required when <paramref name="Kind"/> is <see cref="HotstringKind.DateTime"/>; a whitelisted AHK/.NET date/time token pattern.</param>
@@ -114,7 +114,7 @@ public sealed record UpdateHotstringDto(
     string? ContextValue = null);
 
 /// <summary>Emission-relevant fields for previewing the AutoHotkey snippet a hotstring definition would generate, without saving it.</summary>
-/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/>, <see cref="HotstringKind.DateTime"/>, <see cref="HotstringKind.Macro"/>, and <see cref="HotstringKind.Script"/> are all supported.</param>
+/// <param name="Kind">Hotstring kind. <see cref="HotstringKind.Text"/>, <see cref="HotstringKind.DateTime"/>, <see cref="HotstringKind.Macro"/>, and <see cref="HotstringKind.Raw"/> are all supported.</param>
 /// <param name="Trigger">Abbreviation that activates the replacement.</param>
 /// <param name="Replacement">Text inserted in place of the trigger.</param>
 /// <param name="IsCaseSensitive">Controls AutoHotkey's <c>C</c> option.</param>

--- a/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
@@ -142,4 +142,10 @@ public sealed record HotstringPreviewRequestDto(
 
 /// <summary>The AutoHotkey snippet a hotstring definition would generate.</summary>
 /// <param name="Snippet">The exact <c>.ahk</c> line(s) <c>HotstringEmitter.Emit</c> would produce for the given definition.</param>
-public sealed record HotstringPreviewDto(string Snippet);
+/// <param name="RawSummary">Server-derived trigger and option tokens for a Raw definition; null for other kinds.</param>
+public sealed record HotstringPreviewDto(string Snippet, RawSummaryDto? RawSummary = null);
+
+/// <summary>Parsed summary of a Raw hotstring definition, shown below the editor's raw textarea.</summary>
+/// <param name="Trigger">Trigger derived from the definition's first line.</param>
+/// <param name="OptionTokens">Option flags parsed from the definition, in first-line order.</param>
+public sealed record RawSummaryDto(string Trigger, string[] OptionTokens);

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringPreviewQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringPreviewQuery.cs
@@ -15,10 +15,12 @@ public sealed class GetHotstringPreviewQueryValidator : AbstractValidator<GetHot
 {
     public GetHotstringPreviewQueryValidator()
     {
-        RuleFor(x => x.Input.Trigger).ValidTrigger();
+        // Raw derives its trigger server-side; the client-trigger rules are gated off for Raw.
+        RuleFor(x => x.Input.Trigger).ValidTrigger()
+            .When(x => x.Input.Kind != HotstringKind.Raw);
         RuleFor(x => x.Input.Kind)
-            .Must(k => k is HotstringKind.Text or HotstringKind.DateTime or HotstringKind.Macro or HotstringKind.Script)
-            .WithMessage("Only Text, Date & time, Macro and Script hotstrings are supported.");
+            .Must(k => k is HotstringKind.Text or HotstringKind.DateTime or HotstringKind.Macro or HotstringKind.Raw)
+            .WithMessage("Only Text, Date & time, Macro and Raw hotstrings are supported.");
         this.AddDateTimeKindRules(
             x => x.Input.Kind,
             x => x.Input.Replacement,
@@ -28,7 +30,7 @@ public sealed class GetHotstringPreviewQueryValidator : AbstractValidator<GetHot
         this.AddMacroKindRules(
             x => x.Input.Kind,
             x => x.Input.Replacement);
-        this.AddScriptKindRules(
+        this.AddRawKindRules(
             x => x.Input.Kind,
             x => x.Input.Replacement);
         this.AddWindowContextRules(
@@ -50,11 +52,24 @@ internal sealed class GetHotstringPreviewQueryHandler(TimeProvider clock)
     {
         HotstringPreviewRequestDto input = request.Input;
 
+        // Raw derives its trigger + option summary server-side from the verbatim definition.
+        // Normalize first so the preview matches exactly what a save would persist and emit.
+        string trigger = input.Trigger;
+        string replacement = input.Replacement;
+        RawSummaryDto? rawSummary = null;
+        if (input.Kind == HotstringKind.Raw)
+        {
+            replacement = RawHotstringDefinitionParser.Normalize(input.Replacement);
+            RawParseResult parsed = RawHotstringDefinitionParser.Parse(replacement);
+            trigger = parsed.Trigger;
+            rawSummary = new RawSummaryDto(parsed.Trigger, parsed.OptionTokens);
+        }
+
         var hs = Hotstring.Create(
             Guid.Empty,
             new HotstringDefinition(
-                input.Trigger,
-                input.Replacement,
+                trigger,
+                replacement,
                 Description: null,
                 AppliesToAllProfiles: true,
                 input.IsEndingCharacterRequired,
@@ -76,6 +91,6 @@ internal sealed class GetHotstringPreviewQueryHandler(TimeProvider clock)
         if (hs.ContextMatchType is WindowMatchType matchType)
             snippet = $"{HotstringEmitter.EmitHotIfOpen(matchType, hs.ContextValue!)}\n{snippet}\n{HotstringEmitter.HotIfClose}";
 
-        return Task.FromResult(Result.Success(new HotstringPreviewDto(snippet)));
+        return Task.FromResult(Result.Success(new HotstringPreviewDto(snippet, rawSummary)));
     }
 }

--- a/src/Backend/AHKFlowApp.Application/Services/HotstringEmitter.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/HotstringEmitter.cs
@@ -15,8 +15,15 @@ internal static class HotstringEmitter
     // preview handler so both code paths use the identical close string.
     public const string HotIfClose = "#HotIf";
 
+    // Raw is emitted verbatim: its Replacement already holds the entire ":opts:trigger::"
+    // definition (plus any brace body), so the ":{options}:{trigger}::{body}" template is
+    // bypassed entirely — re-prefixing would double the definition. AhkScriptGenerator adds
+    // each Emit result to a line list joined with "\n", so a multi-line definition slots in
+    // as multiple physical lines.
     public static string Emit(Hotstring hs) =>
-        $":{BuildOptions(hs)}:{Escape(hs.Trigger)}::{BuildBody(hs)}";
+        hs.Kind == HotstringKind.Raw
+            ? hs.Replacement
+            : $":{BuildOptions(hs)}:{Escape(hs.Trigger)}::{BuildBody(hs)}";
 
     // ContextValue has already passed validation guaranteeing no double-quote, backtick, or
     // control characters (see HotstringRules.AddWindowContextRules) — safe to embed raw here.
@@ -49,7 +56,6 @@ internal static class HotstringEmitter
         {
             HotstringKind.DateTime => BuildDateTimeBody(hs),
             HotstringKind.Macro => BuildMacroBody(hs),
-            HotstringKind.Script => BuildScriptBody(hs),
             _ => Escape(hs.Replacement),
         };
 
@@ -129,16 +135,6 @@ internal static class HotstringEmitter
         string body = string.Concat(lines.Select(line => $"\n\t{line}"));
         return $"\n{{{body}\n}}";
     }
-
-    // Assumes hs.Replacement has already passed Script validation (balanced braces, no
-    // '#'-directive lines) — that invariant is enforced elsewhere (Task 1), not re-checked here.
-    // Wraps the raw body in the same outer brace shape BuildMacroBody uses (opening "{" alone on
-    // its own line, closing "}" alone on its own line) but performs no tokenization, no character
-    // escaping, and no per-line re-indentation — the content between the braces is an exact,
-    // verbatim copy of hs.Replacement (line endings, leading/trailing blank lines, and per-line
-    // indentation all preserved as authored).
-    private static string BuildScriptBody(Hotstring hs) =>
-        $"\n{{\n{hs.Replacement}\n}}";
 
     // Keep every hotstring on one physical line and its trigger free of characters
     // AHK v2 would otherwise reinterpret (backtick, a whitespace-preceded ';'). Backtick

--- a/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
@@ -1,0 +1,261 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace AHKFlowApp.Application.Services;
+
+/// <summary>
+/// Outcome of <see cref="RawHotstringDefinitionParser.Parse"/>. Structural facts the Raw
+/// validator (<c>HotstringRules.AddRawKindRules</c>) maps to per-rule messages, plus the
+/// derived <see cref="Trigger"/> and option tokens the handlers and preview summary reuse.
+/// </summary>
+/// <param name="IsValid">First line valid <em>and</em> body structurally complete (no rule 6/7 error).</param>
+/// <param name="FirstLineValid">First non-blank line matches <c>:options:trigger::</c> (rule 1).</param>
+/// <param name="Trigger">Decoded trigger parsed from the first line (empty when <see cref="FirstLineValid"/> is false).</param>
+/// <param name="OptionTokens">Every option token, verbatim, in first-line order (feeds the parsed summary).</param>
+/// <param name="UnknownOptionTokens">Tokens not in the known AHK v2 set (rule 4).</param>
+/// <param name="DefinitionCount">Number of <c>:options:trigger::</c> definition starts in the paste (rule 2).</param>
+/// <param name="Error">Structural error message (rule 1 / 6 / 7); null when <see cref="IsValid"/>.</param>
+internal sealed record RawParseResult(
+    bool IsValid,
+    bool FirstLineValid,
+    string Trigger,
+    string[] OptionTokens,
+    string[] UnknownOptionTokens,
+    int DefinitionCount,
+    string? Error);
+
+/// <summary>
+/// Parses an entire verbatim AHK v2 hotstring definition (first line
+/// <c>:options:trigger::</c>, optional inline replacement or brace body) into the structural
+/// facts the Raw validator and handlers need. Sibling of <see cref="AhkHotstringParser"/> but
+/// intentionally simpler: no Send-body conversion, no v1 rescue, no normalization — it only
+/// splits structure, tokenizes options, and counts definitions.
+///
+/// Deliberately supports a restricted subset of AHK v2 (see <c>HotstringRules.AddRawKindRules</c>):
+/// naive brace counting on brace bodies only, no string/comment/continuation-section lexing,
+/// OTB braces and continuation sections rejected. Known option set is per the official v2 docs:
+/// <see href="https://www.autohotkey.com/docs/v2/Hotstrings.htm"/>.
+/// </summary>
+internal static partial class RawHotstringDefinitionParser
+{
+    private const string FirstLineError = "Not a valid hotstring definition — expected `:options:trigger::replacement`.";
+    private const string BraceRequiredError = "Put `{` on its own line below the trigger.";
+    private const string UnbalancedError = "Raw definition must have balanced braces.";
+    private const string ContentAfterBraceError = "Raw definition has content after the closing brace.";
+    private const string ContentAfterInlineError = "Raw definition has content after the inline replacement.";
+
+    // :options:trigger::replacement — options/trigger contain no ':'; the trigger is
+    // non-greedy so the FIRST '::' delimits, leaving any inline replacement in group 3.
+    [GeneratedRegex(@"^\s*:([^:\r\n]*):(.*?)::(.*)$")]
+    private static partial Regex HotstringLine();
+
+    // Static known-option set (case-insensitive); K<n> and P<n> handled by pattern below.
+    private static readonly HashSet<string> KnownOptions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "*", "*0", "?", "?0", "B", "B0", "C", "C0", "C1",
+        "O", "O0", "R", "R0", "S", "S0", "SI", "SP", "SE",
+        "T", "T0", "X", "Z", "Z0",
+    };
+
+    [GeneratedRegex(@"^K-?\d+$", RegexOptions.IgnoreCase)]
+    private static partial Regex KOption();
+
+    [GeneratedRegex(@"^P\d+$", RegexOptions.IgnoreCase)]
+    private static partial Regex POption();
+
+    /// <summary>
+    /// Save-time normalization for a Raw definition — the only mutation applied before persisting.
+    /// CRLF/lone-CR → LF, trims leading/trailing blank lines and per-line trailing whitespace.
+    /// Interior lines and indentation are preserved exactly. Behavior-neutral: AHK ignores literal
+    /// trailing whitespace on script lines (a meaningful trailing space needs the <c>`s</c>/<c>`t</c>
+    /// escapes, which survive the trim untouched).
+    /// </summary>
+    public static string Normalize(string rawDefinition)
+    {
+        ArgumentNullException.ThrowIfNull(rawDefinition);
+
+        var lines = rawDefinition
+            .Replace("\r\n", "\n")
+            .Replace('\r', '\n')
+            .Split('\n')
+            .Select(l => l.TrimEnd())
+            .ToList();
+
+        int start = 0;
+        while (start < lines.Count && lines[start].Length == 0)
+            start++;
+
+        int end = lines.Count - 1;
+        while (end >= start && lines[end].Length == 0)
+            end--;
+
+        return start > end ? string.Empty : string.Join('\n', lines.GetRange(start, end - start + 1));
+    }
+
+    public static RawParseResult Parse(string rawDefinition)
+    {
+        ArgumentNullException.ThrowIfNull(rawDefinition);
+
+        string[] lines = rawDefinition.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+        int definitionCount = lines.Count(l => HotstringLine().IsMatch(l));
+
+        int firstIdx = Array.FindIndex(lines, l => l.Trim().Length > 0);
+        if (firstIdx < 0)
+            return Invalid(FirstLineError, definitionCount);
+
+        Match match = HotstringLine().Match(lines[firstIdx]);
+        if (!match.Success)
+            return Invalid(FirstLineError, definitionCount);
+
+        string trigger = DecodeEscapes(match.Groups[2].Value).Trim();
+        (string[] optionTokens, string[] unknownTokens) = TokenizeOptions(match.Groups[1].Value);
+        string inlineRest = match.Groups[3].Value;
+        string[] trailing = lines[(firstIdx + 1)..];
+
+        (bool bodyValid, string? bodyError) = ClassifyBody(inlineRest, trailing);
+
+        return new RawParseResult(
+            IsValid: bodyValid,
+            FirstLineValid: true,
+            Trigger: trigger,
+            OptionTokens: optionTokens,
+            UnknownOptionTokens: unknownTokens,
+            DefinitionCount: definitionCount,
+            Error: bodyError);
+    }
+
+    private static RawParseResult Invalid(string error, int definitionCount) =>
+        new(IsValid: false, FirstLineValid: false, Trigger: "", OptionTokens: [],
+            UnknownOptionTokens: [], DefinitionCount: definitionCount, Error: error);
+
+    // Structural rules 6 and 7. An inline replacement forbids further lines and is not
+    // brace-balance checked; a bare "::" first line requires a "{" brace body on its own line.
+    private static (bool Valid, string? Error) ClassifyBody(string inlineRest, string[] trailing)
+    {
+        if (inlineRest.Length > 0)
+        {
+            // OTB: "{" placed on the definition line — rejected (rule 7).
+            if (inlineRest.Trim() == "{")
+                return (false, BraceRequiredError);
+
+            // Real inline replacement — no further non-blank lines allowed.
+            return trailing.Any(l => l.Trim().Length > 0)
+                ? (false, ContentAfterInlineError)
+                : (true, null);
+        }
+
+        int bodyIdx = Array.FindIndex(trailing, l => l.Trim().Length > 0);
+        if (bodyIdx < 0 || trailing[bodyIdx].Trim() != "{")
+            return (false, BraceRequiredError);
+
+        return ScanBraceBody(string.Join('\n', trailing[bodyIdx..]));
+    }
+
+    // Naive brace balance (D12): counts '{'/'}' with no string-literal or comment awareness.
+    private static (bool Valid, string? Error) ScanBraceBody(string region)
+    {
+        int depth = 0;
+        int closedAt = -1;
+
+        for (int k = 0; k < region.Length; k++)
+        {
+            switch (region[k])
+            {
+                case '{':
+                    depth++;
+                    break;
+                case '}':
+                    depth--;
+                    if (depth < 0)
+                        return (false, UnbalancedError);
+                    if (depth == 0 && closedAt < 0)
+                        closedAt = k;
+                    break;
+            }
+        }
+
+        if (depth != 0)
+            return (false, UnbalancedError);
+
+        return region[(closedAt + 1)..].Trim().Length > 0
+            ? (false, ContentAfterBraceError)
+            : (true, null);
+    }
+
+    // Longest-match tokenizer: SE/SP/SI before S, and each flag greedily absorbs its trailing
+    // sign/digits (K-1, K1000, P9, C1, *0) so the whole token is classified against the known set.
+    private static (string[] Tokens, string[] Unknown) TokenizeOptions(string options)
+    {
+        List<string> tokens = [];
+        List<string> unknown = [];
+
+        int i = 0;
+        while (i < options.Length)
+        {
+            if (char.IsWhiteSpace(options[i]))
+            {
+                i++;
+                continue;
+            }
+
+            int start = i;
+            if (options[i] is 'S' or 's'
+                && i + 1 < options.Length
+                && options[i + 1] is 'I' or 'P' or 'E' or 'i' or 'p' or 'e')
+            {
+                i += 2; // SI / SP / SE
+            }
+            else
+            {
+                i++; // flag char
+                if (options[start] is 'K' or 'k' && i < options.Length && options[i] == '-')
+                    i++; // K sign
+                while (i < options.Length && char.IsDigit(options[i]))
+                    i++;
+            }
+
+            string token = options[start..i];
+            tokens.Add(token);
+            if (!IsKnownOption(token))
+                unknown.Add(token);
+        }
+
+        return ([.. tokens], [.. unknown]);
+    }
+
+    private static bool IsKnownOption(string token) =>
+        KnownOptions.Contains(token) || KOption().IsMatch(token) || POption().IsMatch(token);
+
+    private static string DecodeEscapes(string value)
+    {
+        if (!value.Contains('`'))
+            return value;
+
+        StringBuilder sb = new(value.Length);
+        for (int i = 0; i < value.Length; i++)
+        {
+            char c = value[i];
+            if (c != '`')
+            {
+                sb.Append(c);
+                continue;
+            }
+
+            if (i + 1 >= value.Length)
+                break;
+
+            sb.Append(value[++i] switch
+            {
+                '`' => '`',
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                's' => ' ',
+                ';' => ';',
+                var other => other,
+            });
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
@@ -107,7 +107,9 @@ internal static partial class RawHotstringDefinitionParser
         if (!match.Success)
             return Invalid(FirstLineError, definitionCount);
 
-        string trigger = DecodeEscapes(match.Groups[2].Value).Trim();
+        // No trimming: spaces/tabs are literal within an AHK abbreviation, and the raw text is
+        // emitted verbatim, so the derived trigger must match it exactly (dedup, DB, UI display).
+        string trigger = DecodeEscapes(match.Groups[2].Value);
         (string[] optionTokens, string[] unknownTokens) = TokenizeOptions(match.Groups[1].Value);
         string inlineRest = match.Groups[3].Value;
         string[] trailing = lines[(firstIdx + 1)..];

--- a/src/Backend/AHKFlowApp.Application/Services/ScriptToRawComposer.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/ScriptToRawComposer.cs
@@ -1,0 +1,81 @@
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
+
+namespace AHKFlowApp.Application.Services;
+
+/// <summary>
+/// Converts a legacy Script hotstring (body-only <c>Replacement</c> plus option flags) into the
+/// equivalent verbatim Raw definition. The composed text is <em>byte-identical</em> to what the
+/// retired <c>HotstringEmitter</c> Script branch produced for the same row, so generated scripts
+/// are unchanged across the Script→Raw transition.
+///
+/// This is the single C# home of the transform, shared by history restore/revert
+/// (<see cref="ToDefinition"/>) and the edit dialog's kind-switch compose. The EF data migration
+/// hand-writes the same logic in T-SQL (SQL can't call C#); a Testcontainers parity test enforces
+/// the two agree. Mirrors <c>HotstringEmitter.BuildOptions</c> (X/T never apply to a brace-body
+/// kind) and <c>HotstringEmitter.Escape</c> on the trigger.
+/// </summary>
+internal static class ScriptToRawComposer
+{
+    /// <summary>Composes the verbatim <c>:options:trigger::</c> definition with a brace body.</summary>
+    public static string Compose(
+        string trigger,
+        string replacement,
+        bool isEndingCharacterRequired,
+        bool isTriggerInsideWord,
+        bool isCaseSensitive,
+        bool omitEndingCharacter)
+    {
+        string options = "";
+        if (!isEndingCharacterRequired) options += "*";
+        if (isTriggerInsideWord) options += "?";
+        if (isCaseSensitive) options += "C";
+        if (omitEndingCharacter && isEndingCharacterRequired) options += "O"; // O is meaningless with *
+
+        return $":{options}:{Escape(trigger)}::\n{{\n{replacement}\n}}";
+    }
+
+    /// <summary>
+    /// Builds the <see cref="HotstringDefinition"/> to persist when restoring or reverting a
+    /// snapshot. A legacy <c>Kind = Script</c> snapshot is converted to a Raw definition (composed
+    /// verbatim, derived trigger unchanged); every other kind is applied as-is.
+    /// </summary>
+    public static HotstringDefinition ToDefinition(HotstringSnapshot s)
+    {
+#pragma warning disable CS0618 // Script is read only from stored legacy snapshots, never new payloads.
+        bool isLegacyScript = s.Kind == HotstringKind.Script;
+#pragma warning restore CS0618
+
+        if (isLegacyScript)
+        {
+            string raw = Compose(
+                s.Trigger, s.Replacement,
+                s.IsEndingCharacterRequired, s.IsTriggerInsideWord,
+                s.IsCaseSensitive, s.OmitEndingCharacter);
+
+            return new HotstringDefinition(
+                s.Trigger, raw, s.Description, s.AppliesToAllProfiles,
+                s.IsEndingCharacterRequired, s.IsTriggerInsideWord,
+                HotstringKind.Raw, s.IsCaseSensitive, s.OmitEndingCharacter,
+                s.DateTimeFormat, s.DateOffsetAmount, s.DateOffsetUnit,
+                s.ContextMatchType, s.ContextValue);
+        }
+
+        return new HotstringDefinition(
+            s.Trigger, s.Replacement, s.Description, s.AppliesToAllProfiles,
+            s.IsEndingCharacterRequired, s.IsTriggerInsideWord,
+            s.Kind, s.IsCaseSensitive, s.OmitEndingCharacter,
+            s.DateTimeFormat, s.DateOffsetAmount, s.DateOffsetUnit,
+            s.ContextMatchType, s.ContextValue);
+    }
+
+    // Mirrors HotstringEmitter.Escape: backtick first so later escapes are not double-escaped.
+    private static string Escape(string value) =>
+        value
+            .Replace("`", "``")
+            .Replace("\n", "`n")
+            .Replace("\r", "`r")
+            .Replace("\t", "`t")
+            .Replace(";", "`;");
+}

--- a/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
+++ b/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
@@ -111,10 +111,12 @@ internal static partial class HotstringRules
         bool IsDateTime(T x) => kindFn(x) == HotstringKind.DateTime;
         bool BothOffsetsSet(T x) => amountFn(x) is not null && unitFn(x) is not null;
 
-        // Replacement: normal rules for non-DateTime kinds, must be empty for DateTime
+        // Replacement: normal rules for structured non-DateTime kinds, must be empty for DateTime.
+        // Raw is excluded — its own length limit (RawDefinitionMaxLength, 4200) and structural
+        // rules live in AddRawKindRules; ValidReplacement's 4000 cap would otherwise shadow it.
         validator.RuleFor(replacement)
             .ValidReplacement()
-            .When(x => !IsDateTime(x));
+            .When(x => !IsDateTime(x) && kindFn(x) != HotstringKind.Raw);
 
         validator.RuleFor(replacement)
             .Must(r => r == string.Empty)
@@ -239,14 +241,18 @@ internal static partial class HotstringRules
             {
                 value ??= string.Empty;
 
-                // Rule 8 — length (bound before parsing).
+                // Rule 8 — length (bound on raw input before any processing).
                 if (value.Length > RawDefinitionMaxLength)
                 {
                     context.AddFailure($"Raw definition must be {RawDefinitionMaxLength} characters or fewer.");
                     return;
                 }
 
-                RawParseResult parsed = RawHotstringDefinitionParser.Parse(value);
+                // Validate the normalized form — the exact text the handler persists — so validation
+                // and save can never disagree (e.g. a whitespace-only inline replacement that
+                // normalization strips to a bare trigger, or lone-CR-separated directive lines).
+                string normalized = RawHotstringDefinitionParser.Normalize(value);
+                RawParseResult parsed = RawHotstringDefinitionParser.Parse(normalized);
 
                 // Rule 1 — first line must be a valid hotstring definition.
                 if (!parsed.FirstLineValid)
@@ -289,7 +295,7 @@ internal static partial class HotstringRules
                 }
 
                 // Rule 5 — no directive lines (would corrupt #HotIf grouping).
-                if (value.Split('\n').Any(line => line.TrimStart().StartsWith('#')))
+                if (normalized.Split('\n').Any(line => line.TrimStart().StartsWith('#')))
                 {
                     context.AddFailure("Raw definition must not contain directive lines starting with '#'.");
                     return;

--- a/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
+++ b/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
@@ -16,6 +16,13 @@ internal static partial class HotstringRules
     public const int DateOffsetAmountMax = 3650;
     public const int ContextValueMaxLength = 200;
 
+    // Raw-specific limits. RawDefinitionMaxLength = 4000 body + trigger/options/brace
+    // overhead, so migrated near-limit Script rows stay editable. RawTriggerMaxLength is
+    // AHK's own documented abbreviation limit ("no more than 40 characters"), so Raw never
+    // accepts a definition AHK itself would reject. Structured kinds keep TriggerMaxLength (50).
+    public const int RawDefinitionMaxLength = 4200;
+    public const int RawTriggerMaxLength = 40;
+
     public static IRuleBuilderOptions<T, string> ValidTrigger<T>(this IRuleBuilderInitial<T, string> rb) =>
         rb.Cascade(CascadeMode.Stop)
           .Must(t => !string.IsNullOrEmpty(t)).WithMessage("Trigger is required.")
@@ -218,39 +225,81 @@ internal static partial class HotstringRules
     /// <see cref="AddDateTimeKindRules{T}"/> (Script is not DateTime, so it falls into that method's
     /// "otherwise" branches) and are not duplicated here.
     /// </summary>
-    public static void AddScriptKindRules<T>(
+    public static void AddRawKindRules<T>(
         this AbstractValidator<T> validator,
         Expression<Func<T, HotstringKind>> kind,
         Expression<Func<T, string>> replacement)
     {
         Func<T, HotstringKind> kindFn = kind.Compile();
 
-        bool IsScript(T x) => kindFn(x) == HotstringKind.Script;
+        bool IsRaw(T x) => kindFn(x) == HotstringKind.Raw;
 
         validator.RuleFor(replacement)
-            .Must(r => r.Split('\n').All(line => !line.TrimStart().StartsWith('#')))
-            .When(IsScript)
-            .WithMessage("Script replacement must not contain directive lines starting with '#'.");
-
-        validator.RuleFor(replacement)
-            .Must(r =>
+            .Custom((value, context) =>
             {
-                int depth = 0;
-                foreach (char c in r)
+                value ??= string.Empty;
+
+                // Rule 8 — length (bound before parsing).
+                if (value.Length > RawDefinitionMaxLength)
                 {
-                    if (c == '{')
-                        depth++;
-                    else if (c == '}')
-                    {
-                        depth--;
-                        if (depth < 0)
-                            return false;
-                    }
+                    context.AddFailure($"Raw definition must be {RawDefinitionMaxLength} characters or fewer.");
+                    return;
                 }
-                return depth == 0;
+
+                RawParseResult parsed = RawHotstringDefinitionParser.Parse(value);
+
+                // Rule 1 — first line must be a valid hotstring definition.
+                if (!parsed.FirstLineValid)
+                {
+                    context.AddFailure(parsed.Error);
+                    return;
+                }
+
+                // Rule 2 — exactly one definition.
+                if (parsed.DefinitionCount > 1)
+                {
+                    context.AddFailure("Multiple hotstrings detected — paste one definition at a time.");
+                    return;
+                }
+
+                // Rule 3 — derived trigger (Raw-specific 40-char limit; AHK's own abbreviation cap).
+                if (parsed.Trigger.Length == 0)
+                {
+                    context.AddFailure("Trigger is required.");
+                    return;
+                }
+
+                if (parsed.Trigger.Length > RawTriggerMaxLength)
+                {
+                    context.AddFailure($"Trigger must be {RawTriggerMaxLength} characters or fewer.");
+                    return;
+                }
+
+                if (parsed.Trigger.IndexOfAny(['\n', '\r', '\t']) >= 0)
+                {
+                    context.AddFailure("Trigger must not contain line breaks or tabs.");
+                    return;
+                }
+
+                // Rule 4 — every option flag in the known AHK v2 set.
+                if (parsed.UnknownOptionTokens.Length > 0)
+                {
+                    context.AddFailure($"Unknown hotstring option '{parsed.UnknownOptionTokens[0]}'.");
+                    return;
+                }
+
+                // Rule 5 — no directive lines (would corrupt #HotIf grouping).
+                if (value.Split('\n').Any(line => line.TrimStart().StartsWith('#')))
+                {
+                    context.AddFailure("Raw definition must not contain directive lines starting with '#'.");
+                    return;
+                }
+
+                // Rules 6 & 7 — structural body completeness (balanced brace body / inline shape).
+                if (!parsed.IsValid)
+                    context.AddFailure(parsed.Error);
             })
-            .When(IsScript)
-            .WithMessage("Script replacement must have balanced braces.");
+            .When(IsRaw);
     }
 
     /// <summary>

--- a/src/Backend/AHKFlowApp.Domain/Entities/HotstringDefinition.cs
+++ b/src/Backend/AHKFlowApp.Domain/Entities/HotstringDefinition.cs
@@ -6,6 +6,13 @@ namespace AHKFlowApp.Domain.Entities;
 /// Definitional fields of a hotstring, grouped so factory signatures stay stable
 /// as kinds and options grow across the redesign phases.
 /// </summary>
+/// <param name="Replacement">
+/// Meaning is kind-dependent. For <see cref="HotstringKind.Text"/> it is the literal
+/// replacement text; for <see cref="HotstringKind.Macro"/> the macro token string; for
+/// <see cref="HotstringKind.Raw"/> the <em>entire verbatim AHK v2 definition</em>
+/// (first line <c>:options:trigger::</c>, optional brace body below) — the single source
+/// of truth from which <c>Trigger</c> and option flags are derived server-side.
+/// </param>
 public sealed record HotstringDefinition(
     string Trigger,
     string Replacement,

--- a/src/Backend/AHKFlowApp.Domain/Enums/HotstringKind.cs
+++ b/src/Backend/AHKFlowApp.Domain/Enums/HotstringKind.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace AHKFlowApp.Domain.Enums;
 
 public enum HotstringKind
@@ -5,5 +7,21 @@ public enum HotstringKind
     Text = 0,
     DateTime = 1,
     Macro = 2,
+
+    /// <summary>
+    /// Retired legacy kind. Accepted only when deserializing stored history snapshots,
+    /// never in new payloads — validators reject it and restore/revert convert it to
+    /// <see cref="Raw"/> via the shared Script→Raw composer. The value is kept so
+    /// historical snapshots with <c>Kind = 3</c> still deserialize; reusing it for a new
+    /// meaning would not be wire- or history-compatible.
+    /// </summary>
+    [Obsolete("Legacy; accepted only when deserializing history snapshots. Use Raw for new definitions.")]
     Script = 3,
+
+    /// <summary>
+    /// Raw AHK v2 hotstring definition stored verbatim in <c>Replacement</c> (first line
+    /// <c>:options:trigger::</c>, optional brace body). The trigger is derived server-side;
+    /// option-flag columns are ignored. Replaces the legacy <see cref="Script"/> kind.
+    /// </summary>
+    Raw = 4,
 }

--- a/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260713200232_RawHotstringKind.Designer.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260713200232_RawHotstringKind.Designer.cs
@@ -4,6 +4,7 @@ using AHKFlowApp.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AHKFlowApp.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260713200232_RawHotstringKind")]
+    partial class RawHotstringKind
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260713200232_RawHotstringKind.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260713200232_RawHotstringKind.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AHKFlowApp.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class RawHotstringKind : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        // Widen first so embedding a near-limit Script body inside a full definition can't truncate.
+        migrationBuilder.AlterColumn<string>(
+            name: "Replacement",
+            table: "Hotstrings",
+            type: "nvarchar(max)",
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(4000)",
+            oldMaxLength: 4000);
+
+        // Rewrite legacy Script rows (Kind = 3) to Raw (Kind = 4), replacing the body-only
+        // Replacement with the entire verbatim definition. This T-SQL is a hand-written copy of
+        // ScriptToRawComposer (BuildOptions X/T never apply to a brace-body kind; Escape does
+        // backtick first) — the Infrastructure Testcontainers parity test proves the two agree,
+        // so migrated scripts are byte-identical to what the old emitter produced.
+        migrationBuilder.Sql(@"
+UPDATE [Hotstrings]
+SET [Replacement] =
+        ':'
+        + (CASE WHEN [IsEndingCharacterRequired] = 0 THEN '*' ELSE '' END)
+        + (CASE WHEN [IsTriggerInsideWord] = 1 THEN '?' ELSE '' END)
+        + (CASE WHEN [IsCaseSensitive] = 1 THEN 'C' ELSE '' END)
+        + (CASE WHEN [OmitEndingCharacter] = 1 AND [IsEndingCharacterRequired] = 1 THEN 'O' ELSE '' END)
+        + ':'
+        + REPLACE(REPLACE(REPLACE(REPLACE(REPLACE([Trigger],
+              '`', '``'),
+              CHAR(10), '`n'),
+              CHAR(13), '`r'),
+              CHAR(9), '`t'),
+              ';', '`;')
+        + '::' + CHAR(10) + '{' + CHAR(10) + [Replacement] + CHAR(10) + '}',
+    [Kind] = 4
+WHERE [Kind] = 3;");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        // Down-migration is unsupported: the Script→Raw data rewrite is lossy in reverse (the
+        // composed brace wrapper and option flags cannot be reliably decomposed) and reverting
+        // the column to nvarchar(4000) would truncate Raw rows that legitimately exceed 4,000
+        // characters. Restore from backup instead of rolling this migration back.
+        throw new System.NotSupportedException(
+            "The RawHotstringKind migration cannot be reverted. Restore from a database backup instead.");
+    }
+}

--- a/src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/HotstringConfiguration.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/HotstringConfiguration.cs
@@ -17,9 +17,12 @@ internal sealed class HotstringConfiguration : IEntityTypeConfiguration<Hotstrin
             .IsRequired()
             .HasMaxLength(50);
 
+        // nvarchar(max): a Raw definition embeds the trigger line and brace wrapper around a body
+        // that could already be near the old 4,000 limit, so the column must not hard-truncate.
+        // Validation (RawDefinitionMaxLength) keeps user input bounded; this only removes the cap.
         builder.Property(x => x.Replacement)
             .IsRequired()
-            .HasMaxLength(4000);
+            .HasColumnType("nvarchar(max)");
 
         builder.Property(x => x.Description)
             .HasMaxLength(200);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -325,6 +325,11 @@
 
     private bool HasCursorToken => MacroTokens.CursorTokenStart(Item.Replacement) is not null;
 
+    // Raw previews run whether or not the panel is expanded: the parsed trigger/options summary and
+    // inline validation render below the textarea, so they must stay live by default. The panel's
+    // expand state only controls whether the generated snippet is shown.
+    private bool ShouldAutoPreview => _previewExpanded || Item.Kind == HotstringKind.Raw;
+
     protected override void OnParametersSet()
     {
         _profileOptions = [.. Profiles.Select(p => new EntityOption(p.Id, p.Name))];
@@ -342,7 +347,7 @@
 
     protected override Task OnAfterRenderAsync(bool firstRender)
     {
-        if (_previewExpanded)
+        if (ShouldAutoPreview)
         {
             HotstringPreviewRequestDto current = BuildPreviewRequest();
             if (_lastPreviewRequest != current)
@@ -361,6 +366,13 @@
     {
         if (newKind == Item.Kind)
             return;
+
+        // Field-level preview errors and the Raw summary belong to the outgoing kind — drop them so
+        // a stale message (e.g. a Raw brace error) can't linger on the incoming kind's fields.
+        _rawSummary = null;
+        _previewTriggerError = null;
+        _previewReplacementError = null;
+        _previewContextValueError = null;
 
         // Leaving Raw for a structured kind: decompose the definition, warning first when it
         // carries option flags the structured fields can't express (they would be discarded).
@@ -659,8 +671,10 @@
             _lastPreviewRequest = request;
             SchedulePreview(request, debounce: false);
         }
-        else
+        else if (!ShouldAutoPreview)
         {
+            // Nothing left to preview (non-Raw collapsed): stop and clear inline errors. Raw keeps
+            // auto-previewing while collapsed so its summary + inline validation stay live.
             CancelPendingPreview();
             _previewTriggerError = null;
             _previewReplacementError = null;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -24,19 +24,22 @@
                 <MudToggleItem Value="HotstringKind.Text" Text="Text" />
                 <MudToggleItem Value="HotstringKind.DateTime" Text="Date & time" />
                 <MudToggleItem Value="HotstringKind.Macro" Text="Macro" />
-                <MudToggleItem Value="HotstringKind.Script">
+                <MudToggleItem Value="HotstringKind.Raw">
                     <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
                         <MudIcon Icon="@Icons.Material.Filled.Warning" Color="Color.Warning" Size="Size.Small"
-                                 title="Runs arbitrary AutoHotkey code" />
-                        <MudText>Script</MudText>
+                                 title="Verbatim AutoHotkey definition" />
+                        <MudText>Raw</MudText>
                     </MudStack>
                 </MudToggleItem>
             </MudToggleGroup>
 
-            <MudTextField T="string" Label="Trigger" @bind-Value="Item.Trigger" Immediate="true"
-                          Required="true" RequiredError="Trigger is required" MaxLength="50"
-                          Error="@(TriggerErrorText is not null)" ErrorText="@TriggerErrorText"
-                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "trigger-input" })" />
+            @if (Item.Kind != HotstringKind.Raw)
+            {
+                <MudTextField T="string" Label="Trigger" @bind-Value="Item.Trigger" Immediate="true"
+                              Required="true" RequiredError="Trigger is required" MaxLength="50"
+                              Error="@(TriggerErrorText is not null)" ErrorText="@TriggerErrorText"
+                              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "trigger-input" })" />
+            }
             @if (Item.Kind == HotstringKind.Macro)
             {
                 <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap"
@@ -57,12 +60,25 @@
             }
             @if (Item.Kind != HotstringKind.DateTime)
             {
-                <MudTextField T="string" Label="Replacement" @bind-Value="Item.Replacement" @ref="_replacementField"
-                              Immediate="true" Class="@(Item.Kind == HotstringKind.Script ? "ahk-mono" : null)"
-                              Lines="@(Item.Kind == HotstringKind.Script ? 8 : 3)" Required="true" RequiredError="Replacement is required" MaxLength="4000"
+                <MudTextField T="string" Label="@(Item.Kind == HotstringKind.Raw ? "Raw definition" : "Replacement")"
+                              @bind-Value="Item.Replacement" @ref="_replacementField"
+                              Immediate="true" Class="@(Item.Kind == HotstringKind.Raw ? "ahk-mono" : null)"
+                              Lines="@(Item.Kind == HotstringKind.Raw ? 8 : 3)" Required="true" RequiredError="Replacement is required" MaxLength="@(Item.Kind == HotstringKind.Raw ? 4200 : 4000)"
+                              Placeholder="@(Item.Kind == HotstringKind.Raw ? ":K1000 SE*:ftw::for the win" : null)"
                               Error="@(_previewReplacementError is not null)" ErrorText="@_previewReplacementError"
                               HelperText="@ReplacementHelperText"
                               UserAttributes="@GetReplacementUserAttributes()" />
+            }
+            @if (Item.Kind == HotstringKind.Raw && _rawSummary is not null)
+            {
+                <MudStack Row="true" Spacing="4" Class="raw-summary"
+                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "raw-summary" })">
+                    <MudText Typo="Typo.caption"><b>Trigger:</b> @(_rawSummary.Trigger)</MudText>
+                    @if (_rawSummary.OptionTokens.Length > 0)
+                    {
+                        <MudText Typo="Typo.caption"><b>Options:</b> @string.Join(" ", _rawSummary.OptionTokens)</MudText>
+                    }
+                </MudStack>
             }
             @if (Item.Kind == HotstringKind.Text && !_macroSuggestionDismissed && MacroTokens.ContainsKnownToken(Item.Replacement))
             {
@@ -83,20 +99,21 @@
             {
                 <MudAlert Severity="Severity.Info" UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "script-suggestion" })">
                     <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="flex-grow-1">
-                        <MudText Typo="Typo.body2">This looks like AutoHotkey code — switch to Script?</MudText>
+                        <MudText Typo="Typo.body2">This looks like AutoHotkey code — switch to Raw?</MudText>
                         <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-                            <MudButton Size="Size.Small" OnClick="SwitchToScriptFromSuggestion">Switch to Script</MudButton>
+                            <MudButton Size="Size.Small" OnClick="SwitchToRawFromSuggestion">Switch to Raw</MudButton>
                             <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small"
                                            OnClick="@(() => _scriptSuggestionDismissed = true)"
-                                           UserAttributes="@(new Dictionary<string, object?> { ["aria-label"] = "Dismiss script suggestion" })" />
+                                           UserAttributes="@(new Dictionary<string, object?> { ["aria-label"] = "Dismiss raw suggestion" })" />
                         </MudStack>
                     </MudStack>
                 </MudAlert>
             }
-            @if (Item.Kind == HotstringKind.Script)
+            @if (Item.Kind == HotstringKind.Raw)
             {
                 <MudAlert Severity="Severity.Warning" UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "script-warning" })">
-                    Runs arbitrary AutoHotkey code in the generated script. A syntax error here can break the whole profile script.
+                    This is a verbatim AutoHotkey definition — the trigger and options are parsed from the text below.
+                    A syntax error here can break the whole profile script.
                 </MudAlert>
             }
             @if (Item.Kind == HotstringKind.DateTime)
@@ -183,16 +200,19 @@
                                    DataTest="profile-select" />
             }
 
-            <MudText Typo="Typo.subtitle2" Class="mt-1">Trigger options</MudText>
-            <MudCheckBox T="bool" @bind-Value="Item.IsCaseSensitive" Label="Case sensitive"
-                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "case-sensitive-checkbox" })" />
-            <MudCheckBox T="bool" @bind-Value="Item.ExpandImmediately" Label="Expand immediately (no ending character)"
-                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "expand-immediately-checkbox" })" />
-            <MudCheckBox T="bool" @bind-Value="Item.IsTriggerInsideWord" Label="Trigger inside words"
-                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "inside-words-checkbox" })" />
-            <MudCheckBox T="bool" @bind-Value="Item.OmitEndingCharacter" Label="Omit ending character"
-                         Disabled="@Item.ExpandImmediately"
-                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "omit-ending-checkbox" })" />
+            @if (Item.Kind != HotstringKind.Raw)
+            {
+                <MudText Typo="Typo.subtitle2" Class="mt-1">Trigger options</MudText>
+                <MudCheckBox T="bool" @bind-Value="Item.IsCaseSensitive" Label="Case sensitive"
+                             UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "case-sensitive-checkbox" })" />
+                <MudCheckBox T="bool" @bind-Value="Item.ExpandImmediately" Label="Expand immediately (no ending character)"
+                             UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "expand-immediately-checkbox" })" />
+                <MudCheckBox T="bool" @bind-Value="Item.IsTriggerInsideWord" Label="Trigger inside words"
+                             UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "inside-words-checkbox" })" />
+                <MudCheckBox T="bool" @bind-Value="Item.OmitEndingCharacter" Label="Omit ending character"
+                             Disabled="@Item.ExpandImmediately"
+                             UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "omit-ending-checkbox" })" />
+            }
 
             <MudText Typo="Typo.subtitle2" Class="mt-1">Window context</MudText>
             <MudSwitch T="bool" Value="@(Item.ContextMatchType is not null)" ValueChanged="OnContextSwitchChanged"
@@ -233,14 +253,15 @@
     private const string CursorToken = "{{cursor}}";
     private const string MacroHelperText =
         "One {{cursor}} token allowed; Enter/Tab must come before it. Write {{{{...}}}} for literal {{...}} text.";
-    private const string ScriptHelperText =
-        "Raw AutoHotkey v2. No lines starting with '#'. Braces are counted literally (no string/comment awareness), " +
-        "so valid code like SendText \"{\" is rejected — split it or wrap the brace differently.";
+    private const string RawHelperText =
+        "Paste one entire AHK v2 definition (e.g. :K1000 SE*:ftw::for the win). The trigger and options are " +
+        "parsed from the first line. No lines starting with '#'; a bare '::' needs a { brace body below; braces are " +
+        "counted literally (no string/comment awareness); OTB braces and continuation sections are not supported.";
 
     private string? ReplacementHelperText => Item.Kind switch
     {
         HotstringKind.Macro => MacroHelperText,
-        HotstringKind.Script => ScriptHelperText,
+        HotstringKind.Raw => RawHelperText,
         _ => null,
     };
 
@@ -286,6 +307,7 @@
     private MudTextField<string> _replacementField = default!;
     private bool _macroSuggestionDismissed;
     private bool _scriptSuggestionDismissed;
+    private RawSummaryDto? _rawSummary;
     private string? _macroInsertHint;
     private bool _previewExpanded;
     private bool _previewPending;
@@ -340,6 +362,27 @@
         if (newKind == Item.Kind)
             return;
 
+        // Leaving Raw for a structured kind: decompose the definition, warning first when it
+        // carries option flags the structured fields can't express (they would be discarded).
+        if (Item.Kind == HotstringKind.Raw && newKind != HotstringKind.Raw)
+        {
+            RawDecomposition decomposed = RawDefinition.Decompose(Item.Replacement);
+            if (decomposed.UnexpressibleOptions.Count > 0
+                && !await ConfirmSwitchAsync($"Switch to {KindLabel(newKind)}?",
+                    $"Options `{string.Join(" ", decomposed.UnexpressibleOptions)}` will be discarded — continue?"))
+                return;
+
+            Item.Trigger = decomposed.Trigger;
+            Item.Replacement = newKind == HotstringKind.DateTime ? "" : decomposed.Body;
+            Item.IsCaseSensitive = false;
+            Item.OmitEndingCharacter = false;
+            Item.IsEndingCharacterRequired = true;
+            Item.IsTriggerInsideWord = true;
+            ClearDateTimeFields();
+            Item.Kind = newKind;
+            return;
+        }
+
         if (newKind == HotstringKind.DateTime)
         {
             if (!string.IsNullOrEmpty(Item.Replacement)
@@ -364,12 +407,6 @@
                         "Switching to Text will treat any {{...}} tokens in the replacement as literal text instead of macro commands. Continue?"))
                     return;
             }
-            else if (Item.Kind == HotstringKind.Script && !string.IsNullOrEmpty(Item.Replacement))
-            {
-                if (!await ConfirmSwitchAsync("Switch to Text?",
-                        "Switching to Text will treat your code as literal text instead of running it. Continue?"))
-                    return;
-            }
 
             ClearDateTimeFields();
             Item.Kind = HotstringKind.Text;
@@ -384,25 +421,40 @@
             ClearDateTimeFields();
             Item.Kind = HotstringKind.Macro;
         }
-        else if (newKind == HotstringKind.Script)
+        else if (newKind == HotstringKind.Raw)
         {
             if (Item.DateTimeFormat is not null)
             {
-                if (!await ConfirmSwitchAsync("Switch to Script?",
-                        "Switching to Script will clear the date/time format and offset. Continue?"))
+                if (!await ConfirmSwitchAsync("Switch to Raw?",
+                        "Switching to Raw will clear the date/time format and offset. Continue?"))
                     return;
             }
             else if (Item.Kind is HotstringKind.Text or HotstringKind.Macro && !string.IsNullOrEmpty(Item.Replacement))
             {
-                if (!await ConfirmSwitchAsync("Switch to Script?",
-                        "Switching to Script will run your text as AutoHotkey code instead of literal text. Continue?"))
+                if (!await ConfirmSwitchAsync("Switch to Raw?",
+                        "Switching to Raw will wrap your text into a full AHK v2 definition you can edit directly. Continue?"))
                     return;
             }
 
+            // Compose a starting definition from the current structured fields (same shape as the
+            // server's Script→Raw transform). An empty replacement yields just the trigger scaffold.
+            Item.Replacement = RawDefinition.Compose(
+                Item.Trigger, Item.Replacement,
+                Item.IsEndingCharacterRequired, Item.IsTriggerInsideWord,
+                Item.IsCaseSensitive, Item.OmitEndingCharacter);
             ClearDateTimeFields();
-            Item.Kind = HotstringKind.Script;
+            Item.Kind = HotstringKind.Raw;
         }
     }
+
+    private static string KindLabel(HotstringKind kind) => kind switch
+    {
+        HotstringKind.Text => "Text",
+        HotstringKind.DateTime => "Date & time",
+        HotstringKind.Macro => "Macro",
+        HotstringKind.Raw => "Raw",
+        _ => kind.ToString(),
+    };
 
     private async Task<bool> ConfirmSwitchAsync(string title, string message)
     {
@@ -448,7 +500,7 @@
 
     private Task SwitchToMacroFromSuggestion() => OnKindChangedAsync(HotstringKind.Macro);
 
-    private Task SwitchToScriptFromSuggestion() => OnKindChangedAsync(HotstringKind.Script);
+    private Task SwitchToRawFromSuggestion() => OnKindChangedAsync(HotstringKind.Raw);
 
     /// <summary>
     /// Heuristic "looks like AHK code" detector for the Text-kind "Use Script?" suggestion
@@ -475,7 +527,7 @@
     private Dictionary<string, object?> GetReplacementUserAttributes()
     {
         Dictionary<string, object?> attributes = new() { ["data-test"] = "replacement-input" };
-        if (Item.Kind == HotstringKind.Script)
+        if (Item.Kind == HotstringKind.Raw)
             attributes["spellcheck"] = "false";
         return attributes;
     }
@@ -701,11 +753,13 @@
         if (result.IsSuccess)
         {
             _previewSnippet = result.Value!.Snippet;
+            _rawSummary = result.Value.RawSummary;
             _previewError = null;
             return;
         }
 
         _previewSnippet = null;
+        _rawSummary = null;
 
         if (result.Status == ApiResultStatus.Validation && result.Problem?.Errors is { Count: > 0 } errors)
         {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
@@ -43,10 +43,10 @@
                         }
                         <td class="trigger-cell"><code>@item.Trigger</code></td>
                         <td class="replacement-cell">
-                            @if (item.Kind == HotstringKind.Script)
+                            @if (item.Kind == HotstringKind.Raw)
                             {
                                 <MudIcon Icon="@Icons.Material.Filled.Warning" Color="Color.Warning" Size="Size.Small" Class="script-badge"
-                                         title="Script — runs arbitrary AutoHotkey code"
+                                         title="Raw — verbatim AutoHotkey definition"
                                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "script-badge-collapsed" })" />
                             }
                             @RenderReplacementCell(item)
@@ -70,7 +70,7 @@
                                             <strong>Replacement:</strong> <MacroReplacementDisplay Replacement="@item.Replacement" />
                                         </MudText>
                                     }
-                                    else if (item.Kind == HotstringKind.Script)
+                                    else if (item.Kind == HotstringKind.Raw)
                                     {
                                         <MudAlert Severity="Severity.Warning" Dense="true"
                                                   UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "script-warning-expanded" })">
@@ -100,12 +100,17 @@
                                     <MudText Typo="Typo.body2"><strong>Categories:</strong>
                                         <EntityChips Ids="item.CategoryIds" Options="_categoryOptions" />
                                     </MudText>
-                                    <MudText Typo="Typo.body2">
-                                        <strong>End-char:</strong> @(item.IsEndingCharacterRequired ? "✓" : "✗") &nbsp;
-                                        <strong>In-word:</strong> @(item.IsTriggerInsideWord ? "✓" : "✗") &nbsp;
-                                        <strong>Case:</strong> @(item.IsCaseSensitive ? "✓" : "✗") &nbsp;
-                                        <strong>Omit end-char:</strong> @(item.OmitEndingCharacter ? "✓" : "✗")
-                                    </MudText>
+                                    @if (item.Kind != HotstringKind.Raw)
+                                    {
+                                        // Raw rows carry the options inside the verbatim definition; the
+                                        // four flag columns are left at defaults and meaningless to show.
+                                        <MudText Typo="Typo.body2">
+                                            <strong>End-char:</strong> @(item.IsEndingCharacterRequired ? "✓" : "✗") &nbsp;
+                                            <strong>In-word:</strong> @(item.IsTriggerInsideWord ? "✓" : "✗") &nbsp;
+                                            <strong>Case:</strong> @(item.IsCaseSensitive ? "✓" : "✗") &nbsp;
+                                            <strong>Omit end-char:</strong> @(item.OmitEndingCharacter ? "✓" : "✗")
+                                        </MudText>
+                                    }
                                     <MudStack Row="true" Spacing="2" Class="mt-2">
                                         <MudButton Class="start-edit" Variant="Variant.Filled" Color="Color.Primary"
                                                    StartIcon="@Icons.Material.Filled.Edit"
@@ -159,7 +164,7 @@
     private RenderFragment RenderReplacementCell(HotstringEditModel item) => item.Kind switch
     {
         HotstringKind.DateTime => @<text>@item.DateTimeSummary</text>,
-        HotstringKind.Script => @<text>@item.ScriptSummary</text>,
+        HotstringKind.Raw => @<text>@item.RawSummary</text>,
         _ => @<text>@item.Replacement</text>,
     };
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HotstringKind.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HotstringKind.cs
@@ -5,5 +5,5 @@ public enum HotstringKind
     Text = 0,
     DateTime = 1,
     Macro = 2,
-    Script = 3,
+    Raw = 4,
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HotstringPreviewDtos.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HotstringPreviewDtos.cs
@@ -14,4 +14,7 @@ public sealed record HotstringPreviewRequestDto(
     WindowMatchType? ContextMatchType = null,
     string? ContextValue = null);
 
-public sealed record HotstringPreviewDto(string Snippet);
+public sealed record HotstringPreviewDto(string Snippet, RawSummaryDto? RawSummary = null);
+
+/// <summary>Server-derived trigger and option tokens for a Raw definition; null for other kinds.</summary>
+public sealed record RawSummaryDto(string Trigger, string[] OptionTokens);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/RawDefinition.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/RawDefinition.cs
@@ -1,0 +1,150 @@
+using System.Text;
+
+namespace AHKFlowApp.UI.Blazor.Helpers;
+
+/// <summary>Result of decomposing a Raw definition back into structured fields.</summary>
+/// <param name="Trigger">Decoded trigger from the first line.</param>
+/// <param name="Body">Inline replacement, or the brace-body content when the definition uses one.</param>
+/// <param name="UnexpressibleOptions">
+/// Option tokens the four structured checkboxes (<c>*</c>/<c>?</c>/<c>C</c>/<c>O</c>) can't
+/// represent (e.g. <c>K1000</c>, <c>SE</c>) — surfaced in the "discard options?" confirmation.
+/// </param>
+public sealed record RawDecomposition(string Trigger, string Body, IReadOnlyList<string> UnexpressibleOptions);
+
+/// <summary>
+/// Client-side Raw definition compose/decompose for the edit dialog's kind switching. <see cref="Compose"/>
+/// mirrors the server's <c>ScriptToRawComposer.Compose</c> byte-for-byte (guarded by a shared-fixture
+/// test); <see cref="Decompose"/> is best-effort — the server re-parses and validates on save.
+/// </summary>
+public static class RawDefinition
+{
+    private static readonly HashSet<string> ExpressibleOptions =
+        new(StringComparer.OrdinalIgnoreCase) { "*", "?", "C", "O" };
+
+    /// <summary>
+    /// Composes a starting Raw definition from structured fields, matching the server's Script→Raw
+    /// transform: brace body, options in <c>* ? C O</c> order, backtick-first trigger escaping.
+    /// </summary>
+    public static string Compose(
+        string trigger,
+        string replacement,
+        bool isEndingCharacterRequired,
+        bool isTriggerInsideWord,
+        bool isCaseSensitive,
+        bool omitEndingCharacter)
+    {
+        string options = "";
+        if (!isEndingCharacterRequired) options += "*";
+        if (isTriggerInsideWord) options += "?";
+        if (isCaseSensitive) options += "C";
+        if (omitEndingCharacter && isEndingCharacterRequired) options += "O";
+
+        return $":{options}:{Escape(trigger)}::\n{{\n{replacement}\n}}";
+    }
+
+    /// <summary>Best-effort decomposition of a Raw definition into trigger + body + lost options.</summary>
+    public static RawDecomposition Decompose(string rawDefinition)
+    {
+        string[] lines = (rawDefinition ?? "").Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+        int firstIdx = Array.FindIndex(lines, l => l.Trim().Length > 0);
+        if (firstIdx < 0)
+            return new RawDecomposition("", "", []);
+
+        string first = lines[firstIdx].TrimStart();
+        // :options:trigger::rest — options/trigger contain no ':'; first '::' delimits.
+        int firstColon = first.IndexOf(':');
+        if (firstColon != 0)
+            return new RawDecomposition("", rawDefinition ?? "", []);
+
+        int secondColon = first.IndexOf(':', 1);
+        if (secondColon < 0)
+            return new RawDecomposition("", rawDefinition ?? "", []);
+
+        string optionsBlock = first[1..secondColon];
+        int doubleColon = first.IndexOf("::", secondColon + 1, StringComparison.Ordinal);
+        if (doubleColon < 0)
+            return new RawDecomposition("", rawDefinition ?? "", []);
+
+        string triggerRaw = first[(secondColon + 1)..doubleColon];
+        string inlineRest = first[(doubleColon + 2)..];
+
+        string body;
+        string inlineTrim = inlineRest.Trim();
+        if (inlineRest.Length > 0 && inlineTrim != "{")
+        {
+            body = inlineRest;
+        }
+        else
+        {
+            // Brace body: content strictly between the "{" line and the last "}" line.
+            string[] rest = lines[(firstIdx + 1)..];
+            int open = Array.FindIndex(rest, l => l.Trim() == "{");
+            int close = Array.FindLastIndex(rest, l => l.Trim() == "}");
+            body = open >= 0 && close > open
+                ? string.Join('\n', rest[(open + 1)..close])
+                : string.Join('\n', rest).Trim();
+        }
+
+        List<string> unexpressible = [.. TokenizeOptions(optionsBlock).Where(t => !ExpressibleOptions.Contains(t))];
+        return new RawDecomposition(DecodeEscapes(triggerRaw).Trim(), body, unexpressible);
+    }
+
+    // Longest-match tokenizer (SE/SP/SI before S; each flag absorbs its sign/digits), mirroring the
+    // server parser closely enough to identify which options the structured fields can't express.
+    private static IEnumerable<string> TokenizeOptions(string options)
+    {
+        int i = 0;
+        while (i < options.Length)
+        {
+            if (char.IsWhiteSpace(options[i])) { i++; continue; }
+
+            int start = i;
+            if (options[i] is 'S' or 's'
+                && i + 1 < options.Length
+                && options[i + 1] is 'I' or 'P' or 'E' or 'i' or 'p' or 'e')
+            {
+                i += 2;
+            }
+            else
+            {
+                i++;
+                if (options[start] is 'K' or 'k' && i < options.Length && options[i] == '-') i++;
+                while (i < options.Length && char.IsDigit(options[i])) i++;
+            }
+
+            yield return options[start..i];
+        }
+    }
+
+    private static string Escape(string value) =>
+        value
+            .Replace("`", "``")
+            .Replace("\n", "`n")
+            .Replace("\r", "`r")
+            .Replace("\t", "`t")
+            .Replace(";", "`;");
+
+    private static string DecodeEscapes(string value)
+    {
+        if (!value.Contains('`')) return value;
+
+        StringBuilder sb = new(value.Length);
+        for (int i = 0; i < value.Length; i++)
+        {
+            char c = value[i];
+            if (c != '`') { sb.Append(c); continue; }
+            if (i + 1 >= value.Length) break;
+            sb.Append(value[++i] switch
+            {
+                '`' => '`',
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                's' => ' ',
+                ';' => ';',
+                var other => other,
+            });
+        }
+        return sb.ToString();
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/RawDefinition.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/RawDefinition.cs
@@ -86,7 +86,8 @@ public static class RawDefinition
         }
 
         List<string> unexpressible = [.. TokenizeOptions(optionsBlock).Where(t => !ExpressibleOptions.Contains(t))];
-        return new RawDecomposition(DecodeEscapes(triggerRaw).Trim(), body, unexpressible);
+        // No trimming: mirror the server parser — the abbreviation's whitespace is literal.
+        return new RawDecomposition(DecodeEscapes(triggerRaw), body, unexpressible);
     }
 
     // Longest-match tokenizer (SE/SP/SI before S; each flag absorbs its sign/digits), mirroring the

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -702,6 +702,70 @@
         }
     }
 
+    /// <summary>
+    /// Promotes an inline-editing row (draft or existing) to the full <see cref="HotstringEditDialog"/>,
+    /// carrying over everything typed inline. The dialog is seeded with a clone so the inline model is
+    /// untouched until save. On cancel the inline edit state is restored with its values; on save the
+    /// dialog's normal create/update path runs and the grid reloads.
+    /// </summary>
+    private async Task PromoteInlineRowAsync(HotstringEditModel item)
+    {
+        if (_dialogOpen)
+            return;
+
+        bool isDraft = ReferenceEquals(item, _pendingCreate);
+        HotstringEditModel seed = item.Clone();
+
+        // Leave the inline edit while the dialog is open so the row renders read-only underneath.
+        _editingItem = null;
+        if (isDraft)
+            _pendingCreate = null;
+        if (_grid is not null)
+            await _grid.ReloadServerData();
+
+        _dialogOpen = true;
+        try
+        {
+            DialogParameters parameters = new()
+            {
+                [nameof(HotstringEditDialog.Item)] = seed,
+                [nameof(HotstringEditDialog.Profiles)] = _profiles,
+                [nameof(HotstringEditDialog.Categories)] = _categories,
+            };
+
+            IDialogReference dialog = await DialogService.ShowAsync<HotstringEditDialog>(
+                isDraft ? "New hotstring" : "Edit hotstring", parameters,
+                new DialogOptions { FullScreen = true, CloseButton = false });
+
+            DialogResult? result = await dialog.Result;
+            if (result?.Canceled == false)
+            {
+                Snackbar.Add(isDraft ? "Hotstring created." : "Hotstring updated.", Severity.Success);
+                await ReloadAllAsync();
+            }
+            else
+            {
+                // Cancel restores the inline edit with the values it carried before promotion.
+                if (isDraft)
+                {
+                    _pendingCreate = item;
+                    _editingItem = _pendingCreate;
+                }
+                else
+                {
+                    _editingItem = item;
+                }
+                _commitAttempted = false;
+                if (_grid is not null)
+                    await _grid.ReloadServerData();
+            }
+        }
+        finally
+        {
+            _dialogOpen = false;
+        }
+    }
+
     private Task OpenEditDialogAsync(HotstringEditModel item) =>
         OpenEditDialogCoreAsync(item, new DialogOptions { FullScreen = true, CloseButton = false });
 
@@ -892,6 +956,9 @@
                            Color="Color.Success" OnClick="() => CommitEditAsync(item)" />
             <MudIconButton Class="cancel-edit" Icon="@Icons.Material.Filled.Close"
                            Color="Color.Default" OnClick="CancelEditAsync" />
+            <MudIconButton Class="promote-edit" Icon="@Icons.Material.Filled.Tune"
+                           OnClick="() => PromoteInlineRowAsync(item)"
+                           UserAttributes="@(new Dictionary<string, object?> { ["title"] = "More options / change type", ["aria-label"] = "More options / change type" })" />
         }
         else
         {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -44,7 +44,7 @@
                 <MudSelectItem T="HotstringKind?" Value="HotstringKind.Text">Text</MudSelectItem>
                 <MudSelectItem T="HotstringKind?" Value="HotstringKind.DateTime">Date &amp; time</MudSelectItem>
                 <MudSelectItem T="HotstringKind?" Value="HotstringKind.Macro">Macro</MudSelectItem>
-                <MudSelectItem T="HotstringKind?" Value="HotstringKind.Script">Script</MudSelectItem>
+                <MudSelectItem T="HotstringKind?" Value="HotstringKind.Raw">Raw</MudSelectItem>
             </MudSelect>
             <MudTextField T="string" @bind-Value="_search" @bind-Value:after="OnSearchChangedAsync"
                           DebounceInterval="300"
@@ -113,9 +113,9 @@
                             {
                                 <span style="white-space: pre-wrap"><MacroReplacementDisplay Replacement="@context.Item.Replacement" /></span>
                             }
-                            else if (context.Item.Kind == HotstringKind.Script)
+                            else if (context.Item.Kind == HotstringKind.Raw)
                             {
-                                <span class="script-summary">@context.Item.ScriptSummary</span>
+                                <span class="script-summary">@context.Item.RawSummary</span>
                             }
                             else
                             {
@@ -153,8 +153,8 @@
                         <CellTemplate>
                             <MudTooltip Text="@OptionsTooltip(context.Item)">
                                 <span class="type-badge">
-                                    <MudChip T="string" Size="Size.Small" Color="@(context.Item.Kind == HotstringKind.Script ? Color.Warning : Color.Default)"
-                                             Icon="@(context.Item.Kind == HotstringKind.Script ? Icons.Material.Filled.Warning : null)"
+                                    <MudChip T="string" Size="Size.Small" Color="@(context.Item.Kind == HotstringKind.Raw ? Color.Warning : Color.Default)"
+                                             Icon="@(context.Item.Kind == HotstringKind.Raw ? Icons.Material.Filled.Warning : null)"
                                              UserAttributes="@KindChipAttributes(context.Item.Kind)">@KindLabel(context.Item.Kind)</MudChip>
                                     <span class="option-glyphs">@OptionGlyphs(context.Item)</span>
                                     @if (context.Item.ContextMatchType is not null)
@@ -212,7 +212,7 @@
                 <MudSelectItem T="HotstringKind?" Value="HotstringKind.Text">Text</MudSelectItem>
                 <MudSelectItem T="HotstringKind?" Value="HotstringKind.DateTime">Date &amp; time</MudSelectItem>
                 <MudSelectItem T="HotstringKind?" Value="HotstringKind.Macro">Macro</MudSelectItem>
-                <MudSelectItem T="HotstringKind?" Value="HotstringKind.Script">Script</MudSelectItem>
+                <MudSelectItem T="HotstringKind?" Value="HotstringKind.Raw">Raw</MudSelectItem>
             </MudSelect>
 
             @if (_categories.Count > 0)
@@ -850,7 +850,7 @@
         HotstringKind.Text => "Text",
         HotstringKind.DateTime => "Date & time",
         HotstringKind.Macro => "Macro",
-        HotstringKind.Script => "Script",
+        HotstringKind.Raw => "Raw",
         _ => kind.ToString(),
     };
 
@@ -866,12 +866,12 @@
 
     // Warning conveyed to assistive tech and sighted users alike — the chip's warning color and
     // icon alone are not exposed to screen readers.
-    private const string ScriptWarningText = "Runs arbitrary AutoHotkey code — review before running.";
+    private const string ScriptWarningText = "Verbatim AutoHotkey definition — review before running.";
 
     private static string OptionsTooltip(HotstringEditModel item)
     {
         List<string> parts = [KindLabel(item.Kind)];
-        if (item.Kind == HotstringKind.Script) parts.Add(ScriptWarningText);
+        if (item.Kind == HotstringKind.Raw) parts.Add(ScriptWarningText);
         if (!item.IsEndingCharacterRequired) parts.Add("Expands immediately (no ending character)");
         if (item.IsTriggerInsideWord) parts.Add("Triggers inside words");
         if (item.IsCaseSensitive) parts.Add("Case sensitive");
@@ -881,7 +881,7 @@
     }
 
     private static Dictionary<string, object?> KindChipAttributes(HotstringKind kind) =>
-        kind == HotstringKind.Script
+        kind == HotstringKind.Raw
             ? new Dictionary<string, object?> { ["aria-label"] = $"{KindLabel(kind)}. {ScriptWarningText}" }
             : [];
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -920,6 +920,10 @@
 
     private static string OptionGlyphs(HotstringEditModel item)
     {
+        // Raw carries its options inside the verbatim definition; the structured flags are left at
+        // defaults (e.g. CLI-created rows default IsTriggerInsideWord=true) and are meaningless here.
+        if (item.Kind == HotstringKind.Raw) return "";
+
         string glyphs = "";
         if (!item.IsEndingCharacterRequired) glyphs += "*";
         if (item.IsTriggerInsideWord) glyphs += "?";
@@ -935,11 +939,18 @@
     private static string OptionsTooltip(HotstringEditModel item)
     {
         List<string> parts = [KindLabel(item.Kind)];
-        if (item.Kind == HotstringKind.Raw) parts.Add(ScriptWarningText);
-        if (!item.IsEndingCharacterRequired) parts.Add("Expands immediately (no ending character)");
-        if (item.IsTriggerInsideWord) parts.Add("Triggers inside words");
-        if (item.IsCaseSensitive) parts.Add("Case sensitive");
-        if (item.OmitEndingCharacter && item.IsEndingCharacterRequired) parts.Add("Omits ending character");
+        if (item.Kind == HotstringKind.Raw)
+        {
+            // Raw's structured flags are meaningless (options live in the verbatim text) — skip them.
+            parts.Add(ScriptWarningText);
+        }
+        else
+        {
+            if (!item.IsEndingCharacterRequired) parts.Add("Expands immediately (no ending character)");
+            if (item.IsTriggerInsideWord) parts.Add("Triggers inside words");
+            if (item.IsCaseSensitive) parts.Add("Case sensitive");
+            if (item.OmitEndingCharacter && item.IsEndingCharacterRequired) parts.Add("Omits ending character");
+        }
         if (item.ContextMatchType is not null) parts.Add($"Only in {item.ContextSummary}");
         return string.Join(" · ", parts);
     }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Validation/HotstringEditModel.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Validation/HotstringEditModel.cs
@@ -7,7 +7,9 @@ public sealed class HotstringEditModel
 {
     public Guid? Id { get; set; }
 
-    [Required(ErrorMessage = "Trigger is required.")]
+    // Trigger requiredness is conditional on Kind: Raw derives the trigger server-side from the
+    // definition, so the field is hidden and left empty. Enforced by the dialog's field-level
+    // Required param (gated off for Raw) and by server-side validation, not a DataAnnotation here.
     [MaxLength(50, ErrorMessage = "Trigger must be 50 characters or fewer.")]
     public string Trigger { get; set; } = "";
 
@@ -82,16 +84,16 @@ public sealed class HotstringEditModel
     }
 
     /// <summary>
-    /// First line of <see cref="Replacement"/>, trimmed, for grid/mobile display of Script-kind
-    /// rows. Null unless <see cref="Kind"/> is <see cref="HotstringKind.Script"/> — callers fall
-    /// back to plain Replacement text otherwise. Mirrors
-    /// AHKFlowApp.CLI.Output.HotstringTableFormatter's FormatReplacementColumn logic.
+    /// First line of <see cref="Replacement"/> (the <c>:options:trigger::</c> line), trimmed, for
+    /// grid/mobile display of Raw-kind rows. Null unless <see cref="Kind"/> is
+    /// <see cref="HotstringKind.Raw"/> — callers fall back to plain Replacement text otherwise.
+    /// Mirrors AHKFlowApp.CLI.Output.HotstringTableFormatter's FormatReplacementColumn logic.
     /// </summary>
-    public string? ScriptSummary
+    public string? RawSummary
     {
         get
         {
-            if (Kind != HotstringKind.Script) return null;
+            if (Kind != HotstringKind.Raw) return null;
             int newlineIndex = Replacement.IndexOf('\n');
             string firstLine = newlineIndex < 0 ? Replacement : Replacement[..newlineIndex];
             return firstLine.Trim();

--- a/src/Tools/AHKFlowApp.CLI/Commands/Hotstrings/NewHotstringCommand.cs
+++ b/src/Tools/AHKFlowApp.CLI/Commands/Hotstrings/NewHotstringCommand.cs
@@ -11,8 +11,12 @@ public static class NewHotstringCommand
 {
     public static Command Build(IServiceProvider services)
     {
-        Option<string> trigger = new("--trigger", "-t") { Description = "Abbreviation to expand.", Required = true };
-        Option<string> replacement = new("--replacement", "-r") { Description = "Replacement text.", Required = true };
+        Option<string> trigger = new("--trigger", "-t") { Description = "Abbreviation to expand." };
+        Option<string> replacement = new("--replacement", "-r") { Description = "Replacement text." };
+        Option<string> raw = new("--raw")
+        {
+            Description = "Create a Raw hotstring from a full AHK v2 definition, e.g. \":K1000 SE*:ftw::for the win\" (mutually exclusive with --trigger/--replacement).",
+        };
         Option<string[]> profile = new("--profile", "-p") { Description = "Profile name (repeatable)." };
         Option<bool> noEndingChar = new("--no-ending-char") { Description = "Don't require an ending character (default: required)." };
         Option<bool> noInsideWord = new("--no-inside-word") { Description = "Don't trigger inside words (default: triggers inside words)." };
@@ -20,7 +24,7 @@ public static class NewHotstringCommand
 
         Command cmd = new("new", "Create a new hotstring.")
         {
-            trigger, replacement, profile, noEndingChar, noInsideWord, json,
+            trigger, replacement, raw, profile, noEndingChar, noInsideWord, json,
         };
 
         cmd.SetAction(async (ParseResult parse, CancellationToken ct) =>
@@ -32,6 +36,26 @@ public static class NewHotstringCommand
 
             try
             {
+                string? rawDefinition = parse.GetValue(raw);
+                string? triggerValue = parse.GetValue(trigger);
+                string? replacementValue = parse.GetValue(replacement);
+
+                // Validate the two mutually-exclusive input modes up front. The server does all
+                // Raw parsing/validation; the CLI only relays the definition and ProblemDetails.
+                if (rawDefinition is not null)
+                {
+                    if (triggerValue is not null || replacementValue is not null)
+                    {
+                        await stderr.WriteLineAsync("--raw cannot be combined with --trigger or --replacement.");
+                        return 2;
+                    }
+                }
+                else if (triggerValue is null || replacementValue is null)
+                {
+                    await stderr.WriteLineAsync("Specify either --raw, or both --trigger and --replacement.");
+                    return 2;
+                }
+
                 Guid[]? resolvedIds = null;
                 bool appliesToAll = true;
                 string[]? names = parse.GetValue(profile);
@@ -55,13 +79,20 @@ public static class NewHotstringCommand
                     appliesToAll = false;
                 }
 
-                CreateHotstringDto input = new(
-                    Trigger: parse.GetValue(trigger)!,
-                    Replacement: parse.GetValue(replacement)!,
-                    ProfileIds: resolvedIds,
-                    AppliesToAllProfiles: appliesToAll,
-                    IsEndingCharacterRequired: !parse.GetValue(noEndingChar),
-                    IsTriggerInsideWord: !parse.GetValue(noInsideWord));
+                CreateHotstringDto input = rawDefinition is not null
+                    ? new CreateHotstringDto(
+                        Trigger: string.Empty,
+                        Replacement: rawDefinition,
+                        ProfileIds: resolvedIds,
+                        AppliesToAllProfiles: appliesToAll,
+                        Kind: HotstringKind.Raw)
+                    : new CreateHotstringDto(
+                        Trigger: triggerValue!,
+                        Replacement: replacementValue!,
+                        ProfileIds: resolvedIds,
+                        AppliesToAllProfiles: appliesToAll,
+                        IsEndingCharacterRequired: !parse.GetValue(noEndingChar),
+                        IsTriggerInsideWord: !parse.GetValue(noInsideWord));
 
                 HotstringDto created = await hotstrings.CreateAsync(input, ct);
 

--- a/src/Tools/AHKFlowApp.CLI/Output/HotstringTableFormatter.cs
+++ b/src/Tools/AHKFlowApp.CLI/Output/HotstringTableFormatter.cs
@@ -87,10 +87,10 @@ public static class HotstringTableFormatter
 
     private static string FormatReplacementColumn(HotstringDto dto)
     {
-        // Script rows show only the first line (D13) — Macro rows fall through to the
-        // raw-replacement branch below unchanged, per the Phase 3 decision to keep Macro
+        // Raw rows show only the first line of the verbatim definition — Macro rows fall through
+        // to the raw-replacement branch below unchanged, per the Phase 3 decision to keep Macro
         // display raw rather than adding a CLI-side token summary.
-        if (dto.Kind == HotstringKind.Script)
+        if (dto.Kind == HotstringKind.Raw)
             return Truncate(FirstLine(dto.Replacement), ReplacementWidth);
 
         if (dto.Kind != HotstringKind.DateTime)
@@ -120,7 +120,7 @@ public static class HotstringTableFormatter
         HotstringKind.Text => "Text",
         HotstringKind.DateTime => "DateTime",
         HotstringKind.Macro => "Macro",
-        HotstringKind.Script => "Script",
+        HotstringKind.Raw => "Raw",
         _ => kind.ToString(),
     };
 

--- a/src/Tools/AHKFlowApp.CLI/Services/IHotstringsApiClient.cs
+++ b/src/Tools/AHKFlowApp.CLI/Services/IHotstringsApiClient.cs
@@ -17,7 +17,7 @@ public enum HotstringKind
     Text = 0,
     DateTime = 1,
     Macro = 2,
-    Script = 3,
+    Raw = 4,
 }
 
 public enum DateOffsetUnit
@@ -60,7 +60,8 @@ public sealed record CreateHotstringDto(
     Guid[]? ProfileIds = null,
     bool AppliesToAllProfiles = true,
     bool IsEndingCharacterRequired = true,
-    bool IsTriggerInsideWord = true);
+    bool IsTriggerInsideWord = true,
+    HotstringKind Kind = HotstringKind.Text);
 
 public sealed record PagedList<T>(
     IReadOnlyList<T> Items,

--- a/tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs
@@ -381,18 +381,20 @@ public sealed class HotstringsEndpointsTests(ApiTestFixture fixture)
     }
 
     [Fact]
-    public async Task Post_ScriptKind_ReturnsCreatedWithReplacement()
+    public async Task Post_RawKind_ReturnsCreatedWithVerbatimReplacement_AndServerDerivedTrigger()
     {
         using HttpClient client = CreateAuthed();
-        CreateHotstringDto dto = new("~ver", "MsgBox A_AhkVersion", Kind: HotstringKind.Script);
+        // Empty client trigger — the server derives it from the raw definition's first line.
+        CreateHotstringDto dto = new("", ":K1000 SE*:ftw::for the win", Kind: HotstringKind.Raw);
 
         HttpResponseMessage response = await client.PostAsJsonAsync("/api/v1/hotstrings", dto);
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         HotstringDto? body = await response.Content.ReadFromJsonAsync<HotstringDto>();
         body.Should().NotBeNull();
-        body!.Kind.Should().Be(HotstringKind.Script);
-        body.Replacement.Should().Be("MsgBox A_AhkVersion");
+        body!.Kind.Should().Be(HotstringKind.Raw);
+        body.Trigger.Should().Be("ftw");
+        body.Replacement.Should().Be(":K1000 SE*:ftw::for the win");
     }
 
     [Fact]

--- a/tests/AHKFlowApp.API.Tests/OpenApi/SwaggerDocTests.cs
+++ b/tests/AHKFlowApp.API.Tests/OpenApi/SwaggerDocTests.cs
@@ -39,12 +39,12 @@ public sealed class SwaggerDocTests(ApiTestFixture fixture)
     }
 
     [Fact]
-    public async Task SwaggerJson_HotstringExamples_SurfacesBothBtwAndScriptExamples()
+    public async Task SwaggerJson_HotstringExamples_SurfacesBothBtwAndRawExamples()
     {
         // Swashbuckle.AspNetCore.Filters resolves one IExamplesProvider<T> per T — a second
         // provider targeting an already-covered type (HotstringDto/CreateHotstringDto/
         // UpdateHotstringDto/HotstringPreviewRequestDto/HotstringPreviewDto) would silently
-        // replace its example everywhere. This guards against that: the Script example
+        // replace its example everywhere. This guards against that: the Raw example
         // (targeting HotstringHistoryVersionDto, previously uncovered) must not have knocked out
         // the pre-existing "btw" example.
 
@@ -56,6 +56,6 @@ public sealed class SwaggerDocTests(ApiTestFixture fixture)
 
         // Assert
         json.Should().Contain("by the way", "the original 'btw' example must still be present");
-        json.Should().Contain("MsgBox A_AhkVersion", "the new Script example must be present");
+        json.Should().Contain("MsgBox A_AhkVersion", "the new Raw example must be present");
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/History/RestoreCommandTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/History/RestoreCommandTests.cs
@@ -79,6 +79,42 @@ public sealed class RestoreCommandTests(HistoryDbFixture fx)
     }
 
     [Fact]
+    public async Task RestoreHotstring_LegacyScriptSnapshot_ConvertsToRaw()
+    {
+        var owner = Guid.NewGuid();
+        var id = Guid.NewGuid();
+
+        // Hand-craft a pre-Raw Delete tombstone carrying a legacy Kind=Script snapshot.
+#pragma warning disable CS0618 // Simulating a stored legacy snapshot.
+        HotstringSnapshot legacy = new(
+            Trigger: "~ver", Replacement: "MsgBox A_AhkVersion", Description: null,
+            AppliesToAllProfiles: true, IsEndingCharacterRequired: false, IsTriggerInsideWord: false,
+            ProfileIds: [], CategoryIds: [],
+            CreatedAt: DateTimeOffset.UnixEpoch, UpdatedAt: DateTimeOffset.UnixEpoch,
+            Kind: HotstringKind.Script);
+#pragma warning restore CS0618
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.EntityHistories.Add(EntityHistory.Create(
+                owner, TrackedEntityType.Hotstring, id, version: 1, HistoryChangeType.Delete,
+                schemaVersion: 1, System.Text.Json.JsonSerializer.Serialize(legacy), TimeProvider.System));
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        RestoreHotstringCommandHandler handler = new(
+            db, CurrentUserHelper.For(owner), TimeProvider.System, new EntityHistoryRecorder(db, TimeProvider.System));
+
+        Result<HotstringDto> result = await handler.ExecuteAsync(new RestoreHotstringCommand(id), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Kind.Should().Be(HotstringKind.Raw);
+        result.Value.Trigger.Should().Be("~ver");
+        result.Value.Replacement.Should().Be(":*:~ver::\n{\nMsgBox A_AhkVersion\n}");
+    }
+
+    [Fact]
     public async Task RestoreHotstring_TriggerNowTaken_ReturnsConflict()
     {
         var owner = Guid.NewGuid();

--- a/tests/AHKFlowApp.Application.Tests/History/RevertCommandTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/History/RevertCommandTests.cs
@@ -77,6 +77,43 @@ public sealed class RevertCommandTests(HistoryDbFixture fx)
     }
 
     [Fact]
+    public async Task RevertHotstring_LegacyScriptSnapshot_ConvertsToRaw()
+    {
+        var owner = Guid.NewGuid();
+        Hotstring entity = new HotstringBuilder()
+            .WithOwner(owner).WithTrigger("~ver").WithReplacement("current").Build();
+
+        // A version-1 history row carrying a legacy Kind=Script snapshot to revert back to.
+#pragma warning disable CS0618 // Simulating a stored legacy snapshot.
+        HotstringSnapshot legacy = new(
+            Trigger: "~ver", Replacement: "MsgBox A_AhkVersion", Description: null,
+            AppliesToAllProfiles: true, IsEndingCharacterRequired: false, IsTriggerInsideWord: false,
+            ProfileIds: [], CategoryIds: [],
+            CreatedAt: DateTimeOffset.UnixEpoch, UpdatedAt: DateTimeOffset.UnixEpoch,
+            Kind: HotstringKind.Script);
+#pragma warning restore CS0618
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotstrings.Add(entity);
+            seed.EntityHistories.Add(EntityHistory.Create(
+                owner, TrackedEntityType.Hotstring, entity.Id, version: 1, HistoryChangeType.Edit,
+                schemaVersion: 1, System.Text.Json.JsonSerializer.Serialize(legacy), TimeProvider.System));
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        RevertHotstringCommandHandler handler = new(
+            db, CurrentUserHelper.For(owner), TimeProvider.System, new EntityHistoryRecorder(db, TimeProvider.System));
+
+        Result<HotstringDto> result = await handler.ExecuteAsync(new RevertHotstringCommand(entity.Id, 1), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Kind.Should().Be(HotstringKind.Raw);
+        result.Value.Replacement.Should().Be(":*:~ver::\n{\nMsgBox A_AhkVersion\n}");
+    }
+
+    [Fact]
     public async Task RevertHotstring_SnapshotProfileDeleted_DropsMissingLinkSilently()
     {
         var owner = Guid.NewGuid();

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
@@ -262,76 +262,129 @@ public sealed class CreateHotstringCommandValidatorTests
     }
 
     [Fact]
-    public void CreateHotstringCommandValidator_ScriptKind_Accepted()
+    public void RawKind_InlineDefinition_Accepted()
     {
         ValidationResult result = _sut.Validate(Cmd(
-            kind: HotstringKind.Script,
-            replacement: "MsgBox A_AhkVersion"));
+            trigger: "",
+            kind: HotstringKind.Raw,
+            replacement: ":K1000 SE*:ftw::for the win"));
 
-        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Kind");
-        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
+        result.IsValid.Should().BeTrue();
     }
 
     [Fact]
-    public void Validate_ScriptWithUnbalancedBraces_Fails()
+    public void RawKind_BraceBodyDefinition_Accepted()
     {
         ValidationResult result = _sut.Validate(Cmd(
-            kind: HotstringKind.Script,
-            replacement: "if (true) {\nMsgBox \"hi\""));
+            trigger: "",
+            kind: HotstringKind.Raw,
+            replacement: ":*:rng::\n{\nSend String(Random(1, 100))\n}"));
 
-        result.IsValid.Should().BeFalse();
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RawKind_Rule1_NotAHotstring_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Raw, replacement: "just some text"));
+
         result.Errors.Should().Contain(e =>
-            e.PropertyName == "Input.Replacement" &&
-            e.ErrorMessage == "Script replacement must have balanced braces.");
+            e.ErrorMessage == "Not a valid hotstring definition — expected `:options:trigger::replacement`.");
     }
 
     [Fact]
-    public void Validate_ScriptWithDirectiveLine_Fails()
+    public void RawKind_Rule2_MultipleDefinitions_Fails()
     {
         ValidationResult result = _sut.Validate(Cmd(
-            kind: HotstringKind.Script,
-            replacement: "#Requires AutoHotkey v2.0\nMsgBox A_AhkVersion"));
+            kind: HotstringKind.Raw, replacement: "::a::1\n::b::2"));
 
-        result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e =>
-            e.PropertyName == "Input.Replacement" &&
-            e.ErrorMessage == "Script replacement must not contain directive lines starting with '#'.");
+            e.ErrorMessage == "Multiple hotstrings detected — paste one definition at a time.");
     }
 
     [Fact]
-    public void Validate_ScriptWellFormedMultiline_Passes()
+    public void RawKind_Rule3_TriggerOver40Chars_Fails()
     {
         ValidationResult result = _sut.Validate(Cmd(
-            kind: HotstringKind.Script,
-            replacement: "if (WinActive(\"ahk_exe notepad.exe\")) {\n    MsgBox \"hi\"\n}"));
+            kind: HotstringKind.Raw, replacement: $"::{new string('a', 41)}::x"));
 
-        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Trigger must be 40 characters or fewer.");
     }
 
     [Fact]
-    public void Validate_ScriptOver4000Chars_Fails()
+    public void RawKind_Rule3_EscapedNewlineTrigger_Fails()
     {
         ValidationResult result = _sut.Validate(Cmd(
-            kind: HotstringKind.Script,
-            replacement: new string('x', 4001)));
+            kind: HotstringKind.Raw, replacement: "::a`nb::x"));
 
-        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Trigger must not contain line breaks or tabs.");
+    }
+
+    [Fact]
+    public void RawKind_Rule4_UnknownOption_X0_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Raw, replacement: ":X0:t::x"));
+
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Unknown hotstring option 'X0'.");
+    }
+
+    [Fact]
+    public void RawKind_Rule5_DirectiveLine_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Raw, replacement: ":*:t::\n{\n#Requires AutoHotkey v2.0\n}"));
+
         result.Errors.Should().Contain(e =>
-            e.PropertyName == "Input.Replacement" &&
-            e.ErrorMessage == "Replacement must be 4000 characters or fewer.");
+            e.ErrorMessage == "Raw definition must not contain directive lines starting with '#'.");
     }
 
     [Fact]
-    public void Validate_ScriptEmptyReplacement_Fails()
+    public void RawKind_Rule6_UnbalancedBraces_Fails()
     {
         ValidationResult result = _sut.Validate(Cmd(
-            kind: HotstringKind.Script,
-            replacement: ""));
+            kind: HotstringKind.Raw, replacement: ":*:t::\n{\nSend foo\n"));
 
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e =>
-            e.PropertyName == "Input.Replacement" &&
-            e.ErrorMessage == "Replacement is required.");
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Raw definition must have balanced braces.");
+    }
+
+    [Fact]
+    public void RawKind_Rule7_OtbBrace_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Raw, replacement: "::btw:: {\nSend foo\n}"));
+
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Put `{` on its own line below the trigger.");
+    }
+
+    [Fact]
+    public void RawKind_Rule7_ContinuationSection_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Raw, replacement: ":*:long::\n(\nline1\n)"));
+
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Put `{` on its own line below the trigger.");
+    }
+
+    [Fact]
+    public void RawKind_Rule8_OverMaxLength_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Raw, replacement: ":*:t::" + new string('x', 4201)));
+
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Raw definition must be 4200 characters or fewer.");
+    }
+
+    [Fact]
+    public void RawKind_EmptyClientTrigger_PassesTriggerGate()
+    {
+        // The client-sent Trigger is ignored for Raw; an empty one must not raise "Trigger is required."
+        ValidationResult result = _sut.Validate(Cmd(
+            trigger: "", kind: HotstringKind.Raw, replacement: "::btw::by the way"));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Trigger");
+        result.IsValid.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
@@ -377,6 +377,52 @@ public sealed class CreateHotstringCommandValidatorTests
     }
 
     [Fact]
+    public void RawKind_ExactlyMaxLength_Passes()
+    {
+        // 6-char prefix + 4194 = 4200 total. The generic 4000 replacement cap must not shadow this.
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Raw, replacement: ":*:t::" + new string('x', 4194)));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RawKind_BetweenOldAndNewLimit_Passes()
+    {
+        // 4100 chars: over the old 4000 replacement cap, under Raw's 4200 limit. Regression guard for
+        // ValidReplacement shadowing the Raw-specific limit.
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Raw, replacement: ":*:t::" + new string('x', 4094)));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RawKind_WhitespaceOnlyInlineReplacement_NormalizesToBareTrigger_Fails()
+    {
+        // "::t::    " validates as a non-empty inline replacement pre-normalization, but the handler
+        // persists the normalized "::t::" (trailing spaces stripped). Validation must judge the
+        // normalized form so it can't accept what save then persists as an invalid bare trigger.
+        ValidationResult result = _sut.Validate(Cmd(
+            trigger: "", kind: HotstringKind.Raw, replacement: "::t::    "));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Put `{` on its own line below the trigger.");
+    }
+
+    [Fact]
+    public void RawKind_LoneCrDirectiveLine_Fails()
+    {
+        // Directive line separated by lone CRs — undetected when the rule split on '\n' only.
+        ValidationResult result = _sut.Validate(Cmd(
+            trigger: "", kind: HotstringKind.Raw, replacement: ":*:t::\r{\r#foo\r}"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.ErrorMessage == "Raw definition must not contain directive lines starting with '#'.");
+    }
+
+    [Fact]
     public void RawKind_EmptyClientTrigger_PassesTriggerGate()
     {
         // The client-sent Trigger is ignored for Raw; an empty one must not raise "Trigger is required."

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/GetHotstringPreviewQueryValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/GetHotstringPreviewQueryValidatorTests.cs
@@ -81,13 +81,24 @@ public sealed class GetHotstringPreviewQueryValidatorTests
     }
 
     [Fact]
-    public void GetHotstringPreviewQueryValidator_ScriptKind_Accepted()
+    public void GetHotstringPreviewQueryValidator_RawKind_Accepted()
     {
         ValidationResult result = _sut.Validate(Query(
-            kind: HotstringKind.Script,
-            replacement: "MsgBox A_AhkVersion"));
+            kind: HotstringKind.Raw,
+            replacement: ":K1000 SE*:ftw::for the win"));
 
         result.Errors.Should().NotContain(e => e.PropertyName == "Input.Kind");
         result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
+    }
+
+    [Fact]
+    public void GetHotstringPreviewQueryValidator_RawKind_EmptyClientTrigger_PassesTriggerGate()
+    {
+        ValidationResult result = _sut.Validate(Query(
+            trigger: "",
+            kind: HotstringKind.Raw,
+            replacement: "::btw::by the way"));
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Input.Trigger");
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/UpdateHotstringCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/UpdateHotstringCommandValidatorTests.cs
@@ -250,14 +250,24 @@ public sealed class UpdateHotstringCommandValidatorTests
     }
 
     [Fact]
-    public void UpdateHotstringCommandValidator_ScriptKind_Accepted()
+    public void UpdateHotstringCommandValidator_RawKind_Accepted()
     {
         ValidationResult result = _sut.Validate(Cmd(
-            kind: HotstringKind.Script,
-            replacement: "MsgBox A_AhkVersion"));
+            kind: HotstringKind.Raw,
+            replacement: ":K1000 SE*:ftw::for the win"));
 
         result.Errors.Should().NotContain(e => e.PropertyName == "Input.Kind");
         result.Errors.Should().NotContain(e => e.PropertyName == "Input.Replacement");
+    }
+
+    [Fact]
+    public void UpdateHotstringCommandValidator_RawKind_UnknownOption_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Raw,
+            replacement: ":X0:t::x"));
+
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Unknown hotstring option 'X0'.");
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs
@@ -663,16 +663,15 @@ public sealed class AhkScriptGeneratorTests
     }
 
     [Fact]
-    public void Emit_ScriptKind_WrapsBodyVerbatimInBraces()
+    public void Emit_RawKind_EmitsDefinitionVerbatim()
     {
-        // Spec §7 ex. 7: Kind=Script, trigger `~ver`, body `MsgBox A_AhkVersion`.
+        // Raw's Replacement holds the entire ":opts:trigger::" definition; the emitter returns it
+        // verbatim with no option building, escaping, or wrapping.
         Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
         Hotstring hs = new HotstringBuilder()
             .WithTrigger("~ver")
-            .WithKind(HotstringKind.Script)
-            .WithReplacement("MsgBox A_AhkVersion")
-            .WithEndingCharacterRequired(false)
-            .WithTriggerInsideWord(false)
+            .WithKind(HotstringKind.Raw)
+            .WithReplacement(":*:~ver::\n{\nMsgBox A_AhkVersion\n}")
             .Build();
 
         string output = DefaultSut().Generate(profile, [hs], []);
@@ -685,15 +684,13 @@ public sealed class AhkScriptGeneratorTests
     }
 
     [Fact]
-    public void Emit_ScriptKindMultilineBody_PreservesLinesVerbatim()
+    public void Emit_RawKindMultilineBody_PreservesLinesVerbatim()
     {
         Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
         Hotstring hs = new HotstringBuilder()
             .WithTrigger("m")
-            .WithKind(HotstringKind.Script)
-            .WithReplacement("line1\nline2\nline3")
-            .WithEndingCharacterRequired(false)
-            .WithTriggerInsideWord(false)
+            .WithKind(HotstringKind.Raw)
+            .WithReplacement(":*:m::\n{\nline1\nline2\nline3\n}")
             .Build();
 
         string output = DefaultSut().Generate(profile, [hs], []);
@@ -708,15 +705,13 @@ public sealed class AhkScriptGeneratorTests
     }
 
     [Fact]
-    public void Emit_ScriptKindBody_PreservesLeadingIndentation()
+    public void Emit_RawKindBody_PreservesInteriorIndentation()
     {
         Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
         Hotstring hs = new HotstringBuilder()
             .WithTrigger("m")
-            .WithKind(HotstringKind.Script)
-            .WithReplacement("if (true) {\n    MsgBox \"hi\"\n}")
-            .WithEndingCharacterRequired(false)
-            .WithTriggerInsideWord(false)
+            .WithKind(HotstringKind.Raw)
+            .WithReplacement(":*:m::\n{\nif (true) {\n    MsgBox \"hi\"\n}\n}")
             .Build();
 
         string output = DefaultSut().Generate(profile, [hs], []);
@@ -731,38 +726,29 @@ public sealed class AhkScriptGeneratorTests
     }
 
     [Fact]
-    public void Emit_ScriptKindBody_PreservesLeadingAndTrailingBlankLines()
+    public void Emit_RawKindInlineReplacement_EmittedVerbatim()
     {
         Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
         Hotstring hs = new HotstringBuilder()
-            .WithTrigger("m")
-            .WithKind(HotstringKind.Script)
-            .WithReplacement("\n\nMsgBox 1\n\n")
-            .WithEndingCharacterRequired(false)
-            .WithTriggerInsideWord(false)
+            .WithTrigger("ftw")
+            .WithKind(HotstringKind.Raw)
+            .WithReplacement(":K1000 SE*:ftw::for the win")
             .Build();
 
         string output = DefaultSut().Generate(profile, [hs], []);
 
-        output.Should().Contain(
-            ":*:m::\n" +
-            "{\n" +
-            "\n" +
-            "\n" +
-            "MsgBox 1\n" +
-            "\n" +
-            "\n" +
-            "}");
+        output.Should().Contain(":K1000 SE*:ftw::for the win");
     }
 
     [Fact]
-    public void Emit_ScriptKind_NeverEmitsTOption()
+    public void Emit_RawKind_AddsNoSynthesizedOptions()
     {
+        // The emitter never rebuilds an options block for Raw — no T (or any flag) is injected.
         Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
         Hotstring hs = new HotstringBuilder()
             .WithTrigger("m")
-            .WithKind(HotstringKind.Script)
-            .WithReplacement("MsgBox 1")
+            .WithKind(HotstringKind.Raw)
+            .WithReplacement("::m::\n{\nMsgBox 1\n}")
             .Build();
 
         string output = DefaultSut().Generate(profile, [hs], []);
@@ -773,15 +759,13 @@ public sealed class AhkScriptGeneratorTests
     }
 
     [Fact]
-    public void Emit_ScriptKindWithContext_WrapsInHotIfAroundBraceBody()
+    public void Emit_RawKindWithContext_WrapsInHotIfAroundDefinition()
     {
         Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
         Hotstring hs = new HotstringBuilder()
             .WithTrigger("~ver")
-            .WithKind(HotstringKind.Script)
-            .WithReplacement("MsgBox A_AhkVersion")
-            .WithEndingCharacterRequired(false)
-            .WithTriggerInsideWord(false)
+            .WithKind(HotstringKind.Raw)
+            .WithReplacement(":*:~ver::\n{\nMsgBox A_AhkVersion\n}")
             .WithContext(WindowMatchType.Executable, "notepad.exe")
             .Build();
 

--- a/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
@@ -1,0 +1,220 @@
+using AHKFlowApp.Application.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Services;
+
+public sealed class RawHotstringDefinitionParserTests
+{
+    // --- Structure: first-line split -----------------------------------------------------
+
+    [Fact]
+    public void InlineDefinition_SplitsOptionsTriggerBody()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":K1000 SE*:ftw::for the win");
+
+        r.FirstLineValid.Should().BeTrue();
+        r.IsValid.Should().BeTrue();
+        r.Trigger.Should().Be("ftw");
+        r.OptionTokens.Should().Equal("K1000", "SE", "*");
+        r.UnknownOptionTokens.Should().BeEmpty();
+        r.DefinitionCount.Should().Be(1);
+        r.Error.Should().BeNull();
+    }
+
+    [Fact]
+    public void NoOptions_InlineDefinition_IsValid()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse("::btw::by the way");
+
+        r.IsValid.Should().BeTrue();
+        r.Trigger.Should().Be("btw");
+        r.OptionTokens.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void NotAHotstring_FirstLineInvalid()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse("just some text");
+
+        r.FirstLineValid.Should().BeFalse();
+        r.IsValid.Should().BeFalse();
+        r.Error.Should().Be("Not a valid hotstring definition — expected `:options:trigger::replacement`.");
+    }
+
+    [Fact]
+    public void LeadingBlankLines_Tolerated()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse("\n\n::btw::by the way");
+
+        r.IsValid.Should().BeTrue();
+        r.Trigger.Should().Be("btw");
+    }
+
+    // --- Brace body ----------------------------------------------------------------------
+
+    [Fact]
+    public void BraceBody_BalancedIsValid()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:rng::\n{\nSend String(Random(1, 100))\n}");
+
+        r.IsValid.Should().BeTrue();
+        r.Trigger.Should().Be("rng");
+        r.Error.Should().BeNull();
+    }
+
+    [Fact]
+    public void BraceBody_Unbalanced_ReportsBraceError()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:rng::\n{\nSend foo\n");
+
+        r.IsValid.Should().BeFalse();
+        r.Error.Should().Be("Raw definition must have balanced braces.");
+    }
+
+    [Fact]
+    public void BraceBody_ContentAfterClose_ReportsError()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:rng::\n{\nSend foo\n}\ntrailing");
+
+        r.IsValid.Should().BeFalse();
+        r.Error.Should().Be("Raw definition has content after the closing brace.");
+    }
+
+    [Fact]
+    public void BareTrigger_NoBody_RequiresBrace()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:rng::");
+
+        r.IsValid.Should().BeFalse();
+        r.Error.Should().Be("Put `{` on its own line below the trigger.");
+    }
+
+    [Fact]
+    public void NestedBraces_Balanced_IsValid()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:x::\n{\nif (a) {\nb()\n}\n}");
+
+        r.IsValid.Should().BeTrue();
+    }
+
+    // --- Inline replacement forms --------------------------------------------------------
+
+    [Fact]
+    public void InlineWithBrace_NotBraceBalanceChecked()
+    {
+        // Rule 6 does not apply to inline replacements: ":*:brace::{{}" is accepted.
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:brace::{{}");
+
+        r.IsValid.Should().BeTrue();
+        r.Trigger.Should().Be("brace");
+    }
+
+    [Fact]
+    public void InlineReplacement_WithTrailingLines_Rejected()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse("::btw::by the way\nextra line");
+
+        r.IsValid.Should().BeFalse();
+        r.Error.Should().Be("Raw definition has content after the inline replacement.");
+    }
+
+    // --- OTB brace / continuation rejection ----------------------------------------------
+
+    [Fact]
+    public void OpeningBraceOnDefinitionLine_Rejected()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse("::btw:: {\nSend foo\n}");
+
+        r.IsValid.Should().BeFalse();
+        r.Error.Should().Be("Put `{` on its own line below the trigger.");
+    }
+
+    [Fact]
+    public void ContinuationSection_Rejected()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:long::\n(\nline1\nline2\n)");
+
+        r.IsValid.Should().BeFalse();
+        r.Error.Should().Be("Put `{` on its own line below the trigger.");
+    }
+
+    // --- Multi-definition detection ------------------------------------------------------
+
+    [Fact]
+    public void TwoInlineDefinitions_CountIsTwo()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse("::a::1\n::b::2");
+
+        r.DefinitionCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void SingleBraceBodyDefinition_CountIsOne()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:rng::\n{\nSend foo\n}");
+
+        r.DefinitionCount.Should().Be(1);
+    }
+
+    // --- Escaped-trigger decode ----------------------------------------------------------
+
+    [Fact]
+    public void EscapedSemicolonTrigger_Decoded()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse("::`;foo::bar");
+
+        r.Trigger.Should().Be(";foo");
+    }
+
+    [Fact]
+    public void EscapedNewlineTrigger_DecodesToLineBreak()
+    {
+        // Decodes to an actual newline; rule 3 (validator) rejects it, but the parser decodes faithfully.
+        RawParseResult r = RawHotstringDefinitionParser.Parse("::a`nb::x");
+
+        r.Trigger.Should().Be("a\nb");
+    }
+
+    // --- Option tokenization: longest-match & known set ----------------------------------
+
+    [Theory]
+    [InlineData(":SE*:t::x", new[] { "SE", "*" })]
+    [InlineData(":S0:t::x", new[] { "S0" })]
+    [InlineData(":SI:t::x", new[] { "SI" })]
+    [InlineData(":SP:t::x", new[] { "SP" })]
+    [InlineData(":K-1:t::x", new[] { "K-1" })]
+    [InlineData(":P9:t::x", new[] { "P9" })]
+    [InlineData(":C1 B0:t::x", new[] { "C1", "B0" })]
+    public void OptionTokenization_LongestMatch(string input, string[] expected)
+    {
+        RawHotstringDefinitionParser.Parse(input).OptionTokens.Should().Equal(expected);
+    }
+
+    [Theory]
+    [InlineData(":*:t::x")]
+    [InlineData(":?0:t::x")]
+    [InlineData(":c:t::x")]      // lowercase known flag
+    [InlineData(":se*:t::x")]    // lowercase SE
+    public void KnownOptions_ProduceNoUnknownTokens(string input)
+    {
+        RawHotstringDefinitionParser.Parse(input).UnknownOptionTokens.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void X0_IsRejectedAsUnknown()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":X0:t::x");
+
+        r.OptionTokens.Should().Equal("X0");
+        r.UnknownOptionTokens.Should().Equal("X0");
+    }
+
+    [Fact]
+    public void UnknownFlag_Captured()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":Q:t::x");
+
+        r.UnknownOptionTokens.Should().Equal("Q");
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
@@ -176,6 +176,16 @@ public sealed class RawHotstringDefinitionParserTests
         r.Trigger.Should().Be("a\nb");
     }
 
+    [Theory]
+    [InlineData(":*: foo::bar", " foo")]   // leading space
+    [InlineData(":C:bar ::x", "bar ")]     // trailing space
+    public void Trigger_PreservesLiteralWhitespace(string input, string expected)
+    {
+        // Spaces/tabs are literal within an AHK abbreviation and the raw text is emitted verbatim,
+        // so the derived trigger must not be trimmed (else dedup/DB/UI disagree with the script).
+        RawHotstringDefinitionParser.Parse(input).Trigger.Should().Be(expected);
+    }
+
     // --- Option tokenization: longest-match & known set ----------------------------------
 
     [Theory]

--- a/tests/AHKFlowApp.Application.Tests/Services/ScriptToRawComposerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/ScriptToRawComposerTests.cs
@@ -1,0 +1,67 @@
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Services;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
+using AHKFlowApp.TestUtilities.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Services;
+
+public sealed class ScriptToRawComposerTests
+{
+    public static TheoryData<string> FixtureNames()
+    {
+        TheoryData<string> data = [];
+        foreach (ScriptToRawFixture f in ScriptToRawFixtures.All)
+            data.Add(f.Name);
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(FixtureNames))]
+    public void Compose_MatchesGolden(string fixtureName)
+    {
+        ScriptToRawFixture f = ScriptToRawFixtures.All.Single(x => x.Name == fixtureName);
+
+        string composed = ScriptToRawComposer.Compose(
+            f.Trigger, f.Body,
+            f.IsEndingCharacterRequired, f.IsTriggerInsideWord,
+            f.IsCaseSensitive, f.OmitEndingCharacter);
+
+        composed.Should().Be(f.ExpectedRawDefinition);
+    }
+
+    [Fact]
+    public void ToDefinition_LegacyScriptSnapshot_ConvertsToRaw()
+    {
+#pragma warning disable CS0618 // Simulating a stored legacy snapshot.
+        HotstringSnapshot snapshot = Snapshot("rng", "Send foo", HotstringKind.Script);
+#pragma warning restore CS0618
+
+        HotstringDefinition def = ScriptToRawComposer.ToDefinition(snapshot);
+
+        def.Kind.Should().Be(HotstringKind.Raw);
+        def.Trigger.Should().Be("rng");
+        def.Replacement.Should().Be("::rng::\n{\nSend foo\n}");
+    }
+
+    [Fact]
+    public void ToDefinition_NonScriptSnapshot_PassesThroughUnchanged()
+    {
+        HotstringSnapshot snapshot = Snapshot("btw", "by the way", HotstringKind.Text);
+
+        HotstringDefinition def = ScriptToRawComposer.ToDefinition(snapshot);
+
+        def.Kind.Should().Be(HotstringKind.Text);
+        def.Trigger.Should().Be("btw");
+        def.Replacement.Should().Be("by the way");
+    }
+
+    private static HotstringSnapshot Snapshot(string trigger, string replacement, HotstringKind kind) =>
+        new(trigger, replacement, Description: null, AppliesToAllProfiles: true,
+            IsEndingCharacterRequired: true, IsTriggerInsideWord: false,
+            ProfileIds: [], CategoryIds: [],
+            CreatedAt: DateTimeOffset.UnixEpoch, UpdatedAt: DateTimeOffset.UnixEpoch,
+            Kind: kind);
+}

--- a/tests/AHKFlowApp.CLI.Tests/Commands/Hotstrings/NewHotstringCommandTests.cs
+++ b/tests/AHKFlowApp.CLI.Tests/Commands/Hotstrings/NewHotstringCommandTests.cs
@@ -43,6 +43,48 @@ public sealed class NewHotstringCommandTests
     }
 
     [Fact]
+    public async Task Raw_SendsKindRawWithDefinitionAsReplacement()
+    {
+        (IHotstringsApiClient? hs, IProfilesApiClient? profiles) = Fakes();
+
+        (int exit, string _, string _) = await Run(
+            ["hotstring", "new", "--raw", ":K1000 SE*:ftw::for the win"], hs, profiles);
+
+        exit.Should().Be(0);
+        await hs.Received(1).CreateAsync(
+            Arg.Is<CreateHotstringDto>(d =>
+                d.Kind == HotstringKind.Raw
+                && d.Replacement == ":K1000 SE*:ftw::for the win"
+                && d.Trigger == string.Empty),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Raw_WithTrigger_Exit2_MutuallyExclusive()
+    {
+        (IHotstringsApiClient? hs, IProfilesApiClient? profiles) = Fakes();
+
+        (int exit, string _, string? stderr) = await Run(
+            ["hotstring", "new", "--raw", "::a::b", "-t", "a"], hs, profiles);
+
+        exit.Should().Be(2);
+        stderr.Should().Contain("--raw cannot be combined with --trigger or --replacement.");
+        await hs.DidNotReceive().CreateAsync(Arg.Any<CreateHotstringDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task NeitherRawNorTriggerReplacement_Exit2()
+    {
+        (IHotstringsApiClient? hs, IProfilesApiClient? profiles) = Fakes();
+
+        (int exit, string _, string? stderr) = await Run(["hotstring", "new", "-t", "onlytrigger"], hs, profiles);
+
+        exit.Should().Be(2);
+        stderr.Should().Contain("Specify either --raw, or both --trigger and --replacement.");
+        await hs.DidNotReceive().CreateAsync(Arg.Any<CreateHotstringDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task NoProfile_SendsAppliesToAllTrue_NullProfileIds()
     {
         (IHotstringsApiClient? hs, IProfilesApiClient? profiles) = Fakes();

--- a/tests/AHKFlowApp.CLI.Tests/Output/HotstringTableFormatterTests.cs
+++ b/tests/AHKFlowApp.CLI.Tests/Output/HotstringTableFormatterTests.cs
@@ -314,32 +314,32 @@ public sealed class HotstringTableFormatterTests
     }
 
     [Fact]
-    public void Write_ScriptRow_ShowsFirstLineOnlySummary()
+    public void Write_RawRow_ShowsFirstLineOnlySummary()
     {
         StringWriter sw = new();
         PagedList<HotstringDto> page = new(
-            [Hotstring(trigger: "~ver", replacement: "MsgBox A_AhkVersion") with { Kind = HotstringKind.Script }],
+            [Hotstring(trigger: "ftw", replacement: ":K1000 SE*:ftw::for the win") with { Kind = HotstringKind.Raw }],
             1, 50, 1);
 
         HotstringTableFormatter.Write(sw, page, EmptyNames);
 
         string output = sw.ToString();
-        output.Should().Contain("Script");
-        output.Should().Contain("MsgBox A_AhkVersion");
+        output.Should().Contain("Raw");
+        output.Should().Contain(":K1000 SE*:ftw::for the win");
     }
 
     [Fact]
-    public void Write_ScriptRowMultilineBody_TruncatesToFirstLine()
+    public void Write_RawRowMultilineBody_TruncatesToFirstLine()
     {
         StringWriter sw = new();
         PagedList<HotstringDto> page = new(
-            [Hotstring(trigger: "m", replacement: "MsgBox 1\nMsgBox 2\nMsgBox 3") with { Kind = HotstringKind.Script }],
+            [Hotstring(trigger: "m", replacement: ":*:m::\n{\nMsgBox 2\nMsgBox 3\n}") with { Kind = HotstringKind.Raw }],
             1, 50, 1);
 
         HotstringTableFormatter.Write(sw, page, EmptyNames);
 
         string output = sw.ToString();
-        output.Should().Contain("MsgBox 1");
+        output.Should().Contain(":*:m::");
         output.Should().NotContain("MsgBox 2");
         output.Should().NotContain("MsgBox 3");
     }

--- a/tests/AHKFlowApp.E2E.Tests/RawHotstringFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/RawHotstringFlowTests.cs
@@ -5,8 +5,10 @@ using Xunit;
 namespace AHKFlowApp.E2E.Tests;
 
 [Collection(E2ETestCollection.Name)]
-public sealed class ScriptHotstringFlowTests(StackFixture fixture) : IAsyncLifetime
+public sealed class RawHotstringFlowTests(StackFixture fixture) : IAsyncLifetime
 {
+    private const string Definition = ":K1000 SE*:ftw::for the win";
+
     private static readonly BrowserNewContextOptions PhoneViewport = new()
     {
         ViewportSize = new ViewportSize { Width = 375, Height = 812 },
@@ -26,7 +28,7 @@ public sealed class ScriptHotstringFlowTests(StackFixture fixture) : IAsyncLifet
         Task.CompletedTask;
 
     [Fact]
-    public async Task CreateScriptViaDialog_WarningAlertMonospacePreviewMobileBadgeAndByteMatch()
+    public async Task CreateRawViaDialog_WarningAlertMonospaceParsedSummaryMobileBadgeAndByteMatch()
     {
         await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
         IPage page = await ctx.NewPageAsync();
@@ -37,9 +39,9 @@ public sealed class ScriptHotstringFlowTests(StackFixture fixture) : IAsyncLifet
         await page.WaitForSelectorAsync("button.add-profile");
         await page.ClickAsync("button.add-profile");
         await page.WaitForSelectorAsync("input[data-test=\"profile-name-input\"]");
-        await page.FillAsync("input[data-test=\"profile-name-input\"]", "Phase5");
+        await page.FillAsync("input[data-test=\"profile-name-input\"]", "RawFlow");
         await page.ClickAsync("button.commit-edit");
-        await page.WaitForSelectorAsync("text=Phase5");
+        await page.WaitForSelectorAsync("text=RawFlow");
 
         Task<IResponse> profilesLoaded = page.WaitForResponseAsync(response =>
             response.Url.Contains("/api/v1/profiles", StringComparison.OrdinalIgnoreCase) &&
@@ -55,35 +57,34 @@ public sealed class ScriptHotstringFlowTests(StackFixture fixture) : IAsyncLifet
         await page.ClickAsync("button.add-hotstring-fab");
         await page.WaitForSelectorAsync(".hotstring-edit-dialog");
 
-        await page.ClickAsync(".hotstring-edit-dialog .mud-toggle-item:has-text('Script')");
+        await page.ClickAsync(".hotstring-edit-dialog .mud-toggle-item:has-text('Raw')");
         await page.WaitForSelectorAsync("[data-test=\"script-warning\"]");
 
         // Persistent (non-dismissible) warning alert.
         await Assertions.Expect(page.Locator("[data-test=\"script-warning\"]"))
-            .ToContainTextAsync("Runs arbitrary AutoHotkey code in the generated script.");
+            .ToContainTextAsync("verbatim AutoHotkey definition");
         await Assertions.Expect(page.Locator("[data-test=\"script-warning\"] button")).ToHaveCountAsync(0);
 
-        ILocator replacement = page.Locator("textarea[data-test=\"replacement-input\"]");
+        // The trigger field is hidden for Raw — the trigger is derived from the definition.
+        await Assertions.Expect(page.Locator("input[data-test=\"trigger-input\"]")).ToHaveCountAsync(0);
 
-        // Larger monospace editor for Script.
-        string fontFamily = await replacement.EvaluateAsync<string>("el => getComputedStyle(el).fontFamily");
+        ILocator definition = page.Locator("textarea[data-test=\"replacement-input\"]");
+
+        // Larger monospace editor for Raw.
+        string fontFamily = await definition.EvaluateAsync<string>("el => getComputedStyle(el).fontFamily");
         Assert.Contains("monospace", fontFamily, StringComparison.OrdinalIgnoreCase);
 
-        await page.FillAsync("input[data-test=\"trigger-input\"]", "~ver");
-        await replacement.FillAsync("MsgBox A_AhkVersion");
-
-        // Match spec §7 ex. 7's ":*:~ver::" options exactly (expand immediately, not
-        // trigger-inside-word).
-        await page.ClickAsync("[data-test=\"expand-immediately-checkbox\"]");
-        await page.ClickAsync("[data-test=\"inside-words-checkbox\"]");
+        await definition.FillAsync(Definition);
 
         await page.ClickAsync("[data-test=\"ahk-preview\"] .mud-expand-panel-header");
         await page.WaitForSelectorAsync("[data-test=\"preview-snippet\"]");
 
-        ILocator snippet = page.Locator("[data-test=\"preview-snippet\"]");
-        await Assertions.Expect(snippet).ToContainTextAsync(":*:~ver::");
-        // Exact verbatim brace-body passthrough (HotstringEmitter.BuildScriptBody).
-        await Assertions.Expect(snippet).ToContainTextAsync("{\nMsgBox A_AhkVersion\n}");
+        // Verbatim passthrough — the definition is emitted exactly as typed.
+        await Assertions.Expect(page.Locator("[data-test=\"preview-snippet\"]")).ToContainTextAsync(Definition);
+
+        // Server-derived parsed summary (trigger + option tokens).
+        await Assertions.Expect(page.Locator("[data-test=\"raw-summary\"]")).ToContainTextAsync("ftw");
+        await Assertions.Expect(page.Locator("[data-test=\"raw-summary\"]")).ToContainTextAsync("K1000");
 
         OverflowMetrics metrics = await page.EvaluateAsync<OverflowMetrics>(
             "() => ({ BodyOverflow: document.body.scrollWidth - window.innerWidth, DocumentOverflow: document.documentElement.scrollWidth - window.innerWidth })");
@@ -93,16 +94,12 @@ public sealed class ScriptHotstringFlowTests(StackFixture fixture) : IAsyncLifet
         await page.ClickAsync("button.commit-edit");
         await page.WaitForSelectorAsync("text=Hotstring created.");
 
-        // Collapsed mobile row shows the Script warning badge.
-        await page.WaitForSelectorAsync("tr.mobile-row:has-text(\"~ver\")");
+        // Collapsed mobile row (keyed by the derived trigger) shows the Raw warning badge.
+        await page.WaitForSelectorAsync("tr.mobile-row:has-text(\"ftw\")");
         await Assertions.Expect(
-            page.Locator("tr.mobile-row:has-text(\"~ver\") [data-test=\"script-badge-collapsed\"]")).ToBeVisibleAsync();
+            page.Locator("tr.mobile-row:has-text(\"ftw\") [data-test=\"script-badge-collapsed\"]")).ToBeVisibleAsync();
 
-        // Byte-match the downloaded profile script against the golden. Reading the actual
-        // downloaded bytes (not the rendered preview) exercises the real download path and
-        // avoids the DOM whitespace normalization ToContainTextAsync would apply. The header
-        // carries a non-deterministic {GeneratedAt}/{AppVersion}, so match the exact Script
-        // block rather than the whole file.
+        // Byte-match the downloaded profile script — the verbatim Raw line must appear exactly.
         await page.GotoAsync($"{fixture.Spa.BaseUrl}/downloads");
         await page.WaitForSelectorAsync("button.download-profile");
 
@@ -114,6 +111,6 @@ public sealed class ScriptHotstringFlowTests(StackFixture fixture) : IAsyncLifet
         byte[] bytes = await File.ReadAllBytesAsync(path);
         string content = System.Text.Encoding.UTF8.GetString(bytes);
 
-        Assert.Contains(":*:~ver::\n{\nMsgBox A_AhkVersion\n}", content, StringComparison.Ordinal);
+        Assert.Contains(Definition, content, StringComparison.Ordinal);
     }
 }

--- a/tests/AHKFlowApp.E2E.Tests/RawHotstringFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/RawHotstringFlowTests.cs
@@ -76,15 +76,16 @@ public sealed class RawHotstringFlowTests(StackFixture fixture) : IAsyncLifetime
 
         await definition.FillAsync(Definition);
 
+        // Server-derived parsed summary (trigger + option tokens) appears below the textarea by
+        // default — the preview panel need not be expanded first.
+        await Assertions.Expect(page.Locator("[data-test=\"raw-summary\"]")).ToContainTextAsync("ftw");
+        await Assertions.Expect(page.Locator("[data-test=\"raw-summary\"]")).ToContainTextAsync("K1000");
+
         await page.ClickAsync("[data-test=\"ahk-preview\"] .mud-expand-panel-header");
         await page.WaitForSelectorAsync("[data-test=\"preview-snippet\"]");
 
         // Verbatim passthrough — the definition is emitted exactly as typed.
         await Assertions.Expect(page.Locator("[data-test=\"preview-snippet\"]")).ToContainTextAsync(Definition);
-
-        // Server-derived parsed summary (trigger + option tokens).
-        await Assertions.Expect(page.Locator("[data-test=\"raw-summary\"]")).ToContainTextAsync("ftw");
-        await Assertions.Expect(page.Locator("[data-test=\"raw-summary\"]")).ToContainTextAsync("K1000");
 
         OverflowMetrics metrics = await page.EvaluateAsync<OverflowMetrics>(
             "() => ({ BodyOverflow: document.body.scrollWidth - window.innerWidth, DocumentOverflow: document.documentElement.scrollWidth - window.innerWidth })");

--- a/tests/AHKFlowApp.E2E.Tests/RawHotstringFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/RawHotstringFlowTests.cs
@@ -14,6 +14,11 @@ public sealed class RawHotstringFlowTests(StackFixture fixture) : IAsyncLifetime
         ViewportSize = new ViewportSize { Width = 375, Height = 812 },
     };
 
+    private static readonly BrowserNewContextOptions DesktopViewport = new()
+    {
+        ViewportSize = new ViewportSize { Width = 1280, Height = 900 },
+    };
+
     private sealed class OverflowMetrics
     {
         public int BodyOverflow { get; init; }
@@ -113,5 +118,45 @@ public sealed class RawHotstringFlowTests(StackFixture fixture) : IAsyncLifetime
         string content = System.Text.Encoding.UTF8.GetString(bytes);
 
         Assert.Contains(Definition, content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PromoteInlineDraftToRawViaDialog_CreatesRawHotstring()
+    {
+        // Desktop-only flow (P14): start an inline Text draft, promote it to the full dialog via the
+        // Tune action, switch the promoted draft to Raw, and save. Covers the promote path the mobile
+        // create test can't reach.
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(DesktopViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotstrings");
+        await page.WaitForSelectorAsync("button.add-hotstring");
+
+        // Inline Text draft — carry a typed trigger into the promotion.
+        await page.ClickAsync("button.add-hotstring");
+        await page.WaitForSelectorAsync("input[data-test=\"trigger-input\"]");
+        await page.FillAsync("input[data-test=\"trigger-input\"]", "seed");
+
+        // Promote to the full dialog (Tune action).
+        await page.ClickAsync("button.promote-edit");
+        await page.WaitForSelectorAsync(".hotstring-edit-dialog");
+
+        // Switch the promoted draft to Raw (empty replacement, so no discard confirmation) and paste a
+        // full verbatim definition — the trigger is now derived from the text, not the seeded "seed".
+        await page.ClickAsync(".hotstring-edit-dialog .mud-toggle-item:has-text('Raw')");
+        await page.WaitForSelectorAsync("[data-test=\"script-warning\"]");
+
+        ILocator definition = page.Locator(".hotstring-edit-dialog textarea[data-test=\"replacement-input\"]");
+        await definition.FillAsync(Definition);
+
+        // Parsed summary reflects the derived trigger without expanding the preview panel.
+        await Assertions.Expect(page.Locator("[data-test=\"raw-summary\"]")).ToContainTextAsync("ftw");
+
+        await page.ClickAsync(".hotstring-edit-dialog button.commit-edit");
+        await page.WaitForSelectorAsync("text=Hotstring created.");
+
+        // The new Raw row's Trigger column shows the derived trigger.
+        await Assertions.Expect(
+            page.Locator(".desktop-branch .hotstrings-grid td[data-label=\"Trigger\"]")).ToContainTextAsync("ftw");
     }
 }

--- a/tests/AHKFlowApp.Infrastructure.Tests/Migrations/RawHotstringKindMigrationTests.cs
+++ b/tests/AHKFlowApp.Infrastructure.Tests/Migrations/RawHotstringKindMigrationTests.cs
@@ -1,0 +1,90 @@
+using AHKFlowApp.Infrastructure.Persistence;
+using AHKFlowApp.TestUtilities.Fixtures;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AHKFlowApp.Infrastructure.Tests.Migrations;
+
+/// <summary>
+/// Proves the migration's hand-written Script→Raw T-SQL agrees byte-for-byte with
+/// <c>ScriptToRawComposer</c>: every golden fixture is seeded as a legacy Script row (Kind = 3)
+/// before the migration runs, then its migrated Replacement must equal the composer's expected
+/// verbatim definition, with Kind flipped to Raw (4). Includes the 4,000-character body row,
+/// proving the widened column does not truncate.
+/// </summary>
+[Collection("SqlServer")]
+public sealed class RawHotstringKindMigrationTests(SqlContainerFixture sqlFixture)
+{
+    private const string DbName = "RawHotstringKind_Parity";
+
+    private AppDbContext CreateContext()
+    {
+        SqlConnectionStringBuilder csb = new(sqlFixture.ConnectionString) { InitialCatalog = DbName };
+
+        DbContextOptions<AppDbContext> options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlServer(csb.ConnectionString, sql => sql.EnableRetryOnFailure())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task Migration_RewritesLegacyScriptRows_ByteIdenticalToComposer()
+    {
+        Dictionary<Guid, ScriptToRawFixture> seeded = [];
+
+        await using (AppDbContext setup = CreateContext())
+        {
+            // Apply every migration up to but not including RawHotstringKind, so the Hotstrings
+            // table still has the body-only nvarchar(4000) Replacement column.
+            IMigrator migrator = ((IInfrastructure<IServiceProvider>)setup).Instance.GetRequiredService<IMigrator>();
+            await migrator.MigrateAsync("AddHotstringWindowContext");
+
+            foreach (ScriptToRawFixture f in ScriptToRawFixtures.All)
+            {
+                var id = Guid.NewGuid();
+                // Unique owner per row so duplicate triggers (e.g. "t") don't hit the unique index.
+                var owner = Guid.NewGuid();
+                seeded[id] = f;
+
+                await setup.Database.ExecuteSqlRawAsync(
+                    """
+                    INSERT INTO Hotstrings
+                        (Id, OwnerOid, [Trigger], Replacement, AppliesToAllProfiles,
+                         IsEndingCharacterRequired, IsTriggerInsideWord, Kind, IsCaseSensitive,
+                         OmitEndingCharacter, CreatedAt, UpdatedAt)
+                    VALUES
+                        (@id, @owner, @trigger, @body, 1,
+                         @ending, @inside, 3, @case,
+                         @omit, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET());
+                    """,
+                    new SqlParameter("@id", id),
+                    new SqlParameter("@owner", owner),
+                    new SqlParameter("@trigger", f.Trigger),
+                    new SqlParameter("@body", f.Body),
+                    new SqlParameter("@ending", f.IsEndingCharacterRequired),
+                    new SqlParameter("@inside", f.IsTriggerInsideWord),
+                    new SqlParameter("@case", f.IsCaseSensitive),
+                    new SqlParameter("@omit", f.OmitEndingCharacter));
+            }
+
+            // Apply RawHotstringKind — widen column + rewrite Kind=3 rows.
+            await setup.Database.MigrateAsync();
+        }
+
+        await using AppDbContext verify = CreateContext();
+
+        foreach ((Guid id, ScriptToRawFixture f) in seeded)
+        {
+            Domain.Entities.Hotstring row = await verify.Hotstrings.AsNoTracking().SingleAsync(h => h.Id == id);
+
+            row.Kind.Should().Be(Domain.Enums.HotstringKind.Raw, "fixture '{0}' should convert to Raw", f.Name);
+            row.Replacement.Should().Be(f.ExpectedRawDefinition, "fixture '{0}' must match the composer output", f.Name);
+        }
+    }
+}

--- a/tests/AHKFlowApp.TestUtilities/Fixtures/ScriptToRawFixtures.cs
+++ b/tests/AHKFlowApp.TestUtilities/Fixtures/ScriptToRawFixtures.cs
@@ -1,0 +1,52 @@
+namespace AHKFlowApp.TestUtilities.Fixtures;
+
+/// <summary>
+/// One Script→Raw conversion case: the legacy Script row's fields plus the exact verbatim Raw
+/// definition it must convert to (byte-identical to the retired emitter's Script output).
+/// </summary>
+public sealed record ScriptToRawFixture(
+    string Name,
+    string Trigger,
+    string Body,
+    bool IsEndingCharacterRequired,
+    bool IsTriggerInsideWord,
+    bool IsCaseSensitive,
+    bool OmitEndingCharacter,
+    string ExpectedRawDefinition);
+
+/// <summary>
+/// Shared golden set guarding the three copies of the Script→Raw transform: the C# composer
+/// (<c>ScriptToRawComposer</c>), the history restore/revert conversion, and the EF data migration's
+/// hand-written T-SQL. Covers the option-flag matrix, triggers with backtick/semicolon, CRLF bodies,
+/// blank-edged bodies, and a 4,000-character body (the old column max — proves no truncation).
+/// </summary>
+public static class ScriptToRawFixtures
+{
+    public static IReadOnlyList<ScriptToRawFixture> All { get; } = Build();
+
+    private static IReadOnlyList<ScriptToRawFixture> Build()
+    {
+        string big = new('x', 4000);
+        return
+        [
+            new("no-flags-simple", "rng", "Send foo", true, false, false, false,
+                "::rng::\n{\nSend foo\n}"),
+            new("star-insideword-case", "x", "b", false, true, true, false,
+                ":*?C:x::\n{\nb\n}"),
+            new("omit-flag", "y", "c", true, false, false, true,
+                ":O:y::\n{\nc\n}"),
+            new("omit-ignored-with-star", "z", "d", false, false, false, true,
+                ":*:z::\n{\nd\n}"), // O is meaningless with *, so it is not emitted
+            new("semicolon-trigger", "a;b", "x", true, false, false, false,
+                "::a`;b::\n{\nx\n}"),
+            new("backtick-trigger", "c`d", "x", true, false, false, false,
+                "::c``d::\n{\nx\n}"),
+            new("crlf-body", "t", "l1\r\nl2", true, false, false, false,
+                "::t::\n{\nl1\r\nl2\n}"),
+            new("blank-edged-body", "t", "\n\nMsgBox 1\n\n", true, false, false, false,
+                "::t::\n{\n\n\nMsgBox 1\n\n\n}"),
+            new("max-4000-body", "t", big, true, false, false, false,
+                "::t::\n{\n" + big + "\n}"),
+        ];
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -384,7 +384,7 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public async Task KindSelector_HasFourItemsIncludingMacroAndScript()
+    public async Task KindSelector_HasFourItemsIncludingMacroAndRaw()
     {
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
 
@@ -393,7 +393,7 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
             IReadOnlyList<AngleSharp.Dom.IElement> items = provider.FindAll(".mud-toggle-item");
             items.Should().HaveCount(4);
             items.Select(e => e.TextContent.Trim()).Should().Contain("Macro");
-            items.Should().Contain(e => e.TextContent.Contains("Script"));
+            items.Should().Contain(e => e.TextContent.Contains("Raw"));
         });
     }
 
@@ -1134,64 +1134,68 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public async Task KindToggle_SelectScript_ShowsPersistentWarningAlert()
+    public async Task KindToggle_SelectRaw_ShowsPersistentWarningAlert()
     {
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
         provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
 
-        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Script")).Click();
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Raw")).Click();
 
         provider.WaitForAssertion(() =>
         {
             provider.Find("[data-test=\"script-warning\"]").TextContent
-                .Should().Contain("Runs arbitrary AutoHotkey code in the generated script.");
+                .Should().Contain("verbatim AutoHotkey definition");
             provider.FindAll("[data-test=\"script-warning\"] button").Should().BeEmpty(
-                "the script warning is persistent and must not offer a dismiss control");
+                "the raw warning is persistent and must not offer a dismiss control");
         });
     }
 
     [Fact]
-    public async Task KindToggle_SelectScript_AppliesMonospaceClass()
+    public async Task KindToggle_SelectRaw_AppliesMonospaceClass()
     {
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync();
         provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
 
         provider.Markup.Should().NotContain("ahk-mono");
 
-        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Script")).Click();
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Raw")).Click();
 
         provider.WaitForAssertion(() => provider.Markup.Should().Contain("ahk-mono"));
     }
 
     [Fact]
-    public async Task KindToggle_TextToScript_PreservesReplacement()
+    public async Task KindToggle_TextToRaw_PromptsConfirmationAndKeepsFieldsUntilConfirmed()
     {
-        // Text -> Script with non-empty Replacement prompts a confirmation (the interpretation
-        // of the same text changes from literal to executable code) — the shared Replacement
-        // content must never be cleared ahead of that confirmation resolving.
+        // Text -> Raw with non-empty Replacement prompts a confirmation before wrapping the text
+        // into a full definition — nothing must change ahead of that confirmation resolving.
         HotstringEditModel item = new() { Trigger = "ver", Kind = HotstringKind.Text, Replacement = "MsgBox 1" };
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
         provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
 
-        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Script")).Click();
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Raw")).Click();
 
-        provider.WaitForAssertion(() => provider.Markup.Should().Contain("Switch to Script"));
+        provider.WaitForAssertion(() => provider.Markup.Should().Contain("Switch to Raw"));
         item.Kind.Should().Be(HotstringKind.Text);
         item.Replacement.Should().Be("MsgBox 1");
     }
 
     [Fact]
-    public async Task KindToggle_ScriptToText_PreservesReplacement()
+    public async Task KindToggle_RawToText_DecomposesDefinitionIntoFields()
     {
-        HotstringEditModel item = new() { Trigger = "ver", Kind = HotstringKind.Script, Replacement = "MsgBox 1" };
+        // A plain Raw definition (no options the structured fields can't express) decomposes
+        // straight into Trigger + body with no confirmation.
+        HotstringEditModel item = new() { Trigger = "ver", Kind = HotstringKind.Raw, Replacement = "::ver::\n{\nMsgBox 1\n}" };
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
         provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
 
         provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Trim() == "Text").Click();
 
-        provider.WaitForAssertion(() => provider.Markup.Should().Contain("Switch to Text"));
-        item.Kind.Should().Be(HotstringKind.Script);
-        item.Replacement.Should().Be("MsgBox 1");
+        provider.WaitForAssertion(() =>
+        {
+            item.Kind.Should().Be(HotstringKind.Text);
+            item.Trigger.Should().Be("ver");
+            item.Replacement.Should().Be("MsgBox 1");
+        });
     }
 
     [Fact]
@@ -1220,34 +1224,34 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public async Task Save_ScriptKind_SendsReplacementVerbatimInCreateDto()
+    public async Task Save_RawKind_SendsDefinitionVerbatimInCreateDto()
     {
-        HotstringDto created = new(Guid.NewGuid(), [], true, "~ver", "MsgBox A_AhkVersion", null, true, true,
-            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, [], HotstringKind.Script);
+        HotstringDto created = new(Guid.NewGuid(), [], true, "ftw", ":K1000 SE*:ftw::for the win", null, true, true,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, [], HotstringKind.Raw);
         _api.CreateAsync(Arg.Any<CreateHotstringDto>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult<HotstringDto>.Ok(created));
 
-        HotstringEditModel item = new() { Trigger = "~ver", Kind = HotstringKind.Script, Replacement = "MsgBox A_AhkVersion" };
+        HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = ":K1000 SE*:ftw::for the win" };
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
         provider.WaitForAssertion(() => provider.Find("button.commit-edit"));
 
         provider.Find("button.commit-edit").Click();
 
         provider.WaitForAssertion(() => _api.Received(1).CreateAsync(
-            Arg.Is<CreateHotstringDto>(d => d.Kind == HotstringKind.Script && d.Replacement == "MsgBox A_AhkVersion"),
+            Arg.Is<CreateHotstringDto>(d => d.Kind == HotstringKind.Raw && d.Replacement == ":K1000 SE*:ftw::for the win"),
             Arg.Any<CancellationToken>()));
     }
 
     [Fact]
-    public async Task PreviewError_ScriptBraceImbalance_ShownInlineOnReplacementField()
+    public async Task PreviewError_RawBraceImbalance_ShownInlineOnRawDefinitionField()
     {
-        const string braceMessage = "Script replacement must have balanced braces.";
+        const string braceMessage = "Raw definition must have balanced braces.";
         _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult<HotstringPreviewDto>.Failure(ApiResultStatus.Validation,
                 new ApiProblemDetails(null, "Bad Request", 400, null, null,
                     new Dictionary<string, string[]> { ["Input.Replacement"] = [braceMessage] })));
 
-        HotstringEditModel item = new() { Trigger = "m", Kind = HotstringKind.Script, Replacement = "if (true) {" };
+        HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = ":*:m::\n{\nSend foo" };
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
         DisablePreviewDebounce(provider);
         provider.WaitForAssertion(() => provider.Find("[data-test=\"ahk-preview\"]"));
@@ -1256,21 +1260,21 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         provider.WaitForAssertion(() =>
         {
             MudTextField<string> replacementField = provider.FindComponents<MudTextField<string>>()
-                .Single(f => f.Instance.Label == "Replacement").Instance;
+                .Single(f => f.Instance.Label == "Raw definition").Instance;
             replacementField.GetState(x => x.ErrorText).Should().Be(braceMessage);
         });
     }
 
     [Fact]
-    public async Task Save_ScriptBraceImbalance_WithPreviewCollapsed_ShowsInlineReplacementError()
+    public async Task Save_RawBraceImbalance_WithPreviewCollapsed_ShowsInlineRawDefinitionError()
     {
-        const string braceMessage = "Script replacement must have balanced braces.";
+        const string braceMessage = "Raw definition must have balanced braces.";
         _api.CreateAsync(Arg.Any<CreateHotstringDto>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult<HotstringDto>.Failure(ApiResultStatus.Validation,
                 new ApiProblemDetails(null, "Bad Request", 400, null, null,
                     new Dictionary<string, string[]> { ["Input.Replacement"] = [braceMessage] })));
 
-        HotstringEditModel item = new() { Trigger = "m", Kind = HotstringKind.Script, Replacement = "if (true) {" };
+        HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = ":*:m::\n{\nSend foo" };
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
         provider.WaitForAssertion(() => provider.Find("button.commit-edit"));
 
@@ -1281,7 +1285,7 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         provider.WaitForAssertion(() =>
         {
             MudTextField<string> replacementField = provider.FindComponents<MudTextField<string>>()
-                .Single(f => f.Instance.Label == "Replacement").Instance;
+                .Single(f => f.Instance.Label == "Raw definition").Instance;
             replacementField.GetState(x => x.ErrorText).Should().Be(braceMessage);
 
             provider.FindAll(".mud-alert").Should().NotContain(e => e.TextContent.Contains(braceMessage),

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -1293,6 +1293,27 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         });
     }
 
+    [Fact]
+    public async Task RawKind_PreviewCollapsed_AutoRequestsPreviewAndShowsParsedSummary()
+    {
+        // Raw's parsed trigger/options summary must appear below the textarea by default — the
+        // preview runs even while the "Generated AutoHotkey code" panel stays collapsed.
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringPreviewDto>.Ok(new HotstringPreviewDto(
+                ":K1000 SE*:ftw::for the win", new RawSummaryDto("ftw", ["K1000", "SE", "*"]))));
+
+        HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = ":K1000 SE*:ftw::for the win" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        DisablePreviewDebounce(provider);
+
+        provider.WaitForAssertion(() =>
+        {
+            _ = _api.Received().PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>());
+            provider.Find("[data-test=\"raw-summary\"]").TextContent.Should().Contain("ftw");
+            provider.Find("[data-test=\"raw-summary\"]").TextContent.Should().Contain("K1000");
+        });
+    }
+
     private static void DisablePreviewDebounce(IRenderedComponent<MudDialogProvider> provider) =>
         provider.FindComponent<HotstringEditDialog>().Instance.PreviewDebounce = TimeSpan.Zero;
 

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
@@ -30,8 +30,8 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
     private static HotstringEditModel MacroItem(string trigger = "greet", string replacement = "Dear {{{{first_name}}}},{{key:Enter}}{{cursor}}Alex") =>
         new() { Id = Guid.NewGuid(), Trigger = trigger, Replacement = replacement, Kind = HotstringKind.Macro };
 
-    private static HotstringEditModel ScriptItem(string trigger = "~ver", string replacement = "MsgBox A_AhkVersion") =>
-        new() { Id = Guid.NewGuid(), Trigger = trigger, Replacement = replacement, Kind = HotstringKind.Script };
+    private static HotstringEditModel RawItem(string trigger = "~ver", string replacement = ":*:~ver::\n{\nMsgBox A_AhkVersion\n}") =>
+        new() { Id = Guid.NewGuid(), Trigger = trigger, Replacement = replacement, Kind = HotstringKind.Raw };
 
     [Fact]
     public void Renders_TriggerAndReplacement_PerRow()
@@ -287,24 +287,24 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public void MobileList_ScriptRow_ShowsFirstLineInCollapsedView()
+    public void MobileList_RawRow_ShowsFirstLineInCollapsedView()
     {
-        HotstringEditModel item = ScriptItem(replacement: "MsgBox A_AhkVersion\nMsgBox 2");
+        HotstringEditModel item = RawItem(replacement: ":*:~ver::\n{\nMsgBox A_AhkVersion\n}");
 
         IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
             .Add(c => c.Items, [item])
             .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
             .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
 
-        cut.Find("td.replacement-cell").TextContent.Should().Contain("MsgBox A_AhkVersion");
-        cut.Find("td.replacement-cell").TextContent.Should().NotContain("MsgBox 2");
+        cut.Find("td.replacement-cell").TextContent.Should().Contain(":*:~ver::");
+        cut.Find("td.replacement-cell").TextContent.Should().NotContain("MsgBox A_AhkVersion");
     }
 
     [Fact]
-    public void MobileList_ScriptRow_ShowsWarningBadgeCollapsed()
+    public void MobileList_RawRow_ShowsWarningBadgeCollapsed()
     {
         IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
-            .Add(c => c.Items, [ScriptItem(), Item()])
+            .Add(c => c.Items, [RawItem(), Item()])
             .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
             .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
 
@@ -312,9 +312,9 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public async Task MobileList_ScriptExpanded_ShowsFullBodyAndWarningText()
+    public async Task MobileList_RawExpanded_ShowsFullDefinitionAndWarningText()
     {
-        HotstringEditModel item = ScriptItem(replacement: "MsgBox A_AhkVersion\nMsgBox 2");
+        HotstringEditModel item = RawItem(replacement: ":*:~ver::\n{\nMsgBox A_AhkVersion\n}");
 
         IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
             .Add(c => c.Items, [item])
@@ -327,7 +327,7 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
         {
             cut.Find("[data-test=\"script-warning-expanded\"]").TextContent
                 .Should().Contain("Runs arbitrary AutoHotkey code in the generated script.");
-            cut.Find(".script-body").TextContent.Should().Be("MsgBox A_AhkVersion\nMsgBox 2");
+            cut.Find(".script-body").TextContent.Should().Be(":*:~ver::\n{\nMsgBox A_AhkVersion\n}");
         });
     }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/RawDefinitionTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/RawDefinitionTests.cs
@@ -1,0 +1,60 @@
+using AHKFlowApp.TestUtilities.Fixtures;
+using AHKFlowApp.UI.Blazor.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Helpers;
+
+public sealed class RawDefinitionTests
+{
+    public static TheoryData<string> FixtureNames()
+    {
+        TheoryData<string> data = [];
+        foreach (ScriptToRawFixture f in ScriptToRawFixtures.All)
+            data.Add(f.Name);
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(FixtureNames))]
+    public void Compose_MatchesServerComposer(string fixtureName)
+    {
+        ScriptToRawFixture f = ScriptToRawFixtures.All.Single(x => x.Name == fixtureName);
+
+        string composed = RawDefinition.Compose(
+            f.Trigger, f.Body,
+            f.IsEndingCharacterRequired, f.IsTriggerInsideWord,
+            f.IsCaseSensitive, f.OmitEndingCharacter);
+
+        composed.Should().Be(f.ExpectedRawDefinition);
+    }
+
+    [Fact]
+    public void Decompose_BraceBody_ExtractsTriggerAndBody()
+    {
+        RawDecomposition result = RawDefinition.Decompose(":*:rng::\n{\nSend foo\n}");
+
+        result.Trigger.Should().Be("rng");
+        result.Body.Should().Be("Send foo");
+        result.UnexpressibleOptions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Decompose_InlineReplacement_ExtractsBody()
+    {
+        RawDecomposition result = RawDefinition.Decompose("::btw::by the way");
+
+        result.Trigger.Should().Be("btw");
+        result.Body.Should().Be("by the way");
+    }
+
+    [Fact]
+    public void Decompose_SurfacesUnexpressibleOptions()
+    {
+        RawDecomposition result = RawDefinition.Decompose(":K1000 SE*:ftw::for the win");
+
+        result.Trigger.Should().Be("ftw");
+        // '*' is expressible via a checkbox; K1000 and SE are not.
+        result.UnexpressibleOptions.Should().BeEquivalentTo("K1000", "SE");
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -291,6 +291,65 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public Task Page_PromoteExistingRow_OpensEditDialogWithKindToggle()
+    {
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "btw", "by the way", null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        StubList(Page(dto));
+
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+        IRenderedComponent<Hotstrings> cut = Render<Hotstrings>(p => p.AddCascadingValue(AuthenticatedState));
+
+        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
+        cut.Find("button.start-edit").Click();
+
+        // Carry a typed edit into the promotion.
+        cut.WaitForAssertion(() => cut.Find("textarea[data-test=\"replacement-input\"]"));
+        cut.Find("textarea[data-test=\"replacement-input\"]").Input("by the way!");
+        cut.Find("button.promote-edit").Click();
+
+        // The dialog renders into the provider's tree, carrying the typed value.
+        provider.WaitForAssertion(() =>
+        {
+            provider.Find(".hotstring-edit-dialog");
+            provider.Find("[data-test=\"kind-selector\"]");
+            provider.FindComponent<global::AHKFlowApp.UI.Blazor.Components.Hotstrings.HotstringEditDialog>()
+                .Instance.Item.Replacement.Should().Be("by the way!");
+        });
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task Page_PromoteDraftThenCancel_RestoresInlineDraft()
+    {
+        StubList(Page());
+
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+        IRenderedComponent<Hotstrings> cut = Render<Hotstrings>(p => p.AddCascadingValue(AuthenticatedState));
+
+        cut.WaitForAssertion(() => cut.Find("button.add-hotstring"));
+        cut.Find("button.add-hotstring").Click();
+
+        cut.WaitForAssertion(() => cut.Find("input[data-test=\"trigger-input\"]"));
+        cut.Find("input[data-test=\"trigger-input\"]").Input("btw");
+        cut.Find("button.promote-edit").Click();
+
+        // Dialog opens in the provider tree; cancel it via the title back button.
+        provider.WaitForAssertion(() => provider.Find(".hotstring-edit-dialog button.cancel-edit"));
+        provider.Find(".hotstring-edit-dialog button.cancel-edit").Click();
+
+        // The dialog closes and the inline draft edit is restored (its commit control reappears).
+        provider.WaitForAssertion(() => provider.FindAll(".hotstring-edit-dialog").Should().BeEmpty());
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("input[data-test=\"trigger-input\"]");
+            cut.Find("button.commit-edit").Should().NotBeNull();
+        });
+        return Task.CompletedTask;
+    }
+
+    [Fact]
     public async Task Page_WhenAnyToggleIsReenabled_ClearsSpecificProfilesBeforeCreate()
     {
         ProfileDto work = new(Guid.NewGuid(), "Work", false, "header text", "footer text", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -681,6 +681,25 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public Task Page_RawRow_SuppressesOptionGlyphsAndTooltipFlags()
+    {
+        // IsTriggerInsideWord=true is the CLI/default for a Raw row, but its options live in the
+        // verbatim text — the structured flag glyphs ("?") and tooltip flag phrases must not show.
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "~ver", ":*:~ver::\n{\nMsgBox A_AhkVersion\n}",
+            null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.Raw);
+        StubList(Page(dto));
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find(".hotstrings-grid .option-glyphs").TextContent.Should().BeEmpty();
+            cut.Find(".hotstrings-grid .type-badge").TextContent.Should().Contain("Raw");
+        });
+        return Task.CompletedTask;
+    }
+
+    [Fact]
     public void Page_KindFilter_ListsAllFourKinds()
     {
         StubList(Page());

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -582,10 +582,10 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public Task Page_ScriptRow_ShowsFirstLineMonospaceEllipsis()
+    public Task Page_RawRow_ShowsFirstLineMonospaceEllipsis()
     {
-        var dto = new HotstringDto(Guid.NewGuid(), [], true, "~ver", "MsgBox A_AhkVersion\nMsgBox 2",
-            null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.Script);
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "~ver", ":*:~ver::\n{\nMsgBox A_AhkVersion\n}",
+            null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.Raw);
         StubList(Page(dto));
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
@@ -593,17 +593,17 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         cut.WaitForAssertion(() =>
         {
             AngleSharp.Dom.IElement summary = cut.Find(".hotstrings-grid .script-summary");
-            summary.TextContent.Should().Be("MsgBox A_AhkVersion");
-            summary.TextContent.Should().NotContain("MsgBox 2");
+            summary.TextContent.Should().Be(":*:~ver::");
+            summary.TextContent.Should().NotContain("MsgBox A_AhkVersion");
         });
         return Task.CompletedTask;
     }
 
     [Fact]
-    public Task Page_ScriptRow_ShowsWarningColoredBadgeWithAccessibleText()
+    public Task Page_RawRow_ShowsWarningColoredBadgeWithAccessibleText()
     {
-        var dto = new HotstringDto(Guid.NewGuid(), [], true, "~ver", "MsgBox A_AhkVersion",
-            null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.Script);
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "~ver", ":*:~ver::\n{\nMsgBox A_AhkVersion\n}",
+            null, true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.Raw);
         StubList(Page(dto));
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
@@ -611,12 +611,12 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         cut.WaitForAssertion(() =>
         {
             AngleSharp.Dom.IElement badge = cut.Find(".type-badge .mud-chip");
-            badge.TextContent.Should().Contain("Script");
+            badge.TextContent.Should().Contain("Raw");
             badge.ClassList.Should().Contain(c => c.Contains("warning", StringComparison.OrdinalIgnoreCase));
             // Warning must be conveyed semantically, not just via color — screen readers read the
             // aria-label, not the CSS warning color.
             badge.GetAttribute("aria-label").Should()
-                .Contain("Script").And.Contain("Runs arbitrary AutoHotkey code");
+                .Contain("Raw").And.Contain("Verbatim AutoHotkey definition");
         });
         return Task.CompletedTask;
     }
@@ -635,7 +635,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
 
         allValues.Should().HaveCount(8);
         allValues.Distinct().Should().BeEquivalentTo(
-            [HotstringKind.Text, HotstringKind.DateTime, HotstringKind.Macro, HotstringKind.Script]);
+            [HotstringKind.Text, HotstringKind.DateTime, HotstringKind.Macro, HotstringKind.Raw]);
     }
 
     [Fact]

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Validation/HotstringEditModelTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Validation/HotstringEditModelTests.cs
@@ -236,7 +236,7 @@ public sealed class HotstringEditModelTests
     [InlineData(HotstringKind.Text, true)]
     [InlineData(HotstringKind.DateTime, false)]
     [InlineData(HotstringKind.Macro, false)]
-    [InlineData(HotstringKind.Script, false)]
+    [InlineData(HotstringKind.Raw, false)]
     public void IsInlineEditable_OnlyTrueForTextKind(HotstringKind kind, bool expected)
     {
         HotstringEditModel model = new() { Kind = kind };
@@ -288,39 +288,39 @@ public sealed class HotstringEditModelTests
     }
 
     [Fact]
-    public void ScriptSummary_IsNull_ForNonScriptKind()
+    public void RawSummary_IsNull_ForNonRawKind()
     {
         HotstringEditModel model = new() { Kind = HotstringKind.Text, Replacement = "MsgBox 1" };
 
-        model.ScriptSummary.Should().BeNull();
+        model.RawSummary.Should().BeNull();
     }
 
     [Fact]
-    public void ScriptSummary_SingleLine_ReturnsAsIs()
+    public void RawSummary_SingleLine_ReturnsAsIs()
     {
-        HotstringEditModel model = new() { Kind = HotstringKind.Script, Replacement = "MsgBox A_AhkVersion" };
+        HotstringEditModel model = new() { Kind = HotstringKind.Raw, Replacement = ":K1000 SE*:ftw::for the win" };
 
-        model.ScriptSummary.Should().Be("MsgBox A_AhkVersion");
+        model.RawSummary.Should().Be(":K1000 SE*:ftw::for the win");
     }
 
     [Fact]
-    public void ScriptSummary_MultilineBody_ReturnsFirstLineOnly()
+    public void RawSummary_MultilineBody_ReturnsFirstLineOnly()
     {
         HotstringEditModel model = new()
         {
-            Kind = HotstringKind.Script,
-            Replacement = "MsgBox 1\nMsgBox 2\nMsgBox 3",
+            Kind = HotstringKind.Raw,
+            Replacement = ":*:rng::\n{\nSend foo\n}",
         };
 
-        model.ScriptSummary.Should().Be("MsgBox 1");
+        model.RawSummary.Should().Be(":*:rng::");
     }
 
     [Fact]
-    public void ScriptSummary_LeadingWhitespaceOnFirstLine_IsTrimmed()
+    public void RawSummary_LeadingWhitespaceOnFirstLine_IsTrimmed()
     {
-        HotstringEditModel model = new() { Kind = HotstringKind.Script, Replacement = "  MsgBox 1  \nrest" };
+        HotstringEditModel model = new() { Kind = HotstringKind.Raw, Replacement = "  ::btw::hi  \nrest" };
 
-        model.ScriptSummary.Should().Be("MsgBox 1");
+        model.RawSummary.Should().Be("::btw::hi");
     }
 
     [Fact]


### PR DESCRIPTION
Replaces the **Script** hotstring kind with **Raw** (`HotstringKind.Raw = 4`): stores an entire verbatim AHK v2 definition (e.g. `:K1000 SE*:ftw::for the win`), preserving exotic option flags the structured fields can't express. `Script = 3` is retired to legacy-snapshot-only.

Spec/plan: `docs/superpowers/specs/2026-07-13-raw-hotstring-kind-design.md` + `docs/superpowers/plans/2026-07-13-raw-hotstring-kind-implementation-plan.md`.

## What's in it (P0–P14)
- **Parser** — `RawHotstringDefinitionParser`: structural split, option tokenization (longest-match `SE*`/`S0`/`SI`/`SP`, `K`/`P` numeric), multi-definition detection, escaped-trigger decode. Restricted subset (naive brace counting, OTB/continuation rejected).
- **Validation** — `AddRawKindRules` (8 structural rules); client-trigger gated off for Raw (server-derived); Raw trigger ≤ 40, definition ≤ 4200.
- **Emitter / migration / history** — verbatim `Emit` guard; `Script→Raw` composer single-sourced across the EF data migration (parity-tested), restore/revert legacy conversion, and dialog compose. `Replacement` column widened to `nvarchar(max)`.
- **Frontend** — monospace Raw editor, server-authoritative parsed summary, kind-switch compose/decompose with discard-options confirmation, promote-inline-row-to-dialog, list rendering + mobile chip.
- **CLI** — `new --raw "<definition>"`; docs + OpenAPI updated.

## Review fixes (post-implementation)
Addressed a review pass — see commit \`fix: address raw hotstring review findings\`:
1. Raw's 4200-char limit no longer shadowed by the generic 4000 replacement cap.
2. Validation now judges the **normalized** form, so it can't accept what save then persists.
3. Derived trigger keeps literal whitespace (matches the verbatim text used for dedup/DB/UI).
4. Raw parsed summary + inline validation appear without expanding the preview panel.
5. Desktop rows drop meaningless option glyphs/tooltip flags for Raw.

## Testing
- Unit: parser, validators (incl. new length/normalize/whitespace regressions).
- bUnit: dialog (Raw auto-preview while collapsed), page (Raw row glyph suppression).
- Integration (Testcontainers): API handlers, migration byte-equivalence, history round-trip.
- E2E (Playwright): mobile create-Raw byte-match + **desktop promote-flow** coverage.
- `dotnet build`, full `dotnet test`, `dotnet format --verify-no-changes` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)