### PR TITLE
feat: auto-refresh Codex plugin cache on skill changes

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -11,6 +11,7 @@ git rev-parse --verify ORIG_HEAD >/dev/null 2>&1 || exit 0
 
 if git diff --quiet ORIG_HEAD HEAD -- \
     .agents/ \
+    plugins/ahkflowapp/ \
     scripts/agents/setup-cross-agent-skills.ps1 \
     scripts/agents/setup-cross-agent-skills.sh \
     2>/dev/null; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,17 @@ jobs:
           ./tests/WorktreeLocalDevSetup.Tests.ps1
           ./tests/SkillParity.Tests.ps1
 
+  codex-skills-hash-parity:
+    # Runs on Linux: the bash setup script refuses under Windows Git Bash, and this
+    # asserts the bash and PowerShell Codex hash implementations agree (both preinstalled
+    # on ubuntu runners).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Codex skills hash parity test
+        shell: pwsh
+        run: ./tests/CodexSkillsHashParity.Tests.ps1
+
   bicep-lint:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,3 +307,5 @@ The AHK v2 syntax we emit — option flags, escaping, `#HotIf`, bodies per kind 
 - **Roslyn Navigator MCP** (`CWM.RoslynNavigator`) powers the code-navigation calls in the `dck-verify`, `dck-build-fix`, and `dck-de-sloppify` skills — install with `dotnet tool install -g CWM.RoslynNavigator` (registered in the repo's `.mcp.json`). Without it, those skills fall back to Grep/Roslyn LSP instead of the richer diagnostics.
 
 Run `scripts/agents/setup-copilot-symlinks.ps1` after cloning to configure symlinks for GitHub Copilot CLI skill discovery.
+
+`scripts/agents/setup-cross-agent-skills.ps1` (re-run automatically by the `post-merge` hook when skills change) also bumps the Codex plugin version in `plugins/ahkflowapp/.codex-plugin/plugin.json` from a content hash and refreshes the installed Codex plugin cache via `codex plugin add ahkflowapp@ahkflowapp-local`. Codex captures available skills at session start — start a new Codex session after skill changes.

--- a/docs/superpowers/plans/2026-07-17-codex-plugin-cache-refresh-plan.md
+++ b/docs/superpowers/plans/2026-07-17-codex-plugin-cache-refresh-plan.md
@@ -1,0 +1,64 @@
+# Prevent stale Codex plugin cache when skills change
+
+## Context
+
+PR #198 added the `impeccable` skill. The repo-side chain is verified correct after checkout:
+
+- `.claude/skills/impeccable` → symlink → `.agents/impeccable` ✓
+- `.github/skills/impeccable` → symlink → `.agents/impeccable` ✓
+- `plugins/ahkflowapp/skills/impeccable` → hard-linked mirror (SKILL.md + reference/ + scripts/) ✓
+
+But Codex didn't see it: `codex plugin add` freezes a copy of `plugins/ahkflowapp/` into its installed cache, stamped with `plugin.json` version `0.1.0+codex.20260716153142` (July 16, pre-impeccable). Nothing refreshes that cache when skills change, and the version bump is a manual step that only lives in old plan docs. Goal: make the cache refresh automatic (user chose auto-reinstall).
+
+## Design
+
+Both fixes go into `scripts/agents/setup-cross-agent-skills.ps1` (and its `.sh` sibling), because the existing `.githooks/post-merge` hook already re-runs that script whenever `.agents/` changes after a pull — so the pull path, the manual-sync path, and the fresh-clone path all converge there.
+
+### 1. Content-hash version bump (deterministic, idempotent)
+
+After `Sync-CodexPluginSkillDirectory` runs:
+
+- Compute a stable hash of the Codex skills payload: sort all files under `plugins/ahkflowapp/skills/` by relative path, hash `relativePath + file content` (SHA-256, take first 12 hex chars).
+- Rewrite `plugins/ahkflowapp/.codex-plugin/plugin.json` `version` to `0.1.0+codex.<hash12>` **only if it differs** — no churn when nothing changed, and the same content always produces the same version on every machine (so a puller's hook never dirties the tree if the committer ran sync).
+- Print `[FIX] plugin.json version bumped — commit this change` when it rewrites.
+
+Note: semver build metadata (`+…`) may be ignored by strict version comparison, but that doesn't matter here — freshness is guaranteed by step 2's reinstall, not by Codex's own up-to-date check. The hash-version is for visibility and for detecting drift.
+
+### 2. Auto-reinstall the Codex plugin cache
+
+New final step in the script:
+
+- If `codex` CLI is not on PATH → print an informational skip line, exit 0 (no failure on machines without Codex).
+- Otherwise run `codex plugin add ahkflowapp@ahkflowapp-local --json` when the installed cache is stale. Staleness check: read the installed plugin's `plugin.json` version (locate via `codex plugin list --json`; if that output shape is awkward, fall back to always reinstalling — the add is cheap and idempotent).
+- Always print the reminder: `Codex sessions capture skills at startup — start a new Codex session to pick up changes.`
+
+### 3. Mirror in `setup-cross-agent-skills.sh`
+
+Apply the same two steps to the bash variant so non-Windows environments behave identically. Hash with `sha256sum`, reinstall gated on `command -v codex`.
+
+### 4. Docs
+
+- `AGENTS.md` (or the `worktrees`/`dck-verify` skill if more apt — prefer AGENTS.md "Prerequisites"/agent-skills area): one short note that the sync script now bumps `plugin.json` and refreshes the Codex plugin cache automatically; new Codex sessions are required after skill changes.
+- Remove/soften any stale "manually bump version" instructions if found in active docs (the mentions found are in dated plan docs — leave those as history).
+
+Deliberately skipped (YAGNI, per brainstorm): CI guard for version bumps — the deterministic auto-bump plus post-merge hook makes forgetting nearly impossible; revisit only if drift recurs.
+
+## Files touched
+
+- `scripts/agents/setup-cross-agent-skills.ps1` — hash-bump + reinstall logic
+- `scripts/agents/setup-cross-agent-skills.sh` — same, bash
+- `plugins/ahkflowapp/.codex-plugin/plugin.json` — version becomes `0.1.0+codex.<hash12>` (first run of updated script)
+- `AGENTS.md` — one-line doc note
+- This plan: `docs/superpowers/plans/2026-07-17-codex-plugin-cache-refresh-plan.md` (commit first, on the feature branch)
+
+## Workflow
+
+Feature branch (`fix/codex-plugin-cache-refresh`) from `main`, PR to merge — no direct commits to main. Commit spec/plan immediately after writing, before review.
+
+## Verification
+
+1. Run `scripts/agents/setup-cross-agent-skills.ps1` → confirm `plugin.json` version changed to hash form; run again → confirm no changes (idempotent).
+2. Touch a skill file (e.g. add a trailing newline in a `.agents/*/SKILL.md`), re-run → version changes; revert, re-run → version returns to previous hash.
+3. Confirm `codex plugin list` shows the new version and the installed cache directory contains `impeccable/`.
+4. Simulate the pull path: `git merge` a branch touching `.agents/` in a scratch clone (or just verify `.githooks/post-merge` still triggers the script — its trigger paths already include `.agents/` and the setup scripts; add `plugins/ahkflowapp/` to the trigger list if not covered).
+5. Start a new Codex session and confirm `impeccable` appears in available skills.

--- a/docs/superpowers/plans/2026-07-17-codex-plugin-cache-refresh-plan.md
+++ b/docs/superpowers/plans/2026-07-17-codex-plugin-cache-refresh-plan.md
@@ -18,7 +18,7 @@ Both fixes go into `scripts/agents/setup-cross-agent-skills.ps1` (and its `.sh` 
 
 After `Sync-CodexPluginSkillDirectory` runs:
 
-- Compute a stable hash of the Codex skills payload: sort all files under `plugins/ahkflowapp/skills/` by relative path, hash `relativePath + file content` (SHA-256, take first 12 hex chars).
+- Compute a stable hash of the Codex skills payload: sort all files under `plugins/ahkflowapp/skills/` by relative path (ordinal), get each file's git blob OID via `git hash-object` (applies clean filters, so line-ending differences between platforms/checkouts don't change the result), SHA-256 over the `<oid>  <path>` lines, take first 12 hex chars.
 - Rewrite `plugins/ahkflowapp/.codex-plugin/plugin.json` `version` to `0.1.0+codex.<hash12>` **only if it differs** — no churn when nothing changed, and the same content always produces the same version on every machine (so a puller's hook never dirties the tree if the committer ran sync).
 - Print `[FIX] plugin.json version bumped — commit this change` when it rewrites.
 

--- a/plugins/ahkflowapp/.codex-plugin/plugin.json
+++ b/plugins/ahkflowapp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ahkflowapp",
-  "version": "0.1.0+codex.20260716153142",
+  "version": "0.1.0+codex.2f97d7eeb6b0",
   "description": "Repo-local Codex plugin exposing focused AHKFlowApp project skills.",
   "author": {
     "name": "AHKFlowApp maintainers",

--- a/scripts/agents/setup-cross-agent-skills.ps1
+++ b/scripts/agents/setup-cross-agent-skills.ps1
@@ -29,9 +29,11 @@ function Get-CodexSkillsHash {
     # platforms/checkouts don't change the version. Must stay in sync with the
     # equivalent computation in setup-cross-agent-skills.sh: ordinal-sorted
     # forward-slash skills-root-relative paths, SHA-256 over "<blob-oid>  <path>\n" lines.
-    $rootFull = (Resolve-Path -LiteralPath $SkillsRoot).Path.TrimEnd('\')
+    # Trim both separators so the function works under pwsh on Linux (CI parity test)
+    # as well as Windows — FullName uses '/' on Linux, '\' on Windows.
+    $rootFull = (Resolve-Path -LiteralPath $SkillsRoot).Path.TrimEnd('\', '/')
     $relatives = Get-ChildItem -LiteralPath $rootFull -Recurse -File -Force |
-        ForEach-Object { $_.FullName.Substring($rootFull.Length).TrimStart('\').Replace('\', '/') }
+        ForEach-Object { $_.FullName.Substring($rootFull.Length).TrimStart('\', '/').Replace('\', '/') }
     $sorted = [System.Collections.Generic.List[string]]::new()
     foreach ($rel in $relatives) { $sorted.Add($rel) }
     $sorted.Sort([System.StringComparer]::Ordinal)

--- a/scripts/agents/setup-cross-agent-skills.ps1
+++ b/scripts/agents/setup-cross-agent-skills.ps1
@@ -281,8 +281,105 @@ function Sync-CodexPluginSkillDirectory {
     }
 }
 
+function Get-CodexSkillsHash {
+    param([string] $SkillsRoot)
+
+    # Deterministic content hash of the Codex skills payload. Hashes git blob OIDs
+    # (git hash-object applies clean filters) so line-ending differences between
+    # platforms/checkouts don't change the version. Must stay in sync with the
+    # equivalent computation in setup-cross-agent-skills.sh: ordinal-sorted
+    # forward-slash skills-root-relative paths, SHA-256 over "<blob-oid>  <path>\n" lines.
+    $rootFull = (Resolve-Path -LiteralPath $SkillsRoot).Path.TrimEnd('\')
+    $relatives = Get-ChildItem -LiteralPath $rootFull -Recurse -File -Force |
+        ForEach-Object { $_.FullName.Substring($rootFull.Length).TrimStart('\').Replace('\', '/') }
+    $sorted = [System.Collections.Generic.List[string]]::new()
+    foreach ($rel in $relatives) { $sorted.Add($rel) }
+    $sorted.Sort([System.StringComparer]::Ordinal)
+
+    Push-Location $rootFull
+    try {
+        # Paths passed as arguments: piping to native stdin appends CR on Windows PowerShell,
+        # which git would treat as part of the path.
+        $blobs = @(& git hash-object -- @($sorted))
+        if ($LASTEXITCODE -ne 0 -or $blobs.Count -ne $sorted.Count) {
+            Write-Error "git hash-object failed while hashing Codex skills payload."
+            exit 1
+        }
+    } finally {
+        Pop-Location
+    }
+
+    $builder = [System.Text.StringBuilder]::new()
+    for ($i = 0; $i -lt $sorted.Count; $i++) {
+        [void]$builder.Append("$($blobs[$i])  $($sorted[$i])`n")
+    }
+
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $digest = $sha.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($builder.ToString()))
+        return ([System.BitConverter]::ToString($digest) -replace '-', '').Substring(0, 12).ToLowerInvariant()
+    } finally {
+        $sha.Dispose()
+    }
+}
+
+function Update-CodexPluginVersion {
+    param(
+        [string] $PluginJsonPath,
+        [string] $SkillsRoot
+    )
+
+    if (-not (Test-Path -LiteralPath $PluginJsonPath)) {
+        Write-Host "[WARN] $PluginJsonPath not found - skipping Codex plugin version bump." -ForegroundColor Yellow
+        return
+    }
+
+    $hash = Get-CodexSkillsHash $SkillsRoot
+    $content = [System.IO.File]::ReadAllText($PluginJsonPath)
+    if ($content -notmatch '"version":\s*"([^"]+)"') {
+        Write-Host "[WARN] No version field in plugin.json - skipping Codex plugin version bump." -ForegroundColor Yellow
+        return
+    }
+
+    $current = $Matches[1]
+    $base = $current.Split('+')[0]
+    $newVersion = "$base+codex.$hash"
+    if ($newVersion -eq $current) {
+        Write-Host "[OK] Codex plugin version $current matches skills content." -ForegroundColor Green
+        return
+    }
+
+    $updated = $content -replace '("version":\s*")[^"]+(")', "`${1}$newVersion`${2}"
+    [System.IO.File]::WriteAllText($PluginJsonPath, $updated, [System.Text.UTF8Encoding]::new($false))
+    Write-Host "[FIX] Codex plugin version bumped to $newVersion - commit plugin.json." -ForegroundColor Yellow
+}
+
+function Update-CodexInstalledPlugin {
+    if (-not (Get-Command codex -ErrorAction SilentlyContinue)) {
+        Write-Host "[OK] Codex CLI not on PATH - skipping installed plugin refresh." -ForegroundColor Green
+        return
+    }
+
+    Write-Host "[..] Refreshing installed Codex plugin cache (codex plugin add ahkflowapp@ahkflowapp-local)..."
+    # EAP=Continue: under Stop, stderr output from a native command redirected via 2>&1 becomes terminating.
+    $previousEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        codex plugin add 'ahkflowapp@ahkflowapp-local' --json 2>&1 | Out-Null
+    } finally {
+        $ErrorActionPreference = $previousEap
+    }
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "[OK] Codex plugin cache refreshed. Start a new Codex session to pick up skill changes." -ForegroundColor Green
+    } else {
+        Write-Host "[WARN] 'codex plugin add ahkflowapp@ahkflowapp-local' failed (is the ahkflowapp-local marketplace registered?). Run it manually to refresh the Codex plugin cache." -ForegroundColor Yellow
+    }
+}
+
 Sync-SkillLinkDirectory $claudeSkills '.claude/skills' '..\..\.agents' $false
 Sync-SkillLinkDirectory $githubSkills '.github/skills' '..\..\.agents' $false
 Sync-CodexPluginSkillDirectory $codexPluginSkills 'plugins/ahkflowapp/skills'
+Update-CodexPluginVersion (Join-Path $repoRoot 'plugins\ahkflowapp\.codex-plugin\plugin.json') $codexPluginSkills
+Update-CodexInstalledPlugin
 
 Write-Host "[DONE] .claude/skills and .github/skills symlink to active .agents/* skills; Codex plugin skills mirror the same skill directories with hard-linked files" -ForegroundColor Green

--- a/scripts/agents/setup-cross-agent-skills.ps1
+++ b/scripts/agents/setup-cross-agent-skills.ps1
@@ -11,10 +11,62 @@
     Reference docs, disabled dirs, and plugin packaging are ignored.
     Everything stays inside the repo — no user-folder changes.
     Requires Windows Developer Mode and git core.symlinks=true.
+.PARAMETER PrintCodexHash
+    Side-effect-free entry point for the regression test: print the Codex skills
+    hash of the given payload directory and exit before any repo mutation.
 #>
+
+param([string] $PrintCodexHash)
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+function Get-CodexSkillsHash {
+    param([string] $SkillsRoot)
+
+    # Deterministic content hash of the Codex skills payload. Hashes git blob OIDs
+    # (git hash-object applies clean filters) so line-ending differences between
+    # platforms/checkouts don't change the version. Must stay in sync with the
+    # equivalent computation in setup-cross-agent-skills.sh: ordinal-sorted
+    # forward-slash skills-root-relative paths, SHA-256 over "<blob-oid>  <path>\n" lines.
+    $rootFull = (Resolve-Path -LiteralPath $SkillsRoot).Path.TrimEnd('\')
+    $relatives = Get-ChildItem -LiteralPath $rootFull -Recurse -File -Force |
+        ForEach-Object { $_.FullName.Substring($rootFull.Length).TrimStart('\').Replace('\', '/') }
+    $sorted = [System.Collections.Generic.List[string]]::new()
+    foreach ($rel in $relatives) { $sorted.Add($rel) }
+    $sorted.Sort([System.StringComparer]::Ordinal)
+
+    Push-Location $rootFull
+    try {
+        # Paths passed as arguments: piping to native stdin appends CR on Windows PowerShell,
+        # which git would treat as part of the path.
+        $blobs = @(& git hash-object -- @($sorted))
+        if ($LASTEXITCODE -ne 0 -or $blobs.Count -ne $sorted.Count) {
+            Write-Error "git hash-object failed while hashing Codex skills payload."
+            exit 1
+        }
+    } finally {
+        Pop-Location
+    }
+
+    $builder = [System.Text.StringBuilder]::new()
+    for ($i = 0; $i -lt $sorted.Count; $i++) {
+        [void]$builder.Append("$($blobs[$i])  $($sorted[$i])`n")
+    }
+
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $digest = $sha.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($builder.ToString()))
+        return ([System.BitConverter]::ToString($digest) -replace '-', '').Substring(0, 12).ToLowerInvariant()
+    } finally {
+        $sha.Dispose()
+    }
+}
+
+if ($PrintCodexHash) {
+    Get-CodexSkillsHash $PrintCodexHash
+    exit 0
+}
 
 # --- Repo root ---
 $repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
@@ -278,48 +330,6 @@ function Sync-CodexPluginSkillDirectory {
             New-Item -ItemType Directory -Path (Split-Path -Parent $linkPath) -Force | Out-Null
             New-Item -ItemType HardLink -Path $linkPath -Target $sourceFile.FullName | Out-Null
         }
-    }
-}
-
-function Get-CodexSkillsHash {
-    param([string] $SkillsRoot)
-
-    # Deterministic content hash of the Codex skills payload. Hashes git blob OIDs
-    # (git hash-object applies clean filters) so line-ending differences between
-    # platforms/checkouts don't change the version. Must stay in sync with the
-    # equivalent computation in setup-cross-agent-skills.sh: ordinal-sorted
-    # forward-slash skills-root-relative paths, SHA-256 over "<blob-oid>  <path>\n" lines.
-    $rootFull = (Resolve-Path -LiteralPath $SkillsRoot).Path.TrimEnd('\')
-    $relatives = Get-ChildItem -LiteralPath $rootFull -Recurse -File -Force |
-        ForEach-Object { $_.FullName.Substring($rootFull.Length).TrimStart('\').Replace('\', '/') }
-    $sorted = [System.Collections.Generic.List[string]]::new()
-    foreach ($rel in $relatives) { $sorted.Add($rel) }
-    $sorted.Sort([System.StringComparer]::Ordinal)
-
-    Push-Location $rootFull
-    try {
-        # Paths passed as arguments: piping to native stdin appends CR on Windows PowerShell,
-        # which git would treat as part of the path.
-        $blobs = @(& git hash-object -- @($sorted))
-        if ($LASTEXITCODE -ne 0 -or $blobs.Count -ne $sorted.Count) {
-            Write-Error "git hash-object failed while hashing Codex skills payload."
-            exit 1
-        }
-    } finally {
-        Pop-Location
-    }
-
-    $builder = [System.Text.StringBuilder]::new()
-    for ($i = 0; $i -lt $sorted.Count; $i++) {
-        [void]$builder.Append("$($blobs[$i])  $($sorted[$i])`n")
-    }
-
-    $sha = [System.Security.Cryptography.SHA256]::Create()
-    try {
-        $digest = $sha.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($builder.ToString()))
-        return ([System.BitConverter]::ToString($digest) -replace '-', '').Substring(0, 12).ToLowerInvariant()
-    } finally {
-        $sha.Dispose()
     }
 }
 

--- a/scripts/agents/setup-cross-agent-skills.sh
+++ b/scripts/agents/setup-cross-agent-skills.sh
@@ -19,6 +19,43 @@ case "$(uname -s 2>/dev/null || echo unknown)" in
         ;;
 esac
 
+compute_codex_skills_hash() {
+    # Deterministic content hash of the Codex skills payload. Hashes git blob OIDs
+    # (git hash-object applies clean filters) so line-ending differences between
+    # platforms/checkouts don't change the version. Must stay in sync with
+    # Get-CodexSkillsHash in setup-cross-agent-skills.ps1: ordinal-sorted forward-slash
+    # skills-root-relative paths, SHA-256 over "<blob-oid>  <path>\n" lines.
+    # Args: [skills_dir] [git_prefix] — default to the real Codex payload; the
+    # regression test passes a temp payload so it can hash spaced filenames.
+    local skills_dir="${1:-$CODEX_PLUGIN_SKILLS}"
+    local git_prefix="${2:-plugins/ahkflowapp/skills/}"
+    (
+        cd "$skills_dir"
+        local paths_file
+        paths_file=$(mktemp)
+        find . -type f | sed 's|^\./||' | LC_ALL=C sort > "$paths_file"
+        # git hash-object --stdin-paths resolves paths relative to the repo root,
+        # so prefix the skills-root-relative names when feeding git.
+        # paste joins each blob OID to its path with a single space; convert that
+        # first delimiter to two spaces without tokenizing the path — a blob OID
+        # never contains a space, so the first space is always the delimiter, and
+        # paths containing spaces are preserved in full (must match the PowerShell
+        # "<blob-oid>  <path>" format).
+        paste -d' ' \
+            <(sed "s|^|$git_prefix|" "$paths_file" | git hash-object --stdin-paths) \
+            "$paths_file" |
+            sed 's/ /  /'
+        rm -f "$paths_file"
+    ) | sha256sum | cut -c1-12
+}
+
+# Side-effect-free entry point for the regression test: print the hash of an
+# arbitrary payload and exit before any repo mutation (hooks, symlinks, etc.).
+if [ "${1:-}" = "--print-codex-hash" ]; then
+    compute_codex_skills_hash "${2:-}" "${3:-}"
+    exit 0
+fi
+
 REPO_ROOT=$(git rev-parse --show-toplevel)
 AGENTS_ROOT="$REPO_ROOT/.agents"
 CLAUDE_ROOT="$REPO_ROOT/.claude"
@@ -240,27 +277,6 @@ sync_codex_plugin_skill_directory() {
             done
         )
     done
-}
-
-compute_codex_skills_hash() {
-    # Deterministic content hash of the Codex skills payload. Hashes git blob OIDs
-    # (git hash-object applies clean filters) so line-ending differences between
-    # platforms/checkouts don't change the version. Must stay in sync with
-    # Get-CodexSkillsHash in setup-cross-agent-skills.ps1: ordinal-sorted forward-slash
-    # skills-root-relative paths, SHA-256 over "<blob-oid>  <path>\n" lines.
-    (
-        cd "$CODEX_PLUGIN_SKILLS"
-        local paths_file
-        paths_file=$(mktemp)
-        find . -type f | sed 's|^\./||' | LC_ALL=C sort > "$paths_file"
-        # git hash-object --stdin-paths resolves paths relative to the repo root,
-        # so prefix the skills-root-relative names when feeding git.
-        paste -d' ' \
-            <(sed 's|^|plugins/ahkflowapp/skills/|' "$paths_file" | git hash-object --stdin-paths) \
-            "$paths_file" |
-            awk '{print $1 "  " $2}'
-        rm -f "$paths_file"
-    ) | sha256sum | cut -c1-12
 }
 
 update_codex_plugin_version() {

--- a/scripts/agents/setup-cross-agent-skills.sh
+++ b/scripts/agents/setup-cross-agent-skills.sh
@@ -242,10 +242,73 @@ sync_codex_plugin_skill_directory() {
     done
 }
 
+compute_codex_skills_hash() {
+    # Deterministic content hash of the Codex skills payload. Hashes git blob OIDs
+    # (git hash-object applies clean filters) so line-ending differences between
+    # platforms/checkouts don't change the version. Must stay in sync with
+    # Get-CodexSkillsHash in setup-cross-agent-skills.ps1: ordinal-sorted forward-slash
+    # skills-root-relative paths, SHA-256 over "<blob-oid>  <path>\n" lines.
+    (
+        cd "$CODEX_PLUGIN_SKILLS"
+        local paths_file
+        paths_file=$(mktemp)
+        find . -type f | sed 's|^\./||' | LC_ALL=C sort > "$paths_file"
+        # git hash-object --stdin-paths resolves paths relative to the repo root,
+        # so prefix the skills-root-relative names when feeding git.
+        paste -d' ' \
+            <(sed 's|^|plugins/ahkflowapp/skills/|' "$paths_file" | git hash-object --stdin-paths) \
+            "$paths_file" |
+            awk '{print $1 "  " $2}'
+        rm -f "$paths_file"
+    ) | sha256sum | cut -c1-12
+}
+
+update_codex_plugin_version() {
+    local plugin_json="$REPO_ROOT/plugins/ahkflowapp/.codex-plugin/plugin.json"
+    if [ ! -f "$plugin_json" ]; then
+        echo "[WARN] $plugin_json not found — skipping Codex plugin version bump."
+        return
+    fi
+
+    local hash current base new_version
+    hash=$(compute_codex_skills_hash)
+    current=$(sed -nE 's/.*"version":[[:space:]]*"([^"]+)".*/\1/p' "$plugin_json" | head -1)
+    if [ -z "$current" ]; then
+        echo "[WARN] No version field in plugin.json — skipping Codex plugin version bump."
+        return
+    fi
+
+    base=${current%%+*}
+    new_version="$base+codex.$hash"
+    if [ "$new_version" = "$current" ]; then
+        echo "[OK] Codex plugin version $current matches skills content."
+        return
+    fi
+
+    sed -i -E "s|(\"version\":[[:space:]]*\")[^\"]+(\")|\1$new_version\2|" "$plugin_json"
+    echo "[FIX] Codex plugin version bumped to $new_version — commit plugin.json."
+}
+
+update_codex_installed_plugin() {
+    if ! command -v codex >/dev/null 2>&1; then
+        echo "[OK] Codex CLI not on PATH — skipping installed plugin refresh."
+        return
+    fi
+
+    echo "[..] Refreshing installed Codex plugin cache (codex plugin add ahkflowapp@ahkflowapp-local)..."
+    if codex plugin add 'ahkflowapp@ahkflowapp-local' --json >/dev/null 2>&1; then
+        echo "[OK] Codex plugin cache refreshed. Start a new Codex session to pick up skill changes."
+    else
+        echo "[WARN] 'codex plugin add ahkflowapp@ahkflowapp-local' failed (is the ahkflowapp-local marketplace registered?). Run it manually to refresh the Codex plugin cache."
+    fi
+}
+
 mkdir -p "$CLAUDE_ROOT"
 
 sync_skill_link_directory "$CLAUDE_SKILLS" ".claude/skills" "../../.agents" false
 sync_skill_link_directory "$GITHUB_SKILLS" ".github/skills" "../../.agents" false
 sync_codex_plugin_skill_directory "$CODEX_PLUGIN_SKILLS" "plugins/ahkflowapp/skills"
+update_codex_plugin_version
+update_codex_installed_plugin
 
 echo "[DONE] .claude/skills and .github/skills symlink to active .agents/* skills; Codex plugin skills mirror the same skill directories with hard-linked files"

--- a/tests/CodexSkillsHashParity.Tests.ps1
+++ b/tests/CodexSkillsHashParity.Tests.ps1
@@ -1,0 +1,109 @@
+#Requires -Version 7.0
+
+# Cross-platform regression test for the Codex skills content hash.
+#
+# The bash and PowerShell setup scripts each compute the plugin version hash
+# independently and MUST agree byte-for-byte, otherwise the same skills payload
+# produces different Codex plugin versions on Windows vs Linux. A past bug had the
+# bash pipeline tokenize the "<blob-oid>  <path>" line with awk, truncating any
+# path containing a space (e.g. "reference/file with spaces.md" -> "reference/file").
+# This test builds a payload with a spaced filename and asserts:
+#   1. bash and PowerShell produce the same hash (parity), and
+#   2. the full spaced path influences the hash (no truncation).
+#
+# Runs on Linux CI: the bash script refuses to run under Windows Git Bash, and both
+# bash and pwsh are available on ubuntu runners.
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ($IsWindows) {
+    Write-Host 'Skipping Codex skills hash parity test on Windows (bash script is Linux-only).'
+    exit 0
+}
+
+$suiteRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+$bashScript = Join-Path $suiteRoot 'scripts/agents/setup-cross-agent-skills.sh'
+$psScript = Join-Path $suiteRoot 'scripts/agents/setup-cross-agent-skills.ps1'
+$gitPrefix = 'plugins/ahkflowapp/skills/'
+
+# Build a throwaway git repo whose payload mirrors the real plugin skills layout so
+# the bash script's repo-root-relative `git hash-object --stdin-paths` resolves.
+function New-Payload {
+    param([hashtable] $Files)
+
+    $repo = Join-Path ([System.IO.Path]::GetTempPath()) ("codexhash-" + [System.Guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Path $repo -Force | Out-Null
+    git -C $repo init --quiet | Out-Null
+
+    $skillsRoot = Join-Path $repo $gitPrefix
+    foreach ($rel in $Files.Keys) {
+        $full = Join-Path $skillsRoot $rel
+        New-Item -ItemType Directory -Path (Split-Path -Parent $full) -Force | Out-Null
+        [System.IO.File]::WriteAllText($full, $Files[$rel])
+    }
+    return @{ Repo = $repo; SkillsRoot = $skillsRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar) }
+}
+
+function Get-BashHash {
+    param([string] $SkillsRoot)
+    $out = & bash $bashScript --print-codex-hash $SkillsRoot $gitPrefix
+    if ($LASTEXITCODE -ne 0) { throw "bash hash failed for $SkillsRoot" }
+    return ($out | Select-Object -Last 1).Trim()
+}
+
+function Get-PsHash {
+    param([string] $SkillsRoot)
+    $out = & pwsh -NoProfile -File $psScript -PrintCodexHash $SkillsRoot
+    if ($LASTEXITCODE -ne 0) { throw "pwsh hash failed for $SkillsRoot" }
+    return ($out | Select-Object -Last 1).Trim()
+}
+
+$failures = @()
+$payloads = @()
+
+try {
+    # Payload A: contains a spaced filename plus ordinary companions.
+    $a = New-Payload @{
+        'dck-example/SKILL.md'            = "---`nname: dck-example`n---`nBody`n"
+        'reference/file with spaces.md'   = "spaced content`n"
+        'reference/plain.md'              = "plain content`n"
+    }
+    $payloads += $a.Repo
+
+    $aBash = Get-BashHash $a.SkillsRoot
+    $aPs = Get-PsHash $a.SkillsRoot
+
+    if ($aBash -ne $aPs) {
+        $failures += "Parity: bash hash '$aBash' != PowerShell hash '$aPs' for a payload with a spaced filename."
+    }
+
+    # Payload B: identical except the spaced filename's suffix differs (same content).
+    # Under the old awk-truncation bug both A and B collapse the path to "reference/file"
+    # and hash identically; the fixed pipeline keeps the full path, so the hashes differ.
+    $b = New-Payload @{
+        'dck-example/SKILL.md'            = "---`nname: dck-example`n---`nBody`n"
+        'reference/file with spacez.md'   = "spaced content`n"
+        'reference/plain.md'              = "plain content`n"
+    }
+    $payloads += $b.Repo
+
+    $bBash = Get-BashHash $b.SkillsRoot
+    if ($aBash -eq $bBash) {
+        $failures += "Truncation: bash hash is identical for 'file with spaces.md' and 'file with spacez.md' — the spaced path tail is being dropped."
+    }
+}
+finally {
+    foreach ($repo in $payloads) {
+        if (Test-Path -LiteralPath $repo) { Remove-Item -LiteralPath $repo -Recurse -Force }
+    }
+}
+
+if ($failures.Count -gt 0) {
+    throw ($failures -join [Environment]::NewLine)
+}
+
+Write-Host 'Codex skills hash parity tests passed.'


### PR DESCRIPTION
## Why

PR #198 added the `impeccable` skill, but Codex didn't see it: `codex plugin add` freezes a versioned copy of `plugins/ahkflowapp/` into its cache, and nothing refreshed that cache or bumped the plugin version when skills changed. The version bump was a manual step living only in old plan docs.

## What

- **Content-hash version bump**: `setup-cross-agent-skills.ps1`/`.sh` rewrite `plugin.json` version to `0.1.0+codex.<hash12>` whenever the skills payload changes. Hash is over git blob OIDs (`git hash-object`, clean filters applied), so it's deterministic across Windows/Linux and immune to CRLF/LF churn — same content, same version, on every machine.
- **Auto-reinstall**: sync script then runs `codex plugin add ahkflowapp@ahkflowapp-local` (skipped when codex CLI absent) and prints a 'start a new Codex session' reminder.
- **Pull path**: `post-merge` hook trigger paths now include `plugins/ahkflowapp/`, so pulls that change skills re-sync and reinstall automatically.
- **Docs**: AGENTS.md note; plan in `docs/superpowers/plans/2026-07-17-codex-plugin-cache-refresh-plan.md`.

## Verification

- Sync run is idempotent (same hash on repeat runs); change → new version, revert → original version restored.
- PowerShell and bash hash implementations produce identical output (`2f97d7eeb6b0`).
- `~/.codex/plugins/cache` now holds exactly `0.1.0+codex.2f97d7eeb6b0` with `impeccable/` present; stale July 16 copy pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)