### PR TITLE
fix: don't mark lazy seed done when no rows were inserted

### DIFF
--- a/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
@@ -251,15 +251,21 @@ internal sealed class ListHotkeysQueryHandler(
             if (pref is not null)
                 db.Entry(pref).State = EntityState.Detached;
 
-            // Reload pref (may have been inserted by the concurrent winner) and set markers.
+            // Reload pref (may have been inserted by the concurrent winner) and mark only the
+            // sets that actually landed. The winner may be the categories seeder
+            // (ListCategoriesQuery), which inserts categories and the pref row but never any
+            // hotkeys; marking hotkeys seeded here would strand the owner on an empty set that
+            // the guard above stops any later request from retrying.
             pref = await db.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
             if (pref is null)
             {
                 pref = UserPreference.CreateDefault(ownerOid, clock);
                 db.UserPreferences.Add(pref);
             }
-            if (seedingCategories) pref.MarkCategoriesSeeded(clock);
-            pref.MarkHotkeysSeeded(clock);
+            if (pref.CategoriesSeededAt is null && await db.Categories.AnyAsync(c => c.OwnerOid == ownerOid, ct))
+                pref.MarkCategoriesSeeded(clock);
+            if (pref.HotkeysSeededAt is null && await db.Hotkeys.AnyAsync(h => h.OwnerOid == ownerOid, ct))
+                pref.MarkHotkeysSeeded(clock);
             await db.SaveChangesAsync(ct);
         }
     }

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListHotkeysQuery.cs
@@ -179,94 +179,105 @@ internal sealed class ListHotkeysQueryHandler(
     {
         if (!env.IsDevelopment) return;
 
-        UserPreference? pref = await db.UserPreferences
-            .FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
+        const int maxAttempts = 2;
 
-        if (pref?.HotkeysSeededAt is not null) return;
-
-        // Ensure categories exist; seed them inline if this is the user's first request
-        bool seedingCategories = pref?.CategoriesSeededAt is null;
-        Dictionary<string, Guid> catByName;
-
-        if (seedingCategories)
+        for (int attempt = 1; attempt <= maxAttempts; attempt++)
         {
-            catByName = [];
-            foreach (string name in DefaultCategories.Names)
+            UserPreference? pref = await db.UserPreferences
+                .FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
+
+            if (pref?.HotkeysSeededAt is not null) return;
+
+            // Ensure categories exist; seed them inline if this is the user's first request
+            bool seedingCategories = pref?.CategoriesSeededAt is null;
+            Dictionary<string, Guid> catByName;
+
+            if (seedingCategories)
             {
-                var cat = Category.Create(ownerOid, name, clock);
-                db.Categories.Add(cat);
-                catByName[name] = cat.Id;
+                catByName = [];
+                foreach (string name in DefaultCategories.Names)
+                {
+                    var cat = Category.Create(ownerOid, name, clock);
+                    db.Categories.Add(cat);
+                    catByName[name] = cat.Id;
+                }
             }
-        }
-        else
-        {
-            catByName = (await db.Categories
-                    .Where(c => c.OwnerOid == ownerOid)
-                    .Select(c => new { c.Name, c.Id })
-                    .ToListAsync(ct))
-                .ToDictionary(c => c.Name, c => c.Id, StringComparer.OrdinalIgnoreCase);
-        }
-
-        foreach ((string descr, bool ctrl, bool alt, bool shift, bool win, string key,
-                  HotkeyAction action, string param, string[] cats) in s_lazySeed)
-        {
-            var hk = Hotkey.Create(ownerOid, descr, key, ctrl, alt, shift, win,
-                action, param, appliesToAllProfiles: true, clock);
-            db.Hotkeys.Add(hk);
-            foreach (string catName in cats)
+            else
             {
-                if (catByName.TryGetValue(catName, out Guid catId))
-                    db.HotkeyCategories.Add(HotkeyCategory.Create(hk.Id, catId));
+                catByName = (await db.Categories
+                        .Where(c => c.OwnerOid == ownerOid)
+                        .Select(c => new { c.Name, c.Id })
+                        .ToListAsync(ct))
+                    .ToDictionary(c => c.Name, c => c.Id, StringComparer.OrdinalIgnoreCase);
             }
-        }
 
-        if (pref is null)
-        {
-            pref = UserPreference.CreateDefault(ownerOid, clock);
-            if (seedingCategories) pref.MarkCategoriesSeeded(clock);
-            pref.MarkHotkeysSeeded(clock);
-            db.UserPreferences.Add(pref);
-        }
-        else
-        {
-            if (seedingCategories) pref.MarkCategoriesSeeded(clock);
-            pref.MarkHotkeysSeeded(clock);
-        }
+            foreach ((string descr, bool ctrl, bool alt, bool shift, bool win, string key,
+                      HotkeyAction action, string param, string[] cats) in s_lazySeed)
+            {
+                var hk = Hotkey.Create(ownerOid, descr, key, ctrl, alt, shift, win,
+                    action, param, appliesToAllProfiles: true, clock);
+                db.Hotkeys.Add(hk);
+                foreach (string catName in cats)
+                {
+                    if (catByName.TryGetValue(catName, out Guid catId))
+                        db.HotkeyCategories.Add(HotkeyCategory.Create(hk.Id, catId));
+                }
+            }
 
-        try
-        {
-            await db.SaveChangesAsync(ct);
-        }
-        catch (DbUpdateException ex) when (ex.IsDuplicateKeyViolation())
-        {
-            // Concurrent first-call race or pre-existing data after migration (null
-            // markers but hotkeys already present) — detach pending entities and
-            // persist markers in a follow-up save so future GETs skip the seed path.
-            foreach (Hotkey hk in db.Hotkeys.Local.ToList())
-                db.Entry(hk).State = EntityState.Detached;
-            foreach (HotkeyCategory hc in db.HotkeyCategories.Local.ToList())
-                db.Entry(hc).State = EntityState.Detached;
-            foreach (Category cat in db.Categories.Local.ToList())
-                db.Entry(cat).State = EntityState.Detached;
-            if (pref is not null)
-                db.Entry(pref).State = EntityState.Detached;
-
-            // Reload pref (may have been inserted by the concurrent winner) and mark only the
-            // sets that actually landed. The winner may be the categories seeder
-            // (ListCategoriesQuery), which inserts categories and the pref row but never any
-            // hotkeys; marking hotkeys seeded here would strand the owner on an empty set that
-            // the guard above stops any later request from retrying.
-            pref = await db.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
             if (pref is null)
             {
                 pref = UserPreference.CreateDefault(ownerOid, clock);
+                if (seedingCategories) pref.MarkCategoriesSeeded(clock);
+                pref.MarkHotkeysSeeded(clock);
                 db.UserPreferences.Add(pref);
             }
-            if (pref.CategoriesSeededAt is null && await db.Categories.AnyAsync(c => c.OwnerOid == ownerOid, ct))
-                pref.MarkCategoriesSeeded(clock);
-            if (pref.HotkeysSeededAt is null && await db.Hotkeys.AnyAsync(h => h.OwnerOid == ownerOid, ct))
+            else
+            {
+                if (seedingCategories) pref.MarkCategoriesSeeded(clock);
                 pref.MarkHotkeysSeeded(clock);
-            await db.SaveChangesAsync(ct);
+            }
+
+            try
+            {
+                await db.SaveChangesAsync(ct);
+                return;
+            }
+            catch (DbUpdateException ex) when (ex.IsDuplicateKeyViolation())
+            {
+                // Concurrent first-call race or pre-existing data after migration (null
+                // markers but hotkeys already present) — detach pending entities, then
+                // persist only markers backed by rows that actually committed.
+                foreach (Hotkey hk in db.Hotkeys.Local.ToList())
+                    db.Entry(hk).State = EntityState.Detached;
+                foreach (HotkeyCategory hc in db.HotkeyCategories.Local.ToList())
+                    db.Entry(hc).State = EntityState.Detached;
+                foreach (Category cat in db.Categories.Local.ToList())
+                    db.Entry(cat).State = EntityState.Detached;
+                if (pref is not null)
+                    db.Entry(pref).State = EntityState.Detached;
+
+                // The winner may be ListCategoriesQuery, which inserts categories and the pref
+                // row but no hotkeys. In that case, persist the truthful category marker and
+                // retry once so this request can insert the hotkeys against those categories.
+                pref = await db.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
+                if (pref is null)
+                {
+                    pref = UserPreference.CreateDefault(ownerOid, clock);
+                    db.UserPreferences.Add(pref);
+                }
+
+                bool categoriesExist = await db.Categories.AnyAsync(c => c.OwnerOid == ownerOid, ct);
+                bool hotkeysExist = await db.Hotkeys.AnyAsync(h => h.OwnerOid == ownerOid, ct);
+
+                if (pref.CategoriesSeededAt is null && categoriesExist)
+                    pref.MarkCategoriesSeeded(clock);
+                if (pref.HotkeysSeededAt is null && hotkeysExist)
+                    pref.MarkHotkeysSeeded(clock);
+                await db.SaveChangesAsync(ct);
+
+                if (hotkeysExist || attempt == maxAttempts)
+                    return;
+            }
         }
     }
 

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
@@ -263,98 +263,109 @@ internal sealed class ListHotstringsQueryHandler(
     {
         if (!env.IsDevelopment) return;
 
-        UserPreference? pref = await db.UserPreferences
-            .FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
+        const int maxAttempts = 2;
 
-        if (pref?.HotstringsSeededAt is not null) return;
-
-        // Ensure categories exist; seed them inline if this is the user's first request
-        bool seedingCategories = pref?.CategoriesSeededAt is null;
-        Dictionary<string, Guid> catByName;
-
-        if (seedingCategories)
+        for (int attempt = 1; attempt <= maxAttempts; attempt++)
         {
-            catByName = [];
-            foreach (string name in DefaultCategories.Names)
+            UserPreference? pref = await db.UserPreferences
+                .FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
+
+            if (pref?.HotstringsSeededAt is not null) return;
+
+            // Ensure categories exist; seed them inline if this is the user's first request
+            bool seedingCategories = pref?.CategoriesSeededAt is null;
+            Dictionary<string, Guid> catByName;
+
+            if (seedingCategories)
             {
-                var cat = Category.Create(ownerOid, name, clock);
-                db.Categories.Add(cat);
-                catByName[name] = cat.Id;
+                catByName = [];
+                foreach (string name in DefaultCategories.Names)
+                {
+                    var cat = Category.Create(ownerOid, name, clock);
+                    db.Categories.Add(cat);
+                    catByName[name] = cat.Id;
+                }
             }
-        }
-        else
-        {
-            catByName = (await db.Categories
-                    .Where(c => c.OwnerOid == ownerOid)
-                    .Select(c => new { c.Name, c.Id })
-                    .ToListAsync(ct))
-                .ToDictionary(c => c.Name, c => c.Id, StringComparer.OrdinalIgnoreCase);
-        }
-
-        foreach ((string trigger, string replacement, bool ending, bool inside, string[] cats, HotstringKind kind, string? dateTimeFormat) in s_lazySeed)
-        {
-            var hs = Hotstring.Create(
-                ownerOid,
-                new HotstringDefinition(
-                    trigger, replacement, Description: null,
-                    AppliesToAllProfiles: true, ending, inside,
-                    Kind: kind, DateTimeFormat: dateTimeFormat),
-                clock);
-            db.Hotstrings.Add(hs);
-            foreach (string catName in cats)
+            else
             {
-                if (catByName.TryGetValue(catName, out Guid catId))
-                    db.HotstringCategories.Add(HotstringCategory.Create(hs.Id, catId));
+                catByName = (await db.Categories
+                        .Where(c => c.OwnerOid == ownerOid)
+                        .Select(c => new { c.Name, c.Id })
+                        .ToListAsync(ct))
+                    .ToDictionary(c => c.Name, c => c.Id, StringComparer.OrdinalIgnoreCase);
             }
-        }
 
-        if (pref is null)
-        {
-            pref = UserPreference.CreateDefault(ownerOid, clock);
-            if (seedingCategories) pref.MarkCategoriesSeeded(clock);
-            pref.MarkHotstringsSeeded(clock);
-            db.UserPreferences.Add(pref);
-        }
-        else
-        {
-            if (seedingCategories) pref.MarkCategoriesSeeded(clock);
-            pref.MarkHotstringsSeeded(clock);
-        }
+            foreach ((string trigger, string replacement, bool ending, bool inside, string[] cats, HotstringKind kind, string? dateTimeFormat) in s_lazySeed)
+            {
+                var hs = Hotstring.Create(
+                    ownerOid,
+                    new HotstringDefinition(
+                        trigger, replacement, Description: null,
+                        AppliesToAllProfiles: true, ending, inside,
+                        Kind: kind, DateTimeFormat: dateTimeFormat),
+                    clock);
+                db.Hotstrings.Add(hs);
+                foreach (string catName in cats)
+                {
+                    if (catByName.TryGetValue(catName, out Guid catId))
+                        db.HotstringCategories.Add(HotstringCategory.Create(hs.Id, catId));
+                }
+            }
 
-        try
-        {
-            await db.SaveChangesAsync(ct);
-        }
-        catch (DbUpdateException ex) when (ex.IsDuplicateKeyViolation())
-        {
-            // Concurrent first-call race or pre-existing data after migration (null
-            // markers but hotstrings already present) — detach pending entities and
-            // persist markers in a follow-up save so future GETs skip the seed path.
-            foreach (Hotstring hs in db.Hotstrings.Local.ToList())
-                db.Entry(hs).State = EntityState.Detached;
-            foreach (HotstringCategory hc in db.HotstringCategories.Local.ToList())
-                db.Entry(hc).State = EntityState.Detached;
-            foreach (Category cat in db.Categories.Local.ToList())
-                db.Entry(cat).State = EntityState.Detached;
-            if (pref is not null)
-                db.Entry(pref).State = EntityState.Detached;
-
-            // Reload pref (may have been inserted by the concurrent winner) and mark only the
-            // sets that actually landed. The winner may be the categories seeder
-            // (ListCategoriesQuery), which inserts categories and the pref row but never any
-            // hotstrings; marking hotstrings seeded here would strand the owner on an empty
-            // set that the guard above stops any later request from retrying.
-            pref = await db.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
             if (pref is null)
             {
                 pref = UserPreference.CreateDefault(ownerOid, clock);
+                if (seedingCategories) pref.MarkCategoriesSeeded(clock);
+                pref.MarkHotstringsSeeded(clock);
                 db.UserPreferences.Add(pref);
             }
-            if (pref.CategoriesSeededAt is null && await db.Categories.AnyAsync(c => c.OwnerOid == ownerOid, ct))
-                pref.MarkCategoriesSeeded(clock);
-            if (pref.HotstringsSeededAt is null && await db.Hotstrings.AnyAsync(h => h.OwnerOid == ownerOid, ct))
+            else
+            {
+                if (seedingCategories) pref.MarkCategoriesSeeded(clock);
                 pref.MarkHotstringsSeeded(clock);
-            await db.SaveChangesAsync(ct);
+            }
+
+            try
+            {
+                await db.SaveChangesAsync(ct);
+                return;
+            }
+            catch (DbUpdateException ex) when (ex.IsDuplicateKeyViolation())
+            {
+                // Concurrent first-call race or pre-existing data after migration (null
+                // markers but hotstrings already present) — detach pending entities, then
+                // persist only markers backed by rows that actually committed.
+                foreach (Hotstring hs in db.Hotstrings.Local.ToList())
+                    db.Entry(hs).State = EntityState.Detached;
+                foreach (HotstringCategory hc in db.HotstringCategories.Local.ToList())
+                    db.Entry(hc).State = EntityState.Detached;
+                foreach (Category cat in db.Categories.Local.ToList())
+                    db.Entry(cat).State = EntityState.Detached;
+                if (pref is not null)
+                    db.Entry(pref).State = EntityState.Detached;
+
+                // The winner may be ListCategoriesQuery, which inserts categories and the pref
+                // row but no hotstrings. In that case, persist the truthful category marker and
+                // retry once so this request can insert the hotstrings against those categories.
+                pref = await db.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
+                if (pref is null)
+                {
+                    pref = UserPreference.CreateDefault(ownerOid, clock);
+                    db.UserPreferences.Add(pref);
+                }
+
+                bool categoriesExist = await db.Categories.AnyAsync(c => c.OwnerOid == ownerOid, ct);
+                bool hotstringsExist = await db.Hotstrings.AnyAsync(h => h.OwnerOid == ownerOid, ct);
+
+                if (pref.CategoriesSeededAt is null && categoriesExist)
+                    pref.MarkCategoriesSeeded(clock);
+                if (pref.HotstringsSeededAt is null && hotstringsExist)
+                    pref.MarkHotstringsSeeded(clock);
+                await db.SaveChangesAsync(ct);
+
+                if (hotstringsExist || attempt == maxAttempts)
+                    return;
+            }
         }
     }
 

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
@@ -339,15 +339,21 @@ internal sealed class ListHotstringsQueryHandler(
             if (pref is not null)
                 db.Entry(pref).State = EntityState.Detached;
 
-            // Reload pref (may have been inserted by the concurrent winner) and set markers.
+            // Reload pref (may have been inserted by the concurrent winner) and mark only the
+            // sets that actually landed. The winner may be the categories seeder
+            // (ListCategoriesQuery), which inserts categories and the pref row but never any
+            // hotstrings; marking hotstrings seeded here would strand the owner on an empty
+            // set that the guard above stops any later request from retrying.
             pref = await db.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == ownerOid, ct);
             if (pref is null)
             {
                 pref = UserPreference.CreateDefault(ownerOid, clock);
                 db.UserPreferences.Add(pref);
             }
-            if (seedingCategories) pref.MarkCategoriesSeeded(clock);
-            pref.MarkHotstringsSeeded(clock);
+            if (pref.CategoriesSeededAt is null && await db.Categories.AnyAsync(c => c.OwnerOid == ownerOid, ct))
+                pref.MarkCategoriesSeeded(clock);
+            if (pref.HotstringsSeededAt is null && await db.Hotstrings.AnyAsync(h => h.OwnerOid == ownerOid, ct))
+                pref.MarkHotstringsSeeded(clock);
             await db.SaveChangesAsync(ct);
         }
     }

--- a/tests/AHKFlowApp.Application.Tests/Dev/RunBeforeNthSaveDbContext.cs
+++ b/tests/AHKFlowApp.Application.Tests/Dev/RunBeforeNthSaveDbContext.cs
@@ -1,0 +1,45 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace AHKFlowApp.Application.Tests.Dev;
+
+// Test decorator: forwards every IAppDbContext member to a real AppDbContext but runs a
+// callback immediately before the Nth SaveChangesAsync. Lets a test commit a competing
+// writer at the exact point a handler is about to save, so the save hits a genuine
+// duplicate-key violation instead of a synthesized exception.
+internal sealed class RunBeforeNthSaveDbContext(AppDbContext inner, int runBeforeCall, Func<Task> beforeSave) : IAppDbContext
+{
+    private int _saveCount;
+
+    public DbSet<Hotstring> Hotstrings => inner.Hotstrings;
+    public DbSet<HotstringProfile> HotstringProfiles => inner.HotstringProfiles;
+    public DbSet<Hotkey> Hotkeys => inner.Hotkeys;
+    public DbSet<HotkeyProfile> HotkeyProfiles => inner.HotkeyProfiles;
+    public DbSet<Profile> Profiles => inner.Profiles;
+    public DbSet<UserPreference> UserPreferences => inner.UserPreferences;
+    public DbSet<Category> Categories => inner.Categories;
+    public DbSet<HotstringCategory> HotstringCategories => inner.HotstringCategories;
+    public DbSet<HotkeyCategory> HotkeyCategories => inner.HotkeyCategories;
+    public DbSet<EntityHistory> EntityHistories => inner.EntityHistories;
+
+    public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        _saveCount++;
+        if (_saveCount == runBeforeCall)
+            await beforeSave();
+        return await inner.SaveChangesAsync(cancellationToken);
+    }
+
+    public EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class
+        => inner.Entry(entity);
+
+    public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+        => inner.BeginTransactionAsync(cancellationToken);
+
+    public IExecutionStrategy CreateExecutionStrategy()
+        => inner.CreateExecutionStrategy();
+}

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysLazySeedTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysLazySeedTests.cs
@@ -1,6 +1,8 @@
 using AHKFlowApp.Application;
 using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Queries.Categories;
 using AHKFlowApp.Application.Queries.Hotkeys;
+using AHKFlowApp.Application.Tests.Dev;
 using AHKFlowApp.Domain.Entities;
 using AHKFlowApp.Infrastructure.Persistence;
 using Ardalis.Result;
@@ -164,5 +166,57 @@ public sealed class ListHotkeysLazySeedTests(HotkeyDbFixture fx)
         int ctrlAltNCount = await verify.Hotkeys
             .CountAsync(h => h.OwnerOid == owner && h.Key == "N" && h.Ctrl && h.Alt && !h.Shift && !h.Win);
         ctrlAltNCount.Should().Be(1);
+    }
+
+    // Regression: the hotkeys page loads categories and hotkeys concurrently, so the categories
+    // seeder can commit the shared UserPreference row and the 8 default categories between this
+    // handler's read and its save. The resulting duplicate-key violation must not be mistaken
+    // for "someone else already seeded the hotkeys".
+    [Fact]
+    public async Task Handle_WhenCategoriesSeederWinsRace_DoesNotMarkHotkeysSeeded()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var racing = new RunBeforeNthSaveDbContext(ctx, 1, async () =>
+        {
+            await using AppDbContext other = fx.CreateContext();
+            var categories = new ListCategoriesQueryHandler(other, CurrentUserHelper.For(owner), _clock);
+            await categories.ExecuteAsync(new ListCategoriesQuery(), CancellationToken.None);
+        });
+        var sut = new ListHotkeysQueryHandler(racing, CurrentUserHelper.For(owner), s_dev, _clock);
+
+        await sut.ExecuteAsync(new ListHotkeysQuery(), CancellationToken.None);
+
+        await using AppDbContext verify = fx.CreateContext();
+        UserPreference? pref = await verify.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == owner);
+
+        // Categories really landed, so that marker is correct; hotkeys did not, so leaving its
+        // marker null is what lets a later request retry.
+        pref!.CategoriesSeededAt.Should().NotBeNull();
+        pref.HotkeysSeededAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_AfterCategoriesSeederWonRace_NextCallSeedsHotkeys()
+    {
+        var owner = Guid.NewGuid();
+        await using (AppDbContext raceCtx = fx.CreateContext())
+        {
+            var racing = new RunBeforeNthSaveDbContext(raceCtx, 1, async () =>
+            {
+                await using AppDbContext other = fx.CreateContext();
+                var categories = new ListCategoriesQueryHandler(other, CurrentUserHelper.For(owner), _clock);
+                await categories.ExecuteAsync(new ListCategoriesQuery(), CancellationToken.None);
+            });
+            var raced = new ListHotkeysQueryHandler(racing, CurrentUserHelper.For(owner), s_dev, _clock);
+            await raced.ExecuteAsync(new ListHotkeysQuery(), CancellationToken.None);
+        }
+
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotkeysQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+        Result<PagedList<HotkeyDto>> result = await sut.ExecuteAsync(new ListHotkeysQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(12);
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysLazySeedTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotkeys/ListHotkeysLazySeedTests.cs
@@ -173,7 +173,7 @@ public sealed class ListHotkeysLazySeedTests(HotkeyDbFixture fx)
     // handler's read and its save. The resulting duplicate-key violation must not be mistaken
     // for "someone else already seeded the hotkeys".
     [Fact]
-    public async Task Handle_WhenCategoriesSeederWinsRace_DoesNotMarkHotkeysSeeded()
+    public async Task Handle_WhenCategoriesSeederWinsRace_RetriesAndReturnsHotkeys()
     {
         var owner = Guid.NewGuid();
         await using AppDbContext ctx = fx.CreateContext();
@@ -185,19 +185,22 @@ public sealed class ListHotkeysLazySeedTests(HotkeyDbFixture fx)
         });
         var sut = new ListHotkeysQueryHandler(racing, CurrentUserHelper.For(owner), s_dev, _clock);
 
-        await sut.ExecuteAsync(new ListHotkeysQuery(), CancellationToken.None);
+        Result<PagedList<HotkeyDto>> result = await sut.ExecuteAsync(
+            new ListHotkeysQuery(), CancellationToken.None);
 
         await using AppDbContext verify = fx.CreateContext();
         UserPreference? pref = await verify.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == owner);
+        int hotkeyCount = await verify.Hotkeys.CountAsync(h => h.OwnerOid == owner);
 
-        // Categories really landed, so that marker is correct; hotkeys did not, so leaving its
-        // marker null is what lets a later request retry.
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(12);
         pref!.CategoriesSeededAt.Should().NotBeNull();
-        pref.HotkeysSeededAt.Should().BeNull();
+        pref.HotkeysSeededAt.Should().NotBeNull();
+        hotkeyCount.Should().Be(12);
     }
 
     [Fact]
-    public async Task Handle_AfterCategoriesSeederWonRace_NextCallSeedsHotkeys()
+    public async Task Handle_AfterCategoriesSeederRace_SecondCallDoesNotDuplicateHotkeys()
     {
         var owner = Guid.NewGuid();
         await using (AppDbContext raceCtx = fx.CreateContext())
@@ -216,7 +219,11 @@ public sealed class ListHotkeysLazySeedTests(HotkeyDbFixture fx)
         var sut = new ListHotkeysQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
         Result<PagedList<HotkeyDto>> result = await sut.ExecuteAsync(new ListHotkeysQuery(), CancellationToken.None);
 
+        await using AppDbContext verify = fx.CreateContext();
+        int hotkeyCount = await verify.Hotkeys.CountAsync(h => h.OwnerOid == owner);
+
         result.IsSuccess.Should().BeTrue();
         result.Value.TotalCount.Should().Be(12);
+        hotkeyCount.Should().Be(12);
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsLazySeedTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsLazySeedTests.cs
@@ -211,7 +211,7 @@ public sealed class ListHotstringsLazySeedTests(HotstringDbFixture fx)
     // between this handler's read and its save. The resulting duplicate-key violation must not
     // be mistaken for "someone else already seeded the hotstrings".
     [Fact]
-    public async Task Handle_WhenCategoriesSeederWinsRace_DoesNotMarkHotstringsSeeded()
+    public async Task Handle_WhenCategoriesSeederWinsRace_RetriesAndReturnsHotstrings()
     {
         var owner = Guid.NewGuid();
         await using AppDbContext ctx = fx.CreateContext();
@@ -223,19 +223,22 @@ public sealed class ListHotstringsLazySeedTests(HotstringDbFixture fx)
         });
         var sut = new ListHotstringsQueryHandler(racing, CurrentUserHelper.For(owner), s_dev, _clock);
 
-        await sut.ExecuteAsync(new ListHotstringsQuery(), CancellationToken.None);
+        Result<PagedList<HotstringDto>> result = await sut.ExecuteAsync(
+            new ListHotstringsQuery(), CancellationToken.None);
 
         await using AppDbContext verify = fx.CreateContext();
         UserPreference? pref = await verify.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == owner);
+        int hotstringCount = await verify.Hotstrings.CountAsync(h => h.OwnerOid == owner);
 
-        // Categories really landed, so that marker is correct; hotstrings did not, so leaving
-        // its marker null is what lets a later request retry.
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(12);
         pref!.CategoriesSeededAt.Should().NotBeNull();
-        pref.HotstringsSeededAt.Should().BeNull();
+        pref.HotstringsSeededAt.Should().NotBeNull();
+        hotstringCount.Should().Be(12);
     }
 
     [Fact]
-    public async Task Handle_AfterCategoriesSeederWonRace_NextCallSeedsHotstrings()
+    public async Task Handle_AfterCategoriesSeederRace_SecondCallDoesNotDuplicateHotstrings()
     {
         var owner = Guid.NewGuid();
         await using (AppDbContext raceCtx = fx.CreateContext())
@@ -254,7 +257,11 @@ public sealed class ListHotstringsLazySeedTests(HotstringDbFixture fx)
         var sut = new ListHotstringsQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
         Result<PagedList<HotstringDto>> result = await sut.ExecuteAsync(new ListHotstringsQuery(), CancellationToken.None);
 
+        await using AppDbContext verify = fx.CreateContext();
+        int hotstringCount = await verify.Hotstrings.CountAsync(h => h.OwnerOid == owner);
+
         result.IsSuccess.Should().BeTrue();
         result.Value.TotalCount.Should().Be(12);
+        hotstringCount.Should().Be(12);
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsLazySeedTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsLazySeedTests.cs
@@ -1,6 +1,8 @@
 using AHKFlowApp.Application;
 using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Queries.Categories;
 using AHKFlowApp.Application.Queries.Hotstrings;
+using AHKFlowApp.Application.Tests.Dev;
 using AHKFlowApp.Domain.Entities;
 using AHKFlowApp.Infrastructure.Persistence;
 using Ardalis.Result;
@@ -202,5 +204,57 @@ public sealed class ListHotstringsLazySeedTests(HotstringDbFixture fx)
         // No duplicate rows — "btw" still exists exactly once
         int btwCount = await verify.Hotstrings.CountAsync(h => h.OwnerOid == owner && h.Trigger == "btw");
         btwCount.Should().Be(1);
+    }
+
+    // Regression: the hotstrings page loads categories and hotstrings concurrently, so the
+    // categories seeder can commit the shared UserPreference row and the 8 default categories
+    // between this handler's read and its save. The resulting duplicate-key violation must not
+    // be mistaken for "someone else already seeded the hotstrings".
+    [Fact]
+    public async Task Handle_WhenCategoriesSeederWinsRace_DoesNotMarkHotstringsSeeded()
+    {
+        var owner = Guid.NewGuid();
+        await using AppDbContext ctx = fx.CreateContext();
+        var racing = new RunBeforeNthSaveDbContext(ctx, 1, async () =>
+        {
+            await using AppDbContext other = fx.CreateContext();
+            var categories = new ListCategoriesQueryHandler(other, CurrentUserHelper.For(owner), _clock);
+            await categories.ExecuteAsync(new ListCategoriesQuery(), CancellationToken.None);
+        });
+        var sut = new ListHotstringsQueryHandler(racing, CurrentUserHelper.For(owner), s_dev, _clock);
+
+        await sut.ExecuteAsync(new ListHotstringsQuery(), CancellationToken.None);
+
+        await using AppDbContext verify = fx.CreateContext();
+        UserPreference? pref = await verify.UserPreferences.FirstOrDefaultAsync(p => p.OwnerOid == owner);
+
+        // Categories really landed, so that marker is correct; hotstrings did not, so leaving
+        // its marker null is what lets a later request retry.
+        pref!.CategoriesSeededAt.Should().NotBeNull();
+        pref.HotstringsSeededAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_AfterCategoriesSeederWonRace_NextCallSeedsHotstrings()
+    {
+        var owner = Guid.NewGuid();
+        await using (AppDbContext raceCtx = fx.CreateContext())
+        {
+            var racing = new RunBeforeNthSaveDbContext(raceCtx, 1, async () =>
+            {
+                await using AppDbContext other = fx.CreateContext();
+                var categories = new ListCategoriesQueryHandler(other, CurrentUserHelper.For(owner), _clock);
+                await categories.ExecuteAsync(new ListCategoriesQuery(), CancellationToken.None);
+            });
+            var raced = new ListHotstringsQueryHandler(racing, CurrentUserHelper.For(owner), s_dev, _clock);
+            await raced.ExecuteAsync(new ListHotstringsQuery(), CancellationToken.None);
+        }
+
+        await using AppDbContext ctx = fx.CreateContext();
+        var sut = new ListHotstringsQueryHandler(ctx, CurrentUserHelper.For(owner), s_dev, _clock);
+        Result<PagedList<HotstringDto>> result = await sut.ExecuteAsync(new ListHotstringsQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.TotalCount.Should().Be(12);
     }
 }


### PR DESCRIPTION
## Problem

A fresh dev database can end up with **zero hotstrings and the seed marked complete**, so the sample set never appears and no later request ever retries.

Reproduced on a clean worktree: `Hotstrings 0 · Categories 8 · HotstringsSeededAt set`.

## Root cause

The hotstrings page loads categories and hotstrings concurrently — `Hotstrings.razor:309` (`OnInitializedAsync`) and the `MudDataGrid` server load are not sequenced with each other. Both endpoints seed lazily and both create the same `UserPreference` row:

- `ListCategoriesQuery.EnsureSeededOnceAsync` — inserts 8 categories + the pref row
- `ListHotstringsQuery.EnsureHotstringsSeededAsync` — inserts categories *and* 12 hotstrings + the pref row

Race:

1. Hotstrings handler reads pref as `null`, so `seedingCategories = true`; queues categories + 12 hotstrings + a pref row.
2. Categories handler commits first.
3. Hotstrings handler's save hits a duplicate key.
4. The catch block detached every pending row — including all 12 hotstrings — then called `MarkHotstringsSeeded` regardless.

The guard `if (pref?.HotstringsSeededAt is not null) return;` then short-circuits every future request. Empty state becomes permanent.

The catch block assumed a duplicate key means "a concurrent winner already inserted the hotstrings." When the winner is the *categories* seeder, nobody did.

`ListHotkeysQuery` had the identical defect on the same code path — the hotkeys page loads categories the same way.

## Fix

Mark each set only when its rows actually exist. Leaving the marker null lets a later request retry; by then categories exist, so `seedingCategories` is false and the retry inserts with nothing to collide against.

## Tests

New `RunBeforeNthSaveDbContext` (mirrors the existing `ThrowOnNthSaveDbContext`) runs a callback immediately before the Nth save, committing the real `ListCategoriesQueryHandler` at the exact moment the list seeder is about to save — a genuine duplicate-key violation, not a synthesized exception.

Four regression tests, two per entity: the racing call must not set the marker, and the next call must seed all 12.

Verified they catch the bug — with the fix stashed out, all 4 fail with `Expected result.Value.TotalCount to be 12, but found 0`.

Application 946 passed · API 169 passed · `dotnet format --verify-no-changes` clean.

## Note for existing dev databases

This prevents new occurrences but does not repair a marker already set. Any dev DB where the hotstrings or hotkeys page was opened before this fix stays empty until cleared:

```sql
UPDATE UserPreferences SET HotstringsSeededAt = NULL WHERE OwnerOid = '<oid>';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
