### PR TITLE
feat: Raw hotstring continuation sections, OTB & comment lifting

### DIFF
--- a/docs/cli/hotstrings.md
+++ b/docs/cli/hotstrings.md
@@ -44,6 +44,13 @@ actual CLI surface and how each hotstring kind renders in `list` output.
   truncated to 40 chars. A multi-line brace-body definition shows just its opening line so the
   table stays one row per hotstring; use the web UI to see (or edit) the full definition.
 
+## Descriptions in generated scripts
+
+A hotstring's (or hotkey's) **Description** — for **every** kind, not just Raw — is emitted as one
+`; <line>` comment line per line directly above its definition in the generated `.ahk` script. An
+empty Description emits nothing. For Raw, a lifted leading comment is merged into the Description
+first (see below), so it round-trips back out as a comment.
+
 ## Raw validation limitations
 
 A Raw definition is the entire verbatim AHK v2 hotstring, validated (server-side) against a

--- a/docs/cli/hotstrings.md
+++ b/docs/cli/hotstrings.md
@@ -54,14 +54,21 @@ deliberately **restricted subset** of AHK v2:
 - The derived trigger must be non-empty, ≤ 40 characters (AHK's own abbreviation limit), and free
   of line breaks/tabs — so a trigger using escaped tab/newline (`` `t ``/`` `n ``) is rejected.
 - Every option flag must be a known AHK v2 flag; `X0` and other undocumented off-forms are rejected.
-- No line may start with `#` (directive lines corrupt the generated `#HotIf` grouping).
-- A bare `::` first line requires a `{` brace body on its own line, with balanced braces and no
-  content after the closing `}`. Brace counting is **string- and comment-unaware** — a `{` inside a
-  quoted string (e.g. `SendText "{"`) counts toward the balance and is falsely rejected. Inline
-  replacements are exempt from the brace check.
-- **OTB** brace placement (`::btw:: {`) and **continuation sections** (`(` … `)`) are rejected with
-  actionable messages. These are deliberate limitations, not bugs; supporting them is a possible
-  follow-up.
+- No line may start with `#` **outside a continuation section** (directive lines corrupt the
+  generated `#HotIf` grouping). A `#` line *inside* a `(` … `)` body is literal text and is kept.
+- A bare `::` first line must be followed by a body on its own line below the trigger — either a
+  `{` brace **code** body (balanced braces, no content after the closing `}`) or a `(` … `)`
+  **continuation section** holding verbatim multi-line **text** (closed by `)` on its own line).
+  Brace counting is **string- and comment-unaware** — a `{` inside a quoted string (e.g.
+  `SendText "{"`) counts toward the balance and is falsely rejected. Inline replacements are exempt
+  from the brace check.
+- **OTB** brace placement (`:X:run::{`) is **accepted** and normalized to `{` on its own line —
+  except with text/raw send-mode (`T`/`R`) active, where a trailing `{` is an inline literal.
+- **Continuation sections** (`(` … `)`) are **accepted** as literal multi-line text; trailing
+  whitespace inside the body is preserved byte-for-byte (significant under `RTrim0`).
+- Leading `;` comment lines above the definition are **lifted into the hotstring's Description**
+  (and emitted back as `; ` comment lines in the generated script); they don't count toward the
+  length limit. If the merged Description would exceed 200 characters, the paste is rejected.
 
 ## Example
 

--- a/docs/superpowers/plans/2026-07-14-raw-continuation-otb-comments-plan.md
+++ b/docs/superpowers/plans/2026-07-14-raw-continuation-otb-comments-plan.md
@@ -139,14 +139,15 @@ validator/E2E assertions on "Put `{` on its own line").
 (`:47`) still lists OTB and continuation sections as rejected; they are now accepted, so
 that page contradicts behavior. Rewrite those bullets to describe the new acceptance.
 
-## Task 6 — UI: example chips + summary
+## Task 6 — UI: example templates + summary
 
-In `HotstringEditDialog.razor` (Raw kind only), a `MudChipSet`/chip row above the
-textarea with the four spec templates (Inline / Multi-line text `( )` / Code block `{ }` /
-With options). Clicking fills `Item.Replacement`; if the field holds non-template,
-non-empty content, confirm via the existing `ConfirmSwitchAsync`-style dialog before
-overwriting. Summary row renders "code block" / "multi-line text (N lines)" from
-`BodyKind`/`BodyLineCount` and the "comment moved to Description" notice from
+In `HotstringEditDialog.razor` (Raw kind only), a collapsible "Examples"
+`MudExpansionPanel` below the textarea listing the four spec templates (Inline /
+Multi-line text `( )` / Code block `{ }` / With options), one row each with a label +
+monospace preview. Clicking a row fills `Item.Replacement`; if the field holds
+non-template, non-empty content, confirm via the existing `ConfirmSwitchAsync`-style
+dialog before overwriting. Summary row renders "code block" / "multi-line text (N lines)"
+from `BodyKind`/`BodyLineCount` and the "comment moved to Description" notice from
 `LiftedComment`.
 
 **Raw→structured switch (`RawDefinition.Decompose`, `Helpers/RawDefinition.cs:46`):**
@@ -161,8 +162,8 @@ Also update `RawHelperText` (`HotstringEditDialog.razor:256`) — it currently e
 "OTB braces and continuation sections are not supported"; reword to reflect that both
 are now accepted (OTB normalized, `( )` for multi-line text).
 
-**bUnit tests:** each chip inserts its template, overwrite-confirm path, summary shows
-body-kind text + N lines + comment-lift notice.
+**bUnit tests:** each example row inserts its template, preview text renders,
+overwrite-confirm path, summary shows body-kind text + N lines + comment-lift notice.
 
 ## Task 7 — Round-trip + E2E
 
@@ -192,5 +193,5 @@ Commit per task (feature + its tests together).
    discarding when continuation options or significant whitespace are present (Task 6).
 2. Rule 8 (4200): measure **definition-minus-lifted-comments** — spec §6 already decides
    this (lifted comment lines leave the definition, so they don't count).
-3. Chip overwrite confirm: reuse the existing **MessageBox** pattern (`ConfirmSwitchAsync`),
+3. Example overwrite confirm: reuse the existing **MessageBox** pattern (`ConfirmSwitchAsync`),
    consistent with kind-switch confirmation and existing bUnit infrastructure.

--- a/docs/superpowers/plans/2026-07-14-raw-continuation-otb-comments-plan.md
+++ b/docs/superpowers/plans/2026-07-14-raw-continuation-otb-comments-plan.md
@@ -144,9 +144,9 @@ that page contradicts behavior. Rewrite those bullets to describe the new accept
 In `HotstringEditDialog.razor` (Raw kind only), a collapsible "Examples"
 `MudExpansionPanel` below the textarea listing the four spec templates (Inline /
 Multi-line text `( )` / Code block `{ }` / With options), one row each with a label +
-monospace preview. Clicking a row fills `Item.Replacement`; if the field holds
-non-template, non-empty content, confirm via the existing `ConfirmSwitchAsync`-style
-dialog before overwriting. Summary row renders "code block" / "multi-line text (N lines)"
+monospace preview + a copy icon. The copy icon writes the full template to the clipboard
+(snackbar confirms) so the user pastes it in themselves — examples never overwrite
+`Item.Replacement`. Summary row renders "code block" / "multi-line text (N lines)"
 from `BodyKind`/`BodyLineCount` and the "comment moved to Description" notice from
 `LiftedComment`.
 
@@ -162,8 +162,8 @@ Also update `RawHelperText` (`HotstringEditDialog.razor:256`) — it currently e
 "OTB braces and continuation sections are not supported"; reword to reflect that both
 are now accepted (OTB normalized, `( )` for multi-line text).
 
-**bUnit tests:** each example row inserts its template, preview text renders,
-overwrite-confirm path, summary shows body-kind text + N lines + comment-lift notice.
+**bUnit tests:** copy icon writes the template to the clipboard (field untouched),
+preview text renders, summary shows body-kind text + N lines + comment-lift notice.
 
 ## Task 7 — Round-trip + E2E
 
@@ -193,5 +193,5 @@ Commit per task (feature + its tests together).
    discarding when continuation options or significant whitespace are present (Task 6).
 2. Rule 8 (4200): measure **definition-minus-lifted-comments** — spec §6 already decides
    this (lifted comment lines leave the definition, so they don't count).
-3. Example overwrite confirm: reuse the existing **MessageBox** pattern (`ConfirmSwitchAsync`),
-   consistent with kind-switch confirmation and existing bUnit infrastructure.
+3. Examples are copy-to-clipboard (reference-only), not click-to-insert — so no overwrite
+   confirm is needed; the user pastes into the field themselves.

--- a/docs/superpowers/plans/2026-07-14-raw-continuation-otb-comments-plan.md
+++ b/docs/superpowers/plans/2026-07-14-raw-continuation-otb-comments-plan.md
@@ -1,0 +1,154 @@
+# Plan: Raw hotstring continuation sections, OTB & comments
+
+**Date:** 2026-07-14
+**Spec:** [2026-07-14-raw-continuation-otb-comments-design.md](../specs/2026-07-14-raw-continuation-otb-comments-design.md)
+**Branch:** `feature/wt-raw-continuation-otb-comments` (worktree)
+
+## Key files
+
+| Area | File |
+|---|---|
+| Parser | `src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs` |
+| Validation | `src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs` (`AddRawKindRules`) |
+| Save handlers | `Commands/Hotstrings/CreateHotstringCommand.cs`, `UpdateHotstringCommand.cs` |
+| Preview | `Queries/Hotstrings/GetHotstringPreviewQuery.cs`, `DTOs/HotstringDto.cs` (`RawSummaryDto`, `HotstringPreviewRequestDto`) |
+| Generator | `Services/AhkScriptGenerator.cs`, `Services/HotstringEmitter.cs` |
+| UI | `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor`, `DTOs/HotstringPreviewDtos.cs` |
+| Tests | `tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs`, generator tests, bUnit dialog tests, `tests/AHKFlowApp.E2E.Tests/RawHotstringFlowTests.cs` |
+
+## Task 1 — Parser: structural rework (TDD)
+
+The parser currently computes `DefinitionCount` as a flat line scan before body
+classification, and `HotstringRules` rule 5 does its own flat directive scan. Both must
+become body-aware, so the parser takes ownership of line classification:
+
+1. **`RawParseResult` grows:** `BodyKind` enum (`None | Inline | Braces | Continuation`),
+   `BodyLineCount`, `HasDirectiveOutsideBody` (rule 5 moves in here — the validator keeps
+   only the message), and `LiftedComment` (Task 3; declare now to avoid churn).
+2. **Parse flow:** find first non-blank line → match `:opts:trigger::` → classify body
+   with the parsed option tokens (`ClassifyBody(optionTokens, inlineRest, trailing)`):
+   - Inline (unchanged), brace body (unchanged scan), **continuation section**: first
+     non-blank trailing line starts with `(` → continuation. Opener-line remainder is
+     pass-through, but reject if it contains `)`. Body = verbatim lines until first line
+     that is exactly `)` after trim (no nesting). Unclosed → error; non-blank content
+     after close → "content after close" error.
+   - `DefinitionCount` and the directive check skip lines inside brace/continuation
+     bodies — count/scan only structural lines.
+3. Update the class doc comment (it currently says continuation sections are rejected).
+
+**Tests first** (parser test file): continuation happy path, `(Join`, `(LTrim` openers,
+opener containing `)` rejected, unclosed section, content after `)`, interior blank lines
+preserved, `::example::text` and `# Heading` inside body not counted as definition or
+directive, `BodyKind`/`BodyLineCount` for all four shapes.
+
+## Task 2 — Parser: OTB + body-aware Normalize (TDD)
+
+1. **OTB classification (option-sensitive):** in `ClassifyBody`, `inlineRest.Trim() == "{"`
+   is a brace-body opener **only when** neither `T` nor `R` is active (`T0`/`R0` don't
+   suppress). With `T`/`R` active it's an inline literal `{` replacement. OTB opener →
+   validate the brace body starting from that `{` plus trailing lines.
+2. **`Normalize` becomes parse-aware:**
+   - Per-line `TrimEnd()` and blank-line trimming skip lines inside a continuation body
+     (byte-for-byte preservation, `RTrim0`). Requires a light structural pass inside
+     Normalize (reuse the same body-boundary logic as Parse — extract a shared helper).
+   - Genuine OTB → rewritten to `{` on its own line below the trigger.
+   - Invalid input passes through with only the existing line-ending/trim behavior on
+     structural lines (validator reports errors on the normalized text as today).
+
+**Tests first:** OTB accept + Normalize golden (`:X:run::{` → canonical), `:T:brace::{`
+and `:R:brace::{` inline-literal (not OTB) while `:*:x::{` is OTB, `:T0:x::{` is OTB,
+`RTrim0` regression — trailing spaces/tabs inside `( … )` survive Normalize byte-for-byte,
+structural lines outside the body still trimmed.
+
+## Task 3 — Comment lifting (parser + validator + handlers)
+
+1. **Parser:** leading `; …` lines above the first definition line are consumed, joined
+   with `\n` (strip `;` + one following space per line), exposed as `LiftedComment`
+   (null when none). They no longer count as content for "first line" matching.
+   `Normalize` also strips them so the persisted definition never contains them —
+   **decide ordering:** Normalize strips + returns them, or handlers call
+   `Parse` first and persist `definition-without-comments` (pick: Normalize keeps
+   signature `string → string` but skips comment lines; Parse exposes `LiftedComment`
+   and `DefinitionWithoutComments` — handlers persist the latter).
+2. **Merge policy helper** (new small static, e.g. `RawCommentLift.Merge(description,
+   lifted)`): empty → lifted; equal → drop; differs → append on new line. Shared by
+   validator (length check) and both save handlers.
+3. **Validator (`AddRawKindRules`):** gains a `description` expression parameter; after
+   structural checks, compute merged Description and fail with the spec's message when
+   it exceeds `DescriptionMaxLength` (200). Lifted lines excluded from the 4200 length
+   check (they leave the definition) — but rule 8 runs on raw input before parsing;
+   adjust to check the definition-minus-comments length.
+4. **Handlers (Create/Update):** for Raw, persist `DefinitionWithoutComments` (normalized)
+   and the merged Description. Comment lines inside `{…}`/`(…)` bodies stay verbatim.
+
+**Tests first:** merge matrix (empty / equal / differing), 200-char overflow error
+message, comments inside bodies untouched, lifted comment excluded from 4200 count,
+handler persists stripped definition + merged Description (Create + Update).
+
+## Task 4 — Comment emission (generator + preview)
+
+1. **Shared formatter:** `HotstringEmitter` (or a tiny `DescriptionComment` helper) —
+   Description → one `; <line>` per line; empty/null → nothing.
+2. **`AhkScriptGenerator`:** emit comment lines above each hotstring (context groups and
+   global group) and each hotkey with non-empty Description. All kinds.
+3. **Preview:** `HotstringPreviewRequestDto` (+ Blazor mirror) gains `Description`;
+   `GetHotstringPreviewQueryHandler` passes it into the transient hotstring and prepends
+   the formatted comment lines to the snippet via the shared formatter.
+4. **`RawSummaryDto`** (+ Blazor mirror) → `(Trigger, OptionTokens, BodyKind,
+   BodyLineCount, LiftedComment)`. Preview handler fills from the parse result.
+   `BodyKind` enum must exist client-side too (Blazor DTOs file).
+
+**Tests:** generator emits for hotstring + hotkey + multi-line Description; nothing when
+empty; byte-identical output for description-less rows (regression against existing
+goldens); preview snippet includes `; comment` lines; preview `RawSummary` carries new
+fields.
+
+## Task 5 — Error copy
+
+Rule-6 `BraceRequiredError` becomes:
+> Add a replacement after `::`, or put `{` (code) or `(` (multi-line text) on its own line below the trigger.
+
+Update the parser constant + every test asserting the old copy (parser tests, any
+validator/E2E assertions on "Put `{` on its own line").
+
+## Task 6 — UI: example chips + summary
+
+In `HotstringEditDialog.razor` (Raw kind only), a `MudChipSet`/chip row above the
+textarea with the four spec templates (Inline / Multi-line text `( )` / Code block `{ }` /
+With options). Clicking fills `Item.Replacement`; if the field holds non-template,
+non-empty content, confirm via the existing `ConfirmSwitchAsync`-style dialog before
+overwriting. Summary row renders "code block" / "multi-line text (N lines)" from
+`BodyKind`/`BodyLineCount` and the "comment moved to Description" notice from
+`LiftedComment`.
+
+**bUnit tests:** each chip inserts its template, overwrite-confirm path, summary shows
+body-kind text + N lines + comment-lift notice.
+
+## Task 7 — Round-trip + E2E
+
+- **Round-trip integration test:** paste `:*:col::` + `( … )` colors sample → save via
+  Create handler → `AhkScriptGenerator.Generate` → script contains the section
+  byte-identical.
+- **E2E (`RawHotstringFlowTests`):** paste the colors continuation hotstring, save,
+  download, assert exact lines (extend the existing promote-flow pattern).
+
+## Task 8 — Verify
+
+`dotnet build` + `dotnet test` + `dotnet format --verify-no-changes`; run E2E project;
+then PR per GitHub Flow.
+
+## Sequencing
+
+Tasks 1→2→3 are parser-layer and strictly ordered (TDD each). Task 4 is independent of
+2 but needs 3's `LiftedComment`. Task 5 anytime after 1. Task 6 needs 4's DTO shape.
+Commit per task (feature + its tests together).
+
+## Unresolved questions
+
+1. `RawDefinition.Decompose` (client, Raw→structured switch): treat `( … )` body like a
+   brace body (lines between `(` and `)`), or leave untouched (whole text becomes body)?
+   Spec silent — plan assumes: handle it, minimal.
+2. Rule 8 (4200) on definition-minus-comments — OK that a paste >4200 chars *with*
+   comments now passes if the definition alone fits?
+3. Chip overwrite confirm: reuse the existing MessageBox confirm, or inline MudPopover?
+   Plan assumes MessageBox (matches kind-switch confirms).

--- a/docs/superpowers/plans/2026-07-14-raw-continuation-otb-comments-plan.md
+++ b/docs/superpowers/plans/2026-07-14-raw-continuation-otb-comments-plan.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-14
 **Spec:** [2026-07-14-raw-continuation-otb-comments-design.md](../specs/2026-07-14-raw-continuation-otb-comments-design.md)
-**Branch:** `feature/wt-raw-continuation-otb-comments` (worktree)
+**Branch:** `feature/raw-continuation-otb-comments` (worktree)
 
 ## Key files
 
@@ -23,8 +23,8 @@ classification, and `HotstringRules` rule 5 does its own flat directive scan. Bo
 become body-aware, so the parser takes ownership of line classification:
 
 1. **`RawParseResult` grows:** `BodyKind` enum (`None | Inline | Braces | Continuation`),
-   `BodyLineCount`, `HasDirectiveOutsideBody` (rule 5 moves in here — the validator keeps
-   only the message), and `LiftedComment` (Task 3; declare now to avoid churn).
+   `BodyLineCount`, `HasDirectiveOutsideLiteralBody` (rule 5 moves in here — the validator
+   keeps only the message), and `LiftedComment` (Task 3; declare now to avoid churn).
 2. **Parse flow:** find first non-blank line → match `:opts:trigger::` → classify body
    with the parsed option tokens (`ClassifyBody(optionTokens, inlineRest, trailing)`):
    - Inline (unchanged), brace body (unchanged scan), **continuation section**: first
@@ -32,21 +32,29 @@ become body-aware, so the parser takes ownership of line classification:
      pass-through, but reject if it contains `)`. Body = verbatim lines until first line
      that is exactly `)` after trim (no nesting). Unclosed → error; non-blank content
      after close → "content after close" error.
-   - `DefinitionCount` and the directive check skip lines inside brace/continuation
-     bodies — count/scan only structural lines.
+   - **Two distinct scans — do not conflate:** only continuation bodies are literal text.
+     A brace body is *code*, so a `#HotIf`/`#Requires` inside it stays positional and must
+     still be rejected (braces do not scope a directive's effect on later definitions).
+     - `DefinitionCount` (rule 2): skip brace **and** continuation bodies — count only
+       structural `:opts:trigger::` lines.
+     - `HasDirectiveOutsideLiteralBody` (rule 5): skip **continuation bodies only** — still
+       reject a directive found in a brace body or on any structural line.
 3. Update the class doc comment (it currently says continuation sections are rejected).
 
 **Tests first** (parser test file): continuation happy path, `(Join`, `(LTrim` openers,
 opener containing `)` rejected, unclosed section, content after `)`, interior blank lines
-preserved, `::example::text` and `# Heading` inside body not counted as definition or
-directive, `BodyKind`/`BodyLineCount` for all four shapes.
+preserved, `# Heading`/`::example::text` inside a **continuation** body accepted (not a
+directive or definition), `#HotIf`/`#Requires` inside a **brace** body still rejected,
+`BodyKind`/`BodyLineCount` for all four shapes.
 
 ## Task 2 — Parser: OTB + body-aware Normalize (TDD)
 
 1. **OTB classification (option-sensitive):** in `ClassifyBody`, `inlineRest.Trim() == "{"`
-   is a brace-body opener **only when** neither `T` nor `R` is active (`T0`/`R0` don't
-   suppress). With `T`/`R` active it's an inline literal `{` replacement. OTB opener →
-   validate the brace body starting from that `{` plus trailing lines.
+   is a brace-body opener **only when** text/raw send-mode is *not* active. `T`/`R`/`T0`/`R0`
+   are last-wins and mutually exclusive — do **not** test "tokens contain `T`/`R`". Scan the
+   option tokens left-to-right; the effective mode is set by the **last** `T`/`R`/`T0`/`R0`
+   token (`T0`/`R0` turn it off). Mode active → inline literal `{` replacement; mode off →
+   OTB opener → validate the brace body starting from that `{` plus trailing lines.
 2. **`Normalize` becomes parse-aware:**
    - Per-line `TrimEnd()` and blank-line trimming skip lines inside a continuation body
      (byte-for-byte preservation, `RTrim0`). Requires a light structural pass inside
@@ -56,20 +64,29 @@ directive, `BodyKind`/`BodyLineCount` for all four shapes.
      structural lines (validator reports errors on the normalized text as today).
 
 **Tests first:** OTB accept + Normalize golden (`:X:run::{` → canonical), `:T:brace::{`
-and `:R:brace::{` inline-literal (not OTB) while `:*:x::{` is OTB, `:T0:x::{` is OTB,
-`RTrim0` regression — trailing spaces/tabs inside `( … )` survive Normalize byte-for-byte,
-structural lines outside the body still trimmed.
+and `:R:brace::{` inline-literal (not OTB) while `:*:x::{` is OTB, `:T0:x::{` and `:R0:x::{`
+are OTB, **ordered last-wins combos**: `:TT0:x::{` and `:RT0:x::{` are OTB (mode off last),
+`:T0T:x::{` and `:T0R:x::{` are inline literal (mode on last); `RTrim0` regression —
+trailing spaces/tabs inside `( … )` survive Normalize byte-for-byte, structural lines
+outside the body still trimmed.
 
 ## Task 3 — Comment lifting (parser + validator + handlers)
 
-1. **Parser:** leading `; …` lines above the first definition line are consumed, joined
-   with `\n` (strip `;` + one following space per line), exposed as `LiftedComment`
-   (null when none). They no longer count as content for "first line" matching.
-   `Normalize` also strips them so the persisted definition never contains them —
-   **decide ordering:** Normalize strips + returns them, or handlers call
-   `Parse` first and persist `definition-without-comments` (pick: Normalize keeps
-   signature `string → string` but skips comment lines; Parse exposes `LiftedComment`
-   and `DefinitionWithoutComments` — handlers persist the latter).
+1. **Parser — one authoritative preparation op:** leading `; …` lines above the first
+   definition line are consumed, joined with `\n` (strip `;` + one following space per
+   line). They no longer count as content for "first line" matching. Because every live
+   caller runs `Normalize` first then `Parse` (`HotstringRules.cs:254`,
+   `CreateHotstringCommand.cs:72`, `UpdateHotstringCommand.cs:80`,
+   `GetHotstringPreviewQuery.cs:62`), a "Normalize strips the comment before Parse sees
+   it" split would lose the comment. Instead add a single `Prepare(rawDefinition)` that
+   returns `RawPrepared(NormalizedDefinition, LiftedComment, RawParseResult)`:
+   - `NormalizedDefinition` — body-aware normalized text with the lifted comment lines
+     removed (the exact text handlers persist);
+   - `LiftedComment` — the joined comment (null when none);
+   - the full `RawParseResult` (all structural facts, `LiftedComment` mirrored on it for
+     the preview summary).
+   Validation, Create, Update, and preview all consume this **one** result. `Normalize`
+   keeps its `string → string` signature by delegating to `Prepare(...).NormalizedDefinition`.
 2. **Merge policy helper** (new small static, e.g. `RawCommentLift.Merge(description,
    lifted)`): empty → lifted; equal → drop; differs → append on new line. Shared by
    validator (length check) and both save handlers.
@@ -78,8 +95,9 @@ structural lines outside the body still trimmed.
    it exceeds `DescriptionMaxLength` (200). Lifted lines excluded from the 4200 length
    check (they leave the definition) — but rule 8 runs on raw input before parsing;
    adjust to check the definition-minus-comments length.
-4. **Handlers (Create/Update):** for Raw, persist `DefinitionWithoutComments` (normalized)
-   and the merged Description. Comment lines inside `{…}`/`(…)` bodies stay verbatim.
+4. **Handlers (Create/Update):** for Raw, call `Prepare` once and persist its
+   `NormalizedDefinition` and the merged Description (`RawCommentLift.Merge`). Comment
+   lines inside `{…}`/`(…)` bodies stay verbatim.
 
 **Tests first:** merge matrix (empty / equal / differing), 200-char overflow error
 message, comments inside bodies untouched, lifted comment excluded from 4200 count,
@@ -93,10 +111,16 @@ handler persists stripped definition + merged Description (Create + Update).
    global group) and each hotkey with non-empty Description. All kinds.
 3. **Preview:** `HotstringPreviewRequestDto` (+ Blazor mirror) gains `Description`;
    `GetHotstringPreviewQueryHandler` passes it into the transient hotstring and prepends
-   the formatted comment lines to the snippet via the shared formatter.
+   the formatted comment lines to the snippet via the shared formatter. **For Raw, pass
+   `RawCommentLift.Merge(input.Description, parsed.LiftedComment)`** (not the bare request
+   Description) so the preview matches the saved/downloaded script exactly. Also add the
+   200-char `Description` rule to `GetHotstringPreviewQueryValidator` (non-Raw kinds) — it
+   has no Description validation today, so an over-long Description previews but fails save.
 4. **`RawSummaryDto`** (+ Blazor mirror) → `(Trigger, OptionTokens, BodyKind,
-   BodyLineCount, LiftedComment)`. Preview handler fills from the parse result.
-   `BodyKind` enum must exist client-side too (Blazor DTOs file).
+   BodyLineCount, LiftedComment)`. Preview handler fills from the parse result. Since the
+   public `RawSummaryDto` exposes `BodyKind`, it must be a **public** contract type placed
+   in `Application.DTOs` (with XML docs), not the parser's `internal` enum — mirror it
+   client-side in the Blazor DTOs file. The parser's internal `BodyKind` maps to it.
 
 **Tests:** generator emits for hotstring + hotkey + multi-line Description; nothing when
 empty; byte-identical output for description-less rows (regression against existing
@@ -111,6 +135,10 @@ Rule-6 `BraceRequiredError` becomes:
 Update the parser constant + every test asserting the old copy (parser tests, any
 validator/E2E assertions on "Put `{` on its own line").
 
+**Docs:** update `docs/cli/hotstrings.md` — the "Raw validation limitations" section
+(`:47`) still lists OTB and continuation sections as rejected; they are now accepted, so
+that page contradicts behavior. Rewrite those bullets to describe the new acceptance.
+
 ## Task 6 — UI: example chips + summary
 
 In `HotstringEditDialog.razor` (Raw kind only), a `MudChipSet`/chip row above the
@@ -120,6 +148,18 @@ non-empty content, confirm via the existing `ConfirmSwitchAsync`-style dialog be
 overwriting. Summary row renders "code block" / "multi-line text (N lines)" from
 `BodyKind`/`BodyLineCount` and the "comment moved to Description" notice from
 `LiftedComment`.
+
+**Raw→structured switch (`RawDefinition.Decompose`, `Helpers/RawDefinition.cs:46`):**
+handle `( … )` continuation bodies (extract lines between `(` and `)`, like a brace body),
+but do it non-silently. Structured `Text` cannot represent continuation options (`Join`,
+`LTrim`, `RTrim0`) or significant trailing/interior whitespace, so `Decompose` returns an
+explicit lossy flag (extend `RawDecomposition` — e.g. `LossyConversion` / reason list
+alongside `UnexpressibleOptions`) and the dialog confirms before discarding, reusing the
+existing `ConfirmSwitchAsync` MessageBox pattern. Helper + bUnit tests for the lossy path.
+
+Also update `RawHelperText` (`HotstringEditDialog.razor:256`) — it currently ends
+"OTB braces and continuation sections are not supported"; reword to reflect that both
+are now accepted (OTB normalized, `( )` for multi-line text).
 
 **bUnit tests:** each chip inserts its template, overwrite-confirm path, summary shows
 body-kind text + N lines + comment-lift notice.
@@ -134,8 +174,10 @@ body-kind text + N lines + comment-lift notice.
 
 ## Task 8 — Verify
 
-`dotnet build` + `dotnet test` + `dotnet format --verify-no-changes`; run E2E project;
-then PR per GitHub Flow.
+`dotnet restore` → `dotnet build AHKFlowApp.slnx -c Release --no-restore` →
+`dotnet test AHKFlowApp.slnx -c Release --no-build` → `dotnet format --verify-no-changes`
+→ `git diff --check` (whitespace/conflict markers); run the E2E project; then PR per
+GitHub Flow.
 
 ## Sequencing
 
@@ -143,12 +185,12 @@ Tasks 1→2→3 are parser-layer and strictly ordered (TDD each). Task 4 is inde
 2 but needs 3's `LiftedComment`. Task 5 anytime after 1. Task 6 needs 4's DTO shape.
 Commit per task (feature + its tests together).
 
-## Unresolved questions
+## Resolved decisions
 
-1. `RawDefinition.Decompose` (client, Raw→structured switch): treat `( … )` body like a
-   brace body (lines between `(` and `)`), or leave untouched (whole text becomes body)?
-   Spec silent — plan assumes: handle it, minimal.
-2. Rule 8 (4200) on definition-minus-comments — OK that a paste >4200 chars *with*
-   comments now passes if the definition alone fits?
-3. Chip overwrite confirm: reuse the existing MessageBox confirm, or inline MudPopover?
-   Plan assumes MessageBox (matches kind-switch confirms).
+1. `RawDefinition.Decompose` (Raw→structured switch): **handle** `( … )` bodies (lines
+   between `(` and `)`), but return an explicit lossy-conversion result and confirm before
+   discarding when continuation options or significant whitespace are present (Task 6).
+2. Rule 8 (4200): measure **definition-minus-lifted-comments** — spec §6 already decides
+   this (lifted comment lines leave the definition, so they don't count).
+3. Chip overwrite confirm: reuse the existing **MessageBox** pattern (`ConfirmSwitchAsync`),
+   consistent with kind-switch confirmation and existing bUnit infrastructure.

--- a/docs/superpowers/specs/2026-07-14-raw-continuation-otb-comments-design.md
+++ b/docs/superpowers/specs/2026-07-14-raw-continuation-otb-comments-design.md
@@ -31,15 +31,23 @@ Out (still rejected by design): multiple definitions per paste, `#Hotstring` dir
 `RawHotstringDefinitionParser` accepts, after a bare `:opts:trigger::` first line, a
 **continuation section** as an alternative to the existing brace body:
 
-- Opens with a line whose first non-blank character is `(`. Anything after the `(`
-  (continuation options such as `Join`, `LTrim`, `%`, `` ` ``, `C`) is accepted
-  **verbatim and not interpreted**.
-- Body lines are literal text, stored verbatim.
+- Opens with a line whose first non-blank character is `(`. The remainder of the
+  opener line (continuation options such as `Join`, `LTrim`, `RTrim0`, `C`, `` ` ``)
+  is **unvalidated pass-through** — stored verbatim, not interpreted — with one
+  exception: an opener line containing `)` is rejected (AHK itself treats such a
+  line as an expression, not a continuation opener).
+- Body lines are literal text, stored verbatim — including trailing whitespace and
+  interior blank lines (significant under `RTrim0`).
 - Closes at the first line that is exactly `)` (after trim). No nesting.
 - Unclosed section → error. Non-blank content after the closing `)` → same
   "content after close" rule as braces.
-- `RawParseResult` gains `BodyKind` enum: `None | Inline | Braces | Continuation`,
-  so the preview summary can distinguish "code block" from "multi-line text (N lines)".
+- **Existing checks become body-aware:** `DefinitionCount` (rule 2) and the
+  directive rejection (rule 5, `HotstringRules.cs`) skip lines inside a
+  continuation-section body — literal text like `::example::text` or `# Heading`
+  must not be misread as another definition or a directive.
+- `RawParseResult` gains `BodyKind` enum (`None | Inline | Braces | Continuation`)
+  and `BodyLineCount`, so the preview summary can distinguish "code block" from
+  "multi-line text (N lines)".
 
 Docs: continuation sections per <https://www.autohotkey.com/docs/v2/Scripts.htm#continuation-section>.
 
@@ -47,9 +55,17 @@ Docs: continuation sections per <https://www.autohotkey.com/docs/v2/Scripts.htm#
 
 - `:X:trigger::{` (line ends with `{`, nothing after it) is accepted as a brace-body
   opener. Any other trailing content stays rejected.
-- `Normalize()` rewrites OTB to the canonical form — `{` on its own line below the
-  trigger — so stored/emitted definitions have one shape (consistent with existing
-  CRLF/whitespace normalization). Preview shows the normalized result.
+- **Option-sensitive:** a trailing lone `{` is an OTB opener only when neither `T`
+  nor `R` (text/raw mode) is in effect on the definition line (`T0`/`R0` cancel the
+  mode, so they do not suppress OTB). With `T` or `R` active, `:T:brace::{` is an
+  **inline literal replacement** that types `{` — per the official hotstring brace
+  rule. `ClassifyBody` therefore receives the parsed option tokens.
+- `Normalize()` rewrites genuine OTB to the canonical form — `{` on its own line
+  below the trigger — so stored/emitted definitions have one shape (consistent with
+  existing CRLF/whitespace normalization). Preview shows the normalized result.
+- **Normalization is body-aware:** per-line trailing-whitespace trimming and blank-line
+  trimming apply only *outside* a continuation-section body; lines between `(` and `)`
+  are preserved byte-for-byte (trailing spaces/tabs are significant under `RTrim0`).
 
 ## 3. Comments = Description
 
@@ -59,11 +75,33 @@ No new field. `Description` becomes the script comment:
   hotstring **and hotkey** whose Description is non-empty. Multi-line description →
   one `; ` line per line. Applies to all kinds (Text/DateTime/Macro/Raw) and hotkeys.
 - **Paste lifting (Raw only):** leading `; …` comment lines above the pasted definition
-  are stripped from the stored definition and lifted into the Description field —
-  only when Description is currently empty (never clobber an existing value; when
-  non-empty the comment lines are still stripped). Parsed summary notes
-  "comment moved to Description".
+  are stripped from the stored definition and lifted into Description with an explicit
+  merge policy — no silent data loss:
+  - Description empty → lifted comment becomes the Description.
+  - Description equals the lifted comment → dropped as a duplicate.
+  - Description differs → lifted comment is **appended** on a new line.
+  - If the merged Description would exceed `DescriptionMaxLength` (200), validation
+    fails with an explicit error ("Pasted comment does not fit in Description
+    (200-char max) — shorten it or remove the comment lines") and nothing is saved.
+  The parsed summary notes "comment moved to Description".
 - Comment lines *inside* a `( … )` or `{ … }` body are body content and stay verbatim.
+
+### Preview contract
+
+The existing preview endpoint carries the new facts end-to-end (backend DTO +
+mirrored Blazor DTO):
+
+- `RawSummary` grows from `(Trigger, OptionTokens)` to
+  `(Trigger, OptionTokens, BodyKind, BodyLineCount, LiftedComment)` —
+  `LiftedComment` is the comment text the save would move into Description
+  (null when none), letting the dialog render the "comment moved to Description"
+  notice and the merge outcome before saving.
+- The preview request gains `Description`, and `GetHotstringPreviewQuery`'s handler
+  passes it into the transient hotstring (today it hardcodes `Description: null`),
+  so the preview script shows the emitted `; comment` lines exactly as the download
+  will.
+- One shared comment formatter (Description → `; ` lines) is used by both
+  `AhkScriptGenerator` and the preview path — single source of truth.
 
 ## 4. Error copy
 
@@ -95,9 +133,14 @@ definition).
 
 ## 7. Testing
 
-- **Parser (TDD):** continuation happy path incl. `(Join` and `(LTrim`, unclosed `)`,
-  content after `)`, blank lines inside body preserved, OTB accept + Normalize goldens,
-  comment-lift (empty vs non-empty Description), `BodyKind` classification.
+- **Parser (TDD):** continuation happy path incl. `(Join` and `(LTrim`, opener line
+  containing `)` rejected, unclosed `)`, content after `)`, blank lines inside body
+  preserved, `RTrim0` regression with significant trailing spaces/tabs surviving
+  Normalize byte-for-byte, body lines like `::example::text` / `# Heading` not
+  counted as definitions or directives, OTB accept + Normalize goldens,
+  `:T:brace::{` and `:R:brace::{` classified as inline literal (not OTB) while
+  `:*:x::{` is OTB, comment-lift merge matrix (empty / equal / differing Description)
+  + 200-char overflow error, `BodyKind` + `BodyLineCount` classification.
 - **Generator:** comment emission for hotstring + hotkey + multi-line description;
   none emitted when Description empty; byte-identical output for rows without
   descriptions (regression).

--- a/docs/superpowers/specs/2026-07-14-raw-continuation-otb-comments-design.md
+++ b/docs/superpowers/specs/2026-07-14-raw-continuation-otb-comments-design.md
@@ -113,17 +113,18 @@ Rule-6 message becomes:
 ## 5. UX: example templates
 
 Collapsible "Examples" panel below the Raw textarea in `HotstringEditDialog`, one row
-per template (label + monospace preview):
+per template (label + monospace preview + copy icon):
 
-| Example | Preview | Inserts |
+| Example | Preview | Copies |
 |---|---|---|
 | Inline | `:*:btw::by the way` | `:*:btw::by the way` |
 | Multi-line text ( ) | `:*:col::  ( red / green / blue )` | `:*:col::` + `(` + sample lines + `)` |
 | Code block { } | `:X:run::  { Run "notepad.exe" }` | `:X:run::` + `{` + `Run "notepad.exe"` + `}` |
 | With options | `:K1000 SE*:ftw::for the win` | `:K1000 SE*:ftw::for the win` |
 
-Clicking a row fills the textarea; if it already holds non-template content, confirm
-before overwriting. bUnit-tested.
+The copy icon writes the full template to the clipboard (snackbar confirms) so the user
+pastes it in themselves — the examples are reference-only and never overwrite the field.
+bUnit-tested.
 
 ## 6. Validation & limits (unchanged)
 
@@ -147,6 +148,7 @@ definition).
   descriptions (regression).
 - **Round-trip:** paste `:*:col::` + `( … )` → save → generate → script contains the
   section byte-identical.
-- **bUnit:** example rows insert templates, overwrite confirm, preview text renders,
-  summary shows "multi-line text (N lines)" and comment-lift notice.
+- **bUnit:** copy icon writes the template to the clipboard (leaving the field
+  untouched), preview text renders, summary shows "multi-line text (N lines)" and
+  comment-lift notice.
 - **E2E:** paste the colors continuation hotstring, save, download, assert exact lines.

--- a/docs/superpowers/specs/2026-07-14-raw-continuation-otb-comments-design.md
+++ b/docs/superpowers/specs/2026-07-14-raw-continuation-otb-comments-design.md
@@ -20,8 +20,8 @@ generator ignores.
 ## Scope
 
 In: continuation-section bodies, OTB acceptance (normalized), Description-as-comment
-emission for hotstrings and hotkeys, comment-line lifting on Raw paste, example chips
-in the Raw editor, error-copy update.
+emission for hotstrings and hotkeys, comment-line lifting on Raw paste, example
+templates in the Raw editor, error-copy update.
 
 Out (still rejected by design): multiple definitions per paste, `#Hotstring` directives,
 `Hotstring()` calls, interpreting continuation options, any schema change.
@@ -110,19 +110,20 @@ Rule-6 message becomes:
 > Add a replacement after `::`, or put `{` (code) or `(` (multi-line text) on its own
 > line below the trigger.
 
-## 5. UX: example chips
+## 5. UX: example templates
 
-Row of four chips above the Raw textarea in `HotstringEditDialog`:
+Collapsible "Examples" panel below the Raw textarea in `HotstringEditDialog`, one row
+per template (label + monospace preview):
 
-| Chip | Inserts |
-|---|---|
-| Inline | `:*:btw::by the way` |
-| Multi-line text ( ) | `:*:col::` + `(` + sample lines + `)` |
-| Code block { } | `:X:run::` + `{` + `Run "notepad.exe"` + `}` |
-| With options | `:K1000 SE*:ftw::for the win` |
+| Example | Preview | Inserts |
+|---|---|---|
+| Inline | `:*:btw::by the way` | `:*:btw::by the way` |
+| Multi-line text ( ) | `:*:col::  ( red / green / blue )` | `:*:col::` + `(` + sample lines + `)` |
+| Code block { } | `:X:run::  { Run "notepad.exe" }` | `:X:run::` + `{` + `Run "notepad.exe"` + `}` |
+| With options | `:K1000 SE*:ftw::for the win` | `:K1000 SE*:ftw::for the win` |
 
-Clicking a chip fills the textarea; if it already holds non-template content, confirm
-before overwriting. Chips are bUnit-tested.
+Clicking a row fills the textarea; if it already holds non-template content, confirm
+before overwriting. bUnit-tested.
 
 ## 6. Validation & limits (unchanged)
 
@@ -146,6 +147,6 @@ definition).
   descriptions (regression).
 - **Round-trip:** paste `:*:col::` + `( … )` → save → generate → script contains the
   section byte-identical.
-- **bUnit:** chips insert templates, overwrite confirm, summary shows
-  "multi-line text (N lines)" and comment-lift notice.
+- **bUnit:** example rows insert templates, overwrite confirm, preview text renders,
+  summary shows "multi-line text (N lines)" and comment-lift notice.
 - **E2E:** paste the colors continuation hotstring, save, download, assert exact lines.

--- a/docs/superpowers/specs/2026-07-14-raw-continuation-otb-comments-design.md
+++ b/docs/superpowers/specs/2026-07-14-raw-continuation-otb-comments-design.md
@@ -1,0 +1,108 @@
+# Design: Raw hotstring continuation sections, OTB & comments
+
+**Date:** 2026-07-14
+**Builds on:** [2026-07-13-raw-hotstring-kind-design.md](2026-07-13-raw-hotstring-kind-design.md) (implemented, PR #182)
+**Status:** Approved
+
+## Problem
+
+The Raw hotstring kind rejects valid AHK v2 forms users paste from real scripts:
+
+1. **Continuation sections** — `:*:col::` followed by `( … )` holding literal multi-line
+   replacement text. Rejected today with "Put `{` on its own line below the trigger",
+   which is wrong advice: a brace body is *code*, the user wanted *literal text*.
+2. **OTB** — `{` at the end of the definition line.
+
+Separately, there is no way to get a comment into the generated script for a specific
+hotstring or hotkey, even though both entities already store a `Description` that the
+generator ignores.
+
+## Scope
+
+In: continuation-section bodies, OTB acceptance (normalized), Description-as-comment
+emission for hotstrings and hotkeys, comment-line lifting on Raw paste, example chips
+in the Raw editor, error-copy update.
+
+Out (still rejected by design): multiple definitions per paste, `#Hotstring` directives,
+`Hotstring()` calls, interpreting continuation options, any schema change.
+
+## 1. Parser: continuation sections
+
+`RawHotstringDefinitionParser` accepts, after a bare `:opts:trigger::` first line, a
+**continuation section** as an alternative to the existing brace body:
+
+- Opens with a line whose first non-blank character is `(`. Anything after the `(`
+  (continuation options such as `Join`, `LTrim`, `%`, `` ` ``, `C`) is accepted
+  **verbatim and not interpreted**.
+- Body lines are literal text, stored verbatim.
+- Closes at the first line that is exactly `)` (after trim). No nesting.
+- Unclosed section → error. Non-blank content after the closing `)` → same
+  "content after close" rule as braces.
+- `RawParseResult` gains `BodyKind` enum: `None | Inline | Braces | Continuation`,
+  so the preview summary can distinguish "code block" from "multi-line text (N lines)".
+
+Docs: continuation sections per <https://www.autohotkey.com/docs/v2/Scripts.htm#continuation-section>.
+
+## 2. Parser: OTB, normalized on save
+
+- `:X:trigger::{` (line ends with `{`, nothing after it) is accepted as a brace-body
+  opener. Any other trailing content stays rejected.
+- `Normalize()` rewrites OTB to the canonical form — `{` on its own line below the
+  trigger — so stored/emitted definitions have one shape (consistent with existing
+  CRLF/whitespace normalization). Preview shows the normalized result.
+
+## 3. Comments = Description
+
+No new field. `Description` becomes the script comment:
+
+- **Emission:** `AhkScriptGenerator` emits `; <description>` on the line(s) above each
+  hotstring **and hotkey** whose Description is non-empty. Multi-line description →
+  one `; ` line per line. Applies to all kinds (Text/DateTime/Macro/Raw) and hotkeys.
+- **Paste lifting (Raw only):** leading `; …` comment lines above the pasted definition
+  are stripped from the stored definition and lifted into the Description field —
+  only when Description is currently empty (never clobber an existing value; when
+  non-empty the comment lines are still stripped). Parsed summary notes
+  "comment moved to Description".
+- Comment lines *inside* a `( … )` or `{ … }` body are body content and stay verbatim.
+
+## 4. Error copy
+
+Rule-6 message becomes:
+
+> Add a replacement after `::`, or put `{` (code) or `(` (multi-line text) on its own
+> line below the trigger.
+
+## 5. UX: example chips
+
+Row of four chips above the Raw textarea in `HotstringEditDialog`:
+
+| Chip | Inserts |
+|---|---|
+| Inline | `:*:btw::by the way` |
+| Multi-line text ( ) | `:*:col::` + `(` + sample lines + `)` |
+| Code block { } | `:X:run::` + `{` + `Run "notepad.exe"` + `}` |
+| With options | `:K1000 SE*:ftw::for the win` |
+
+Clicking a chip fills the textarea; if it already holds non-template content, confirm
+before overwriting. Chips are bUnit-tested.
+
+## 6. Validation & limits (unchanged)
+
+4200-char max, single definition per paste, unknown-option rejection, trigger
+derivation + dedup, `#HotIf` context wrapping — all as-is. Continuation bodies count
+toward the same length limit. Lifted comment lines do not count (they leave the
+definition).
+
+## 7. Testing
+
+- **Parser (TDD):** continuation happy path incl. `(Join` and `(LTrim`, unclosed `)`,
+  content after `)`, blank lines inside body preserved, OTB accept + Normalize goldens,
+  comment-lift (empty vs non-empty Description), `BodyKind` classification.
+- **Generator:** comment emission for hotstring + hotkey + multi-line description;
+  none emitted when Description empty; byte-identical output for rows without
+  descriptions (regression).
+- **Round-trip:** paste `:*:col::` + `( … )` → save → generate → script contains the
+  section byte-identical.
+- **bUnit:** chips insert templates, overwrite confirm, summary shows
+  "multi-line text (N lines)" and comment-lift notice.
+- **E2E:** paste the colors continuation hotstring, save, download, assert exact lines.

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/CreateHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/CreateHotstringCommand.cs
@@ -42,7 +42,8 @@ public sealed class CreateHotstringCommandValidator : AbstractValidator<CreateHo
             x => x.Input.Replacement);
         this.AddRawKindRules(
             x => x.Input.Kind,
-            x => x.Input.Replacement);
+            x => x.Input.Replacement,
+            x => x.Input.Description);
         this.AddWindowContextRules(
             x => x.Input.ContextMatchType,
             x => x.Input.ContextValue);
@@ -63,14 +64,17 @@ internal sealed class CreateHotstringCommandHandler(
         CreateHotstringDto input = request.Input;
 
         // Raw stores the verbatim definition and derives its trigger server-side; the client-sent
-        // Trigger is ignored. Normalize first, then parse — the parsed trigger drives the duplicate
-        // check and entity construction. Validation (ValidatingUseCase) already guaranteed a valid Raw.
+        // Trigger is ignored. One Prepare pass lifts leading comments, normalizes, and parses — the
+        // parsed trigger drives the duplicate check. Validation already guaranteed a valid Raw.
         string trigger = input.Trigger;
         string replacement = input.Replacement;
+        string? liftedComment = null;
         if (input.Kind == HotstringKind.Raw)
         {
-            replacement = RawHotstringDefinitionParser.Normalize(input.Replacement);
-            trigger = RawHotstringDefinitionParser.Parse(replacement).Trigger;
+            RawPrepared prepared = RawHotstringDefinitionParser.Prepare(input.Replacement);
+            replacement = prepared.NormalizedDefinition;
+            trigger = prepared.Parsed.Trigger;
+            liftedComment = prepared.LiftedComment;
         }
 
         bool duplicate = await db.Hotstrings.AnyAsync(
@@ -91,7 +95,9 @@ internal sealed class CreateHotstringCommandHandler(
                 return Result.Invalid(profileError);
         }
 
-        string? description = string.IsNullOrWhiteSpace(input.Description) ? null : input.Description.Trim();
+        string? description = input.Kind == HotstringKind.Raw
+            ? RawCommentLift.Merge(input.Description, liftedComment)
+            : string.IsNullOrWhiteSpace(input.Description) ? null : input.Description.Trim();
 
         Guid[] distinctCategoryIds = input.CategoryIds?.Distinct().ToArray() ?? [];
         ValidationError? categoryError = await OwnedIdsValidation.CheckOwnedIdsAsync(

--- a/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/UpdateHotstringCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Hotstrings/UpdateHotstringCommand.cs
@@ -42,7 +42,8 @@ public sealed class UpdateHotstringCommandValidator : AbstractValidator<UpdateHo
             x => x.Input.Replacement);
         this.AddRawKindRules(
             x => x.Input.Kind,
-            x => x.Input.Replacement);
+            x => x.Input.Replacement,
+            x => x.Input.Description);
         this.AddWindowContextRules(
             x => x.Input.ContextMatchType,
             x => x.Input.ContextValue);
@@ -72,13 +73,17 @@ internal sealed class UpdateHotstringCommandHandler(
         UpdateHotstringDto input = request.Input;
 
         // Raw stores the verbatim definition and derives its trigger server-side; the client-sent
-        // Trigger is ignored. Normalize first, then parse. Validation already guaranteed a valid Raw.
+        // Trigger is ignored. One Prepare pass lifts leading comments, normalizes, and parses.
+        // Validation already guaranteed a valid Raw.
         string trigger = input.Trigger;
         string replacement = input.Replacement;
+        string? liftedComment = null;
         if (input.Kind == HotstringKind.Raw)
         {
-            replacement = RawHotstringDefinitionParser.Normalize(input.Replacement);
-            trigger = RawHotstringDefinitionParser.Parse(replacement).Trigger;
+            RawPrepared prepared = RawHotstringDefinitionParser.Prepare(input.Replacement);
+            replacement = prepared.NormalizedDefinition;
+            trigger = prepared.Parsed.Trigger;
+            liftedComment = prepared.LiftedComment;
         }
 
         Guid[] distinctProfileIds = input.ProfileIds?.Distinct().ToArray() ?? [];
@@ -91,7 +96,9 @@ internal sealed class UpdateHotstringCommandHandler(
                 return Result.Invalid(profileError);
         }
 
-        string? description = string.IsNullOrWhiteSpace(input.Description) ? null : input.Description.Trim();
+        string? description = input.Kind == HotstringKind.Raw
+            ? RawCommentLift.Merge(input.Description, liftedComment)
+            : string.IsNullOrWhiteSpace(input.Description) ? null : input.Description.Trim();
 
         Guid[] distinctCategoryIds = input.CategoryIds?.Distinct().ToArray() ?? [];
         ValidationError? categoryError = await OwnedIdsValidation.CheckOwnedIdsAsync(

--- a/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/HotstringDto.cs
@@ -126,6 +126,7 @@ public sealed record UpdateHotstringDto(
 /// <param name="DateOffsetUnit">Unit for <paramref name="DateOffsetAmount"/>; requires <paramref name="DateOffsetAmount"/>.</param>
 /// <param name="ContextMatchType">How <paramref name="ContextValue"/> is matched against the active window; requires <paramref name="ContextValue"/>. Kind-agnostic.</param>
 /// <param name="ContextValue">Value matched against the active window (executable name, window class, or title substring, per <paramref name="ContextMatchType"/>); requires <paramref name="ContextMatchType"/>.</param>
+/// <param name="Description">Optional note previewed as <c>; </c> comment lines above the definition; for Raw, merged with any lifted comment.</param>
 public sealed record HotstringPreviewRequestDto(
     HotstringKind Kind,
     string Trigger,
@@ -138,14 +139,39 @@ public sealed record HotstringPreviewRequestDto(
     int? DateOffsetAmount = null,
     DateOffsetUnit? DateOffsetUnit = null,
     WindowMatchType? ContextMatchType = null,
-    string? ContextValue = null);
+    string? ContextValue = null,
+    string? Description = null);
 
 /// <summary>The AutoHotkey snippet a hotstring definition would generate.</summary>
-/// <param name="Snippet">The exact <c>.ahk</c> line(s) <c>HotstringEmitter.Emit</c> would produce for the given definition.</param>
-/// <param name="RawSummary">Server-derived trigger and option tokens for a Raw definition; null for other kinds.</param>
+/// <param name="Snippet">The exact <c>.ahk</c> line(s) a save would produce for the given definition, including any <c>; </c> Description comment lines.</param>
+/// <param name="RawSummary">Server-derived summary for a Raw definition; null for other kinds.</param>
 public sealed record HotstringPreviewDto(string Snippet, RawSummaryDto? RawSummary = null);
+
+/// <summary>Body shape of a Raw hotstring definition, surfaced in the preview summary.</summary>
+public enum RawBodyKind
+{
+    /// <summary>No recognizable body (structurally invalid).</summary>
+    None,
+
+    /// <summary>Inline replacement on the definition line.</summary>
+    Inline,
+
+    /// <summary>AutoHotkey code block <c>{ … }</c>.</summary>
+    Braces,
+
+    /// <summary>Literal multi-line text continuation section <c>( … )</c>.</summary>
+    Continuation,
+}
 
 /// <summary>Parsed summary of a Raw hotstring definition, shown below the editor's raw textarea.</summary>
 /// <param name="Trigger">Trigger derived from the definition's first line.</param>
 /// <param name="OptionTokens">Option flags parsed from the definition, in first-line order.</param>
-public sealed record RawSummaryDto(string Trigger, string[] OptionTokens);
+/// <param name="BodyKind">Classified body shape (code block vs multi-line text vs inline).</param>
+/// <param name="BodyLineCount">Literal line count for a continuation body; 0 for other shapes.</param>
+/// <param name="LiftedComment">Leading comment text a save would move into Description; null when none.</param>
+public sealed record RawSummaryDto(
+    string Trigger,
+    string[] OptionTokens,
+    RawBodyKind BodyKind,
+    int BodyLineCount,
+    string? LiftedComment);

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringPreviewQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringPreviewQuery.cs
@@ -21,6 +21,12 @@ public sealed class GetHotstringPreviewQueryValidator : AbstractValidator<GetHot
         RuleFor(x => x.Input.Kind)
             .Must(k => k is HotstringKind.Text or HotstringKind.DateTime or HotstringKind.Macro or HotstringKind.Raw)
             .WithMessage("Only Text, Date & time, Macro and Raw hotstrings are supported.");
+        // Non-Raw Description length (Raw's merged-comment length is checked in AddRawKindRules), so
+        // an over-long Description fails preview the same way it fails save.
+        RuleFor(x => x.Input.Description)
+            .MaximumLength(HotstringRules.DescriptionMaxLength)
+            .WithMessage($"Description must be {HotstringRules.DescriptionMaxLength} characters or fewer.")
+            .When(x => x.Input.Kind != HotstringKind.Raw);
         this.AddDateTimeKindRules(
             x => x.Input.Kind,
             x => x.Input.Replacement,
@@ -33,7 +39,7 @@ public sealed class GetHotstringPreviewQueryValidator : AbstractValidator<GetHot
         this.AddRawKindRules(
             x => x.Input.Kind,
             x => x.Input.Replacement,
-            x => null); // Preview carries no Description in Task 3; wired in Task 4.
+            x => x.Input.Description);
         this.AddWindowContextRules(
             x => x.Input.ContextMatchType,
             x => x.Input.ContextValue);
@@ -53,17 +59,22 @@ internal sealed class GetHotstringPreviewQueryHandler(TimeProvider clock)
     {
         HotstringPreviewRequestDto input = request.Input;
 
-        // Raw derives its trigger + option summary server-side from the verbatim definition.
-        // Normalize first so the preview matches exactly what a save would persist and emit.
+        // Raw derives its trigger + option summary server-side from the verbatim definition. One
+        // Prepare pass (lift comments, normalize, parse) so the preview matches exactly what a save
+        // would persist and emit — including the Description merged from any lifted comment.
         string trigger = input.Trigger;
         string replacement = input.Replacement;
+        string? description = string.IsNullOrWhiteSpace(input.Description) ? null : input.Description.Trim();
         RawSummaryDto? rawSummary = null;
         if (input.Kind == HotstringKind.Raw)
         {
-            replacement = RawHotstringDefinitionParser.Normalize(input.Replacement);
-            RawParseResult parsed = RawHotstringDefinitionParser.Parse(replacement);
+            RawPrepared prepared = RawHotstringDefinitionParser.Prepare(input.Replacement);
+            RawParseResult parsed = prepared.Parsed;
+            replacement = prepared.NormalizedDefinition;
             trigger = parsed.Trigger;
-            rawSummary = new RawSummaryDto(parsed.Trigger, parsed.OptionTokens);
+            description = RawCommentLift.Merge(input.Description, parsed.LiftedComment);
+            rawSummary = new RawSummaryDto(
+                parsed.Trigger, parsed.OptionTokens, parsed.BodyKind, parsed.BodyLineCount, parsed.LiftedComment);
         }
 
         var hs = Hotstring.Create(
@@ -71,7 +82,7 @@ internal sealed class GetHotstringPreviewQueryHandler(TimeProvider clock)
             new HotstringDefinition(
                 trigger,
                 replacement,
-                Description: null,
+                description,
                 AppliesToAllProfiles: true,
                 input.IsEndingCharacterRequired,
                 input.IsTriggerInsideWord,
@@ -85,7 +96,12 @@ internal sealed class GetHotstringPreviewQueryHandler(TimeProvider clock)
                 input.ContextValue),
             clock);
 
+        // Prepend the Description comment lines above the definition, via the same shared formatter
+        // AhkScriptGenerator uses, so the live preview matches the downloaded script byte-for-byte.
         string snippet = HotstringEmitter.Emit(hs);
+        string commentBlock = string.Join('\n', HotstringEmitter.DescriptionCommentLines(hs.Description));
+        if (commentBlock.Length > 0)
+            snippet = $"{commentBlock}\n{snippet}";
 
         // Mirrors AhkScriptGenerator's context-group wrapping (D9) so the live preview matches
         // exactly what the downloaded script would contain for this hotstring.

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringPreviewQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringPreviewQuery.cs
@@ -21,12 +21,12 @@ public sealed class GetHotstringPreviewQueryValidator : AbstractValidator<GetHot
         RuleFor(x => x.Input.Kind)
             .Must(k => k is HotstringKind.Text or HotstringKind.DateTime or HotstringKind.Macro or HotstringKind.Raw)
             .WithMessage("Only Text, Date & time, Macro and Raw hotstrings are supported.");
-        // Non-Raw Description length (Raw's merged-comment length is checked in AddRawKindRules), so
-        // an over-long Description fails preview the same way it fails save.
+        // Base Description length applies to every kind (matching the Create/Update save rule), so an
+        // over-long typed Description fails preview the same way it fails save. Raw additionally checks
+        // the base+lifted-comment merged length in AddRawKindRules.
         RuleFor(x => x.Input.Description)
             .MaximumLength(HotstringRules.DescriptionMaxLength)
-            .WithMessage($"Description must be {HotstringRules.DescriptionMaxLength} characters or fewer.")
-            .When(x => x.Input.Kind != HotstringKind.Raw);
+            .WithMessage($"Description must be {HotstringRules.DescriptionMaxLength} characters or fewer.");
         this.AddDateTimeKindRules(
             x => x.Input.Kind,
             x => x.Input.Replacement,
@@ -72,9 +72,9 @@ internal sealed class GetHotstringPreviewQueryHandler(TimeProvider clock)
             RawParseResult parsed = prepared.Parsed;
             replacement = prepared.NormalizedDefinition;
             trigger = parsed.Trigger;
-            description = RawCommentLift.Merge(input.Description, parsed.LiftedComment);
+            description = RawCommentLift.Merge(input.Description, prepared.LiftedComment);
             rawSummary = new RawSummaryDto(
-                parsed.Trigger, parsed.OptionTokens, parsed.BodyKind, parsed.BodyLineCount, parsed.LiftedComment);
+                parsed.Trigger, parsed.OptionTokens, parsed.BodyKind, parsed.BodyLineCount, prepared.LiftedComment);
         }
 
         var hs = Hotstring.Create(

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringPreviewQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringPreviewQuery.cs
@@ -32,7 +32,8 @@ public sealed class GetHotstringPreviewQueryValidator : AbstractValidator<GetHot
             x => x.Input.Replacement);
         this.AddRawKindRules(
             x => x.Input.Kind,
-            x => x.Input.Replacement);
+            x => x.Input.Replacement,
+            x => null); // Preview carries no Description in Task 3; wired in Task 4.
         this.AddWindowContextRules(
             x => x.Input.ContextMatchType,
             x => x.Input.ContextValue);

--- a/src/Backend/AHKFlowApp.Application/Services/AhkScriptGenerator.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/AhkScriptGenerator.cs
@@ -49,7 +49,10 @@ public sealed class AhkScriptGenerator(
         {
             lines.Add(HotstringEmitter.EmitHotIfOpen(group.Key.MatchType!.Value, group.Key.Value!));
             foreach (Hotstring hs in group)
+            {
+                lines.AddRange(HotstringEmitter.DescriptionCommentLines(hs.Description));
                 lines.Add(HotstringEmitter.Emit(hs));
+            }
             lines.Add(HotstringEmitter.HotIfClose);
         }
 
@@ -58,12 +61,18 @@ public sealed class AhkScriptGenerator(
 
         if (globalGroup is not null)
             foreach (Hotstring hs in globalGroup)
+            {
+                lines.AddRange(HotstringEmitter.DescriptionCommentLines(hs.Description));
                 lines.Add(HotstringEmitter.Emit(hs));
+            }
 
         lines.Add(HotkeysSection);
 
         foreach (Hotkey hk in hkList)
+        {
+            lines.AddRange(HotstringEmitter.DescriptionCommentLines(hk.Description));
             lines.Add(FormatHotkey(hk));
+        }
 
         lines.Add(renderer.Render(profile.FooterTemplate, ctx));
 

--- a/src/Backend/AHKFlowApp.Application/Services/HotstringEmitter.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/HotstringEmitter.cs
@@ -25,6 +25,18 @@ internal static class HotstringEmitter
             ? hs.Replacement
             : $":{BuildOptions(hs)}:{Escape(hs.Trigger)}::{BuildBody(hs)}";
 
+    // Single source of truth for Description-as-comment emission, shared by AhkScriptGenerator
+    // (script lines above each entity) and the preview handler (snippet). Each Description line
+    // becomes a "; " comment line; an empty/whitespace Description yields nothing.
+    public static IEnumerable<string> DescriptionCommentLines(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            yield break;
+
+        foreach (string line in description.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n'))
+            yield return line.Length == 0 ? ";" : $"; {line}";
+    }
+
     // ContextValue has already passed validation guaranteeing no double-quote, backtick, or
     // control characters (see HotstringRules.AddWindowContextRules) — safe to embed raw here.
     public static string EmitHotIfOpen(WindowMatchType matchType, string value)

--- a/src/Backend/AHKFlowApp.Application/Services/RawCommentLift.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/RawCommentLift.cs
@@ -1,0 +1,30 @@
+namespace AHKFlowApp.Application.Services;
+
+/// <summary>
+/// Merge policy for a comment lifted off a pasted Raw definition into the hotstring's Description.
+/// Single source of truth shared by the Raw validator (length check) and the Create/Update
+/// handlers (persisted value) so they can never disagree. No data loss: an existing Description is
+/// never overwritten — the lifted comment is appended unless it is empty or an exact duplicate.
+/// </summary>
+internal static class RawCommentLift
+{
+    /// <summary>
+    /// Merges <paramref name="lifted"/> into <paramref name="description"/>:
+    /// empty Description → the lifted comment; equal → the Description unchanged (duplicate dropped);
+    /// otherwise the lifted comment appended on a new line. Returns null when both are empty.
+    /// </summary>
+    public static string? Merge(string? description, string? lifted)
+    {
+        string? desc = string.IsNullOrWhiteSpace(description) ? null : description.Trim();
+        string? lift = string.IsNullOrWhiteSpace(lifted) ? null : lifted;
+
+        if (lift is null)
+            return desc;
+        if (desc is null)
+            return lift;
+        if (string.Equals(desc, lift, StringComparison.Ordinal))
+            return desc;
+
+        return $"{desc}\n{lift}";
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
@@ -4,6 +4,21 @@ using System.Text.RegularExpressions;
 namespace AHKFlowApp.Application.Services;
 
 /// <summary>
+/// Body shape of a Raw definition as classified by <see cref="RawHotstringDefinitionParser"/>.
+/// <see cref="Continuation"/> is a literal multi-line text section <c>( … )</c>;
+/// <see cref="Braces"/> is an AHK code block <c>{ … }</c>; <see cref="Inline"/> is a replacement
+/// on the definition line; <see cref="None"/> means no recognizable body (structurally invalid).
+/// Maps to the public preview summary's body-kind (<c>RawSummaryDto.BodyKind</c>).
+/// </summary>
+internal enum RawBodyKind
+{
+    None,
+    Inline,
+    Braces,
+    Continuation,
+}
+
+/// <summary>
 /// Outcome of <see cref="RawHotstringDefinitionParser.Parse"/>. Structural facts the Raw
 /// validator (<c>HotstringRules.AddRawKindRules</c>) maps to per-rule messages, plus the
 /// derived <see cref="Trigger"/> and option tokens the handlers and preview summary reuse.
@@ -13,7 +28,11 @@ namespace AHKFlowApp.Application.Services;
 /// <param name="Trigger">Decoded trigger parsed from the first line (empty when <see cref="FirstLineValid"/> is false).</param>
 /// <param name="OptionTokens">Every option token, verbatim, in first-line order (feeds the parsed summary).</param>
 /// <param name="UnknownOptionTokens">Tokens not in the known AHK v2 set (rule 4).</param>
-/// <param name="DefinitionCount">Number of <c>:options:trigger::</c> definition starts in the paste (rule 2).</param>
+/// <param name="DefinitionCount">Number of structural <c>:options:trigger::</c> lines outside any body (rule 2).</param>
+/// <param name="BodyKind">Classified body shape (feeds the preview summary).</param>
+/// <param name="BodyLineCount">Literal line count for a continuation body (0 for other shapes).</param>
+/// <param name="HasDirectiveOutsideLiteralBody">A <c>#</c> directive line exists outside a literal continuation body (rule 5).</param>
+/// <param name="LiftedComment">Leading comment text lifted into Description on save (null when none; set by <c>Prepare</c>).</param>
 /// <param name="Error">Structural error message (rule 1 / 6 / 7); null when <see cref="IsValid"/>.</param>
 internal sealed record RawParseResult(
     bool IsValid,
@@ -22,19 +41,26 @@ internal sealed record RawParseResult(
     string[] OptionTokens,
     string[] UnknownOptionTokens,
     int DefinitionCount,
+    RawBodyKind BodyKind,
+    int BodyLineCount,
+    bool HasDirectiveOutsideLiteralBody,
+    string? LiftedComment,
     string? Error);
 
 /// <summary>
 /// Parses an entire verbatim AHK v2 hotstring definition (first line
-/// <c>:options:trigger::</c>, optional inline replacement or brace body) into the structural
-/// facts the Raw validator and handlers need. Sibling of <see cref="AhkHotstringParser"/> but
-/// intentionally simpler: no Send-body conversion, no v1 rescue, no normalization — it only
-/// splits structure, tokenizes options, and counts definitions.
+/// <c>:options:trigger::</c>, optional inline replacement, brace <c>{ … }</c> code body, or
+/// literal <c>( … )</c> continuation section) into the structural facts the Raw validator and
+/// handlers need. Sibling of <see cref="AhkHotstringParser"/> but intentionally simpler: no
+/// Send-body conversion, no v1 rescue — it splits structure, tokenizes options, counts
+/// definitions, and classifies the body.
 ///
 /// Deliberately supports a restricted subset of AHK v2 (see <c>HotstringRules.AddRawKindRules</c>):
-/// naive brace counting on brace bodies only, no string/comment/continuation-section lexing,
-/// OTB braces and continuation sections rejected. Known option set is per the official v2 docs:
-/// <see href="https://www.autohotkey.com/docs/v2/Hotstrings.htm"/>.
+/// naive brace counting on brace bodies only, no string/comment lexing. Continuation sections are
+/// accepted as verbatim literal text; OTB braces (<c>:X:t::{</c>) are accepted and normalized
+/// (Task 2). Known option set is per the official v2 docs:
+/// <see href="https://www.autohotkey.com/docs/v2/Hotstrings.htm"/>. Continuation sections per
+/// <see href="https://www.autohotkey.com/docs/v2/Scripts.htm#continuation-section"/>.
 /// </summary>
 internal static partial class RawHotstringDefinitionParser
 {
@@ -43,6 +69,9 @@ internal static partial class RawHotstringDefinitionParser
     private const string UnbalancedError = "Raw definition must have balanced braces.";
     private const string ContentAfterBraceError = "Raw definition has content after the closing brace.";
     private const string ContentAfterInlineError = "Raw definition has content after the inline replacement.";
+    private const string OpenerWithParenError = "A continuation section opener must not contain `)` — put the closing `)` on its own line.";
+    private const string UnclosedContinuationError = "Raw definition has an unclosed continuation section — add a closing `)` on its own line.";
+    private const string ContentAfterCloseError = "Raw definition has content after the closing `)`.";
 
     // :options:trigger::replacement — options/trigger contain no ':'; the trigger is
     // non-greedy so the FIRST '::' delimits, leaving any inline replacement in group 3.
@@ -97,60 +126,178 @@ internal static partial class RawHotstringDefinitionParser
         ArgumentNullException.ThrowIfNull(rawDefinition);
 
         string[] lines = rawDefinition.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
-        int definitionCount = lines.Count(l => HotstringLine().IsMatch(l));
 
         int firstIdx = Array.FindIndex(lines, l => l.Trim().Length > 0);
         if (firstIdx < 0)
-            return Invalid(FirstLineError, definitionCount);
+            return Invalid(FirstLineError);
 
         Match match = HotstringLine().Match(lines[firstIdx]);
         if (!match.Success)
-            return Invalid(FirstLineError, definitionCount);
+            return Invalid(FirstLineError);
 
         // No trimming: spaces/tabs are literal within an AHK abbreviation, and the raw text is
         // emitted verbatim, so the derived trigger must match it exactly (dedup, DB, UI display).
         string trigger = DecodeEscapes(match.Groups[2].Value);
         (string[] optionTokens, string[] unknownTokens) = TokenizeOptions(match.Groups[1].Value);
         string inlineRest = match.Groups[3].Value;
-        string[] trailing = lines[(firstIdx + 1)..];
 
-        (bool bodyValid, string? bodyError) = ClassifyBody(inlineRest, trailing);
+        BodyClassification body = ClassifyBody(optionTokens, inlineRest, lines, firstIdx);
+
+        // Body-aware structural facts across the whole paste (rules 2 and 5).
+        (int definitionCount, bool directiveOutside) = ScanStructure(lines, body);
 
         return new RawParseResult(
-            IsValid: bodyValid,
+            IsValid: body.Valid,
             FirstLineValid: true,
             Trigger: trigger,
             OptionTokens: optionTokens,
             UnknownOptionTokens: unknownTokens,
             DefinitionCount: definitionCount,
-            Error: bodyError);
+            BodyKind: body.Kind,
+            BodyLineCount: body.BodyLineCount,
+            HasDirectiveOutsideLiteralBody: directiveOutside,
+            LiftedComment: null,
+            Error: body.Error);
     }
 
-    private static RawParseResult Invalid(string error, int definitionCount) =>
+    private static RawParseResult Invalid(string error) =>
         new(IsValid: false, FirstLineValid: false, Trigger: "", OptionTokens: [],
-            UnknownOptionTokens: [], DefinitionCount: definitionCount, Error: error);
+            UnknownOptionTokens: [], DefinitionCount: 0, BodyKind: RawBodyKind.None,
+            BodyLineCount: 0, HasDirectiveOutsideLiteralBody: false, LiftedComment: null, Error: error);
+
+    /// <summary>
+    /// Classification of a definition's body, including the absolute line range it spans so the
+    /// whole-paste structural scan can skip body interiors. <see cref="BodyLineStart"/>/
+    /// <see cref="BodyLineEnd"/> are -1 when there is no multi-line body (inline / none).
+    /// </summary>
+    private sealed record BodyClassification(
+        bool Valid,
+        string? Error,
+        RawBodyKind Kind,
+        int BodyLineCount,
+        int BodyLineStart,
+        int BodyLineEnd);
 
     // Structural rules 6 and 7. An inline replacement forbids further lines and is not
-    // brace-balance checked; a bare "::" first line requires a "{" brace body on its own line.
-    private static (bool Valid, string? Error) ClassifyBody(string inlineRest, string[] trailing)
+    // brace-balance checked; a bare "::" first line requires a brace body or continuation section.
+    private static BodyClassification ClassifyBody(string[] optionTokens, string inlineRest, string[] lines, int firstIdx)
     {
         if (inlineRest.Length > 0)
         {
-            // OTB: "{" placed on the definition line — rejected (rule 7).
+            // OTB: "{" placed on the definition line — rejected here (accepted + normalized in Task 2).
             if (inlineRest.Trim() == "{")
-                return (false, BraceRequiredError);
+                return new(false, BraceRequiredError, RawBodyKind.None, 0, -1, -1);
 
             // Real inline replacement — no further non-blank lines allowed.
-            return trailing.Any(l => l.Trim().Length > 0)
-                ? (false, ContentAfterInlineError)
-                : (true, null);
+            return HasNonBlank(lines, firstIdx + 1)
+                ? new(false, ContentAfterInlineError, RawBodyKind.Inline, 0, -1, -1)
+                : new(true, null, RawBodyKind.Inline, 0, -1, -1);
         }
 
-        int bodyIdx = Array.FindIndex(trailing, l => l.Trim().Length > 0);
-        if (bodyIdx < 0 || trailing[bodyIdx].Trim() != "{")
-            return (false, BraceRequiredError);
+        int bodyIdx = FirstNonBlank(lines, firstIdx + 1);
+        if (bodyIdx < 0)
+            return new(false, BraceRequiredError, RawBodyKind.None, 0, -1, -1);
 
-        return ScanBraceBody(string.Join('\n', trailing[bodyIdx..]));
+        string opener = lines[bodyIdx];
+
+        // Continuation section: opener's first non-blank character is '('.
+        if (opener.TrimStart().StartsWith('('))
+            return ClassifyContinuation(lines, bodyIdx);
+
+        // Brace body: opener line is exactly "{".
+        if (opener.Trim() == "{")
+            return ClassifyBraces(lines, bodyIdx);
+
+        return new(false, BraceRequiredError, RawBodyKind.None, 0, -1, -1);
+    }
+
+    // Continuation section: verbatim literal text between an opener line starting with '(' and a
+    // closing line that is exactly ')'. The opener remainder (Join/LTrim/RTrim0/…) is unvalidated
+    // pass-through, except a ')' on the opener line makes AHK read it as an expression, not an opener.
+    private static BodyClassification ClassifyContinuation(string[] lines, int openerIdx)
+    {
+        if (lines[openerIdx].Contains(')'))
+            return new(false, OpenerWithParenError, RawBodyKind.None, 0, -1, -1);
+
+        int closeIdx = -1;
+        for (int i = openerIdx + 1; i < lines.Length; i++)
+        {
+            if (lines[i].Trim() == ")")
+            {
+                closeIdx = i;
+                break;
+            }
+        }
+
+        if (closeIdx < 0)
+            return new(false, UnclosedContinuationError, RawBodyKind.None, 0, -1, -1);
+
+        int bodyLineCount = closeIdx - openerIdx - 1;
+
+        return HasNonBlank(lines, closeIdx + 1)
+            ? new(false, ContentAfterCloseError, RawBodyKind.Continuation, bodyLineCount, openerIdx, closeIdx)
+            : new(true, null, RawBodyKind.Continuation, bodyLineCount, openerIdx, closeIdx);
+    }
+
+    private static BodyClassification ClassifyBraces(string[] lines, int openerIdx)
+    {
+        (bool valid, string? error) = ScanBraceBody(string.Join('\n', lines[openerIdx..]));
+        int closeIdx = FindBraceCloseLine(lines, openerIdx);
+        return new(valid, error, RawBodyKind.Braces, 0, openerIdx, closeIdx);
+    }
+
+    // Line index where naive brace depth returns to zero (the closing-brace line). Falls back to
+    // the last line when unbalanced; the validity error is reported separately by ScanBraceBody.
+    private static int FindBraceCloseLine(string[] lines, int startIdx)
+    {
+        int depth = 0;
+        for (int i = startIdx; i < lines.Length; i++)
+        {
+            foreach (char c in lines[i])
+            {
+                if (c == '{')
+                {
+                    depth++;
+                }
+                else if (c == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                        return i;
+                }
+            }
+        }
+
+        return lines.Length - 1;
+    }
+
+    // Whole-paste structural scan (rules 2 and 5), body-aware:
+    // - continuation bodies are literal text → skipped entirely (no definition, no directive);
+    // - brace bodies are code → interior lines are not counted as definitions, but a directive
+    //   inside is still rejected (braces do not scope a directive's effect on later definitions).
+    private static (int DefinitionCount, bool DirectiveOutsideLiteral) ScanStructure(string[] lines, BodyClassification body)
+    {
+        int definitionCount = 0;
+        bool directive = false;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            bool inBody = body.BodyLineStart >= 0 && i >= body.BodyLineStart && i <= body.BodyLineEnd;
+
+            if (inBody)
+            {
+                if (body.Kind == RawBodyKind.Braces && lines[i].TrimStart().StartsWith('#'))
+                    directive = true;
+                continue;
+            }
+
+            if (HotstringLine().IsMatch(lines[i]))
+                definitionCount++;
+            else if (lines[i].TrimStart().StartsWith('#'))
+                directive = true;
+        }
+
+        return (definitionCount, directive);
     }
 
     // Naive brace balance (D12): counts '{'/'}' with no string-literal or comment awareness.
@@ -182,6 +329,16 @@ internal static partial class RawHotstringDefinitionParser
         return region[(closedAt + 1)..].Trim().Length > 0
             ? (false, ContentAfterBraceError)
             : (true, null);
+    }
+
+    private static bool HasNonBlank(string[] lines, int from) => FirstNonBlank(lines, from) >= 0;
+
+    private static int FirstNonBlank(string[] lines, int from)
+    {
+        for (int i = from; i < lines.Length; i++)
+            if (lines[i].Trim().Length > 0)
+                return i;
+        return -1;
     }
 
     // Longest-match tokenizer: SE/SP/SI before S, and each flag greedily absorbs its trailing

--- a/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
@@ -48,6 +48,16 @@ internal sealed record RawParseResult(
     string? Error);
 
 /// <summary>
+/// Result of <see cref="RawHotstringDefinitionParser.Prepare"/> — the single authoritative
+/// preparation of a pasted Raw definition that every caller (validator, Create/Update handlers,
+/// preview) consumes.
+/// </summary>
+/// <param name="NormalizedDefinition">Body-aware normalized text with lifted comment lines removed — the exact text handlers persist.</param>
+/// <param name="LiftedComment">Leading <c>;</c> comment lines joined with <c>\n</c> (marker stripped), moved into Description; null when none.</param>
+/// <param name="Parsed">Structural parse of <see cref="NormalizedDefinition"/>, with <see cref="RawParseResult.LiftedComment"/> mirrored on it.</param>
+internal sealed record RawPrepared(string NormalizedDefinition, string? LiftedComment, RawParseResult Parsed);
+
+/// <summary>
 /// Parses an entire verbatim AHK v2 hotstring definition (first line
 /// <c>:options:trigger::</c>, optional inline replacement, brace <c>{ … }</c> code body, or
 /// literal <c>( … )</c> continuation section) into the structural facts the Raw validator and
@@ -93,19 +103,64 @@ internal static partial class RawHotstringDefinitionParser
     private static partial Regex POption();
 
     /// <summary>
-    /// Save-time normalization for a Raw definition — the only mutation applied before persisting.
-    /// CRLF/lone-CR → LF, trims leading/trailing blank lines and per-line trailing whitespace, and
-    /// rewrites a genuine OTB brace (<c>:X:t::{</c>) to <c>{</c> on its own line below the trigger.
-    /// Body-aware: lines <em>between</em> a continuation section's <c>(</c> and <c>)</c> are
-    /// preserved byte-for-byte (trailing spaces/tabs are significant under <c>RTrim0</c>);
-    /// everywhere else, AHK ignores literal trailing whitespace on script lines (a meaningful
-    /// trailing space needs the <c>`s</c>/<c>`t</c> escapes, which survive the trim untouched).
+    /// Save-time normalization for a Raw definition — delegates to <see cref="Prepare"/> and
+    /// returns just the persisted text. Callers that also need the lifted comment or parse facts
+    /// should call <see cref="Prepare"/> directly (a single pass) rather than re-parsing.
     /// </summary>
-    public static string Normalize(string rawDefinition)
+    public static string Normalize(string rawDefinition) => Prepare(rawDefinition).NormalizedDefinition;
+
+    /// <summary>
+    /// One authoritative preparation pass for a pasted Raw definition: lift leading <c>;</c>
+    /// comment lines into <see cref="RawPrepared.LiftedComment"/>, body-aware normalize the
+    /// remainder, and parse it — so validation, save, and preview never disagree.
+    /// </summary>
+    public static RawPrepared Prepare(string rawDefinition)
     {
         ArgumentNullException.ThrowIfNull(rawDefinition);
 
-        (string[] lines, int firstIdx, Match? match, BodyClassification? body) = Analyze(rawDefinition);
+        string[] rawLines = rawDefinition.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+        (string? lifted, int defStartIdx) = LiftLeadingComments(rawLines);
+
+        string definitionText = string.Join('\n', rawLines[defStartIdx..]);
+        string normalized = NormalizeCore(definitionText);
+        RawParseResult parsed = Parse(normalized) with { LiftedComment = lifted };
+
+        return new RawPrepared(normalized, lifted, parsed);
+    }
+
+    // Consume leading blank/comment lines above the first definition line. Comment lines (first
+    // non-blank char ';') are joined with '\n' with the ';' + one following space stripped;
+    // returns the joined comment (null when none) and the index of the first non-comment line.
+    private static (string? Lifted, int DefStartIdx) LiftLeadingComments(string[] lines)
+    {
+        List<string> comments = [];
+        int i = 0;
+        for (; i < lines.Length; i++)
+        {
+            string trimmed = lines[i].TrimStart();
+            if (trimmed.Length == 0)
+                continue;
+            if (trimmed.StartsWith(';'))
+            {
+                string rest = trimmed[1..];
+                comments.Add((rest.StartsWith(' ') ? rest[1..] : rest).TrimEnd());
+                continue;
+            }
+
+            break;
+        }
+
+        return comments.Count == 0 ? (null, 0) : (string.Join('\n', comments), i);
+    }
+
+    // Body-aware normalization: CRLF/lone-CR → LF, trims leading/trailing blank lines and per-line
+    // trailing whitespace, and rewrites a genuine OTB brace (:X:t::{) to { on its own line below
+    // the trigger. Lines between a continuation section's ( and ) are preserved byte-for-byte
+    // (trailing spaces/tabs are significant under RTrim0); elsewhere AHK ignores literal trailing
+    // whitespace on script lines (a meaningful trailing space needs the `s/`t escapes, untouched).
+    private static string NormalizeCore(string definitionText)
+    {
+        (string[] lines, int firstIdx, Match? match, BodyClassification? body) = Analyze(definitionText);
 
         List<string> outLines = new(lines.Length + 1);
         for (int i = 0; i < lines.Length; i++)

--- a/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
@@ -18,7 +18,6 @@ namespace AHKFlowApp.Application.Services;
 /// <param name="BodyKind">Classified body shape (feeds the preview summary).</param>
 /// <param name="BodyLineCount">Literal line count for a continuation body (0 for other shapes).</param>
 /// <param name="HasDirectiveOutsideLiteralBody">A <c>#</c> directive line exists outside a literal continuation body (rule 5).</param>
-/// <param name="LiftedComment">Leading comment text lifted into Description on save (null when none; set by <c>Prepare</c>).</param>
 /// <param name="Error">Structural error message (rule 1 / 6 / 7); null when <see cref="IsValid"/>.</param>
 internal sealed record RawParseResult(
     bool IsValid,
@@ -30,7 +29,6 @@ internal sealed record RawParseResult(
     RawBodyKind BodyKind,
     int BodyLineCount,
     bool HasDirectiveOutsideLiteralBody,
-    string? LiftedComment,
     string? Error);
 
 /// <summary>
@@ -40,7 +38,7 @@ internal sealed record RawParseResult(
 /// </summary>
 /// <param name="NormalizedDefinition">Body-aware normalized text with lifted comment lines removed — the exact text handlers persist.</param>
 /// <param name="LiftedComment">Leading <c>;</c> comment lines joined with <c>\n</c> (marker stripped), moved into Description; null when none.</param>
-/// <param name="Parsed">Structural parse of <see cref="NormalizedDefinition"/>, with <see cref="RawParseResult.LiftedComment"/> mirrored on it.</param>
+/// <param name="Parsed">Structural parse of <see cref="NormalizedDefinition"/>.</param>
 internal sealed record RawPrepared(string NormalizedDefinition, string? LiftedComment, RawParseResult Parsed);
 
 /// <summary>
@@ -65,7 +63,7 @@ internal static partial class RawHotstringDefinitionParser
     private const string UnbalancedError = "Raw definition must have balanced braces.";
     private const string ContentAfterBraceError = "Raw definition has content after the closing brace.";
     private const string ContentAfterInlineError = "Raw definition has content after the inline replacement.";
-    private const string OpenerWithParenError = "A continuation section opener must not contain `)` — put the closing `)` on its own line.";
+    private const string OpenerIsExpressionError = "A continuation section opener must contain only options after `(` — an extra `(` or `)` (outside the Join parameter) makes AutoHotkey read the line as an expression; put the closing `)` on its own line.";
     private const string UnclosedContinuationError = "Raw definition has an unclosed continuation section — add a closing `)` on its own line.";
     private const string ContentAfterCloseError = "Raw definition has content after the closing `)`.";
 
@@ -109,7 +107,7 @@ internal static partial class RawHotstringDefinitionParser
 
         string definitionText = string.Join('\n', rawLines[defStartIdx..]);
         string normalized = NormalizeCore(definitionText);
-        RawParseResult parsed = Parse(normalized) with { LiftedComment = lifted };
+        RawParseResult parsed = Parse(normalized);
 
         return new RawPrepared(normalized, lifted, parsed);
     }
@@ -204,7 +202,6 @@ internal static partial class RawHotstringDefinitionParser
             BodyKind: body.Kind,
             BodyLineCount: body.BodyLineCount,
             HasDirectiveOutsideLiteralBody: directiveOutside,
-            LiftedComment: null,
             Error: body.Error);
     }
 
@@ -231,7 +228,7 @@ internal static partial class RawHotstringDefinitionParser
     private static RawParseResult Invalid(string error) =>
         new(IsValid: false, FirstLineValid: false, Trigger: "", OptionTokens: [],
             UnknownOptionTokens: [], DefinitionCount: 0, BodyKind: RawBodyKind.None,
-            BodyLineCount: 0, HasDirectiveOutsideLiteralBody: false, LiftedComment: null, Error: error);
+            BodyLineCount: 0, HasDirectiveOutsideLiteralBody: false, Error: error);
 
     /// <summary>
     /// Classification of a definition's body, including the absolute line range it spans so the
@@ -291,11 +288,12 @@ internal static partial class RawHotstringDefinitionParser
 
     // Continuation section: verbatim literal text between an opener line starting with '(' and a
     // closing line that is exactly ')'. The opener remainder (Join/LTrim/RTrim0/…) is unvalidated
-    // pass-through, except a ')' on the opener line makes AHK read it as an expression, not an opener.
+    // pass-through, except an extra '(' or ')' to the right of the initial '(' (outside the Join
+    // option's parameter) makes AHK read the line as an expression, not an opener (Scripts.htm).
     private static BodyClassification ClassifyContinuation(string[] lines, int openerIdx)
     {
-        if (lines[openerIdx].Contains(')'))
-            return new(false, OpenerWithParenError, RawBodyKind.None, 0, -1, -1);
+        if (OpenerIsExpression(lines[openerIdx]))
+            return new(false, OpenerIsExpressionError, RawBodyKind.None, 0, -1, -1);
 
         int closeIdx = -1;
         for (int i = openerIdx + 1; i < lines.Length; i++)
@@ -307,14 +305,36 @@ internal static partial class RawHotstringDefinitionParser
             }
         }
 
+        // Unclosed: still treat opener→EOF as the intended literal body so the whole-paste scan
+        // skips it — otherwise interior "::x::y" or "#…" lines would trip the multiple-definition
+        // or directive rules before this (more accurate) unclosed-section error surfaces.
         if (closeIdx < 0)
-            return new(false, UnclosedContinuationError, RawBodyKind.None, 0, -1, -1);
+            return new(false, UnclosedContinuationError, RawBodyKind.Continuation,
+                lines.Length - openerIdx - 1, openerIdx, lines.Length - 1);
 
         int bodyLineCount = closeIdx - openerIdx - 1;
 
         return HasNonBlank(lines, closeIdx + 1)
             ? new(false, ContentAfterCloseError, RawBodyKind.Continuation, bodyLineCount, openerIdx, closeIdx)
             : new(true, null, RawBodyKind.Continuation, bodyLineCount, openerIdx, closeIdx);
+    }
+
+    // AHK v2 (Scripts.htm): a line whose first non-blank char is '(' opens a continuation section
+    // unless an extra '(' or ')' appears to its right — then it is reinterpreted as an expression.
+    // Parentheses inside the Join option's parameter are exempt (e.g. `(Join)` joins lines with ')').
+    // Options are whitespace-delimited; the Join parameter is the non-blank run right after "Join".
+    private static bool OpenerIsExpression(string openerLine)
+    {
+        string rest = openerLine.TrimStart()[1..]; // drop the initial '('
+        foreach (string token in rest.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (token.StartsWith("Join", StringComparison.OrdinalIgnoreCase))
+                continue; // Join's parameter may legitimately carry '(' or ')'
+            if (token.IndexOfAny(['(', ')']) >= 0)
+                return true;
+        }
+
+        return false;
     }
 
     private static BodyClassification ClassifyBraces(string[] lines, int openerIdx)

--- a/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
@@ -61,7 +61,7 @@ internal sealed record RawPrepared(string NormalizedDefinition, string? LiftedCo
 internal static partial class RawHotstringDefinitionParser
 {
     private const string FirstLineError = "Not a valid hotstring definition — expected `:options:trigger::replacement`.";
-    private const string BraceRequiredError = "Put `{` on its own line below the trigger.";
+    private const string BraceRequiredError = "Add a replacement after `::`, or put `{` (code) or `(` (multi-line text) on its own line below the trigger.";
     private const string UnbalancedError = "Raw definition must have balanced braces.";
     private const string ContentAfterBraceError = "Raw definition has content after the closing brace.";
     private const string ContentAfterInlineError = "Raw definition has content after the inline replacement.";

--- a/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
@@ -94,54 +94,61 @@ internal static partial class RawHotstringDefinitionParser
 
     /// <summary>
     /// Save-time normalization for a Raw definition — the only mutation applied before persisting.
-    /// CRLF/lone-CR → LF, trims leading/trailing blank lines and per-line trailing whitespace.
-    /// Interior lines and indentation are preserved exactly. Behavior-neutral: AHK ignores literal
-    /// trailing whitespace on script lines (a meaningful trailing space needs the <c>`s</c>/<c>`t</c>
-    /// escapes, which survive the trim untouched).
+    /// CRLF/lone-CR → LF, trims leading/trailing blank lines and per-line trailing whitespace, and
+    /// rewrites a genuine OTB brace (<c>:X:t::{</c>) to <c>{</c> on its own line below the trigger.
+    /// Body-aware: lines <em>between</em> a continuation section's <c>(</c> and <c>)</c> are
+    /// preserved byte-for-byte (trailing spaces/tabs are significant under <c>RTrim0</c>);
+    /// everywhere else, AHK ignores literal trailing whitespace on script lines (a meaningful
+    /// trailing space needs the <c>`s</c>/<c>`t</c> escapes, which survive the trim untouched).
     /// </summary>
     public static string Normalize(string rawDefinition)
     {
         ArgumentNullException.ThrowIfNull(rawDefinition);
 
-        var lines = rawDefinition
-            .Replace("\r\n", "\n")
-            .Replace('\r', '\n')
-            .Split('\n')
-            .Select(l => l.TrimEnd())
-            .ToList();
+        (string[] lines, int firstIdx, Match? match, BodyClassification? body) = Analyze(rawDefinition);
+
+        List<string> outLines = new(lines.Length + 1);
+        for (int i = 0; i < lines.Length; i++)
+        {
+            // Expand a genuine OTB brace onto its own line below the trigger.
+            if (body is { IsOtb: true } && i == firstIdx)
+            {
+                string defLine = lines[i];
+                outLines.Add(defLine[..^match!.Groups[3].Value.Length].TrimEnd());
+                outLines.Add("{");
+                continue;
+            }
+
+            // Preserve continuation-body lines (strictly between "(" and ")") byte-for-byte.
+            bool preserve = body is { Kind: RawBodyKind.Continuation }
+                && i > body.BodyLineStart && i < body.BodyLineEnd;
+
+            outLines.Add(preserve ? lines[i] : lines[i].TrimEnd());
+        }
 
         int start = 0;
-        while (start < lines.Count && lines[start].Length == 0)
+        while (start < outLines.Count && outLines[start].Length == 0)
             start++;
 
-        int end = lines.Count - 1;
-        while (end >= start && lines[end].Length == 0)
+        int end = outLines.Count - 1;
+        while (end >= start && outLines[end].Length == 0)
             end--;
 
-        return start > end ? string.Empty : string.Join('\n', lines.GetRange(start, end - start + 1));
+        return start > end ? string.Empty : string.Join('\n', outLines.GetRange(start, end - start + 1));
     }
 
     public static RawParseResult Parse(string rawDefinition)
     {
         ArgumentNullException.ThrowIfNull(rawDefinition);
 
-        string[] lines = rawDefinition.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
-
-        int firstIdx = Array.FindIndex(lines, l => l.Trim().Length > 0);
-        if (firstIdx < 0)
-            return Invalid(FirstLineError);
-
-        Match match = HotstringLine().Match(lines[firstIdx]);
-        if (!match.Success)
+        (string[] lines, _, Match? match, BodyClassification? body) = Analyze(rawDefinition);
+        if (match is null || body is null)
             return Invalid(FirstLineError);
 
         // No trimming: spaces/tabs are literal within an AHK abbreviation, and the raw text is
         // emitted verbatim, so the derived trigger must match it exactly (dedup, DB, UI display).
         string trigger = DecodeEscapes(match.Groups[2].Value);
         (string[] optionTokens, string[] unknownTokens) = TokenizeOptions(match.Groups[1].Value);
-        string inlineRest = match.Groups[3].Value;
-
-        BodyClassification body = ClassifyBody(optionTokens, inlineRest, lines, firstIdx);
 
         // Body-aware structural facts across the whole paste (rules 2 and 5).
         (int definitionCount, bool directiveOutside) = ScanStructure(lines, body);
@@ -160,6 +167,26 @@ internal static partial class RawHotstringDefinitionParser
             Error: body.Error);
     }
 
+    // Shared structural pass used by both Parse and Normalize: LF-normalize, find the first
+    // non-blank line, match it as a definition, and classify its body. Match/Body are null when
+    // the first line is missing or not a valid definition.
+    private static (string[] Lines, int FirstIdx, Match? Match, BodyClassification? Body) Analyze(string rawDefinition)
+    {
+        string[] lines = rawDefinition.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+
+        int firstIdx = FirstNonBlank(lines, 0);
+        if (firstIdx < 0)
+            return (lines, -1, null, null);
+
+        Match match = HotstringLine().Match(lines[firstIdx]);
+        if (!match.Success)
+            return (lines, firstIdx, null, null);
+
+        (string[] optionTokens, _) = TokenizeOptions(match.Groups[1].Value);
+        BodyClassification body = ClassifyBody(optionTokens, match.Groups[3].Value, lines, firstIdx);
+        return (lines, firstIdx, match, body);
+    }
+
     private static RawParseResult Invalid(string error) =>
         new(IsValid: false, FirstLineValid: false, Trigger: "", OptionTokens: [],
             UnknownOptionTokens: [], DefinitionCount: 0, BodyKind: RawBodyKind.None,
@@ -176,17 +203,27 @@ internal static partial class RawHotstringDefinitionParser
         RawBodyKind Kind,
         int BodyLineCount,
         int BodyLineStart,
-        int BodyLineEnd);
+        int BodyLineEnd,
+        bool IsOtb = false);
 
     // Structural rules 6 and 7. An inline replacement forbids further lines and is not
     // brace-balance checked; a bare "::" first line requires a brace body or continuation section.
     private static BodyClassification ClassifyBody(string[] optionTokens, string inlineRest, string[] lines, int firstIdx)
     {
-        if (inlineRest.Length > 0)
+        // A whitespace-only inline rest is a bare trigger — normalization strips it, so classify
+        // the following lines as the body (Normalize analyzes pre-normalization text).
+        if (inlineRest.Trim().Length > 0)
         {
-            // OTB: "{" placed on the definition line — rejected here (accepted + normalized in Task 2).
-            if (inlineRest.Trim() == "{")
-                return new(false, BraceRequiredError, RawBodyKind.None, 0, -1, -1);
+            // A lone trailing "{" is either an OTB brace-body opener or, when text/raw send-mode
+            // is active, an inline literal replacement that types "{" (per the AHK brace rule).
+            if (inlineRest.Trim() == "{" && !TextOrRawModeActive(optionTokens))
+            {
+                // OTB: validate the brace body from this "{" (depth 1) plus the trailing lines.
+                string region = string.Join('\n', lines[(firstIdx + 1)..].Prepend("{"));
+                (bool otbValid, string? otbError) = ScanBraceBody(region);
+                int otbCloseIdx = FindBraceCloseLine(lines, firstIdx + 1, 1);
+                return new(otbValid, otbError, RawBodyKind.Braces, 0, firstIdx + 1, otbCloseIdx, IsOtb: true);
+            }
 
             // Real inline replacement — no further non-blank lines allowed.
             return HasNonBlank(lines, firstIdx + 1)
@@ -242,15 +279,32 @@ internal static partial class RawHotstringDefinitionParser
     private static BodyClassification ClassifyBraces(string[] lines, int openerIdx)
     {
         (bool valid, string? error) = ScanBraceBody(string.Join('\n', lines[openerIdx..]));
-        int closeIdx = FindBraceCloseLine(lines, openerIdx);
+        int closeIdx = FindBraceCloseLine(lines, openerIdx, 0);
         return new(valid, error, RawBodyKind.Braces, 0, openerIdx, closeIdx);
     }
 
-    // Line index where naive brace depth returns to zero (the closing-brace line). Falls back to
-    // the last line when unbalanced; the validity error is reported separately by ScanBraceBody.
-    private static int FindBraceCloseLine(string[] lines, int startIdx)
+    // Text/raw send-mode is active when the LAST of the mutually-exclusive T/R/T0/R0 option tokens
+    // turns it on. T/R enable it, T0/R0 cancel it; last-wins (do not test "tokens contain T/R").
+    private static bool TextOrRawModeActive(string[] optionTokens)
     {
-        int depth = 0;
+        bool active = false;
+        foreach (string token in optionTokens)
+        {
+            if (token.Equals("T", StringComparison.OrdinalIgnoreCase) || token.Equals("R", StringComparison.OrdinalIgnoreCase))
+                active = true;
+            else if (token.Equals("T0", StringComparison.OrdinalIgnoreCase) || token.Equals("R0", StringComparison.OrdinalIgnoreCase))
+                active = false;
+        }
+
+        return active;
+    }
+
+    // Line index where naive brace depth returns to zero (the closing-brace line), starting from
+    // <paramref name="initialDepth"/> (1 for an OTB "{" already consumed on the definition line).
+    // Falls back to the last line when unbalanced; ScanBraceBody reports the validity error.
+    private static int FindBraceCloseLine(string[] lines, int startIdx, int initialDepth)
+    {
+        int depth = initialDepth;
         for (int i = startIdx; i < lines.Length; i++)
         {
             foreach (char c in lines[i])

--- a/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/RawHotstringDefinitionParser.cs
@@ -1,22 +1,8 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using AHKFlowApp.Application.DTOs;
 
 namespace AHKFlowApp.Application.Services;
-
-/// <summary>
-/// Body shape of a Raw definition as classified by <see cref="RawHotstringDefinitionParser"/>.
-/// <see cref="Continuation"/> is a literal multi-line text section <c>( … )</c>;
-/// <see cref="Braces"/> is an AHK code block <c>{ … }</c>; <see cref="Inline"/> is a replacement
-/// on the definition line; <see cref="None"/> means no recognizable body (structurally invalid).
-/// Maps to the public preview summary's body-kind (<c>RawSummaryDto.BodyKind</c>).
-/// </summary>
-internal enum RawBodyKind
-{
-    None,
-    Inline,
-    Braces,
-    Continuation,
-}
 
 /// <summary>
 /// Outcome of <see cref="RawHotstringDefinitionParser.Parse"/>. Structural facts the Raw

--- a/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
+++ b/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
@@ -294,8 +294,9 @@ internal static partial class HotstringRules
                     return;
                 }
 
-                // Rule 5 — no directive lines (would corrupt #HotIf grouping).
-                if (normalized.Split('\n').Any(line => line.TrimStart().StartsWith('#')))
+                // Rule 5 — no directive lines outside a literal continuation body (would corrupt
+                // #HotIf grouping). Body-awareness lives in the parser; the validator keeps the message.
+                if (parsed.HasDirectiveOutsideLiteralBody)
                 {
                     context.AddFailure("Raw definition must not contain directive lines starting with '#'.");
                     return;

--- a/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
+++ b/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
@@ -230,9 +230,11 @@ internal static partial class HotstringRules
     public static void AddRawKindRules<T>(
         this AbstractValidator<T> validator,
         Expression<Func<T, HotstringKind>> kind,
-        Expression<Func<T, string>> replacement)
+        Expression<Func<T, string>> replacement,
+        Expression<Func<T, string?>> description)
     {
         Func<T, HotstringKind> kindFn = kind.Compile();
+        Func<T, string?> descriptionFn = description.Compile();
 
         bool IsRaw(T x) => kindFn(x) == HotstringKind.Raw;
 
@@ -241,18 +243,18 @@ internal static partial class HotstringRules
             {
                 value ??= string.Empty;
 
-                // Rule 8 — length (bound on raw input before any processing).
-                if (value.Length > RawDefinitionMaxLength)
+                // One authoritative preparation: lift leading comments, normalize, parse. Validating
+                // the persisted form (normalized, comment-stripped) keeps validation and save in
+                // lockstep (e.g. a whitespace-only inline replacement normalized to a bare trigger).
+                RawPrepared prepared = RawHotstringDefinitionParser.Prepare(value);
+                RawParseResult parsed = prepared.Parsed;
+
+                // Rule 8 — length. Lifted comment lines leave the definition, so they don't count.
+                if (prepared.NormalizedDefinition.Length > RawDefinitionMaxLength)
                 {
                     context.AddFailure($"Raw definition must be {RawDefinitionMaxLength} characters or fewer.");
                     return;
                 }
-
-                // Validate the normalized form — the exact text the handler persists — so validation
-                // and save can never disagree (e.g. a whitespace-only inline replacement that
-                // normalization strips to a bare trigger, or lone-CR-separated directive lines).
-                string normalized = RawHotstringDefinitionParser.Normalize(value);
-                RawParseResult parsed = RawHotstringDefinitionParser.Parse(normalized);
 
                 // Rule 1 — first line must be a valid hotstring definition.
                 if (!parsed.FirstLineValid)
@@ -304,7 +306,19 @@ internal static partial class HotstringRules
 
                 // Rules 6 & 7 — structural body completeness (balanced brace body / inline shape).
                 if (!parsed.IsValid)
+                {
                     context.AddFailure(parsed.Error);
+                    return;
+                }
+
+                // A lifted comment merges into Description — reject when it no longer fits. Only the
+                // lifted case is checked here; the standalone Description rule covers the rest.
+                if (prepared.LiftedComment is not null)
+                {
+                    string? merged = RawCommentLift.Merge(descriptionFn(context.InstanceToValidate), prepared.LiftedComment);
+                    if (merged is not null && merged.Length > DescriptionMaxLength)
+                        context.AddFailure("Pasted comment does not fit in Description (200-char max) — shorten it or remove the comment lines.");
+                }
             })
             .When(IsRaw);
     }

--- a/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
+++ b/src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs
@@ -215,17 +215,19 @@ internal static partial class HotstringRules
     }
 
     /// <summary>
-    /// Adds kind-conditional validation for Script hotstrings.
-    /// When <paramref name="kind"/> is <see cref="HotstringKind.Script"/>, <paramref name="replacement"/> must:
-    /// (1) not contain any line starting with <c>#</c> after trimming (directive lines would corrupt the
-    /// generated <c>#HotIf</c> grouping), and (2) have balanced braces. Brace balance is checked via naive
-    /// <c>{</c>/<c>}</c> character counting with no string-literal or comment awareness (D12) — a <c>{</c>
-    /// inside a quoted string (e.g. <c>SendText "{"</c>) counts toward the balance and can false-positive
-    /// reject an otherwise valid script. This is a deliberate limitation, not a bug: a string/comment-aware
-    /// scanner would cross the "not a script IDE" boundary (D8) and introduces its own edge cases.
-    /// The Replacement-required, max-length, and date-field-null rules for Script are already covered by
-    /// <see cref="AddDateTimeKindRules{T}"/> (Script is not DateTime, so it falls into that method's
-    /// "otherwise" branches) and are not duplicated here.
+    /// Adds kind-conditional validation for Raw hotstrings.
+    /// When <paramref name="kind"/> is <see cref="HotstringKind.Raw"/>, <paramref name="replacement"/> (the
+    /// verbatim AHK v2 definition) is run through <see cref="RawHotstringDefinitionParser.Prepare"/> — one
+    /// authoritative pass that lifts leading <c>;</c> comments, body-aware-normalizes, and parses — and the
+    /// resulting structural facts are mapped to per-rule failures: length (rule 8), first-line shape (1),
+    /// single definition (2), derived trigger (3), known option flags (4), no directive lines outside a
+    /// literal continuation body (5), and structural body completeness (6/7). Brace balance is checked via
+    /// naive <c>{</c>/<c>}</c> counting with no string-literal or comment awareness (D12) — a <c>{</c> inside
+    /// a quoted string (e.g. <c>SendText "{"</c>) counts toward the balance and can false-positive reject an
+    /// otherwise valid definition. This is a deliberate limitation, not a bug: a string/comment-aware scanner
+    /// would cross the "not a script IDE" boundary (D8). When a comment is lifted, its merge into
+    /// <paramref name="description"/> (via <see cref="RawCommentLift.Merge"/>) is length-checked here; the
+    /// base Description length rule for the typed value lives on the Create/Update/preview validators.
     /// </summary>
     public static void AddRawKindRules<T>(
         this AbstractValidator<T> validator,

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
@@ -18,6 +18,7 @@
         <MudStack Spacing="3" Class="pa-2">
             <MudTextField T="string" Label="Description" @bind-Value="Item.Description"
                           Required="true" RequiredError="Description is required" MaxLength="200"
+                          HelperText="Emitted as ; comment lines in the generated script."
                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "description-input" })" />
             <MudTextField T="string" Label="Key" @bind-Value="Item.Key"
                           Required="true" RequiredError="Key is required" MaxLength="20"

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -60,8 +60,9 @@
             }
             @if (Item.Kind == HotstringKind.Raw)
             {
-                <MudStack Row="true" Spacing="1" Class="raw-templates"
+                <MudStack Row="true" Spacing="1" Class="raw-templates" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center"
                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "raw-templates" })">
+                    <MudText Typo="Typo.caption">Start with:</MudText>
                     @foreach ((string label, string template, string dataTest) in RawChipTemplates)
                     {
                         <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small" Color="Color.Primary"
@@ -85,7 +86,7 @@
             }
             @if (Item.Kind == HotstringKind.Raw && _rawSummary is not null)
             {
-                <MudStack Row="true" Spacing="4" Class="raw-summary"
+                <MudStack Row="true" Spacing="4" Class="raw-summary" Wrap="Wrap.Wrap"
                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "raw-summary" })">
                     <MudText Typo="Typo.caption"><b>Trigger:</b> @(_rawSummary.Trigger)</MudText>
                     @if (_rawSummary.OptionTokens.Length > 0)
@@ -100,7 +101,7 @@
                     {
                         <MudText Typo="Typo.caption" Color="Color.Info"
                                  UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "raw-comment-lift" })">
-                            Comment moved to Description
+                            Comment will be added to Description: @MergedDescriptionPreview()
                         </MudText>
                     }
                 </MudStack>
@@ -212,7 +213,7 @@
             </MudExpansionPanels>
 
             <MudTextField T="string" Label="Description" @bind-Value="Item.Description"
-                          MaxLength="200"
+                          MaxLength="200" HelperText="Emitted as ; comment lines in the generated script."
                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "description-input" })" />
 
             <MudCheckBox T="bool" @bind-Value="Item.AppliesToAllProfiles" Label="Apply to all profiles"
@@ -341,6 +342,9 @@
     private bool _macroSuggestionDismissed;
     private bool _scriptSuggestionDismissed;
     private RawSummaryDto? _rawSummary;
+    // The blank definition scaffold generated when an empty item switches to Raw — disposable, so
+    // an example chip may overwrite it without a confirmation prompt. Null once real content exists.
+    private string? _rawScaffold;
     private string? _macroInsertHint;
     private bool _previewExpanded;
     private bool _previewPending;
@@ -403,6 +407,7 @@
         // Field-level preview errors and the Raw summary belong to the outgoing kind — drop them so
         // a stale message (e.g. a Raw brace error) can't linger on the incoming kind's fields.
         _rawSummary = null;
+        _rawScaffold = null;
         _previewTriggerError = null;
         _previewReplacementError = null;
         _previewContextValueError = null;
@@ -423,6 +428,9 @@
 
             Item.Trigger = decomposed.Trigger;
             Item.Replacement = newKind == HotstringKind.DateTime ? "" : decomposed.Body;
+            // Fold a lifted leading comment into Description (mirrors the server) so switching away
+            // from Raw doesn't silently drop it.
+            Item.Description = MergeDescription(Item.Description, decomposed.LiftedComment);
             Item.IsCaseSensitive = false;
             Item.OmitEndingCharacter = false;
             Item.IsEndingCharacterRequired = true;
@@ -486,28 +494,35 @@
             }
 
             // Compose a starting definition from the current structured fields (same shape as the
-            // server's Script→Raw transform). An empty replacement yields just the trigger scaffold.
+            // server's Script→Raw transform). An empty replacement yields just the trigger scaffold,
+            // which is disposable — the example chips overwrite it without a confirmation prompt.
+            bool blankScaffold = string.IsNullOrEmpty(Item.Replacement);
             Item.Replacement = RawDefinition.Compose(
                 Item.Trigger, Item.Replacement,
                 Item.IsEndingCharacterRequired, Item.IsTriggerInsideWord,
                 Item.IsCaseSensitive, Item.OmitEndingCharacter);
+            _rawScaffold = blankScaffold ? Item.Replacement : null;
             ClearDateTimeFields();
             Item.Kind = HotstringKind.Raw;
         }
     }
 
-    // Applies a Raw example template to the definition field. When the field already holds non-empty,
-    // non-template content, confirm first (same MessageBox pattern as kind switching) before overwriting.
+    // Applies a Raw example template to the definition field. When the field already holds real
+    // content — non-empty, not another template, and not the disposable blank scaffold — confirm
+    // first (same MessageBox pattern as kind switching) before replacing it.
     private async Task ApplyRawTemplateAsync(string template)
     {
-        bool nonTemplateContent = !string.IsNullOrWhiteSpace(Item.Replacement)
-            && !RawChipTemplates.Any(t => t.Template == Item.Replacement);
-        if (nonTemplateContent
+        bool disposable = string.IsNullOrWhiteSpace(Item.Replacement)
+            || Item.Replacement == _rawScaffold
+            || RawChipTemplates.Any(t => t.Template == Item.Replacement);
+        if (!disposable
             && !await ConfirmSwitchAsync("Replace definition?",
-                "This replaces the current Raw definition with the example. Continue?"))
+                "This replaces the current Raw definition with the example. Continue?",
+                yesText: "Replace"))
             return;
 
         Item.Replacement = template;
+        _rawScaffold = null;
     }
 
     private static string? RawBodyKindLabel(RawSummaryDto summary) => summary.BodyKind switch
@@ -526,12 +541,32 @@
         _ => kind.ToString(),
     };
 
-    private async Task<bool> ConfirmSwitchAsync(string title, string message)
+    private async Task<bool> ConfirmSwitchAsync(string title, string message, string yesText = "Switch")
     {
         bool? confirm = await DialogService.ShowMessageBoxAsync(
-            title: title, message: message, yesText: "Switch", cancelText: "Cancel");
+            title: title, message: message, yesText: yesText, cancelText: "Cancel");
         return confirm == true;
     }
+
+    // Description merge policy mirroring the server's RawCommentLift.Merge: empty Description → the
+    // lifted comment; equal → unchanged; otherwise the comment appended on a new line.
+    private static string? MergeDescription(string? description, string? lifted)
+    {
+        string? desc = string.IsNullOrWhiteSpace(description) ? null : description.Trim();
+        string? lift = string.IsNullOrWhiteSpace(lifted) ? null : lifted;
+
+        if (lift is null)
+            return desc;
+        if (desc is null)
+            return lift;
+
+        return string.Equals(desc, lift, StringComparison.Ordinal) ? desc : $"{desc}\n{lift}";
+    }
+
+    // The Description as it will be persisted once the lifted comment is merged in — shown in the
+    // summary so the user sees the resulting text before saving.
+    private string MergedDescriptionPreview() =>
+        MergeDescription(Item.Description, _rawSummary?.LiftedComment) ?? "";
 
     private void ClearDateTimeFields()
     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -58,6 +58,20 @@
                     </MudText>
                 }
             }
+            @if (Item.Kind == HotstringKind.Raw)
+            {
+                <MudStack Row="true" Spacing="1" Class="raw-templates"
+                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "raw-templates" })">
+                    @foreach ((string label, string template, string dataTest) in RawChipTemplates)
+                    {
+                        <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small" Color="Color.Primary"
+                                 OnClick="@(() => ApplyRawTemplateAsync(template))"
+                                 UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = dataTest })">
+                            @label
+                        </MudChip>
+                    }
+                </MudStack>
+            }
             @if (Item.Kind != HotstringKind.DateTime)
             {
                 <MudTextField T="string" Label="@(Item.Kind == HotstringKind.Raw ? "Raw definition" : "Replacement")"
@@ -77,6 +91,17 @@
                     @if (_rawSummary.OptionTokens.Length > 0)
                     {
                         <MudText Typo="Typo.caption"><b>Options:</b> @string.Join(" ", _rawSummary.OptionTokens)</MudText>
+                    }
+                    @if (RawBodyKindLabel(_rawSummary) is string bodyLabel)
+                    {
+                        <MudText Typo="Typo.caption"><b>Body:</b> @bodyLabel</MudText>
+                    }
+                    @if (_rawSummary.LiftedComment is not null)
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Info"
+                                 UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "raw-comment-lift" })">
+                            Comment moved to Description
+                        </MudText>
                     }
                 </MudStack>
             }
@@ -255,8 +280,16 @@
         "One {{cursor}} token allowed; Enter/Tab must come before it. Write {{{{...}}}} for literal {{...}} text.";
     private const string RawHelperText =
         "Paste one entire AHK v2 definition (e.g. :K1000 SE*:ftw::for the win). The trigger and options are " +
-        "parsed from the first line. No lines starting with '#'; a bare '::' needs a { brace body below; braces are " +
-        "counted literally (no string/comment awareness); OTB braces and continuation sections are not supported.";
+        "parsed from the first line. Below a bare '::' put { code } or ( multi-line text ) on their own lines; " +
+        "OTB braces are normalized. Leading ';' comment lines move into the Description.";
+
+    private static readonly (string Label, string Template, string DataTest)[] RawChipTemplates =
+    [
+        ("Inline", ":*:btw::by the way", "raw-template-inline"),
+        ("Multi-line text ( )", ":*:col::\n(\nred\ngreen\nblue\n)", "raw-template-continuation"),
+        ("Code block { }", ":X:run::\n{\nRun \"notepad.exe\"\n}", "raw-template-braces"),
+        ("With options", ":K1000 SE*:ftw::for the win", "raw-template-options"),
+    ];
 
     private string? ReplacementHelperText => Item.Kind switch
     {
@@ -379,9 +412,13 @@
         if (Item.Kind == HotstringKind.Raw && newKind != HotstringKind.Raw)
         {
             RawDecomposition decomposed = RawDefinition.Decompose(Item.Replacement);
-            if (decomposed.UnexpressibleOptions.Count > 0
+            List<string> losses = [];
+            if (decomposed.UnexpressibleOptions.Count > 0)
+                losses.Add($"options `{string.Join(" ", decomposed.UnexpressibleOptions)}`");
+            losses.AddRange(decomposed.LossyReasons);
+            if (losses.Count > 0
                 && !await ConfirmSwitchAsync($"Switch to {KindLabel(newKind)}?",
-                    $"Options `{string.Join(" ", decomposed.UnexpressibleOptions)}` will be discarded — continue?"))
+                    $"Converting to {KindLabel(newKind)} will discard {string.Join(" and ", losses)} — continue?"))
                 return;
 
             Item.Trigger = decomposed.Trigger;
@@ -458,6 +495,27 @@
             Item.Kind = HotstringKind.Raw;
         }
     }
+
+    // Applies a Raw example template to the definition field. When the field already holds non-empty,
+    // non-template content, confirm first (same MessageBox pattern as kind switching) before overwriting.
+    private async Task ApplyRawTemplateAsync(string template)
+    {
+        bool nonTemplateContent = !string.IsNullOrWhiteSpace(Item.Replacement)
+            && !RawChipTemplates.Any(t => t.Template == Item.Replacement);
+        if (nonTemplateContent
+            && !await ConfirmSwitchAsync("Replace definition?",
+                "This replaces the current Raw definition with the example. Continue?"))
+            return;
+
+        Item.Replacement = template;
+    }
+
+    private static string? RawBodyKindLabel(RawSummaryDto summary) => summary.BodyKind switch
+    {
+        RawBodyKind.Braces => "code block",
+        RawBodyKind.Continuation => $"multi-line text ({summary.BodyLineCount} lines)",
+        _ => null,
+    };
 
     private static string KindLabel(HotstringKind kind) => kind switch
     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -688,7 +688,7 @@
         Item.Kind, Item.Trigger, Item.Replacement, Item.IsCaseSensitive,
         Item.OmitEndingCharacter, Item.IsEndingCharacterRequired, Item.IsTriggerInsideWord,
         Item.DateTimeFormat, Item.DateOffsetAmount, Item.DateOffsetUnit,
-        Item.ContextMatchType, Item.ContextValue);
+        Item.ContextMatchType, Item.ContextValue, Item.Description);
 
     private void SchedulePreview(HotstringPreviewRequestDto request, bool debounce)
     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -78,11 +78,16 @@
                         <MudList T="string" Dense="true">
                             @foreach ((string label, string template, string preview, string dataTest) in RawExampleTemplates)
                             {
-                                <MudListItem T="string" OnClick="@(() => ApplyRawTemplateAsync(template))"
-                                             UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = dataTest })">
-                                    <MudStack Row="true" Spacing="3" AlignItems="AlignItems.Baseline" Wrap="Wrap.Wrap">
-                                        <MudText Typo="Typo.body2" Style="min-width: 130px"><b>@label</b></MudText>
-                                        <MudText Typo="Typo.caption" Class="ahk-mono">@preview</MudText>
+                                <MudListItem T="string" Ripple="false" Gutters="true">
+                                    <MudStack Row="true" Spacing="3" AlignItems="AlignItems.Center"
+                                              Justify="Justify.SpaceBetween">
+                                        <MudStack Row="true" Spacing="3" AlignItems="AlignItems.Baseline" Wrap="Wrap.Wrap">
+                                            <MudText Typo="Typo.body2" Style="min-width: 130px"><b>@label</b></MudText>
+                                            <MudText Typo="Typo.caption" Class="ahk-mono">@preview</MudText>
+                                        </MudStack>
+                                        <MudIconButton Icon="@Icons.Material.Filled.ContentCopy" Size="Size.Small"
+                                                       OnClick="@(() => CopyTemplateAsync(template))"
+                                                       UserAttributes="@(new Dictionary<string, object?> { ["aria-label"] = $"Copy {label} example", ["data-test"] = dataTest })" />
                                     </MudStack>
                                 </MudListItem>
                             }
@@ -349,9 +354,6 @@
     private bool _scriptSuggestionDismissed;
     private RawSummaryDto? _rawSummary;
     private bool _rawExamplesExpanded;
-    // The blank definition scaffold generated when an empty item switches to Raw — disposable, so
-    // an example template may overwrite it without a confirmation prompt. Null once real content exists.
-    private string? _rawScaffold;
     private string? _macroInsertHint;
     private bool _previewExpanded;
     private bool _previewPending;
@@ -414,7 +416,6 @@
         // Field-level preview errors and the Raw summary belong to the outgoing kind — drop them so
         // a stale message (e.g. a Raw brace error) can't linger on the incoming kind's fields.
         _rawSummary = null;
-        _rawScaffold = null;
         _previewTriggerError = null;
         _previewReplacementError = null;
         _previewContextValueError = null;
@@ -501,35 +502,29 @@
             }
 
             // Compose a starting definition from the current structured fields (same shape as the
-            // server's Script→Raw transform). An empty replacement yields just the trigger scaffold,
-            // which is disposable — an example template overwrites it without a confirmation prompt.
-            bool blankScaffold = string.IsNullOrEmpty(Item.Replacement);
+            // server's Script→Raw transform). An empty replacement yields just the trigger scaffold.
             Item.Replacement = RawDefinition.Compose(
                 Item.Trigger, Item.Replacement,
                 Item.IsEndingCharacterRequired, Item.IsTriggerInsideWord,
                 Item.IsCaseSensitive, Item.OmitEndingCharacter);
-            _rawScaffold = blankScaffold ? Item.Replacement : null;
             ClearDateTimeFields();
             Item.Kind = HotstringKind.Raw;
         }
     }
 
-    // Applies a Raw example template to the definition field. When the field already holds real
-    // content — non-empty, not another template, and not the disposable blank scaffold — confirm
-    // first (same MessageBox pattern as kind switching) before replacing it.
-    private async Task ApplyRawTemplateAsync(string template)
+    // Copies a Raw example definition to the clipboard so the user can paste it into the field
+    // themselves — the examples are a reference, never an overwrite of what they've typed.
+    private async Task CopyTemplateAsync(string template)
     {
-        bool disposable = string.IsNullOrWhiteSpace(Item.Replacement)
-            || Item.Replacement == _rawScaffold
-            || RawExampleTemplates.Any(t => t.Template == Item.Replacement);
-        if (!disposable
-            && !await ConfirmSwitchAsync("Replace definition?",
-                "This replaces the current Raw definition with the example. Continue?",
-                yesText: "Replace"))
-            return;
-
-        Item.Replacement = template;
-        _rawScaffold = null;
+        try
+        {
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", template);
+            Snackbar.Add("Example copied — paste it into the definition.", Severity.Success);
+        }
+        catch (JSException)
+        {
+            Snackbar.Add("Copy to clipboard failed.", Severity.Warning);
+        }
     }
 
     private static string? RawBodyKindLabel(RawSummaryDto summary) => summary.BodyKind switch

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -58,21 +58,6 @@
                     </MudText>
                 }
             }
-            @if (Item.Kind == HotstringKind.Raw)
-            {
-                <MudStack Row="true" Spacing="1" Class="raw-templates" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center"
-                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "raw-templates" })">
-                    <MudText Typo="Typo.caption">Start with:</MudText>
-                    @foreach ((string label, string template, string dataTest) in RawChipTemplates)
-                    {
-                        <MudChip T="string" Variant="Variant.Outlined" Size="Size.Small" Color="Color.Primary"
-                                 OnClick="@(() => ApplyRawTemplateAsync(template))"
-                                 UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = dataTest })">
-                            @label
-                        </MudChip>
-                    }
-                </MudStack>
-            }
             @if (Item.Kind != HotstringKind.DateTime)
             {
                 <MudTextField T="string" Label="@(Item.Kind == HotstringKind.Raw ? "Raw definition" : "Replacement")"
@@ -83,6 +68,27 @@
                               Error="@(_previewReplacementError is not null)" ErrorText="@_previewReplacementError"
                               HelperText="@ReplacementHelperText"
                               UserAttributes="@GetReplacementUserAttributes()" />
+            }
+            @if (Item.Kind == HotstringKind.Raw)
+            {
+                <MudExpansionPanels Elevation="0" Class="raw-templates"
+                                    UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "raw-templates" })">
+                    <MudExpansionPanel Text="Examples" Dense="true" Expanded="_rawExamplesExpanded"
+                                       ExpandedChanged="@(e => _rawExamplesExpanded = e)">
+                        <MudList T="string" Dense="true">
+                            @foreach ((string label, string template, string preview, string dataTest) in RawExampleTemplates)
+                            {
+                                <MudListItem T="string" OnClick="@(() => ApplyRawTemplateAsync(template))"
+                                             UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = dataTest })">
+                                    <MudStack Row="true" Spacing="3" AlignItems="AlignItems.Baseline" Wrap="Wrap.Wrap">
+                                        <MudText Typo="Typo.body2" Style="min-width: 130px"><b>@label</b></MudText>
+                                        <MudText Typo="Typo.caption" Class="ahk-mono">@preview</MudText>
+                                    </MudStack>
+                                </MudListItem>
+                            }
+                        </MudList>
+                    </MudExpansionPanel>
+                </MudExpansionPanels>
             }
             @if (Item.Kind == HotstringKind.Raw && _rawSummary is not null)
             {
@@ -284,12 +290,12 @@
         "parsed from the first line. Below a bare '::' put { code } or ( multi-line text ) on their own lines; " +
         "OTB braces are normalized. Leading ';' comment lines move into the Description.";
 
-    private static readonly (string Label, string Template, string DataTest)[] RawChipTemplates =
+    private static readonly (string Label, string Template, string Preview, string DataTest)[] RawExampleTemplates =
     [
-        ("Inline", ":*:btw::by the way", "raw-template-inline"),
-        ("Multi-line text ( )", ":*:col::\n(\nred\ngreen\nblue\n)", "raw-template-continuation"),
-        ("Code block { }", ":X:run::\n{\nRun \"notepad.exe\"\n}", "raw-template-braces"),
-        ("With options", ":K1000 SE*:ftw::for the win", "raw-template-options"),
+        ("Inline", ":*:btw::by the way", ":*:btw::by the way", "raw-template-inline"),
+        ("Multi-line text ( )", ":*:col::\n(\nred\ngreen\nblue\n)", ":*:col::  ( red / green / blue )", "raw-template-continuation"),
+        ("Code block { }", ":X:run::\n{\nRun \"notepad.exe\"\n}", ":X:run::  { Run \"notepad.exe\" }", "raw-template-braces"),
+        ("With options", ":K1000 SE*:ftw::for the win", ":K1000 SE*:ftw::for the win", "raw-template-options"),
     ];
 
     private string? ReplacementHelperText => Item.Kind switch
@@ -342,8 +348,9 @@
     private bool _macroSuggestionDismissed;
     private bool _scriptSuggestionDismissed;
     private RawSummaryDto? _rawSummary;
+    private bool _rawExamplesExpanded;
     // The blank definition scaffold generated when an empty item switches to Raw — disposable, so
-    // an example chip may overwrite it without a confirmation prompt. Null once real content exists.
+    // an example template may overwrite it without a confirmation prompt. Null once real content exists.
     private string? _rawScaffold;
     private string? _macroInsertHint;
     private bool _previewExpanded;
@@ -495,7 +502,7 @@
 
             // Compose a starting definition from the current structured fields (same shape as the
             // server's Script→Raw transform). An empty replacement yields just the trigger scaffold,
-            // which is disposable — the example chips overwrite it without a confirmation prompt.
+            // which is disposable — an example template overwrites it without a confirmation prompt.
             bool blankScaffold = string.IsNullOrEmpty(Item.Replacement);
             Item.Replacement = RawDefinition.Compose(
                 Item.Trigger, Item.Replacement,
@@ -514,7 +521,7 @@
     {
         bool disposable = string.IsNullOrWhiteSpace(Item.Replacement)
             || Item.Replacement == _rawScaffold
-            || RawChipTemplates.Any(t => t.Template == Item.Replacement);
+            || RawExampleTemplates.Any(t => t.Template == Item.Replacement);
         if (!disposable
             && !await ConfirmSwitchAsync("Replace definition?",
                 "This replaces the current Raw definition with the example. Continue?",

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HotstringPreviewDtos.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HotstringPreviewDtos.cs
@@ -12,9 +12,24 @@ public sealed record HotstringPreviewRequestDto(
     int? DateOffsetAmount = null,
     DateOffsetUnit? DateOffsetUnit = null,
     WindowMatchType? ContextMatchType = null,
-    string? ContextValue = null);
+    string? ContextValue = null,
+    string? Description = null);
 
 public sealed record HotstringPreviewDto(string Snippet, RawSummaryDto? RawSummary = null);
 
-/// <summary>Server-derived trigger and option tokens for a Raw definition; null for other kinds.</summary>
-public sealed record RawSummaryDto(string Trigger, string[] OptionTokens);
+/// <summary>Body shape of a Raw hotstring definition (mirror of the backend enum).</summary>
+public enum RawBodyKind
+{
+    None,
+    Inline,
+    Braces,
+    Continuation,
+}
+
+/// <summary>Server-derived summary of a Raw definition; null for other kinds.</summary>
+public sealed record RawSummaryDto(
+    string Trigger,
+    string[] OptionTokens,
+    RawBodyKind BodyKind,
+    int BodyLineCount,
+    string? LiftedComment);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/RawDefinition.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/RawDefinition.cs
@@ -14,11 +14,17 @@ namespace AHKFlowApp.UI.Blazor.Helpers;
 /// continuation section's options (<c>Join</c>, <c>RTrim0</c>) or significant trailing whitespace.
 /// Empty when the conversion is clean; surfaced in the confirmation alongside discarded options.
 /// </param>
+/// <param name="LiftedComment">
+/// Leading <c>;</c> comment lines above the definition, joined with <c>\n</c> (marker stripped) —
+/// mirrors the server lift so the dialog can fold them into Description instead of dropping them.
+/// Null when there is no leading comment.
+/// </param>
 public sealed record RawDecomposition(
     string Trigger,
     string Body,
     IReadOnlyList<string> UnexpressibleOptions,
-    IReadOnlyList<string> LossyReasons);
+    IReadOnlyList<string> LossyReasons,
+    string? LiftedComment = null);
 
 /// <summary>
 /// Client-side Raw definition compose/decompose for the edit dialog's kind switching. <see cref="Compose"/>
@@ -55,34 +61,53 @@ public static class RawDefinition
     public static RawDecomposition Decompose(string rawDefinition)
     {
         string[] lines = (rawDefinition ?? "").Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
-        int firstIdx = Array.FindIndex(lines, l => l.Trim().Length > 0);
+
+        // Lift leading ';' comment lines the same way the server does, so a commented definition
+        // still parses (and the comment folds into Description rather than being treated as body).
+        (string? lifted, int defStart) = LiftLeadingComments(lines);
+        string remainder = string.Join('\n', lines[defStart..]);
+
+        int firstIdx = Array.FindIndex(lines, defStart, l => l.Trim().Length > 0);
         if (firstIdx < 0)
-            return new RawDecomposition("", "", [], []);
+            return new RawDecomposition("", "", [], [], lifted);
 
         string first = lines[firstIdx].TrimStart();
         // :options:trigger::rest — options/trigger contain no ':'; first '::' delimits.
         int firstColon = first.IndexOf(':');
         if (firstColon != 0)
-            return new RawDecomposition("", rawDefinition ?? "", [], []);
+            return new RawDecomposition("", remainder, [], [], lifted);
 
         int secondColon = first.IndexOf(':', 1);
         if (secondColon < 0)
-            return new RawDecomposition("", rawDefinition ?? "", [], []);
+            return new RawDecomposition("", remainder, [], [], lifted);
 
         string optionsBlock = first[1..secondColon];
         int doubleColon = first.IndexOf("::", secondColon + 1, StringComparison.Ordinal);
         if (doubleColon < 0)
-            return new RawDecomposition("", rawDefinition ?? "", [], []);
+            return new RawDecomposition("", remainder, [], [], lifted);
 
         string triggerRaw = first[(secondColon + 1)..doubleColon];
         string inlineRest = first[(doubleColon + 2)..];
+        string[] optionTokens = [.. TokenizeOptions(optionsBlock)];
 
         string body;
         List<string> lossy = [];
         string inlineTrim = inlineRest.Trim();
-        if (inlineTrim.Length > 0 && inlineTrim != "{")
+        bool textOrRawMode = TextOrRawModeActive(optionTokens);
+
+        if (inlineTrim.Length > 0 && (inlineTrim != "{" || textOrRawMode))
         {
+            // Real inline replacement. With text/raw send-mode active a lone trailing "{" is a
+            // literal replacement (it types "{"), not an OTB brace-body opener.
             body = inlineRest;
+        }
+        else if (inlineTrim == "{")
+        {
+            // OTB: the "{" opens the brace body on the trigger line, so the body is the following
+            // lines up to the last "}" (there is no separate "{" opener line to skip).
+            string[] rest = lines[(firstIdx + 1)..];
+            int close = Array.FindLastIndex(rest, l => l.Trim() == "}");
+            body = close >= 0 ? string.Join('\n', rest[..close]) : string.Join('\n', rest).Trim();
         }
         else
         {
@@ -114,9 +139,50 @@ public static class RawDefinition
             }
         }
 
-        List<string> unexpressible = [.. TokenizeOptions(optionsBlock).Where(t => !ExpressibleOptions.Contains(t))];
+        List<string> unexpressible = [.. optionTokens.Where(t => !ExpressibleOptions.Contains(t))];
         // No trimming: mirror the server parser — the abbreviation's whitespace is literal.
-        return new RawDecomposition(DecodeEscapes(triggerRaw), body, unexpressible, lossy);
+        return new RawDecomposition(DecodeEscapes(triggerRaw), body, unexpressible, lossy, lifted);
+    }
+
+    // Consume leading blank/comment lines above the definition (mirrors the server's lift): comment
+    // lines (first non-blank char ';') join with '\n' with the ';' + one following space stripped.
+    // Returns the joined comment (null when none) and the index of the first non-comment line.
+    private static (string? Lifted, int DefStart) LiftLeadingComments(string[] lines)
+    {
+        List<string> comments = [];
+        int i = 0;
+        for (; i < lines.Length; i++)
+        {
+            string trimmed = lines[i].TrimStart();
+            if (trimmed.Length == 0)
+                continue;
+            if (trimmed.StartsWith(';'))
+            {
+                string rest = trimmed[1..];
+                comments.Add((rest.StartsWith(' ') ? rest[1..] : rest).TrimEnd());
+                continue;
+            }
+
+            break;
+        }
+
+        return comments.Count == 0 ? (null, 0) : (string.Join('\n', comments), i);
+    }
+
+    // Text/raw send-mode is active when the LAST of the mutually-exclusive T/R/T0/R0 option tokens
+    // turns it on (T/R enable, T0/R0 cancel) — mirrors the server's TextOrRawModeActive.
+    private static bool TextOrRawModeActive(IReadOnlyList<string> optionTokens)
+    {
+        bool active = false;
+        foreach (string token in optionTokens)
+        {
+            if (token.Equals("T", StringComparison.OrdinalIgnoreCase) || token.Equals("R", StringComparison.OrdinalIgnoreCase))
+                active = true;
+            else if (token.Equals("T0", StringComparison.OrdinalIgnoreCase) || token.Equals("R0", StringComparison.OrdinalIgnoreCase))
+                active = false;
+        }
+
+        return active;
     }
 
     // Longest-match tokenizer (SE/SP/SI before S; each flag absorbs its sign/digits), mirroring the

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/RawDefinition.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/RawDefinition.cs
@@ -4,12 +4,21 @@ namespace AHKFlowApp.UI.Blazor.Helpers;
 
 /// <summary>Result of decomposing a Raw definition back into structured fields.</summary>
 /// <param name="Trigger">Decoded trigger from the first line.</param>
-/// <param name="Body">Inline replacement, or the brace-body content when the definition uses one.</param>
+/// <param name="Body">Inline replacement, or the brace/continuation-body content when the definition uses one.</param>
 /// <param name="UnexpressibleOptions">
 /// Option tokens the four structured checkboxes (<c>*</c>/<c>?</c>/<c>C</c>/<c>O</c>) can't
 /// represent (e.g. <c>K1000</c>, <c>SE</c>) — surfaced in the "discard options?" confirmation.
 /// </param>
-public sealed record RawDecomposition(string Trigger, string Body, IReadOnlyList<string> UnexpressibleOptions);
+/// <param name="LossyReasons">
+/// Human-readable reasons the conversion loses information a structured kind can't hold — e.g. a
+/// continuation section's options (<c>Join</c>, <c>RTrim0</c>) or significant trailing whitespace.
+/// Empty when the conversion is clean; surfaced in the confirmation alongside discarded options.
+/// </param>
+public sealed record RawDecomposition(
+    string Trigger,
+    string Body,
+    IReadOnlyList<string> UnexpressibleOptions,
+    IReadOnlyList<string> LossyReasons);
 
 /// <summary>
 /// Client-side Raw definition compose/decompose for the edit dialog's kind switching. <see cref="Compose"/>
@@ -48,46 +57,66 @@ public static class RawDefinition
         string[] lines = (rawDefinition ?? "").Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
         int firstIdx = Array.FindIndex(lines, l => l.Trim().Length > 0);
         if (firstIdx < 0)
-            return new RawDecomposition("", "", []);
+            return new RawDecomposition("", "", [], []);
 
         string first = lines[firstIdx].TrimStart();
         // :options:trigger::rest — options/trigger contain no ':'; first '::' delimits.
         int firstColon = first.IndexOf(':');
         if (firstColon != 0)
-            return new RawDecomposition("", rawDefinition ?? "", []);
+            return new RawDecomposition("", rawDefinition ?? "", [], []);
 
         int secondColon = first.IndexOf(':', 1);
         if (secondColon < 0)
-            return new RawDecomposition("", rawDefinition ?? "", []);
+            return new RawDecomposition("", rawDefinition ?? "", [], []);
 
         string optionsBlock = first[1..secondColon];
         int doubleColon = first.IndexOf("::", secondColon + 1, StringComparison.Ordinal);
         if (doubleColon < 0)
-            return new RawDecomposition("", rawDefinition ?? "", []);
+            return new RawDecomposition("", rawDefinition ?? "", [], []);
 
         string triggerRaw = first[(secondColon + 1)..doubleColon];
         string inlineRest = first[(doubleColon + 2)..];
 
         string body;
+        List<string> lossy = [];
         string inlineTrim = inlineRest.Trim();
-        if (inlineRest.Length > 0 && inlineTrim != "{")
+        if (inlineTrim.Length > 0 && inlineTrim != "{")
         {
             body = inlineRest;
         }
         else
         {
-            // Brace body: content strictly between the "{" line and the last "}" line.
             string[] rest = lines[(firstIdx + 1)..];
-            int open = Array.FindIndex(rest, l => l.Trim() == "{");
-            int close = Array.FindLastIndex(rest, l => l.Trim() == "}");
-            body = open >= 0 && close > open
-                ? string.Join('\n', rest[(open + 1)..close])
-                : string.Join('\n', rest).Trim();
+            int bodyIdx = Array.FindIndex(rest, l => l.Trim().Length > 0);
+
+            if (bodyIdx >= 0 && rest[bodyIdx].TrimStart().StartsWith('('))
+            {
+                // Continuation section: literal text strictly between the "(" and ")" lines.
+                int close = Array.FindIndex(rest, bodyIdx + 1, l => l.Trim() == ")");
+                string[] bodyLines = close > bodyIdx ? rest[(bodyIdx + 1)..close] : rest[(bodyIdx + 1)..];
+                body = string.Join('\n', bodyLines);
+
+                // Structured Text can't hold continuation options or significant trailing whitespace.
+                string openerOptions = rest[bodyIdx].TrimStart()[1..].Trim();
+                if (openerOptions.Length > 0)
+                    lossy.Add($"continuation options `{openerOptions}`");
+                if (bodyLines.Any(l => l.Length != l.TrimEnd().Length))
+                    lossy.Add("significant trailing whitespace");
+            }
+            else
+            {
+                // Brace body: content strictly between the "{" line and the last "}" line.
+                int open = Array.FindIndex(rest, l => l.Trim() == "{");
+                int close = Array.FindLastIndex(rest, l => l.Trim() == "}");
+                body = open >= 0 && close > open
+                    ? string.Join('\n', rest[(open + 1)..close])
+                    : string.Join('\n', rest).Trim();
+            }
         }
 
         List<string> unexpressible = [.. TokenizeOptions(optionsBlock).Where(t => !ExpressibleOptions.Contains(t))];
         // No trimming: mirror the server parser — the abbreviation's whitespace is literal.
-        return new RawDecomposition(DecodeEscapes(triggerRaw), body, unexpressible);
+        return new RawDecomposition(DecodeEscapes(triggerRaw), body, unexpressible, lossy);
     }
 
     // Longest-match tokenizer (SE/SP/SI before S; each flag absorbs its sign/digits), mirroring the

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandHandlerTests.cs
@@ -66,6 +66,24 @@ public sealed class CreateHotstringCommandHandlerTests(HotstringDbFixture fx)
     }
 
     [Fact]
+    public async Task Handle_RawWithLeadingComment_StripsDefinitionAndMergesDescription()
+    {
+        await using AppDbContext db = fx.CreateContext();
+        var owner = Guid.NewGuid();
+        var handler = new CreateHotstringCommandHandler(db, CurrentUserHelper.For(owner), _clock);
+        var cmd = new CreateHotstringCommand(new CreateHotstringDto(
+            "ignored", "; pasted note\n::btw::by the way",
+            Kind: HotstringKind.Raw, Description: "existing"));
+
+        Result<HotstringDto> result = await handler.ExecuteAsync(cmd, default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Trigger.Should().Be("btw");
+        result.Value.Replacement.Should().Be("::btw::by the way");
+        result.Value.Description.Should().Be("existing\npasted note");
+    }
+
+    [Fact]
     public async Task Handle_WhenNoOid_ReturnsUnauthorized()
     {
         await using AppDbContext db = fx.CreateContext();

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
@@ -368,6 +368,41 @@ public sealed class CreateHotstringCommandValidatorTests
     }
 
     [Fact]
+    public void RawKind_LeadingComment_Passes()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Raw, replacement: "; a note\n::btw::by the way"));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RawKind_LiftedCommentOverflowsDescription_Fails()
+    {
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Raw,
+            description: new string('d', 195),
+            replacement: "; " + new string('c', 50) + "\n::btw::by the way"));
+
+        result.Errors.Should().Contain(e =>
+            e.ErrorMessage == "Pasted comment does not fit in Description (200-char max) — shorten it or remove the comment lines.");
+    }
+
+    [Fact]
+    public void RawKind_LiftedCommentExcludedFrom4200_Passes()
+    {
+        // Definition body is exactly at the limit; a leading comment pushes the raw paste over 4200
+        // but comment lines leave the definition, so length is measured without them.
+        string comment = "; note\n";
+        string definition = ":*:t::" + new string('x', 4194); // 6 + 4194 = 4200
+
+        ValidationResult result = _sut.Validate(Cmd(
+            kind: HotstringKind.Raw, replacement: comment + definition));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
     public void RawKind_Rule8_OverMaxLength_Fails()
     {
         ValidationResult result = _sut.Validate(Cmd(

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
@@ -359,12 +359,12 @@ public sealed class CreateHotstringCommandValidatorTests
     }
 
     [Fact]
-    public void RawKind_Rule7_ContinuationSection_Fails()
+    public void RawKind_ContinuationSection_Passes()
     {
         ValidationResult result = _sut.Validate(Cmd(
-            kind: HotstringKind.Raw, replacement: ":*:long::\n(\nline1\n)"));
+            kind: HotstringKind.Raw, replacement: ":*:long::\n(\nline1\nline2\n)"));
 
-        result.Errors.Should().Contain(e => e.ErrorMessage == "Put `{` on its own line below the trigger.");
+        result.IsValid.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
@@ -350,12 +350,12 @@ public sealed class CreateHotstringCommandValidatorTests
     }
 
     [Fact]
-    public void RawKind_Rule7_OtbBrace_Fails()
+    public void RawKind_OtbBrace_Passes()
     {
         ValidationResult result = _sut.Validate(Cmd(
-            kind: HotstringKind.Raw, replacement: "::btw:: {\nSend foo\n}"));
+            kind: HotstringKind.Raw, replacement: "::btw::{\nSend foo\n}"));
 
-        result.Errors.Should().Contain(e => e.ErrorMessage == "Put `{` on its own line below the trigger.");
+        result.IsValid.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/CreateHotstringCommandValidatorTests.cs
@@ -442,7 +442,7 @@ public sealed class CreateHotstringCommandValidatorTests
             trigger: "", kind: HotstringKind.Raw, replacement: "::t::    "));
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.ErrorMessage == "Put `{` on its own line below the trigger.");
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Add a replacement after `::`, or put `{` (code) or `(` (multi-line text) on its own line below the trigger.");
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/GetHotstringPreviewQueryHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/GetHotstringPreviewQueryHandlerTests.cs
@@ -1,0 +1,54 @@
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Queries.Hotstrings;
+using AHKFlowApp.Domain.Enums;
+using Ardalis.Result;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Hotstrings;
+
+public sealed class GetHotstringPreviewQueryHandlerTests
+{
+    private readonly GetHotstringPreviewQueryHandler _sut = new(TimeProvider.System);
+
+    private static GetHotstringPreviewQuery Query(
+        HotstringKind kind, string replacement, string? description = null, string trigger = "btw")
+        => new(new HotstringPreviewRequestDto(
+            kind, trigger, replacement,
+            IsCaseSensitive: false, OmitEndingCharacter: false,
+            IsEndingCharacterRequired: true, IsTriggerInsideWord: false,
+            Description: description));
+
+    [Fact]
+    public async Task Preview_NonRawWithDescription_PrependsCommentToSnippet()
+    {
+        Result<HotstringPreviewDto> result = await _sut.ExecuteAsync(
+            Query(HotstringKind.Text, "by the way", description: "a note"), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Snippet.Should().Be("; a note\n:T:btw::by the way");
+    }
+
+    [Fact]
+    public async Task Preview_RawContinuation_SummaryCarriesBodyKindAndLineCount()
+    {
+        Result<HotstringPreviewDto> result = await _sut.ExecuteAsync(
+            Query(HotstringKind.Raw, ":*:col::\n(\nred\ngreen\nblue\n)"), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RawSummary!.BodyKind.Should().Be(RawBodyKind.Continuation);
+        result.Value.RawSummary.BodyLineCount.Should().Be(3);
+        result.Value.RawSummary.LiftedComment.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Preview_RawWithLeadingComment_LiftsIntoSummaryAndSnippet()
+    {
+        Result<HotstringPreviewDto> result = await _sut.ExecuteAsync(
+            Query(HotstringKind.Raw, "; moved note\n::btw::by the way"), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RawSummary!.LiftedComment.Should().Be("moved note");
+        result.Value.Snippet.Should().Be("; moved note\n::btw::by the way");
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/GetHotstringPreviewQueryValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/GetHotstringPreviewQueryValidatorTests.cs
@@ -17,7 +17,8 @@ public sealed class GetHotstringPreviewQueryValidatorTests
         HotstringKind kind = HotstringKind.Text,
         string? dateTimeFormat = null,
         WindowMatchType? contextMatchType = null,
-        string? contextValue = null)
+        string? contextValue = null,
+        string? description = null)
         => new(new HotstringPreviewRequestDto(
             kind,
             trigger,
@@ -28,7 +29,8 @@ public sealed class GetHotstringPreviewQueryValidatorTests
             IsTriggerInsideWord: true,
             DateTimeFormat: dateTimeFormat,
             ContextMatchType: contextMatchType,
-            ContextValue: contextValue));
+            ContextValue: contextValue,
+            Description: description));
 
     [Fact]
     public void Validate_ContextMatchTypeWithoutValue_Fails()
@@ -78,6 +80,22 @@ public sealed class GetHotstringPreviewQueryValidatorTests
         result.Errors.Should().Contain(e =>
             e.PropertyName == "Input.ContextValue" &&
             e.ErrorMessage == "ContextValue must not be blank or whitespace.");
+    }
+
+    [Fact]
+    public void GetHotstringPreviewQueryValidator_RawKind_OverlongDescription_Fails()
+    {
+        // The base 200-char Description rule applies to every kind (matching save), so an over-long
+        // typed Description on a Raw item fails preview instead of previewing then failing save.
+        ValidationResult result = _sut.Validate(Query(
+            kind: HotstringKind.Raw,
+            replacement: "::btw::by the way",
+            description: new string('x', 201)));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Description" &&
+            e.ErrorMessage == "Description must be 200 characters or fewer.");
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/UpdateHotstringCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/UpdateHotstringCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using AHKFlowApp.Application.Commands.Hotstrings;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Application.Services;
 using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
 using AHKFlowApp.Infrastructure.Persistence;
 using Ardalis.Result;
 using FluentAssertions;
@@ -40,6 +41,34 @@ public sealed class UpdateHotstringCommandHandlerTests(HotstringDbFixture fx)
         result.Value.Replacement.Should().Be("by the way");
         result.Value.IsEndingCharacterRequired.Should().BeFalse();
         result.Value.UpdatedAt.Should().BeAfter(result.Value.CreatedAt);
+    }
+
+    [Fact]
+    public async Task Handle_RawWithLeadingComment_StripsDefinitionAndMergesDescription()
+    {
+        var owner = Guid.NewGuid();
+        FixedClock clock = new(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        var entity = Hotstring.Create(owner, new HotstringDefinition("old", "old", null, true, true, true), clock);
+
+        await using (AppDbContext seed = fx.CreateContext())
+        {
+            seed.Hotstrings.Add(entity);
+            await seed.SaveChangesAsync();
+        }
+
+        await using AppDbContext db = fx.CreateContext();
+        UpdateHotstringCommandHandler handler =
+            new(db, CurrentUserHelper.For(owner), clock, new EntityHistoryRecorder(db, clock));
+        UpdateHotstringCommand cmd = new(entity.Id, new UpdateHotstringDto(
+            "ignored", "; moved note\n::btw::by the way", null, true, false, false, null,
+            Kind: HotstringKind.Raw));
+
+        Result<HotstringDto> result = await handler.ExecuteAsync(cmd, default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Trigger.Should().Be("btw");
+        result.Value.Replacement.Should().Be("::btw::by the way");
+        result.Value.Description.Should().Be("moved note");
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Queries/Downloads/GenerateAllProfileScriptsQueryTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Queries/Downloads/GenerateAllProfileScriptsQueryTests.cs
@@ -111,6 +111,7 @@ public sealed class GenerateAllProfileScriptsQueryTests(ScriptGeneratorDbFixture
             "; --- Hotstrings ---\n" +
             ":T:btw::by the way\n" +
             "; --- Hotkeys ---\n" +
+            "; Open Notepad\n" +
             "^n::Run(\"notepad.exe\")\n" +
             "FP");
     }

--- a/tests/AHKFlowApp.Application.Tests/Queries/Downloads/GenerateProfileScriptQueryTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Queries/Downloads/GenerateProfileScriptQueryTests.cs
@@ -100,6 +100,7 @@ public sealed class GenerateProfileScriptQueryTests(ScriptGeneratorDbFixture fx)
             ":T:addr::123 Main St\n" +
             ":*?T:btw::by the way\n" +
             "; --- Hotkeys ---\n" +
+            "; Open Notepad\n" +
             "^!n::Run(\"notepad.exe\")\n" +
             "; end");
     }

--- a/tests/AHKFlowApp.Application.Tests/Queries/Downloads/GetProfileScriptPreviewQueryTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Queries/Downloads/GetProfileScriptPreviewQueryTests.cs
@@ -101,6 +101,7 @@ public sealed class GetProfileScriptPreviewQueryTests(ScriptGeneratorDbFixture f
             "; --- Hotstrings ---\n" +
             ":T:btw::by the way\n" +
             "; --- Hotkeys ---\n" +
+            "; Open Notepad\n" +
             "^n::Run(\"notepad.exe\")\n" +
             "; end");
     }

--- a/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorIntegrationTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorIntegrationTests.cs
@@ -94,7 +94,9 @@ public sealed class AhkScriptGeneratorIntegrationTests(ScriptGeneratorDbFixture 
             ":T:addr::123 Main St\n" +       // Ordinal: 'a' < 'b' so addr before btw
             ":*?T:btw::by the way\n" +
             "; --- Hotkeys ---\n" +
+            "; Open Notepad\n" +             // Description emitted as a comment above the hotkey
             "^!n::Run(\"notepad.exe\")\n" +  // 'O' < 'R' so Open Notepad before Reload
+            "; Reload\n" +
             "^F5::Send(\"{F5}\")\n" +
             "; end");
     }

--- a/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs
@@ -161,7 +161,47 @@ public sealed class AhkScriptGeneratorTests
             ":T:a::alpha\n" +
             ":T:b::beta\n" +
             "; --- Hotkeys ---\n" +
+            "; d\n" +
             "n::Send(\"hi\")\n" +
+            "F");
+    }
+
+    [Fact]
+    public void Generate_HotstringWithDescription_EmitsCommentAbove()
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder().WithTrigger("btw").WithReplacement("by the way")
+            .WithEndingCharacterRequired(true).WithTriggerInsideWord(false)
+            .WithDescription("a friendly note").Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Be(
+            "H\n" +
+            "; --- Hotstrings ---\n" +
+            "; a friendly note\n" +
+            ":T:btw::by the way\n" +
+            "; --- Hotkeys ---\n" +
+            "F");
+    }
+
+    [Fact]
+    public void Generate_HotstringWithMultilineDescription_EmitsOneCommentPerLine()
+    {
+        Profile profile = new ProfileBuilder().WithHeader("H").WithFooter("F").Build();
+        Hotstring hs = new HotstringBuilder().WithTrigger("btw").WithReplacement("by the way")
+            .WithEndingCharacterRequired(true).WithTriggerInsideWord(false)
+            .WithDescription("line one\nline two").Build();
+
+        string output = DefaultSut().Generate(profile, [hs], []);
+
+        output.Should().Be(
+            "H\n" +
+            "; --- Hotstrings ---\n" +
+            "; line one\n" +
+            "; line two\n" +
+            ":T:btw::by the way\n" +
+            "; --- Hotkeys ---\n" +
             "F");
     }
 
@@ -211,6 +251,7 @@ public sealed class AhkScriptGeneratorTests
             "H\n" +
             "; --- Hotstrings ---\n" +
             "; --- Hotkeys ---\n" +
+            "; d\n" +
             $"{expectedLhs}::Send(\"hi\")\n" +
             "F");
     }
@@ -966,6 +1007,7 @@ public sealed class AhkScriptGeneratorTests
             ":T:t::r\n" +
             "#HotIf\n" +
             "; --- Hotkeys ---\n" +
+            "; d\n" +
             "n::Send(\"hi\")\n" +
             "F");
     }

--- a/tests/AHKFlowApp.Application.Tests/Services/RawCommentLiftTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/RawCommentLiftTests.cs
@@ -1,0 +1,44 @@
+using AHKFlowApp.Application.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Services;
+
+public sealed class RawCommentLiftTests
+{
+    [Fact]
+    public void Merge_EmptyDescription_UsesLifted()
+    {
+        RawCommentLift.Merge(null, "moved comment").Should().Be("moved comment");
+    }
+
+    [Fact]
+    public void Merge_WhitespaceDescription_UsesLifted()
+    {
+        RawCommentLift.Merge("   ", "moved comment").Should().Be("moved comment");
+    }
+
+    [Fact]
+    public void Merge_EqualDescription_DropsDuplicate()
+    {
+        RawCommentLift.Merge("same note", "same note").Should().Be("same note");
+    }
+
+    [Fact]
+    public void Merge_DifferingDescription_AppendsOnNewLine()
+    {
+        RawCommentLift.Merge("existing", "lifted").Should().Be("existing\nlifted");
+    }
+
+    [Fact]
+    public void Merge_NoLifted_ReturnsTrimmedDescription()
+    {
+        RawCommentLift.Merge("  keep  ", null).Should().Be("keep");
+    }
+
+    [Fact]
+    public void Merge_BothEmpty_ReturnsNull()
+    {
+        RawCommentLift.Merge(null, null).Should().BeNull();
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Services/RawContinuationRoundTripTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/RawContinuationRoundTripTests.cs
@@ -1,0 +1,55 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.Commands.Hotstrings;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Services;
+using AHKFlowApp.Application.Tests.Hotstrings;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
+using AHKFlowApp.Infrastructure.Persistence;
+using AHKFlowApp.TestUtilities.Builders;
+using Ardalis.Result;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Services;
+
+[Collection("HotstringDb")]
+[Trait("Category", "Integration")]
+public sealed class RawContinuationRoundTripTests(HotstringDbFixture fx)
+{
+    [Fact]
+    public async Task PasteColorsContinuation_SaveThenGenerate_ContainsSectionByteIdentical()
+    {
+        // Paste a :*:col:: continuation section holding literal multi-line text, save it through the
+        // real Create handler, then regenerate the profile script — the section must survive verbatim.
+        const string definition = ":*:col::\n(\nred\ngreen\nblue\n)";
+        var owner = Guid.NewGuid();
+
+        await using AppDbContext db = fx.CreateContext();
+        CreateHotstringCommandHandler handler = new(db, CurrentUserHelper.For(owner), TimeProvider.System);
+        Result<HotstringDto> created = await handler.ExecuteAsync(
+            new CreateHotstringCommand(new CreateHotstringDto("ignored", definition, Kind: HotstringKind.Raw)),
+            default);
+
+        created.IsSuccess.Should().BeTrue();
+        created.Value.Trigger.Should().Be("col");
+
+        await using AppDbContext verify = fx.CreateContext();
+        List<Hotstring> hotstrings = await verify.Hotstrings.AsNoTracking()
+            .Where(h => h.OwnerOid == owner).ToListAsync();
+
+        Profile profile = new ProfileBuilder().WithOwner(owner).WithHeader("H").WithFooter("F").Build();
+        string script = CreateGenerator().Generate(profile, hotstrings, []);
+
+        script.Should().Contain(definition);
+    }
+
+    private static AhkScriptGenerator CreateGenerator()
+    {
+        IAppVersionProvider version = Substitute.For<IAppVersionProvider>();
+        version.GetVersion().Returns("0.0.0");
+        return new AhkScriptGenerator(new HeaderTokenRenderer(), TimeProvider.System, version);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
@@ -119,15 +119,72 @@ public sealed class RawHotstringDefinitionParserTests
         r.Error.Should().Be("Raw definition has content after the inline replacement.");
     }
 
-    // --- OTB brace / continuation rejection ----------------------------------------------
+    // --- OTB braces (option-sensitive) ---------------------------------------------------
 
     [Fact]
-    public void OpeningBraceOnDefinitionLine_Rejected()
+    public void Otb_BraceOnDefinitionLine_Accepted()
     {
-        RawParseResult r = RawHotstringDefinitionParser.Parse("::btw:: {\nSend foo\n}");
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":X:run::{\nRun \"notepad.exe\"\n}");
 
-        r.IsValid.Should().BeFalse();
-        r.Error.Should().Be("Put `{` on its own line below the trigger.");
+        r.IsValid.Should().BeTrue();
+        r.BodyKind.Should().Be(RawBodyKind.Braces);
+        r.Trigger.Should().Be("run");
+    }
+
+    [Fact]
+    public void Otb_NoOptions_Accepted()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse("::btw::{\nSend foo\n}");
+
+        r.IsValid.Should().BeTrue();
+        r.BodyKind.Should().Be(RawBodyKind.Braces);
+    }
+
+    [Theory]
+    [InlineData(":T:brace::{")]   // text mode: "{" is an inline literal replacement
+    [InlineData(":R:brace::{")]   // raw mode: same
+    [InlineData(":T0T:brace::{")] // last T wins → mode active → inline literal
+    [InlineData(":T0R:brace::{")]
+    public void Otb_TextOrRawModeActive_IsInlineLiteral_NotOtb(string input)
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(input);
+
+        r.IsValid.Should().BeTrue();
+        r.BodyKind.Should().Be(RawBodyKind.Inline);
+    }
+
+    [Theory]
+    [InlineData(":*:x::{\n}")]     // no send-mode → OTB
+    [InlineData(":T0:x::{\n}")]    // T0 cancels text mode → OTB
+    [InlineData(":R0:x::{\n}")]    // R0 cancels raw mode → OTB
+    [InlineData(":TT0:x::{\n}")]   // last T0 wins → mode off → OTB
+    [InlineData(":RT0:x::{\n}")]
+    public void Otb_ModeOff_IsBraceBody(string input)
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(input);
+
+        r.IsValid.Should().BeTrue();
+        r.BodyKind.Should().Be(RawBodyKind.Braces);
+    }
+
+    [Fact]
+    public void Normalize_Otb_RewritesBraceToOwnLine()
+    {
+        string normalized = RawHotstringDefinitionParser.Normalize(":X:run::{\nRun \"notepad.exe\"\n}");
+
+        normalized.Should().Be(":X:run::\n{\nRun \"notepad.exe\"\n}");
+    }
+
+    [Fact]
+    public void Normalize_ContinuationBody_PreservesTrailingWhitespaceByteForByte()
+    {
+        // Trailing spaces/tabs inside ( … ) are significant under RTrim0 and must survive; the
+        // def/opener/closer lines outside the body are still trimmed.
+        string input = ":*:col::   \n(\nred   \n\tblue\t\n)";
+
+        string normalized = RawHotstringDefinitionParser.Normalize(input);
+
+        normalized.Should().Be(":*:col::\n(\nred   \n\tblue\t\n)");
     }
 
     // --- Continuation sections -----------------------------------------------------------

--- a/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
@@ -387,6 +387,55 @@ public sealed class RawHotstringDefinitionParserTests
         RawHotstringDefinitionParser.Parse(input).UnknownOptionTokens.Should().BeEmpty();
     }
 
+    // --- Comment lifting (Prepare) -------------------------------------------------------
+
+    [Fact]
+    public void Prepare_LeadingComment_LiftedAndStripped()
+    {
+        RawPrepared p = RawHotstringDefinitionParser.Prepare("; my note\n::btw::by the way");
+
+        p.LiftedComment.Should().Be("my note");
+        p.NormalizedDefinition.Should().Be("::btw::by the way");
+        p.Parsed.LiftedComment.Should().Be("my note");
+        p.Parsed.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Prepare_MultipleLeadingComments_JoinedWithNewline()
+    {
+        RawPrepared p = RawHotstringDefinitionParser.Prepare("; line one\n;line two\n::btw::x");
+
+        p.LiftedComment.Should().Be("line one\nline two");
+        p.NormalizedDefinition.Should().Be("::btw::x");
+    }
+
+    [Fact]
+    public void Prepare_NoComment_PassesThrough()
+    {
+        RawPrepared p = RawHotstringDefinitionParser.Prepare("::btw::by the way");
+
+        p.LiftedComment.Should().BeNull();
+        p.NormalizedDefinition.Should().Be("::btw::by the way");
+    }
+
+    [Fact]
+    public void Prepare_CommentInsideContinuationBody_NotLifted()
+    {
+        RawPrepared p = RawHotstringDefinitionParser.Prepare(":*:x::\n(\n; not a comment, literal text\nbody\n)");
+
+        p.LiftedComment.Should().BeNull();
+        p.NormalizedDefinition.Should().Be(":*:x::\n(\n; not a comment, literal text\nbody\n)");
+    }
+
+    [Fact]
+    public void Prepare_CommentInsideBraceBody_NotLifted()
+    {
+        RawPrepared p = RawHotstringDefinitionParser.Prepare(":*:x::\n{\n; inside code\nSend foo\n}");
+
+        p.LiftedComment.Should().BeNull();
+        p.NormalizedDefinition.Should().Be(":*:x::\n{\n; inside code\nSend foo\n}");
+    }
+
     [Fact]
     public void X0_IsRejectedAsUnknown()
     {

--- a/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
@@ -88,7 +88,7 @@ public sealed class RawHotstringDefinitionParserTests
         RawParseResult r = RawHotstringDefinitionParser.Parse(":*:rng::");
 
         r.IsValid.Should().BeFalse();
-        r.Error.Should().Be("Put `{` on its own line below the trigger.");
+        r.Error.Should().Be("Add a replacement after `::`, or put `{` (code) or `(` (multi-line text) on its own line below the trigger.");
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
@@ -1,3 +1,4 @@
+using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Application.Services;
 using FluentAssertions;
 using Xunit;

--- a/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
@@ -130,13 +130,132 @@ public sealed class RawHotstringDefinitionParserTests
         r.Error.Should().Be("Put `{` on its own line below the trigger.");
     }
 
+    // --- Continuation sections -----------------------------------------------------------
+
     [Fact]
-    public void ContinuationSection_Rejected()
+    public void ContinuationSection_HappyPath_IsValid()
     {
         RawParseResult r = RawHotstringDefinitionParser.Parse(":*:long::\n(\nline1\nline2\n)");
 
+        r.IsValid.Should().BeTrue();
+        r.Trigger.Should().Be("long");
+        r.BodyKind.Should().Be(RawBodyKind.Continuation);
+        r.BodyLineCount.Should().Be(2);
+        r.DefinitionCount.Should().Be(1);
+        r.Error.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(":*:x::\n(Join`n\nline1\nline2\n)")]
+    [InlineData(":*:x::\n(LTrim\nline1\nline2\n)")]
+    public void ContinuationSection_OpenerOptions_ArePassThrough(string input)
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(input);
+
+        r.IsValid.Should().BeTrue();
+        r.BodyKind.Should().Be(RawBodyKind.Continuation);
+    }
+
+    [Fact]
+    public void ContinuationSection_OpenerWithParen_Rejected()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:x::\n(Join)\nline1\n)");
+
         r.IsValid.Should().BeFalse();
-        r.Error.Should().Be("Put `{` on its own line below the trigger.");
+        r.Error.Should().Be("A continuation section opener must not contain `)` — put the closing `)` on its own line.");
+    }
+
+    [Fact]
+    public void ContinuationSection_Unclosed_Rejected()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:x::\n(\nline1\nline2");
+
+        r.IsValid.Should().BeFalse();
+        r.Error.Should().Be("Raw definition has an unclosed continuation section — add a closing `)` on its own line.");
+    }
+
+    [Fact]
+    public void ContinuationSection_ContentAfterClose_Rejected()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:x::\n(\nline1\n)\ntrailing");
+
+        r.IsValid.Should().BeFalse();
+        r.Error.Should().Be("Raw definition has content after the closing `)`.");
+    }
+
+    [Fact]
+    public void ContinuationSection_InteriorBlankLines_Preserved()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:x::\n(\nline1\n\nline3\n)");
+
+        r.IsValid.Should().BeTrue();
+        r.BodyLineCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void ContinuationSection_LiteralDefinitionLine_NotCountedAsDefinition()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:x::\n(\n::example::text\nmore\n)");
+
+        r.IsValid.Should().BeTrue();
+        r.DefinitionCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void ContinuationSection_LiteralDirectiveLine_NotADirective()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:x::\n(\n# Heading\nbody\n)");
+
+        r.IsValid.Should().BeTrue();
+        r.HasDirectiveOutsideLiteralBody.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(":*:x::\n{\n#HotIf WinActive(\"X\")\nSend foo\n}")]
+    [InlineData(":*:x::\n{\n#Requires AutoHotkey v2.0\n}")]
+    public void BraceBody_DirectiveInside_StillFlagged(string input)
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(input);
+
+        r.HasDirectiveOutsideLiteralBody.Should().BeTrue();
+    }
+
+    // --- BodyKind / BodyLineCount classification -----------------------------------------
+
+    [Fact]
+    public void BodyKind_Inline()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse("::btw::by the way");
+
+        r.BodyKind.Should().Be(RawBodyKind.Inline);
+        r.BodyLineCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void BodyKind_Braces()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:rng::\n{\nSend foo\n}");
+
+        r.BodyKind.Should().Be(RawBodyKind.Braces);
+        r.BodyLineCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void BodyKind_Continuation()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:x::\n(\nline1\nline2\nline3\n)");
+
+        r.BodyKind.Should().Be(RawBodyKind.Continuation);
+        r.BodyLineCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void BodyKind_None_WhenNoBody()
+    {
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:rng::");
+
+        r.BodyKind.Should().Be(RawBodyKind.None);
+        r.BodyLineCount.Should().Be(0);
     }
 
     // --- Multi-definition detection ------------------------------------------------------

--- a/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/RawHotstringDefinitionParserTests.cs
@@ -214,13 +214,38 @@ public sealed class RawHotstringDefinitionParserTests
         r.BodyKind.Should().Be(RawBodyKind.Continuation);
     }
 
-    [Fact]
-    public void ContinuationSection_OpenerWithParen_Rejected()
+    [Theory]
+    [InlineData(":*:x::\n((\nline1\n)")]        // second '(' → expression, not a section opener
+    [InlineData(":*:x::\n(LTrim)\nline1\n)")]   // stray ')' outside a Join parameter
+    public void ContinuationSection_OpenerIsExpression_Rejected(string input)
     {
-        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:x::\n(Join)\nline1\n)");
+        RawParseResult r = RawHotstringDefinitionParser.Parse(input);
 
         r.IsValid.Should().BeFalse();
-        r.Error.Should().Be("A continuation section opener must not contain `)` — put the closing `)` on its own line.");
+        r.Error.Should().Contain("makes AutoHotkey read the line as an expression");
+    }
+
+    [Fact]
+    public void ContinuationSection_JoinParameterWithParen_Accepted()
+    {
+        // ')' as the Join parameter is exempt from the expression rule (AHK v2 Scripts.htm).
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:x::\n(Join)\nline1\nline2\n)");
+
+        r.IsValid.Should().BeTrue();
+        r.BodyKind.Should().Be(RawBodyKind.Continuation);
+    }
+
+    [Fact]
+    public void ContinuationSection_Unclosed_WithLiteralDefinitionLine_ReportsUnclosed()
+    {
+        // The opener→EOF body is skipped by the structural scan, so an interior "::x::y" doesn't
+        // trip the multiple-definition rule before the (more accurate) unclosed error.
+        RawParseResult r = RawHotstringDefinitionParser.Parse(":*:x::\n(\n::example::text\nmore");
+
+        r.IsValid.Should().BeFalse();
+        r.DefinitionCount.Should().Be(1);
+        r.HasDirectiveOutsideLiteralBody.Should().BeFalse();
+        r.Error.Should().Be("Raw definition has an unclosed continuation section — add a closing `)` on its own line.");
     }
 
     [Fact]
@@ -397,7 +422,6 @@ public sealed class RawHotstringDefinitionParserTests
 
         p.LiftedComment.Should().Be("my note");
         p.NormalizedDefinition.Should().Be("::btw::by the way");
-        p.Parsed.LiftedComment.Should().Be("my note");
         p.Parsed.IsValid.Should().BeTrue();
     }
 

--- a/tests/AHKFlowApp.E2E.Tests/RawHotstringFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/RawHotstringFlowTests.cs
@@ -8,6 +8,7 @@ namespace AHKFlowApp.E2E.Tests;
 public sealed class RawHotstringFlowTests(StackFixture fixture) : IAsyncLifetime
 {
     private const string Definition = ":K1000 SE*:ftw::for the win";
+    private const string ContinuationDefinition = ":*:col::\n(\nred\ngreen\nblue\n)";
 
     private static readonly BrowserNewContextOptions PhoneViewport = new()
     {
@@ -118,6 +119,61 @@ public sealed class RawHotstringFlowTests(StackFixture fixture) : IAsyncLifetime
         string content = System.Text.Encoding.UTF8.GetString(bytes);
 
         Assert.Contains(Definition, content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CreateRawContinuationSection_SavesAndDownloadsSectionByteIdentical()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        // A profile is required so the generated profile script has something to byte-match against.
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/profiles");
+        await page.WaitForSelectorAsync("button.add-profile");
+        await page.ClickAsync("button.add-profile");
+        await page.WaitForSelectorAsync("input[data-test=\"profile-name-input\"]");
+        await page.FillAsync("input[data-test=\"profile-name-input\"]", "ColorsFlow");
+        await page.ClickAsync("button.commit-edit");
+        await page.WaitForSelectorAsync("text=ColorsFlow");
+
+        Task<IResponse> profilesLoaded = page.WaitForResponseAsync(response =>
+            response.Url.Contains("/api/v1/profiles", StringComparison.OrdinalIgnoreCase) &&
+            response.Status == 200);
+        Task<IResponse> categoriesLoaded = page.WaitForResponseAsync(response =>
+            response.Url.Contains("/api/v1/categories", StringComparison.OrdinalIgnoreCase) &&
+            response.Status == 200);
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotstrings");
+        await page.WaitForSelectorAsync("button.add-hotstring-fab");
+        await Task.WhenAll(profilesLoaded, categoriesLoaded);
+
+        await page.ClickAsync("button.add-hotstring-fab");
+        await page.WaitForSelectorAsync(".hotstring-edit-dialog");
+
+        await page.ClickAsync(".hotstring-edit-dialog .mud-toggle-item:has-text('Raw')");
+        await page.WaitForSelectorAsync("[data-test=\"script-warning\"]");
+
+        await page.Locator("textarea[data-test=\"replacement-input\"]").FillAsync(ContinuationDefinition);
+
+        // Derived trigger + body-kind summary appear below the textarea (multi-line text, 3 lines).
+        await Assertions.Expect(page.Locator("[data-test=\"raw-summary\"]")).ToContainTextAsync("col");
+        await Assertions.Expect(page.Locator("[data-test=\"raw-summary\"]")).ToContainTextAsync("multi-line text (3 lines)");
+
+        await page.ClickAsync("button.commit-edit");
+        await page.WaitForSelectorAsync("text=Hotstring created.");
+
+        // Byte-match the downloaded profile script — the continuation section must appear exactly.
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/downloads");
+        await page.WaitForSelectorAsync("button.download-profile");
+
+        IDownload download = await page.RunAndWaitForDownloadAsync(() =>
+            page.ClickAsync("button.download-profile"));
+
+        string path = await download.PathAsync()
+            ?? throw new InvalidOperationException("Download produced no file path.");
+        string content = System.Text.Encoding.UTF8.GetString(await File.ReadAllBytesAsync(path));
+
+        Assert.Contains(ContinuationDefinition, content, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -1330,49 +1330,38 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public async Task RawExample_InsertsTemplateIntoEmptyDefinition()
-    {
-        HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = "" };
-        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
-        provider.WaitForAssertion(() => provider.Find("[data-test=\"raw-template-inline\"]"));
-
-        provider.Find("[data-test=\"raw-template-inline\"]").Click();
-
-        provider.WaitForAssertion(() => item.Replacement.Should().Be(":*:btw::by the way"));
-    }
-
-    [Fact]
-    public async Task RawExample_WithExistingContent_PromptsBeforeOverwrite()
+    public async Task RawExample_CopyButton_CopiesTemplateAndLeavesDefinitionUntouched()
     {
         HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = ":*:custom::my own text" };
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
-        provider.WaitForAssertion(() => provider.Find("[data-test=\"raw-template-braces\"]"));
-
-        provider.Find("[data-test=\"raw-template-braces\"]").Click();
-
-        // A confirmation MudMessageBox appears and the definition stays untouched until it resolves.
-        provider.WaitForAssertion(() => provider.Markup.Should().Contain("This replaces the current Raw definition"));
-        item.Replacement.Should().Be(":*:custom::my own text");
-    }
-
-    [Fact]
-    public async Task RawExample_AfterSwitchingEmptyItemToRaw_ReplacesScaffoldWithoutPrompt()
-    {
-        HotstringEditModel item = new() { Trigger = "", Kind = HotstringKind.Text, Replacement = "" };
-        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
-        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
-
-        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Raw")).Click();
-        provider.WaitForAssertion(() => item.Kind.Should().Be(HotstringKind.Raw));
-
-        // The generated blank scaffold is disposable — a chip replaces it with no confirmation.
         provider.WaitForAssertion(() => provider.Find("[data-test=\"raw-template-inline\"]"));
+
         provider.Find("[data-test=\"raw-template-inline\"]").Click();
 
         provider.WaitForAssertion(() =>
         {
-            provider.Markup.Should().NotContain("This replaces the current Raw definition");
-            item.Replacement.Should().Be(":*:btw::by the way");
+            Bunit.JSRuntimeInvocation invocation = JSInterop.VerifyInvoke("navigator.clipboard.writeText");
+            invocation.Arguments.Should().Contain(":*:btw::by the way");
+            _snackbar.Received(1).Add("Example copied — paste it into the definition.", Severity.Success,
+                Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>());
+        });
+        // Copy is a reference action — the user's own definition is never overwritten.
+        item.Replacement.Should().Be(":*:custom::my own text");
+    }
+
+    [Fact]
+    public async Task RawExample_CopyButton_CopiesMultiLineTemplateVerbatim()
+    {
+        HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = "" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"raw-template-continuation\"]"));
+
+        provider.Find("[data-test=\"raw-template-continuation\"]").Click();
+
+        provider.WaitForAssertion(() =>
+        {
+            Bunit.JSRuntimeInvocation invocation = JSInterop.VerifyInvoke("navigator.clipboard.writeText");
+            invocation.Arguments.Should().Contain(":*:col::\n(\nred\ngreen\nblue\n)");
         });
     }
 

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -1342,6 +1342,27 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public async Task RawTemplateChip_AfterSwitchingEmptyItemToRaw_ReplacesScaffoldWithoutPrompt()
+    {
+        HotstringEditModel item = new() { Trigger = "", Kind = HotstringKind.Text, Replacement = "" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"kind-selector\"]"));
+
+        provider.FindAll(".mud-toggle-item").First(e => e.TextContent.Contains("Raw")).Click();
+        provider.WaitForAssertion(() => item.Kind.Should().Be(HotstringKind.Raw));
+
+        // The generated blank scaffold is disposable — a chip replaces it with no confirmation.
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"raw-template-inline\"]"));
+        provider.Find("[data-test=\"raw-template-inline\"]").Click();
+
+        provider.WaitForAssertion(() =>
+        {
+            provider.Markup.Should().NotContain("This replaces the current Raw definition");
+            item.Replacement.Should().Be(":*:btw::by the way");
+        });
+    }
+
+    [Fact]
     public async Task RawSummary_ShowsBodyKindAndCommentLiftNotice()
     {
         _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
@@ -1356,7 +1377,7 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         provider.WaitForAssertion(() =>
         {
             provider.Find("[data-test=\"raw-summary\"]").TextContent.Should().Contain("multi-line text (3 lines)");
-            provider.Find("[data-test=\"raw-comment-lift\"]").TextContent.Should().Contain("Comment moved to Description");
+            provider.Find("[data-test=\"raw-comment-lift\"]").TextContent.Should().Contain("Comment will be added to Description: note");
         });
     }
 

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -1300,7 +1300,8 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         // preview runs even while the "Generated AutoHotkey code" panel stays collapsed.
         _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult<HotstringPreviewDto>.Ok(new HotstringPreviewDto(
-                ":K1000 SE*:ftw::for the win", new RawSummaryDto("ftw", ["K1000", "SE", "*"]))));
+                ":K1000 SE*:ftw::for the win",
+                new RawSummaryDto("ftw", ["K1000", "SE", "*"], RawBodyKind.Inline, 0, null))));
 
         HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = ":K1000 SE*:ftw::for the win" };
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -1315,6 +1315,51 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         });
     }
 
+    [Fact]
+    public async Task RawTemplateChip_InsertsTemplateIntoEmptyDefinition()
+    {
+        HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = "" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"raw-template-inline\"]"));
+
+        provider.Find("[data-test=\"raw-template-inline\"]").Click();
+
+        provider.WaitForAssertion(() => item.Replacement.Should().Be(":*:btw::by the way"));
+    }
+
+    [Fact]
+    public async Task RawTemplateChip_WithExistingContent_PromptsBeforeOverwrite()
+    {
+        HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = ":*:custom::my own text" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"raw-template-braces\"]"));
+
+        provider.Find("[data-test=\"raw-template-braces\"]").Click();
+
+        // A confirmation MudMessageBox appears and the definition stays untouched until it resolves.
+        provider.WaitForAssertion(() => provider.Markup.Should().Contain("This replaces the current Raw definition"));
+        item.Replacement.Should().Be(":*:custom::my own text");
+    }
+
+    [Fact]
+    public async Task RawSummary_ShowsBodyKindAndCommentLiftNotice()
+    {
+        _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotstringPreviewDto>.Ok(new HotstringPreviewDto(
+                "; note\n:*:col::\n(\nred\ngreen\nblue\n)",
+                new RawSummaryDto("col", ["*"], RawBodyKind.Continuation, 3, "note"))));
+
+        HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = "; note\n:*:col::\n(\nred\ngreen\nblue\n)" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        DisablePreviewDebounce(provider);
+
+        provider.WaitForAssertion(() =>
+        {
+            provider.Find("[data-test=\"raw-summary\"]").TextContent.Should().Contain("multi-line text (3 lines)");
+            provider.Find("[data-test=\"raw-comment-lift\"]").TextContent.Should().Contain("Comment moved to Description");
+        });
+    }
+
     private static void DisablePreviewDebounce(IRenderedComponent<MudDialogProvider> provider) =>
         provider.FindComponent<HotstringEditDialog>().Instance.PreviewDebounce = TimeSpan.Zero;
 

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -1316,7 +1316,21 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public async Task RawTemplateChip_InsertsTemplateIntoEmptyDefinition()
+    public async Task RawExamples_RenderPreviewTextBelowDefinition()
+    {
+        HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = "" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+
+        provider.WaitForAssertion(() =>
+        {
+            AngleSharp.Dom.IElement examples = provider.Find("[data-test=\"raw-templates\"]");
+            examples.TextContent.Should().Contain("Examples");
+            examples.TextContent.Should().Contain(":*:col::  ( red / green / blue )");
+        });
+    }
+
+    [Fact]
+    public async Task RawExample_InsertsTemplateIntoEmptyDefinition()
     {
         HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = "" };
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
@@ -1328,7 +1342,7 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public async Task RawTemplateChip_WithExistingContent_PromptsBeforeOverwrite()
+    public async Task RawExample_WithExistingContent_PromptsBeforeOverwrite()
     {
         HotstringEditModel item = new() { Kind = HotstringKind.Raw, Replacement = ":*:custom::my own text" };
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
@@ -1342,7 +1356,7 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public async Task RawTemplateChip_AfterSwitchingEmptyItemToRaw_ReplacesScaffoldWithoutPrompt()
+    public async Task RawExample_AfterSwitchingEmptyItemToRaw_ReplacesScaffoldWithoutPrompt()
     {
         HotstringEditModel item = new() { Trigger = "", Kind = HotstringKind.Text, Replacement = "" };
         IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/RawDefinitionTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/RawDefinitionTests.cs
@@ -57,4 +57,31 @@ public sealed class RawDefinitionTests
         // '*' is expressible via a checkbox; K1000 and SE are not.
         result.UnexpressibleOptions.Should().BeEquivalentTo("K1000", "SE");
     }
+
+    [Fact]
+    public void Decompose_CleanContinuationSection_ExtractsBodyWithoutLoss()
+    {
+        RawDecomposition result = RawDefinition.Decompose(":*:col::\n(\nred\ngreen\nblue\n)");
+
+        result.Trigger.Should().Be("col");
+        result.Body.Should().Be("red\ngreen\nblue");
+        result.LossyReasons.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Decompose_ContinuationWithOptions_IsLossy()
+    {
+        RawDecomposition result = RawDefinition.Decompose(":*:col::\n(Join`n RTrim0\nred\nblue\n)");
+
+        result.Body.Should().Be("red\nblue");
+        result.LossyReasons.Should().Contain(r => r.Contains("continuation options"));
+    }
+
+    [Fact]
+    public void Decompose_ContinuationWithTrailingWhitespace_IsLossy()
+    {
+        RawDecomposition result = RawDefinition.Decompose(":*:col::\n(\nred   \nblue\n)");
+
+        result.LossyReasons.Should().Contain("significant trailing whitespace");
+    }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/RawDefinitionTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/RawDefinitionTests.cs
@@ -84,4 +84,32 @@ public sealed class RawDefinitionTests
 
         result.LossyReasons.Should().Contain("significant trailing whitespace");
     }
+
+    [Fact]
+    public void Decompose_LeadingComment_LiftedAndDefinitionParsed()
+    {
+        RawDecomposition result = RawDefinition.Decompose("; my note\n::btw::by the way");
+
+        result.Trigger.Should().Be("btw");
+        result.Body.Should().Be("by the way");
+        result.LiftedComment.Should().Be("my note");
+    }
+
+    [Fact]
+    public void Decompose_OtbBraceWithBody_ExcludesClosingBrace()
+    {
+        RawDecomposition result = RawDefinition.Decompose(":X:run::{\nRun \"notepad\"\n}");
+
+        result.Trigger.Should().Be("run");
+        result.Body.Should().Be("Run \"notepad\"");
+    }
+
+    [Fact]
+    public void Decompose_TextModeLiteralBrace_IsInlineReplacement()
+    {
+        RawDecomposition result = RawDefinition.Decompose(":T:x::{");
+
+        result.Trigger.Should().Be("x");
+        result.Body.Should().Be("{");
+    }
 }


### PR DESCRIPTION
Adds Raw hotstring support for `( … )` continuation sections and OTB (`:X:t::{`) braces, lifts leading `;` comments into Description, and emits Descriptions as `;` comments in generated scripts. Final commit addresses a local code review.

## Feature (earlier commits)
- Parser: body-aware structural scan; accepts continuation sections and OTB braces (option-sensitive, `T`/`R`/`T0`/`R0` last-wins); one authoritative `Prepare` pass (lift comments → normalize → parse).
- Validation/handlers/preview: consume a single `RawPrepared`; merge lifted comment into Description via shared `RawCommentLift.Merge`.
- Generator + preview: emit Description as `;` comment lines for every kind (hotstrings + hotkeys).
- UI: Raw example chips, body-kind summary, lossy Raw→structured decompose confirmation.

## Review fixes (final commit `ab1edac`)
1. **Continuation opener grammar** — real AHK v2 rule (Scripts.htm): reject a stray `(`/`)` to the right of the initial `(`, accept a `)` inside the Join parameter (`((` rejected, `(Join)` accepted).
2. **Unclosed continuation** — keeps the opener→EOF body range so interior `::x::y` / `#…` lines no longer mask the unclosed-section error with "Multiple hotstrings"/directive errors.
3. **Preview/save Description parity** — the base 200-char Description rule now applies to every kind (matching Create/Update), so an over-long Raw Description fails preview instead of only save.
4. **Client `Decompose`** — lifts leading comments (folded into Description on Raw→structured switch), extracts OTB bodies without the trailing `}`, treats a `T`/`R` inline `{` as a literal replacement.
5. **UX** — disposable blank scaffold (no overwrite prompt), "Replace" button label, "Start with:" chip-row label, wrapping on chip/summary rows; Description helper copy in both dialogs; lift notice shows the merged Description.
6. **Simplify** — dropped the duplicated `LiftedComment` on `RawParseResult`; corrected the stale "Script hotstrings" XML doc on `AddRawKindRules`; documented Description→comment emission for all kinds.

## Testing
- Application.Tests 888 passed, UI.Blazor.Tests 432 passed; full `run-coverage.ps1` green (all 5 assemblies above thresholds; line 92.8% / branch 74.5%).
- `dotnet format --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)