### PR TITLE
docs: narrow interim hotkey validation claims per review

### DIFF
--- a/docs/development/ahk-v2-syntax.md
+++ b/docs/development/ahk-v2-syntax.md
@@ -274,13 +274,16 @@ Emitted in the fixed order `^ ! + #` (`AhkScriptGenerator.FormatHotkey`). Action
 ```
 
 Both hotkey `Key` and `Parameters` are interpolated **without** passing through either escape
-routine. What keeps that safe is boundary validation, not the emitter: `HotkeyRules` rejects `"`,
-backticks, and control characters in both fields, plus `:` in `Key` (a colon there would emit
-`a:::...`, which AHK parses as hotstring syntax) — the same trust model as `ContextValue` for
-`#HotIf`. `Generate_Hotkey_EmitsParametersVerbatim_NoEscaping` pins the emitter's raw embedding.
-This is the interim resolution of issue #193; proper escaping of `Parameters` (and a `Key`
-whitelist, relaxing these rejections) is deferred to its follow-up issue. Rows created before the
-validation landed are not retroactively checked.
+routine. Boundary validation rejects the known-unsafe characters — `"`, backticks, and control
+characters in both fields, plus `:` in `Key` (a colon there would emit `a:::...`, which AHK
+parses as hotstring syntax) — the same trust model as `ContextValue` for `#HotIf`. This blocks
+the syntax breaks from issue #193, but is **not** a guarantee the line is valid AHK: `Key` is not
+whitelisted against real key names, so e.g. an invalid `vk`/`sc` spec still fails at load.
+`Generate_Hotkey_EmitsParametersVerbatim_NoEscaping` pins the emitter's raw embedding. Proper
+escaping of `Parameters` and a `Key` whitelist (relaxing these rejections) are deferred to the
+follow-up issue. Rows and history snapshots written before the validation landed are not
+retroactively checked — restore/revert rehydrate snapshots without validation (by design, see
+`RevertHotstringCommand`), so pre-validation values can return until edited.
 
 ## Input limits
 

--- a/src/Backend/AHKFlowApp.Application/Validation/HotkeyRules.cs
+++ b/src/Backend/AHKFlowApp.Application/Validation/HotkeyRules.cs
@@ -15,10 +15,11 @@ internal static class HotkeyRules
           .MaximumLength(DescriptionMaxLength).WithMessage($"Description must be {DescriptionMaxLength} characters or fewer.");
 
     // Key and Parameters are embedded raw by AhkScriptGenerator.FormatHotkey; the character
-    // rejections below keep the generated line valid AHK v2 (same trust model as ContextValue
-    // in HotstringRules.AddWindowContextRules). Colon is rejected only in Key: "a:" would emit
-    // "a:::...", which AHK parses as hotstring syntax. Interim until escaping lands (see the
-    // follow-up to issue #193).
+    // rejections below keep known-unsafe characters out of the generated line (same trust
+    // model as ContextValue in HotstringRules.AddWindowContextRules) — they do not guarantee
+    // Key is a valid AHK key name. Colon is rejected only in Key: "a:" would emit "a:::...",
+    // which AHK parses as hotstring syntax. Interim until escaping and a Key whitelist land
+    // (see the follow-up to issue #193).
     public static IRuleBuilderOptions<T, string> ValidKey<T>(this IRuleBuilderInitial<T, string> rb) =>
         rb.Cascade(CascadeMode.Stop)
           .Must(k => !string.IsNullOrEmpty(k)).WithMessage("Key is required.")


### PR DESCRIPTION
## Summary
- Follow-up to #196 (merged): narrows overclaiming language about the interim hotkey `Key`/`Parameters` validation — the char rejections block known-unsafe characters, not all invalid AHK (`Key` isn't whitelisted against real key names).
- Notes that restore/revert rehydrates history snapshots without re-validation, by design (`RevertHotstringCommand`).
- Doc + comment wording only — no behavior change.

## Test plan
- [x] `dotnet build` unaffected (docs/comment-only change)