### PR TITLE
fix: reject unsafe chars in hotkey Key/Parameters (interim for #193)

### DIFF
--- a/docs/development/ahk-v2-syntax.md
+++ b/docs/development/ahk-v2-syntax.md
@@ -273,12 +273,14 @@ Emitted in the fixed order `^ ! + #` (`AhkScriptGenerator.FormatHotkey`). Action
 ^!t::Run("notepad.exe")
 ```
 
-Note that both hotkey `Key` and `Parameters` are interpolated **without** passing through either
-escape routine — a `"` in `Parameters` emits a broken line (`^a::Send("he said "hi"")`), and
-quotes, backticks, or newlines in either field can break the generated script. This is current
-pinned behaviour, not an accident of reading: `Generate_Hotkey_EmitsParametersVerbatim_NoEscaping`
-asserts it (as characterization, not endorsement). Hotstrings escape, hotkeys don't; if you touch
-this, that test is the thing to change first.
+Both hotkey `Key` and `Parameters` are interpolated **without** passing through either escape
+routine. What keeps that safe is boundary validation, not the emitter: `HotkeyRules` rejects `"`,
+backticks, and control characters in both fields, plus `:` in `Key` (a colon there would emit
+`a:::...`, which AHK parses as hotstring syntax) — the same trust model as `ContextValue` for
+`#HotIf`. `Generate_Hotkey_EmitsParametersVerbatim_NoEscaping` pins the emitter's raw embedding.
+This is the interim resolution of issue #193; proper escaping of `Parameters` (and a `Key`
+whitelist, relaxing these rejections) is deferred to its follow-up issue. Rows created before the
+validation landed are not retroactively checked.
 
 ## Input limits
 

--- a/docs/superpowers/plans/2026-07-17-hotkey-interim-validation-plan.md
+++ b/docs/superpowers/plans/2026-07-17-hotkey-interim-validation-plan.md
@@ -1,0 +1,61 @@
+# Issue #193 — Interim hotkey Key/Parameters validation
+
+## Context
+
+`AhkScriptGenerator.FormatHotkey` interpolates `Key` and `Parameters` into the generated AHK line with no escaping (`src/Backend/AHKFlowApp.Application/Services/AhkScriptGenerator.cs:100`). A `"` or backtick in either field produces invalid AHK v2 syntax, and AHK fails the **whole file** at load — one bad hotkey takes down the user's entire profile script.
+
+Full fix (escape `Parameters`, whitelist `Key` against AHK key names) is deferred until after v1: escaping requires deciding whether `Parameters` is literal text or a raw AHK fragment, and that semantics decision isn't made yet. Interim approach: **reject** the dangerous characters at the validation boundary, mirroring the existing `ContextValue` precedent (`HotstringRules.AddWindowContextRules`, `src/Backend/AHKFlowApp.Application/Validation/HotstringRules.cs:400-405`). This makes v1 unable to generate a load-breaking script; the later escaping work *relaxes* validation, which is non-breaking.
+
+Decisions made with user (grilling session):
+- Land Key + interim Parameters validation now; defer escaping/whitelist to a follow-up issue.
+- No pre-release deadline on the literal-vs-raw semantics decision — it's the follow-up issue's first task (record in `CONTEXT.md`).
+- Rejected chars: `Parameters` → `"`, backtick, control chars (ContextValue set). `Key` → same set **plus `:`** (Key=`a:` emits `a:::...` which AHK parses as hotstring syntax).
+- No data cleanup for pre-existing rows (pre-v1, disposable data). Mention in PR that old rows aren't retroactively checked.
+- Server-side only — no Blazor client-side mirror. Existing surfacing suffices: `HotkeyEditDialog.razor` shows 400 ValidationProblem errors in an inline MudAlert via `ApiErrorMessageFactory`. CLI has no hotkey commands at all — nothing to do there.
+- Close #193 via the PR; open a follow-up issue for semantics decision + escaping + Key whitelist.
+
+## Changes
+
+### 1. `src/Backend/AHKFlowApp.Application/Validation/HotkeyRules.cs`
+
+`ValidKey`: extend the existing chain. It already rejects `\n`/`\r`/`\t` and leading/trailing spaces. Add:
+- no `"` — "Key must not contain double-quote characters."
+- no `` ` `` — "Key must not contain backtick characters."
+- no `:` — "Key must not contain colon characters."
+- no control chars (`char.IsControl`) — subsumes the existing `\n\r\t` check; replace that rule with the broader one, keeping a message like "Key must not contain control characters."
+
+`ValidParameters`: currently only max length. Add (mirror ContextValue rules, messages adapted):
+- no `"`, no backtick, no control chars.
+
+Both `CreateHotkeyCommandValidator` (`Commands/Hotkeys/CreateHotkeyCommand.cs:15-27`) and `UpdateHotkeyCommandValidator` (`Commands/Hotkeys/UpdateHotkeyCommand.cs:16-28`) already call `.ValidKey()` / `.ValidParameters()` — no changes there.
+
+### 2. Tests — `tests/AHKFlowApp.Application.Tests/Hotkeys/CreateHotkeyCommandValidatorTests.cs`
+
+Follow existing style: `Cmd(...)` factory, FluentAssertions, assert `PropertyName` (`"Input.Key"` / `"Input.Parameters"`) + message. Add:
+- `Validate_WithKeyContainingForbiddenChars_Fails` (Theory: `"a\""`, `` "a`" ``, `"a:"`)
+- `Validate_WithParametersContainingForbiddenChars_Fails` (Theory: `"he said \"hi\""`, `` "x`n" ``, `"x\n"`)
+- Success counterparts: colon in Parameters stays valid (`"C:\\tools\\app.exe"`), `;` in Key stays valid.
+
+Update the existing `Validate_WithKeyContainingControlChars_Fails` theory if the message text changes. `UpdateHotkeyCommandValidatorTests` doesn't re-test Key/Parameters details — leave as is.
+
+### 3. Characterization test — `tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs:422`
+
+`Generate_Hotkey_EmitsParametersVerbatim_NoEscaping` stays (generator behavior is unchanged) but update its comment: such input is now rejected at the validation boundary; the test pins that the emitter still trusts validated input, per the project's no-defensive-validation rule.
+
+### 4. Doc — `docs/development/ahk-v2-syntax.md` (Hotkeys section)
+
+Update the "known sharp edge" note: Key/Parameters can no longer contain `"`, backtick, control chars (Key also `:`) — rejected at validation, emitter embeds raw, same trust model as `ContextValue`. Reference the follow-up issue for future escaping.
+
+## Workflow
+
+1. New branch from `main`: `fix/wt-193-hotkey-interim-validation` (worktree naming convention).
+2. Implement + tests (TDD: validator tests first — pure functions).
+3. `dotnet build` + `dotnet test tests/AHKFlowApp.Application.Tests`.
+4. PR with `Closes #193`; note pre-existing rows aren't retroactively validated.
+5. Open follow-up issue: "Hotkey Parameters escaping + Key whitelist" — first task: decide literal-vs-raw semantics for `Parameters`, record in `CONTEXT.md`; then escape at emission, whitelist Key, relax interim validation, update doc + tests.
+
+## Verification
+
+- `dotnet test tests/AHKFlowApp.Application.Tests --filter "FullyQualifiedName~HotkeyCommandValidator"` — new rules pass.
+- Full `dotnet build` + `dotnet test` before PR.
+- Optional end-to-end: POST a hotkey with `"` in Parameters via API → expect 400 ValidationProblem naming `Input.Parameters`.

--- a/src/Backend/AHKFlowApp.Application/Validation/HotkeyRules.cs
+++ b/src/Backend/AHKFlowApp.Application/Validation/HotkeyRules.cs
@@ -14,18 +14,36 @@ internal static class HotkeyRules
           .NotEmpty().WithMessage("Description is required.")
           .MaximumLength(DescriptionMaxLength).WithMessage($"Description must be {DescriptionMaxLength} characters or fewer.");
 
+    // Key and Parameters are embedded raw by AhkScriptGenerator.FormatHotkey; the character
+    // rejections below keep the generated line valid AHK v2 (same trust model as ContextValue
+    // in HotstringRules.AddWindowContextRules). Colon is rejected only in Key: "a:" would emit
+    // "a:::...", which AHK parses as hotstring syntax. Interim until escaping lands (see the
+    // follow-up to issue #193).
     public static IRuleBuilderOptions<T, string> ValidKey<T>(this IRuleBuilderInitial<T, string> rb) =>
         rb.Cascade(CascadeMode.Stop)
           .Must(k => !string.IsNullOrEmpty(k)).WithMessage("Key is required.")
           .MaximumLength(KeyMaxLength).WithMessage($"Key must be {KeyMaxLength} characters or fewer.")
-          .Must(k => k is not null && k.IndexOfAny(['\n', '\r', '\t']) < 0)
-              .WithMessage("Key must not contain line breaks or tabs.")
+          .Must(k => k is not null && !k.Any(char.IsControl))
+              .WithMessage("Key must not contain control characters.")
           .Must(k => k is not null && k.Length == k.TrimStart(' ').TrimEnd(' ').Length)
-              .WithMessage("Key must not have leading or trailing whitespace.");
+              .WithMessage("Key must not have leading or trailing whitespace.")
+          .Must(k => k is not null && !k.Contains('"'))
+              .WithMessage("Key must not contain double-quote characters.")
+          .Must(k => k is not null && !k.Contains('`'))
+              .WithMessage("Key must not contain backtick characters.")
+          .Must(k => k is not null && !k.Contains(':'))
+              .WithMessage("Key must not contain colon characters.");
 
     public static IRuleBuilderOptions<T, string> ValidParameters<T>(this IRuleBuilderInitial<T, string> rb) =>
-        rb.MaximumLength(ParametersMaxLength)
-          .WithMessage($"Parameters must be {ParametersMaxLength} characters or fewer.");
+        rb.Cascade(CascadeMode.Stop)
+          .MaximumLength(ParametersMaxLength)
+              .WithMessage($"Parameters must be {ParametersMaxLength} characters or fewer.")
+          .Must(p => p is null || !p.Contains('"'))
+              .WithMessage("Parameters must not contain double-quote characters.")
+          .Must(p => p is null || !p.Contains('`'))
+              .WithMessage("Parameters must not contain backtick characters.")
+          .Must(p => p is null || !p.Any(char.IsControl))
+              .WithMessage("Parameters must not contain control characters.");
 
     public static IRuleBuilderOptions<T, HotkeyAction> ValidAction<T>(this IRuleBuilderInitial<T, HotkeyAction> rb) =>
         rb.IsInEnum().WithMessage("Action must be a valid HotkeyAction value.");

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/CreateHotkeyCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/CreateHotkeyCommandValidatorTests.cs
@@ -110,6 +110,7 @@ public sealed class CreateHotkeyCommandValidatorTests
     [InlineData("n\r")]
     [InlineData("n\n")]
     [InlineData("n\t")]
+    [InlineData("n\u0001")]
     public void Validate_WithKeyContainingControlChars_Fails(string key)
     {
         ValidationResult result = _sut.Validate(Cmd(key: key));
@@ -117,7 +118,29 @@ public sealed class CreateHotkeyCommandValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e =>
             e.PropertyName == "Input.Key" &&
-            e.ErrorMessage == "Key must not contain line breaks or tabs.");
+            e.ErrorMessage == "Key must not contain control characters.");
+    }
+
+    [Theory]
+    [InlineData("a\"", "Key must not contain double-quote characters.")]
+    [InlineData("a`", "Key must not contain backtick characters.")]
+    [InlineData("a:", "Key must not contain colon characters.")]
+    public void Validate_WithKeyContainingForbiddenChars_Fails(string key, string expectedMessage)
+    {
+        ValidationResult result = _sut.Validate(Cmd(key: key));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Key" &&
+            e.ErrorMessage == expectedMessage);
+    }
+
+    [Fact]
+    public void Validate_WithSemicolonKey_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd(key: ";"));
+
+        result.IsValid.Should().BeTrue();
     }
 
     [Fact]
@@ -137,6 +160,29 @@ public sealed class CreateHotkeyCommandValidatorTests
         result.Errors.Should().Contain(e =>
             e.PropertyName == "Input.Parameters" &&
             e.ErrorMessage == "Parameters must be 4000 characters or fewer.");
+    }
+
+    [Theory]
+    [InlineData("he said \"hi\"", "Parameters must not contain double-quote characters.")]
+    [InlineData("x`n", "Parameters must not contain backtick characters.")]
+    [InlineData("x\n", "Parameters must not contain control characters.")]
+    [InlineData("x\t", "Parameters must not contain control characters.")]
+    public void Validate_WithParametersContainingForbiddenChars_Fails(string parameters, string expectedMessage)
+    {
+        ValidationResult result = _sut.Validate(Cmd(parameters: parameters));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Input.Parameters" &&
+            e.ErrorMessage == expectedMessage);
+    }
+
+    [Fact]
+    public void Validate_WithParametersContainingColonsAndPath_Succeeds()
+    {
+        ValidationResult result = _sut.Validate(Cmd(parameters: @"C:\tools\app.exe --flag"));
+
+        result.IsValid.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorTests.cs
@@ -418,6 +418,9 @@ public sealed class AhkScriptGeneratorTests
         output.Should().Contain($"F5::{expectedFn}(\"notepad.exe\")");
     }
 
+    // Validation now rejects '"', backtick, and control chars in Key/Parameters
+    // (HotkeyRules), so this input can no longer arrive via the API. Pins that the
+    // emitter still trusts validated input and embeds raw — no defensive escaping.
     [Fact]
     public void Generate_Hotkey_EmitsParametersVerbatim_NoEscaping()
     {


### PR DESCRIPTION
## Summary

`AhkScriptGenerator.FormatHotkey` embeds `Key` and `Parameters` raw into the generated line; a `"` or backtick in either field made the emitted script invalid AHK v2, and AHK fails the **whole file** at load — one bad hotkey took down the user's entire profile.

Interim fix (escaping deferred to #195): reject the dangerous characters at the validation boundary, same trust model as `ContextValue`:

- `Parameters`: no `"`, backtick, or control characters
- `Key`: same set plus `:` (Key `a:` would emit `a:::...`, which AHK parses as hotstring syntax); the existing line-break/tab rule broadened to all control chars
- Server-side only — the Blazor dialog already surfaces 400 validation errors; the CLI has no hotkey commands

Also updates the syntax reference doc and the `Generate_Hotkey_EmitsParametersVerbatim_NoEscaping` characterization comment (emitter behavior unchanged — it still trusts validated input).

**Note:** rows created before this validation are not retroactively checked (pre-v1, no real data).

Closes #193. Follow-up (semantics decision, escaping, Key whitelist, relaxing these rules): #195.

## Test plan

- [x] New validator tests: forbidden chars in Key/Parameters fail with per-char messages; `;` in Key and `C:\tools\app.exe` in Parameters stay valid (TDD, watched fail first)
- [x] Full suite: 1,843 tests green across all 8 projects
- [x] `dotnet format --verify-no-changes` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)