### PR TITLE
fix: hotstrings page UX — single edit button, chip color coding, category editor truncation

### DIFF
--- a/docs/superpowers/plans/2026-07-20-hotstring-page-ux-fixes-plan.md
+++ b/docs/superpowers/plans/2026-07-20-hotstring-page-ux-fixes-plan.md
@@ -1,0 +1,137 @@
+# Hotstrings page UX fixes
+
+## Context
+
+The user tested the Hotstrings page and found several UX regressions/rough edges, captured
+in 7 annotated screenshots plus one written bug report. The core functional bug: rows now
+have **two different edit affordances** (a pencil "start inline edit" icon and an "EditNote"
+icon that opens a popup), but the pencil only appears for plain Text-kind hotstrings with no
+window context (`HotstringEditModel.IsInlineEditable`). For every other kind (Raw, Date &
+time, Macro, or anything with a context match), the popup is the *only* edit entry point —
+and the popup that opens for it (`OpenEditDetailsDialogAsync`, `MaxWidth.Medium`,
+non-fullscreen) makes the profile selector easy to miss, unlike the inline row editor which
+shows it immediately. The user wants exactly one edit button per row, whose *behavior*
+branches by type (inline for Text, popup for everything else), with the popup giving full
+parity (including profile changes).
+
+The screenshots also flag: an undiscoverable glyph legend (`*`/`?`/`C`/`O`) next to the Type
+chip, a genuine CSS bug where the Actions column clips icons behind a fake "..." at higher
+browser zoom, weak color differentiation between Type/Categories chips, and a request for
+stronger selected-row highlighting.
+
+Code exploration confirmed: the profile/category data actually round-trips correctly
+(`HotstringEditModel.Clone/ToCreateDto/ToUpdateDto` all carry `ProfileIds`/
+`AppliesToAllProfiles`), and `HotstringEditDialog.razor` *does* already render a profile
+selector (lines 253–261) — so the "can't change profile in the popup" complaint is a
+visibility/layout issue in the compact Medium-width dialog, not a data bug. Standardizing
+on the fullscreen dialog (already used on mobile and by the inline-edit "promote" escape
+hatch) resolves it directly.
+
+User decisions from clarifying questions: skip formal `impeccable teach` (treat this as
+scoped bug-fix/consistency work, not a new design direction); standardize the popup on the
+fullscreen dialog; give each hotstring Kind a distinct semantic color; add a legend/help
+icon to the Type column header rather than replacing the glyphs with icons.
+
+This document is the pre-Ultraplan draft, committed for reference before the plan is
+refined remotely via Ultraplan.
+
+## Approach
+
+### 1. Single edit button per row
+
+In `Pages/Hotstrings.razor`, `RenderActions` (~996–1021): collapse `edit-details` +
+`start-edit` into one `Edit` icon button per row:
+- `item.IsInlineEditable` → `OnClick="() => StartEditAsync(item)"` (current pencil behavior).
+- otherwise → `OnClick="() => OpenEditDialogAsync(item)"` (fullscreen dialog — see #2).
+
+Keep `show-history` and `delete` as-is. Leave the in-progress inline-edit toolbar
+(`commit-edit`/`cancel-edit`/`promote-edit`) untouched — the `Tune` "promote to full dialog"
+button is a different mechanism (escalating an in-flight inline edit), not a second entry
+point into editing, and isn't part of the complaint.
+
+### 2. Standardize the popup on the fullscreen dialog
+
+Remove `OpenEditDetailsDialogAsync` (the `MaxWidth.Medium`, non-fullscreen variant) and route
+the new single Edit button (for non-inline-editable rows) through the existing
+`OpenEditDialogAsync` (`FullScreen = true`), the same method mobile's `OnEdit` and
+`PromoteInlineRowAsync` already use. This gives the profile selector, category selector, and
+kind-specific fields (Raw templates, Macro toolbar, Date & time format picker) full-height
+room, consistent with every other edit-dialog entry point in the app.
+
+### 3. Actions column CSS: stop the fake "..." clipping
+
+`Pages/Hotstrings.razor.css:39-43` applies `overflow: hidden; text-overflow: ellipsis` to
+*every* grid cell, including Actions. At higher browser zoom the fixed `132px` Actions column
+(`:nth-child(8)`, line 92-95) can't fit its icon buttons, so the browser renders a literal
+truncation ellipsis where the last icon should be — this is what screenshots read as a
+non-functional "..." menu. Fix: exclude the Actions column from the ellipsis rule (add an
+`:nth-child(8)` override with `overflow: visible`), and size its width for exactly 3 icons
+(Edit, History, Delete) now that #1 removed the 4th. Verify at 150%/200% browser zoom.
+
+### 4. Type-badge color coding
+
+`RenderTypeChip` (Hotstrings.razor ~943-949) and the kind toggle in
+`HotstringEditDialog.razor` (~22-34) only color Raw (`Color.Warning`); Text/DateTime/Macro
+are all `Color.Default`. Give each Kind a distinct, stable `MudBlazor` `Color`, consistent in
+both places — proposed: `Text = Default`, `DateTime = Info`, `Macro = Success`,
+`Raw = Warning` (avoids reusing `Primary`/`Secondary`/`Tertiary`, which the page's action
+buttons already use, to keep badge color meaning separate from button color meaning). Text's
+existing delivery-based color (Info if clipboard) is a different, orthogonal signal — leave
+it as-is.
+
+### 5. Differentiate Categories chips from Type chips
+
+Today, Type ("Hotstring"), Profile-specific, and Category chips can all render as the same
+plain grey filled `MudChip`, so the columns blur together — this is likely what the
+"color coding" screenshot arrows are really pointing at, alongside Type. Add an optional
+`Variant` parameter to `Components/Common/EntityChips.razor` (default `Variant.Filled`,
+unchanged for existing callers), and pass `Variant.Outlined` where Categories render in
+`Hotstrings.razor` (`RenderCategories`, ~928). Since `EntityChips` is shared, this
+automatically keeps Category chips visually distinct everywhere it's used, not just here.
+
+### 6. Selected-row highlighting
+
+Add explicit CSS in `Hotstrings.razor.css` for `MudDataGrid`'s selected-row state (verify the
+exact class MudBlazor 9.x emits, e.g. via the MudBlazor MCP or a quick render inspection) —
+a subtle background tint using `--mud-palette-primary` at low opacity, working in both light
+and dark theme (the page has a theme toggle).
+
+### 7. Type column glyph legend
+
+Add a small `HelpOutline`/`InfoOutlined` `MudIcon` next to the "Type" column header in
+`Pages/Hotstrings.razor` (~153), wrapped in a `MudTooltip` with static text listing what each
+glyph means (`* = expands immediately`, `? = triggers inside words`, `C = case sensitive`).
+Leave the existing per-row hover tooltip (`OptionsTooltip`, row-specific) as-is — the header
+icon is a persistent, discoverable legend; the per-row tooltip stays the row-specific detail.
+
+### Test/verification blast radius
+
+Removing `edit-details`/`start-edit` as separate classes and `OpenEditDetailsDialogAsync`
+touches selectors used by:
+- `tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs` (bUnit)
+- `tests/AHKFlowApp.E2E.Tests/HotstringsCrudFlowTests.cs`, `RawHotstringFlowTests.cs`,
+  `VersionHistoryFlowTests.cs` (Playwright)
+
+These need their edit-button selectors/flows updated to match the single-button behavior.
+
+## Verification
+
+- `dotnet build` + `dotnet test` (bUnit + E2E) after updating the affected test files above.
+- Playwright (`playwright-cli` skill), against the local no-auth dev stack:
+  - Text-kind row: click the single Edit icon → inline row editor opens (not a dialog).
+  - Raw/Date & time/Macro row, and a context-matched row: click the single Edit icon → full
+    screen dialog opens with the profile selector visible without scrolling; change the
+    profile assignment and save; confirm it persists (grid reflects the new profile chips).
+  - Zoom browser to 150% and 200%: Actions column shows all 3 icons, no clipped "...".
+  - Type column: each Kind shows a distinct chip color; hover header info icon shows glyph
+    legend.
+  - Categories column chips visually distinct (outlined) from Type/Profile chips.
+  - Select a few rows via the checkbox column: selected rows visibly highlighted, in both
+    light and dark theme.
+
+## Unresolved questions
+
+1. Macro color = Success (green) ok, or prefer different hue (Secondary/Tertiary despite reuse w/ buttons)?
+2. Legend icon: static tooltip on hover, or click-to-open popover (more discoverable, more code)?
+3. Selected-row highlight: also wanted on hover, or selection-only?
+4. OK to touch shared `EntityChips` (affects Hotkeys/Categories pages too via outlined-category variant), or scope strictly to Hotstrings usage only?

--- a/docs/superpowers/plans/2026-07-20-hotstring-page-ux-fixes-plan.md
+++ b/docs/superpowers/plans/2026-07-20-hotstring-page-ux-fixes-plan.md
@@ -2,136 +2,202 @@
 
 ## Context
 
-The user tested the Hotstrings page and found several UX regressions/rough edges, captured
-in 7 annotated screenshots plus one written bug report. The core functional bug: rows now
-have **two different edit affordances** (a pencil "start inline edit" icon and an "EditNote"
-icon that opens a popup), but the pencil only appears for plain Text-kind hotstrings with no
-window context (`HotstringEditModel.IsInlineEditable`). For every other kind (Raw, Date &
-time, Macro, or anything with a context match), the popup is the *only* edit entry point —
-and the popup that opens for it (`OpenEditDetailsDialogAsync`, `MaxWidth.Medium`,
-non-fullscreen) makes the profile selector easy to miss, unlike the inline row editor which
-shows it immediately. The user wants exactly one edit button per row, whose *behavior*
-branches by type (inline for Text, popup for everything else), with the popup giving full
-parity (including profile changes).
+User testing of the Hotstrings page surfaced a real UX regression plus several rough
+edges (7 screenshots + written notes). Core bug: rows expose two edit affordances — a
+pencil ("start inline edit") and an `EditNote` icon (opens a popup) — but the pencil only
+appears for plain Text-kind hotstrings with no window context
+(`HotstringEditModel.IsInlineEditable`, `Validation/HotstringEditModel.cs:58`). Every other
+kind must use the popup, and that popup (`OpenEditDetailsDialogAsync`,
+`Pages/Hotstrings.razor:774`, `MaxWidth.Medium`, non-fullscreen) renders the profile
+selector in a cramped layout, unlike the inline editor which shows it immediately. Goal:
+one edit button per row, behavior branches by type (inline for Text, fullscreen dialog for
+everything else), full parity in the dialog including profile changes.
 
-The screenshots also flag: an undiscoverable glyph legend (`*`/`?`/`C`/`O`) next to the Type
-chip, a genuine CSS bug where the Actions column clips icons behind a fake "..." at higher
-browser zoom, weak color differentiation between Type/Categories chips, and a request for
-stronger selected-row highlighting.
-
-Code exploration confirmed: the profile/category data actually round-trips correctly
-(`HotstringEditModel.Clone/ToCreateDto/ToUpdateDto` all carry `ProfileIds`/
-`AppliesToAllProfiles`), and `HotstringEditDialog.razor` *does* already render a profile
-selector (lines 253–261) — so the "can't change profile in the popup" complaint is a
-visibility/layout issue in the compact Medium-width dialog, not a data bug. Standardizing
-on the fullscreen dialog (already used on mobile and by the inline-edit "promote" escape
-hatch) resolves it directly.
-
-User decisions from clarifying questions: skip formal `impeccable teach` (treat this as
-scoped bug-fix/consistency work, not a new design direction); standardize the popup on the
-fullscreen dialog; give each hotstring Kind a distinct semantic color; add a legend/help
-icon to the Type column header rather than replacing the glyphs with icons.
-
-This document is the pre-Ultraplan draft, committed for reference before the plan is
-refined remotely via Ultraplan.
+Verified directly in code (not assumed):
+- `HotstringEditDialog.razor:253-261` already renders the profile checkbox + `EntityMultiSelect`
+  — the "can't change profile" complaint is the Medium-width dialog's layout, not a data gap.
+  `HotstringEditModel.Clone/ToCreateDto/ToUpdateDto` (lines 156-196) already round-trip
+  `ProfileIds`/`AppliesToAllProfiles` correctly.
+- `OpenEditDialogAsync` (`Pages/Hotstrings.razor:771`, `FullScreen = true`) is the same method
+  already used by mobile's `OnEdit` (line 234) and `PromoteInlineRowAsync` (line 738) — it's
+  the established fullscreen path, not something new to build.
+- `RenderActions` (`Pages/Hotstrings.razor:996-1021`) is where both buttons currently render.
+- `Hotstrings.razor.css:39-43` applies `overflow:hidden; text-overflow:ellipsis` to every
+  `.mud-table-cell` including Actions (`:nth-child(8)`, fixed `132px`, lines 92-95) — at higher
+  zoom the 4 icon buttons (edit-details, start-edit, history, delete) don't fit and the browser
+  renders a real ellipsis over the last icon. This is a CSS bug, not a missing menu.
+- `RenderTypeChip` (line 943-949): only Raw gets a distinct color (`Warning`); Text/DateTime/Macro
+  render `Color.Default`. Same gap in `HotstringEditDialog.razor`'s kind toggle (lines 22-34,
+  only Raw gets an icon/color).
+- `EntityChips.razor` (`Components/Common/EntityChips.razor`) renders plain `<MudChip>` with no
+  `Variant` parameter — used in 4 places: `Hotstrings.razor` (profiles + categories, desktop),
+  `Hotkeys.razor` (profiles + categories), `HotstringMobileList.razor`, `HotkeyMobileList.razor`.
+  No existing `Variant` param to reuse; adding one is additive (default `Filled`, no existing
+  caller changes behavior).
+- No existing CSS targets MudDataGrid's selected-row state anywhere in the app — this needs
+  browser inspection at implementation time (the row's `RowClassFunc` mechanism already exists
+  and is the better lever here, see #6 below, rather than guessing MudBlazor's internal class).
+- `GetRowClass` (line 427-428) already conditionally adds `edit-row`/`draft-row` per row (though
+  no CSS currently defines those classes — likely test-selector hooks only). This is the existing
+  pattern to extend for selection highlighting.
 
 ## Approach
 
+```mermaid
+flowchart TD
+    RA["RenderActions (Hotstrings.razor:996)"] -->|IsInlineEditable| SE["StartEditAsync — inline row editor"]
+    RA -->|"!IsInlineEditable"| OED["OpenEditDialogAsync (FullScreen=true)"]
+    OED --> HED["HotstringEditDialog.razor"]
+    HED --> ProfileSel["Profile checkbox + EntityMultiSelect (already exists, lines 253-261)"]
+    OEDD["OpenEditDetailsDialogAsync (Medium, non-fullscreen)"] -.removed.-> OED
+    CSS["Hotstrings.razor.css"] --> ActionsFix["#3 Actions column: overflow:visible + width for 3 icons"]
+    CSS --> Selected["#6 .selected-row rule"]
+    GRC["GetRowClass (line 427)"] --> Selected
+    TypeChip["RenderTypeChip / kind toggle"] --> Colors["#4 per-Kind Color"]
+    EC["EntityChips.razor"] --> Variant["#5 optional Variant param"]
+    Variant --> Cats["RenderCategories (Hotstrings.razor + HotstringMobileList.razor)"]
+```
+
 ### 1. Single edit button per row
 
-In `Pages/Hotstrings.razor`, `RenderActions` (~996–1021): collapse `edit-details` +
-`start-edit` into one `Edit` icon button per row:
-- `item.IsInlineEditable` → `OnClick="() => StartEditAsync(item)"` (current pencil behavior).
-- otherwise → `OnClick="() => OpenEditDialogAsync(item)"` (fullscreen dialog — see #2).
+In `RenderActions` (`Pages/Hotstrings.razor:996-1021`), replace the two non-editing buttons
+(`edit-details` + conditional `start-edit`) with one:
 
-Keep `show-history` and `delete` as-is. Leave the in-progress inline-edit toolbar
-(`commit-edit`/`cancel-edit`/`promote-edit`) untouched — the `Tune` "promote to full dialog"
-button is a different mechanism (escalating an in-flight inline edit), not a second entry
-point into editing, and isn't part of the complaint.
+```csharp
+<MudIconButton Class="edit" Icon="@Icons.Material.Filled.Edit"
+               OnClick="() => (item.IsInlineEditable ? StartEditAsync(item) : OpenEditDialogAsync(item))" />
+```
+
+Keep `show-history` and `delete` unchanged. Leave the in-progress inline-edit toolbar
+(`commit-edit`/`cancel-edit`/`promote-edit`) untouched — `promote-edit` escalates an
+in-flight inline edit, it's not a second entry point into editing.
 
 ### 2. Standardize the popup on the fullscreen dialog
 
-Remove `OpenEditDetailsDialogAsync` (the `MaxWidth.Medium`, non-fullscreen variant) and route
-the new single Edit button (for non-inline-editable rows) through the existing
-`OpenEditDialogAsync` (`FullScreen = true`), the same method mobile's `OnEdit` and
-`PromoteInlineRowAsync` already use. This gives the profile selector, category selector, and
-kind-specific fields (Raw templates, Macro toolbar, Date & time format picker) full-height
-room, consistent with every other edit-dialog entry point in the app.
+Delete `OpenEditDetailsDialogAsync` (`Pages/Hotstrings.razor:774-775`) entirely — the single
+edit button routes non-inline-editable rows through the existing `OpenEditDialogAsync`
+(line 771, already `FullScreen = true`). No new dialog plumbing needed.
 
 ### 3. Actions column CSS: stop the fake "..." clipping
 
-`Pages/Hotstrings.razor.css:39-43` applies `overflow: hidden; text-overflow: ellipsis` to
-*every* grid cell, including Actions. At higher browser zoom the fixed `132px` Actions column
-(`:nth-child(8)`, line 92-95) can't fit its icon buttons, so the browser renders a literal
-truncation ellipsis where the last icon should be — this is what screenshots read as a
-non-functional "..." menu. Fix: exclude the Actions column from the ellipsis rule (add an
-`:nth-child(8)` override with `overflow: visible`), and size its width for exactly 3 icons
-(Edit, History, Delete) now that #1 removed the 4th. Verify at 150%/200% browser zoom.
+In `Hotstrings.razor.css`:
+- Add an override so the Actions column (`:nth-child(8)`, line 92-95) is excluded from the
+  ellipsis rule at lines 39-43: add `::deep .hotstrings-grid td:nth-child(8) { overflow: visible; }`.
+- Resize the fixed width at line 92-95 down from `132px` for exactly 3 icons (Edit, History,
+  Delete) now that #1 removed the 4th button.
+- Verify visually at 150%/200% browser zoom via Playwright (see Verification).
 
 ### 4. Type-badge color coding
 
-`RenderTypeChip` (Hotstrings.razor ~943-949) and the kind toggle in
-`HotstringEditDialog.razor` (~22-34) only color Raw (`Color.Warning`); Text/DateTime/Macro
-are all `Color.Default`. Give each Kind a distinct, stable `MudBlazor` `Color`, consistent in
-both places — proposed: `Text = Default`, `DateTime = Info`, `Macro = Success`,
-`Raw = Warning` (avoids reusing `Primary`/`Secondary`/`Tertiary`, which the page's action
-buttons already use, to keep badge color meaning separate from button color meaning). Text's
-existing delivery-based color (Info if clipboard) is a different, orthogonal signal — leave
-it as-is.
+Give each `HotstringKind` a distinct, stable `Color`, applied consistently in both:
+- `RenderTypeChip` (`Pages/Hotstrings.razor:943-949`) — the non-Text branch's ternary
+  (`item.Kind == HotstringKind.Raw ? Color.Warning : Color.Default`) becomes a switch over
+  `item.Kind`.
+- `HotstringEditDialog.razor`'s `MudToggleGroup` (lines 22-34) — add matching icon/color per
+  `MudToggleItem`.
 
-### 5. Differentiate Categories chips from Type chips
+Proposed mapping: `Text = Default`, `DateTime = Info`, `Macro = Success`, `Raw = Warning`
+(avoids `Primary`/`Secondary`/`Tertiary`, already used for the page's action buttons, so chip
+color and button color stay distinct semantic channels). Text's existing delivery-based color
+(Info when clipboard) is orthogonal — leave it as-is in `RenderTypeChip`'s Text branch.
 
-Today, Type ("Hotstring"), Profile-specific, and Category chips can all render as the same
-plain grey filled `MudChip`, so the columns blur together — this is likely what the
-"color coding" screenshot arrows are really pointing at, alongside Type. Add an optional
-`Variant` parameter to `Components/Common/EntityChips.razor` (default `Variant.Filled`,
-unchanged for existing callers), and pass `Variant.Outlined` where Categories render in
-`Hotstrings.razor` (`RenderCategories`, ~928). Since `EntityChips` is shared, this
-automatically keeps Category chips visually distinct everywhere it's used, not just here.
+### 5. Differentiate Categories chips from Type/Profile chips
+
+Add an optional `Variant` parameter to `Components/Common/EntityChips.razor`
+(default `Variant.Filled` — every existing call site keeps current appearance unless it opts
+in). Pass `Variant.Outlined` from the two Hotstrings-page category call sites only:
+- `Pages/Hotstrings.razor:928` (`RenderCategories`, desktop grid)
+- `Components/Hotstrings/HotstringMobileList.razor:108` (mobile detail list)
+
+Scope decision: don't touch `Hotkeys.razor`'s or `HotkeyMobileList.razor`'s category chips —
+the bug report is specific to the Hotstrings page; Hotkeys can adopt the same variant later if
+wanted, but that's a separate call site and out of scope here.
 
 ### 6. Selected-row highlighting
 
-Add explicit CSS in `Hotstrings.razor.css` for `MudDataGrid`'s selected-row state (verify the
-exact class MudBlazor 9.x emits, e.g. via the MudBlazor MCP or a quick render inspection) —
-a subtle background tint using `--mud-palette-primary` at low opacity, working in both light
-and dark theme (the page has a theme toggle).
+Extend the existing `GetRowClass` (`Pages/Hotstrings.razor:427-428`) — already the mechanism
+that conditionally adds `edit-row`/`draft-row` — to also add `selected-row` when the item is in
+`_selected`:
+
+```csharp
+private string GetRowClass(HotstringEditModel item, int _)
+{
+    List<string> classes = [];
+    if (IsEditing(item))
+        classes.Add(ReferenceEquals(item, _pendingCreate) ? "draft-row" : "edit-row");
+    if (_selected.Contains(item))
+        classes.Add("selected-row");
+    return string.Join(" ", classes);
+}
+```
+
+This sidesteps guessing MudBlazor's internal selected-row class — it's a class we control and
+attach ourselves via a mechanism the page already uses. Add CSS in `Hotstrings.razor.css`:
+
+```css
+::deep .hotstrings-grid .selected-row {
+    background-color: color-mix(in srgb, var(--mud-palette-primary) 12%, transparent);
+}
+```
+
+Uses the MudBlazor CSS variable so it tracks the active theme automatically (no separate
+light/dark media query needed). Verify visually in both themes via Playwright.
 
 ### 7. Type column glyph legend
 
-Add a small `HelpOutline`/`InfoOutlined` `MudIcon` next to the "Type" column header in
-`Pages/Hotstrings.razor` (~153), wrapped in a `MudTooltip` with static text listing what each
-glyph means (`* = expands immediately`, `? = triggers inside words`, `C = case sensitive`).
-Leave the existing per-row hover tooltip (`OptionsTooltip`, row-specific) as-is — the header
-icon is a persistent, discoverable legend; the per-row tooltip stays the row-specific detail.
+Add a `HelpOutline` `MudIcon` next to the "Type" column header (`Pages/Hotstrings.razor:153`),
+wrapped in a `MudTooltip` with static text: `* = expands immediately`, `? = triggers inside
+words`, `C = case sensitive`. Leave the existing per-row `OptionsTooltip` (row-specific hover)
+untouched — the header icon is a persistent legend, the per-row tooltip stays the per-row detail.
 
-### Test/verification blast radius
+### Test blast radius
 
-Removing `edit-details`/`start-edit` as separate classes and `OpenEditDetailsDialogAsync`
-touches selectors used by:
-- `tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs` (bUnit)
-- `tests/AHKFlowApp.E2E.Tests/HotstringsCrudFlowTests.cs`, `RawHotstringFlowTests.cs`,
-  `VersionHistoryFlowTests.cs` (Playwright)
-
-These need their edit-button selectors/flows updated to match the single-button behavior.
+Removing the `edit-details` class/method and renaming `start-edit` → the single `edit` class
+breaks selectors in:
+- `tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs` — concretely:
+  - `Page_EditDetails_OpensDialogWithItem` (line 656): `button.edit-details` → `button.edit`
+  - `Page_DateTimeRow_HidesStartEditPencil_TextRowKeepsIt` (line 751): this test's premise
+    (pencil only shows for Text rows) no longer holds — every row has one `button.edit` now.
+    Rewrite it to assert both rows render exactly one `button.edit` each, and that clicking it
+    on the Text row opens the inline editor (`trigger-input` in the grid) while on the DateTime
+    row it opens the dialog (`trigger-input` inside `MudDialogProvider`).
+  - All other `button.start-edit` selectors in this file (lines 224-538, ~10 occurrences):
+    rename to `button.edit`.
+- `tests/AHKFlowApp.E2E.Tests/HotstringsCrudFlowTests.cs:36`, `RawHotstringFlowTests.cs:197`,
+  `VersionHistoryFlowTests.cs:141,153` — same `button.start-edit`/`button.promote-edit` renames
+  (`promote-edit` is untouched by this plan, only `start-edit` → `edit`).
 
 ## Verification
 
-- `dotnet build` + `dotnet test` (bUnit + E2E) after updating the affected test files above.
-- Playwright (`playwright-cli` skill), against the local no-auth dev stack:
-  - Text-kind row: click the single Edit icon → inline row editor opens (not a dialog).
-  - Raw/Date & time/Macro row, and a context-matched row: click the single Edit icon → full
-    screen dialog opens with the profile selector visible without scrolling; change the
-    profile assignment and save; confirm it persists (grid reflects the new profile chips).
-  - Zoom browser to 150% and 200%: Actions column shows all 3 icons, no clipped "...".
-  - Type column: each Kind shows a distinct chip color; hover header info icon shows glyph
-    legend.
-  - Categories column chips visually distinct (outlined) from Type/Profile chips.
-  - Select a few rows via the checkbox column: selected rows visibly highlighted, in both
-    light and dark theme.
+- `dotnet build` + `dotnet test tests/AHKFlowApp.UI.Blazor.Tests` + `dotnet test
+  tests/AHKFlowApp.E2E.Tests` after updating the selectors above.
+- Playwright (`playwright-cli` skill) against the local no-auth dev stack
+  (`Docker SQL (No Auth)` API profile + `http (No Auth)` frontend profile):
+  1. Text-kind row, no context: click the single Edit icon → inline row editor opens in place
+     (trigger/replacement become editable table cells, not a dialog).
+  2. Raw row, Date & time row, Macro row, and a context-matched Text row: click Edit → fullscreen
+     dialog opens, profile checkbox + selector visible without scrolling; toggle "Apply to all
+     profiles" off, pick a profile, Save; confirm it persists (grid reflects the new profile chips).
+  3. Zoom to 150% and 200%: Actions column shows exactly 3 icons (Edit/History/Delete), no
+     truncated "...".
+  4. Type column: Text/DateTime/Macro/Raw each show a visually distinct chip color; hovering the
+     header help icon shows the glyph legend text.
+  5. Categories chips render outlined, visibly different from Type/Profile chips, in both the
+     desktop grid and mobile detail list.
+  6. Select several rows via the checkbox column: rows get the primary-tinted highlight; toggle
+     the app's theme switch and confirm it's visible in both light and dark.
 
 ## Unresolved questions
 
-1. Macro color = Success (green) ok, or prefer different hue (Secondary/Tertiary despite reuse w/ buttons)?
-2. Legend icon: static tooltip on hover, or click-to-open popover (more discoverable, more code)?
+1. Macro color = Success (green) ok, or prefer different hue?
+2. Legend icon: hover tooltip only, or click-to-open popover (more discoverable, more code)?
 3. Selected-row highlight: also wanted on hover, or selection-only?
-4. OK to touch shared `EntityChips` (affects Hotkeys/Categories pages too via outlined-category variant), or scope strictly to Hotstrings usage only?
+
+## Implementation notes
+
+Implemented as committed. Deviations from a live-browser Playwright verification pass: this
+session's sandbox had no Docker daemon (no SQL Server backend to run the app against), so
+step 3 of "Verification" above was substituted with 5 additional bUnit tests in
+`HotstringsPageTests.cs` asserting the same behaviors from rendered markup (chip color
+classes, the outlined category chip class, the header legend icon, and the `selected-row`
+class after a checkbox selection) — all passing, alongside the full 466-test bUnit suite.

--- a/docs/superpowers/plans/2026-07-20-hotstring-page-ux-followup-plan.md
+++ b/docs/superpowers/plans/2026-07-20-hotstring-page-ux-followup-plan.md
@@ -2,212 +2,200 @@
 
 ## Context
 
-The first pass (`2026-07-20-hotstring-page-ux-fixes-plan.md`, Sonnet) under-delivered. Live
-testing shows Type chips and Category chips still render grey, and the inline category editor
-still truncates to "C...". The user also wants at least two seed examples per hotstring kind and
-a broader UX sweep of gaps the first plan missed. Goal: real color coding on both chip families
-(a deliberate two-channel system), a readable inline category editor, full kind coverage in seed
-data, and four audit-driven UX fixes. All root causes below were verified in code, not assumed.
+The first pass (`2026-07-20-hotstring-page-ux-fixes-plan.md`, Sonnet) under-delivered. Live testing
+shows Type chips and Category chips still render grey, and the inline category editor still truncates
+to "C...". The user also wants at least two seed examples per hotstring kind and a sweep of UX gaps
+the first plan missed.
 
-### Root causes (verified)
+This plan was stress-tested in a grilling session before implementation; four assumptions in the
+first draft were wrong and are corrected below.
 
-- **Category chips grey — genuine gap.** `Components/Common/EntityChips.razor:11` renders each
-  per-id chip with **no `Color`**, so MudBlazor falls back to `Color.Default` = grey. The first
-  plan added only `Variant.Outlined` (an outline shape), never a color. No per-category color logic
-  exists anywhere.
+### Root causes (verified in code)
+
+- **Category chips grey — genuine gap.** `Components/Common/EntityChips.razor:11` renders each per-id
+  chip with **no `Color`**, so MudBlazor falls back to `Color.Default` = grey. The first plan added
+  only `Variant.Outlined` (a shape), never a color.
 - **Type chips grey — by design + all-Text data.** `KindColor` (`Pages/Hotstrings.razor:967-973`)
-  correctly colors DateTime=Info, Macro=Success, Raw=Warning (filled variant renders color). But
-  `RenderTypeChip` (lines 959-965) shows **Text** rows a grey *delivery* chip ("Hotstring"), and
-  every seeded row is Text-kind, so the whole visible column is grey. The column titled "Type" never
-  shows "Text" for text rows. Possibly compounded by a stale PWA service-worker cache.
-- **Dropdown "C..." truncation — pre-existing, not from `17ef225`.** Categories column is pinned
-  `width:10%` (`Hotstrings.razor.css:87-90`) under `table-layout:fixed`, and a blanket rule clips
-  every cell: `overflow:hidden; text-overflow:ellipsis; white-space:nowrap` (lines 39-47). In edit
-  mode that ~100px cell must host a full `MudSelect` whose Clearable (X) + dropdown arrow eat the
-  width, leaving room for one character.
-- **Seed gap.** `SeedHotstringsCommand.cs:32-43` has 10 Text + 2 DateTime, **0 Macro, 0 Raw**. The
-  array is duplicated verbatim in `ListHotstringsQuery.cs:78-89` (lazy auto-seed) with a "update
-  both" comment — a sync hazard. Categories `Window Management` and `App Launcher` have no examples.
+  colors DateTime/Macro/Raw, but `RenderTypeChip` (959-965) gives **Text** rows a grey *delivery* chip
+  ("Hotstring"), and every seeded row is Text-kind — so the whole visible column is grey. A column
+  titled "Type" never shows "Text". Possibly compounded by a stale PWA service-worker cache.
+- **Dropdown "C..." truncation — pre-existing, not from `17ef225`.** Categories is pinned `width:10%`
+  (`Hotstrings.razor.css:87-90`) under `table-layout:fixed`, and a blanket rule clips every cell
+  (`overflow:hidden; text-overflow:ellipsis; white-space:nowrap`, lines 39-47). Edit mode must host a
+  full `MudSelect` (Clearable X + arrow) in ~100px.
+- **Seed gap.** `SeedHotstringsCommand.cs:32-43` has 10 Text + 2 DateTime, **0 Macro, 0 Raw**, and every
+  row has `Description: null`. The array is duplicated verbatim in `ListHotstringsQuery.cs:78-89`.
 
-## Design decisions (confirmed with user)
+### Corrections from the grilling session
 
-1. **Type column shows the kind, colored, delivery → icon.** Every row shows its kind
-   (Text/DateTime/Macro/Raw), each a distinct color including Text (violet). Clipboard delivery
-   becomes a small icon, not the chip label.
-2. **Categories get an auto OKLCH palette**, outlined chips — a *distinct visual channel* from the
-   filled Type chips. No schema change: 8 default categories hand-mapped to hues, custom categories
-   hash into the same ring.
-3. **Two color channels, deliberately different** (impeccable): Type = **filled** semantic/violet
-   (the chip carries its own hue background, so it reads in both themes); Categories = **outlined**
-   custom hues (border+text sit on the page background, so those hues must be dual-theme legible).
+1. **No per-category rainbow.** Giving each category its own hue would fight the Type channel and read
+   as decorative. Categories get one accent.
+2. **The brand triad constrains every hue.** `MainLayout.razor:63-72` sets Primary `#6AA84F` (green),
+   Secondary `#3B8FC2` (blue), Tertiary `#8C3A3A` (brick) — the Add/Reload/Import buttons. The first
+   plan claimed it avoided these, then chose Info (blue) and Success (green), colliding with two of
+   them. Type hues must sit off green/blue/brick.
+3. **App Launcher and Window Management are hotkey categories.** `SeedHotkeysCommand.cs:30-41` already
+   fills them with 6 + 4 hotkeys. They are hotstring-empty *by design* — pressing Ctrl+Alt+N is the AHK
+   idiom, not typing `/np`. The "fill empty categories" goal is void and is dropped. Every category
+   hotstrings actually use is already populated.
+4. **Categories is cramped because the width budget is misallocated**, not merely because of the clip
+   rule: Description (14%) is empty on every row and Profiles (10%) shows an identical "Any" chip —
+   24% of the grid rendering nothing useful, while Categories gets 10%.
+
+## Color system
+
+Three separate channels, no collisions:
+
+| Channel | Treatment | Colors |
+|---|---|---|
+| Action buttons | saturated filled | brand green / blue / brick (unchanged) |
+| **Type** (kind) | **soft hue tint** | violet ~300, teal ~200, rose ~350, amber ~70 |
+| **Categories** | **outlined, one accent** | brand green via `Color.Primary` |
+
+Type chips are tinted rather than saturated so data doesn't compete with the three saturated toolbar
+buttons. Theme is handled without a dark-mode selector, reusing the `color-mix` pattern the first plan
+already established for `.selected-row`:
+
+```css
+background: color-mix(in oklch, var(--mud-palette-surface) 85%, <hue>);
+color:      color-mix(in oklch, var(--mud-palette-text-primary) 40%, <hue>);
+```
 
 ## Approach
 
-### 1. Type column: kind label, colored, delivery as icon
+### 1. Type column: kind label, tinted, delivery as icon
 
-`RenderTypeChip` (`Pages/Hotstrings.razor:959-965`) currently branches Text→delivery chip,
-else→kind chip. Replace with: **always render a kind chip** via `KindLabel` (already exists, 947-954),
-colored per kind, plus a small delivery icon when `DeliveryDisplay.IsClipboard(item.EffectiveDelivery)`.
+`RenderTypeChip` (`Pages/Hotstrings.razor:959-965`) currently branches Text→delivery chip, else→kind
+chip. Replace with **always a kind chip** via the existing `KindLabel` (947-954), tinted per kind, plus
+a small clipboard icon when `DeliveryDisplay.IsClipboard(item.EffectiveDelivery)`.
 
-Kind colors — one coherent 4-hue OKLCH set applied as **inline `Style`** on the filled chip (inline
-style reliably overrides MudBlazor's filled background; a filled chip's own hue background reads in
-both themes):
-
-| Kind | Hue (approx OKLCH, tune at build) | Note |
+| Kind | Hue | Note |
 |---|---|---|
-| Text | violet `oklch(0.55 0.16 300)` | new distinct color, replaces grey |
-| DateTime | blue `oklch(0.58 0.14 240)` | matches prior Info intent |
-| Macro | green `oklch(0.56 0.13 150)` | matches prior Success intent |
-| Raw | amber `oklch(0.62 0.14 70)` | + keep the existing `Warning` icon |
+| Text | violet ~300 | replaces the grey delivery chip |
+| DateTime | teal ~200 | off Secondary blue |
+| Macro | rose ~350 | off Primary green |
+| Raw | amber ~70 | keep the existing `Warning` icon + `ScriptWarningText` aria-label |
 
-Foreground text near-white `oklch(0.98 0 0)` for contrast on all four. Keep the Raw warning icon and
-its aria-label (`ScriptWarningText`, lines 994/1015-1018). Add the clipboard icon
-(`Icons.Material.Filled.ContentPaste`, small, muted) only for Text-clipboard rows, inside the existing
-Type-cell composition (chip + `.option-glyphs` + context icon, lines 168-179); mention delivery in the
-per-row Type tooltip so the info stays discoverable. The dialog toggle
-(`HotstringEditDialog.razor:22-44`) already colors kinds via icons — optionally align those icon hues
-to the same set; not required.
+Applied as a per-kind class (`kind-chip--text` etc.) in `Hotstrings.razor.css` using the `color-mix`
+formula above. Delivery is shown only for the exception (clipboard, which overwrites the user's
+clipboard); default keystroke rows show no mark. Mention delivery in the per-row Type tooltip and the
+header legend so it stays discoverable. Keep the existing cell composition (chip + `.option-glyphs` +
+context icon, 168-179) and watch the 130px width — verify no overflow at 150%/200% zoom.
 
-### 2. Category color palette (auto, outlined, dual-theme)
+### 2. Categories: one brand-green accent
 
-New `CategoryPalette` helper (Frontend, e.g. `Components/Common/CategoryPalette.cs`):
-
-```csharp
-internal static class CategoryPalette
-{
-    private static readonly string[] Ring =
-        ["cat-hue-0","cat-hue-1","cat-hue-2","cat-hue-3","cat-hue-4","cat-hue-5","cat-hue-6","cat-hue-7"];
-
-    private static readonly Dictionary<string, string> Defaults = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["Autocorrect"] = "cat-hue-0", ["Communication"] = "cat-hue-1", ["DateTime"] = "cat-hue-2",
-        ["Email"] = "cat-hue-3", ["Code"] = "cat-hue-4", ["Symbols"] = "cat-hue-5",
-        ["Window Management"] = "cat-hue-6", ["App Launcher"] = "cat-hue-7",
-    };
-
-    public static string ClassFor(string name) =>
-        Defaults.TryGetValue(name, out string? c) ? c : Ring[StableHash(name) % Ring.Length];
-
-    // Stable across sessions/platforms (string.GetHashCode is not) — FNV-1a, non-negative.
-    private static int StableHash(string s) { /* ... */ }
-}
-```
-
-Add an optional pass-through to the shared component — `Components/Common/EntityChips.razor`:
+Minimal change — no custom CSS, no palette helper. Add an optional `Color` to the shared component
+(`Components/Common/EntityChips.razor`) and let MudBlazor track the theme:
 
 ```razor
-[Parameter] public Func<Guid, string?>? ColorClassFor { get; set; }
+[Parameter] public Color? Color { get; set; }
 ...
-<MudChip T="string" Size="Size.Small" Variant="Variant" Class="@ColorClassFor?.Invoke(id)">@NameFor(id)</MudChip>
+<MudChip T="string" Size="Size.Small" Variant="Variant" Color="@(Color ?? MudBlazor.Color.Default)">@NameFor(id)</MudChip>
 ```
 
-Profiles and every other caller pass nothing → unchanged. `RenderCategories`
-(`Pages/Hotstrings.razor:944-945`) and `HotstringMobileList.razor:108` pass
-`ColorClassFor="@(id => CategoryPalette.ClassFor(nameFor(id)))"` (resolve name via `_categoryOptions`).
+Pass `Color="Color.Primary"` from the two category call sites — `RenderCategories`
+(`Pages/Hotstrings.razor:944-945`) and `HotstringMobileList.razor:108`. Profiles and every other caller
+pass nothing and are unchanged. Outlined + Primary gives a green border/text chip, structurally
+distinct from the tinted Type fills. Verify legibility in dark theme.
 
-Global CSS in `wwwroot/css/app.css` (not scoped — the chips render in two different components):
-`.cat-hue-0` … `.cat-hue-7`, each setting **border-color + text color** to a mid-tone OKLCH hue chosen
-to read on both light and dark page backgrounds. Selector specificity must beat MudBlazor's default
-outlined-chip color (likely needs `.mud-chip.cat-hue-N` or a cascade layer) — verify live. Add a dark
-override only for any hue that fails contrast in the live both-theme check.
+### 3. Inline category editor: fix the "C..." clip
 
-### 3. Inline category editor: stop the "C..." clip
+Three changes:
+- **Un-clip editing rows.** `::deep .hotstrings-grid .edit-row .mud-table-cell,
+  ::deep .hotstrings-grid .draft-row .mud-table-cell { overflow: visible; white-space: normal; }` —
+  those classes are already attached by `GetRowClass` (427-428).
+- **Rebalance the width budget** (`Hotstrings.razor.css`), same 70% total:
 
-Two changes in `Hotstrings.razor.css`:
-- **Un-clip editing rows.** The blanket clip (39-47) is meant for read-only text columns. Exclude the
-  in-edit cell: `::deep .hotstrings-grid .edit-row .mud-table-cell,
-  ::deep .hotstrings-grid .draft-row .mud-table-cell { overflow: visible; white-space: normal; }`
-  (the `edit-row`/`draft-row` classes are already attached by `GetRowClass`, 427-428).
-- **Give the editor room.** Modestly widen the Categories column (`nth-child(7)`, 87-90) from `10%`
-  (rebalance a couple of the other `%` columns so the row still sums sanely), and ensure
-  `EntityMultiSelect`'s `MudSelect` fills the cell (add a `FullWidth`/min-width via a class param, or a
-  `.category-select` rule). Optionally set MudSelect `MultiSelectionTextFunc` to a compact
-  "N selected" so multiple picks don't overflow. Verify live that the selected category name is fully
-  readable.
+  | Column | Now | New |
+  |---|---|---|
+  | Description (`nth-child(4)`) | 14% | 13% |
+  | Profiles (`nth-child(5)`) | 10% | **7%** |
+  | Categories (`nth-child(7)`) | 10% | **14%** |
 
-### 4. Seed: +2 Macro, +2 Raw, fill empty categories, de-dupe the array
+- **Compact selection text.** Set `MultiSelectionTextFunc` on `EntityMultiSelect`'s `MudSelect`:
+  none → placeholder, exactly one → the category name, more than one → "N selected". Structurally
+  cannot truncate. Add the parameter to `EntityMultiSelect` so other callers are unaffected.
 
-Add four samples. The seed tuple needs **no new fields** (Kind + Replacement carry Macro/Raw):
+### 4. Seed: kind coverage, descriptions, de-duplication
+
+Add four samples (the tuple needs no new fields — Kind + Replacement carry Macro/Raw):
 
 | Trigger | Replacement | Kind | Category |
 |---|---|---|---|
 | `htag` | `<b>{{cursor}}</b>` | Macro | Code |
 | `alink` | `<a href="{{cursor}}"></a>` | Macro | Code |
-| `/np` | `:X:/np::Run("notepad.exe")` | Raw | App Launcher |
-| `/wmax` | `:X:/wmax::WinMaximize("A")` | Raw | Window Management |
+| *(tbd)* | hand-authored verbatim definition | Raw | Code / Symbols |
+| *(tbd)* | hand-authored verbatim definition | Raw | Code / Symbols |
 
-Macro replacements use the documented token vocabulary (`{{cursor}}` with text but no keys after —
-valid per `ahk-v2-syntax.md`). Raw replacements are the entire verbatim `:X:trigger::` definition with
-the `X` execute flag. **Risk to resolve at build:** the seed path constructs `HotstringDefinition`
-directly and bypasses `RawHotstringDefinitionParser.Prepare`. For Raw seeds, run the replacement
-through `RawHotstringDefinitionParser.Prepare` (same as `CreateHotstringCommand`) so stored
-`Replacement` = `NormalizedDefinition` and Trigger is consistent; Macro stores the token string
-directly. Verify a seeded Raw/Macro row renders and its generated `.ahk` is valid.
+Macro replacements use the documented token vocabulary (`{{cursor}}` with text but no keys after — valid
+per `ahk-v2-syntax.md`). Raw examples must showcase what Raw is *for* — a hand-authored definition the
+structured kinds can't express — and land in Code/Symbols, **not** App Launcher/Window Management.
+Finalize the exact Raw text at build; keep it single-line where possible (the brace-balance check is
+naive) and confirm it survives `RawHotstringDefinitionParser` and emits valid AHK v2.
 
-**De-dupe while here:** extract the sample array to one shared static (e.g.
-`Application/.../HotstringSeedSamples.cs`) and have both `SeedHotstringsCommand` and
-`ListHotstringsQuery` consume it — removes the "update both files" hazard the current comment warns of.
+Also:
+- **Add a `Description` to every seed row** (existing 12 + new 4). A blank Description column on every
+  row looks unfinished and wastes its 13%.
+- **De-duplicate.** Extract the sample array into one shared static consumed by both
+  `SeedHotstringsCommand` and `ListHotstringsQuery`, removing the "update both files" hazard.
 
 ### 5. Grid loading indicator
 
 `_loading` is set around every load (`LoadServerData` 335/354, `LoadMobileAsync` 637/649) but bound to
-nothing visible. Bind `Loading="_loading"` on the desktop `MudDataGrid` (70-77) with a `LoadingContent`;
-add a `MudProgressLinear`/skeleton on the mobile branch gated on `_loading`.
+nothing visible. Bind `Loading="_loading"` on the desktop `MudDataGrid` (70-77); add a
+`MudProgressLinear` on the mobile branch gated on `_loading`.
 
-### 6. "No results for filter" empty state
+### 6. Filtered-empty state
 
-Both the grid `NoRecordsContent` (line 197) and the mobile empty block say "No hotstrings yet."
-regardless of active filters. Add a computed `_hasActiveFilters` (search non-empty OR `_selectedKind`
-set OR `_selectedCategoryIds` non-empty) and branch: filtered-empty → "No hotstrings match these
-filters." plus a **Clear filters** action; true-empty → keep "No hotstrings yet." Apply to both
-desktop and mobile.
+`NoRecordsContent` (197) and the mobile empty block both say "No hotstrings yet." regardless of filters.
+Add a computed `_hasActiveFilters` (search non-empty OR `_selectedKind` set OR `_selectedCategoryIds`
+non-empty) and branch: filtered → "No hotstrings match these filters." plus a **Clear filters** action;
+otherwise keep "No hotstrings yet." Apply to desktop and mobile.
 
-### 7. Complete the glyph legend + confirm selection highlight
+### 7. Glyph legend + selection highlight
 
-- Header legend tooltip (`Pages/Hotstrings.razor:161`) documents only `* ? C`. Add `O` (omit ending
-  char) and the window-context icon meaning, matching what the cell actually renders (`OptionGlyphs`
-  978-990) and the per-row `OptionsTooltip` (996-1013).
-- Selection highlighting (`.selected-row`) already shipped in the first plan. Verify it's actually
-  visible in both themes at the current 12% tint; bump the mix if too subtle.
+- Header legend tooltip (161) lists only `* ? C`. Add `O` (omit ending char) and the window-context
+  icon, matching `OptionGlyphs` (978-990) and `OptionsTooltip` (996-1013). Mention clipboard delivery.
+- `.selected-row` already shipped; verify it's actually visible at 12% tint in both themes, bump if not.
+
+## Constraints
+
+- Per `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md`: verify MudBlazor parameters against the MudMCP
+  server (`mcp__mudblazor__*`, pinned 9.3.0) before changing markup — specifically
+  `MultiSelectionTextFunc`, `MudDataGrid.Loading`, and `MudChip` `Class`/`Variant`/`Color`.
+- Reuse `Components/Common/` shared components; don't hand-roll `MudSelect`/`MudChip` blocks.
+- `HotstringMobileList.razor:169-176` deliberately shows raw replacement text for Macro in *collapsed*
+  rows (token chips live in the expanded detail). This is a documented density decision — do not
+  "fix" it. But Macro rows have never existed before, so check how `<b>{{cursor}}</b>` reads once
+  seeded and report back rather than changing it unilaterally.
 
 ## Test blast radius
 
-- **bUnit** (`tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs`): any assertion that the
-  Type column shows delivery text ("Hotstring"/"Clipboard") for Text rows now expects the kind label
-  "Text"; the first plan's chip-color assertions change from semantic `Color` classes to the new
-  inline-style / kind-class scheme. Add: a category chip carries a `cat-hue-*` class; the filtered-empty
-  state renders distinct text; the grid exposes a loading state.
+- **bUnit** (`tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs`): assertions expecting
+  delivery text ("Hotstring"/"Clipboard") in the Type column now expect the kind label; the first plan's
+  chip-color assertions move to the new tint classes. Add coverage for the category accent, the
+  filtered-empty state, and the grid loading state.
 - **E2E** (`HotstringsCrudFlowTests.cs`, `RawHotstringFlowTests.cs`, `VersionHistoryFlowTests.cs`):
-  category-editor selector unaffected (`data-test="category-select"` preserved by `EntityMultiSelect`);
-  re-check any assertion reading the Type column's text.
-- **Backend**: a seeding test (if present) that counts samples per kind updates to expect Macro=2,
-  Raw=2; the shared-array extraction must keep both seed paths byte-identical (assert they reference the
-  same source).
+  `data-test="category-select"` is preserved; re-check assertions reading Type column text.
+- **Backend**: any test counting seed samples per kind updates to Macro=2, Raw=2; assert both seed paths
+  consume the same shared array.
 
 ## Verification
 
-- `dotnet build` + `dotnet test` (UI.Blazor, then E2E, then the seed/backend tests touched).
+- `dotnet build` + `dotnet test` (UI.Blazor, E2E, touched backend tests).
 - Playwright (`playwright-cli` skill) against the no-auth dev stack (`Docker SQL (No Auth)` API +
-  `http (No Auth)` frontend). **Reset the PWA cache / hard-reload first** to rule out stale assets.
-  1. Trigger a seed reset; confirm the grid shows Macro rows (`htag`, `alink`) and Raw rows
-     (`/np`, `/wmax`), and that `Window Management` + `App Launcher` category filters now return rows.
-  2. Type column: Text=violet, DateTime=blue, Macro=green, Raw=amber+warning icon — four visibly
-     distinct filled chips; a Text-clipboard row shows the clipboard icon.
-  3. Category chips: outlined, each category a distinct hue, clearly a different channel from Type
-     chips. Toggle the theme switch — confirm both Type and Category colors stay legible in light and
-     dark; fix any failing category hue.
-  4. Inline-edit a row's categories: the `MudSelect` is fully readable (no "C..."), selected names
-     visible.
-  5. Force a load (reload) and confirm the loading indicator shows; apply a filter with no matches and
-     confirm the filtered-empty text + Clear filters; clear it and confirm rows return.
-  6. Hover the Type header help icon: legend lists `* ? C O` and the window-context icon.
-  7. Select rows via checkboxes: highlight visible in both themes.
-- Generate/download a profile `.ahk` (or use the preview) to confirm the seeded Macro/Raw emit valid
-  AHK v2.
-
-## Unresolved questions
-
-1. Kind hues — violet/blue/green/amber ok, or swap any? (green Macro sits near the app's green Primary.)
-2. Custom (non-default) categories: hash-into-8-hues acceptable, or only color the 8 defaults and leave
-   custom ones neutral?
-3. Inline multi-category editor: keep per-name chips in the closed anchor, or switch to "N selected"?
+  `http (No Auth)` frontend). **Hard-reload / unregister the service worker first** to rule out stale
+  PWA assets.
+  1. Seed reset; confirm Macro and Raw rows appear and every row shows a Description.
+  2. Type column: four visibly distinct tinted chips (violet/teal/rose/amber); a Text-clipboard row
+     shows the clipboard icon; Raw keeps its warning icon. Confirm chips read as *data*, not competing
+     with the saturated toolbar buttons.
+  3. Category chips: green outlined, clearly a different channel from Type. Toggle the theme — confirm
+     both channels stay legible in light and dark.
+  4. Inline-edit categories: no truncation; 0/1/many render placeholder / name / "N selected".
+  5. Reload to confirm the loading indicator; filter to zero matches for the filtered-empty state +
+     Clear filters; clear and confirm rows return.
+  6. Hover the Type header help icon: legend covers `* ? C O`, the context icon, and clipboard delivery.
+  7. Select rows: highlight visible in both themes.
+  8. Zoom 150% / 200%: Type and Actions columns don't overflow.
+- Generate a profile `.ahk` and confirm the seeded Macro/Raw emit valid AHK v2.

--- a/docs/superpowers/plans/2026-07-20-hotstring-page-ux-followup-plan.md
+++ b/docs/superpowers/plans/2026-07-20-hotstring-page-ux-followup-plan.md
@@ -1,0 +1,213 @@
+# Hotstrings page UX fixes — follow-up
+
+## Context
+
+The first pass (`2026-07-20-hotstring-page-ux-fixes-plan.md`, Sonnet) under-delivered. Live
+testing shows Type chips and Category chips still render grey, and the inline category editor
+still truncates to "C...". The user also wants at least two seed examples per hotstring kind and
+a broader UX sweep of gaps the first plan missed. Goal: real color coding on both chip families
+(a deliberate two-channel system), a readable inline category editor, full kind coverage in seed
+data, and four audit-driven UX fixes. All root causes below were verified in code, not assumed.
+
+### Root causes (verified)
+
+- **Category chips grey — genuine gap.** `Components/Common/EntityChips.razor:11` renders each
+  per-id chip with **no `Color`**, so MudBlazor falls back to `Color.Default` = grey. The first
+  plan added only `Variant.Outlined` (an outline shape), never a color. No per-category color logic
+  exists anywhere.
+- **Type chips grey — by design + all-Text data.** `KindColor` (`Pages/Hotstrings.razor:967-973`)
+  correctly colors DateTime=Info, Macro=Success, Raw=Warning (filled variant renders color). But
+  `RenderTypeChip` (lines 959-965) shows **Text** rows a grey *delivery* chip ("Hotstring"), and
+  every seeded row is Text-kind, so the whole visible column is grey. The column titled "Type" never
+  shows "Text" for text rows. Possibly compounded by a stale PWA service-worker cache.
+- **Dropdown "C..." truncation — pre-existing, not from `17ef225`.** Categories column is pinned
+  `width:10%` (`Hotstrings.razor.css:87-90`) under `table-layout:fixed`, and a blanket rule clips
+  every cell: `overflow:hidden; text-overflow:ellipsis; white-space:nowrap` (lines 39-47). In edit
+  mode that ~100px cell must host a full `MudSelect` whose Clearable (X) + dropdown arrow eat the
+  width, leaving room for one character.
+- **Seed gap.** `SeedHotstringsCommand.cs:32-43` has 10 Text + 2 DateTime, **0 Macro, 0 Raw**. The
+  array is duplicated verbatim in `ListHotstringsQuery.cs:78-89` (lazy auto-seed) with a "update
+  both" comment — a sync hazard. Categories `Window Management` and `App Launcher` have no examples.
+
+## Design decisions (confirmed with user)
+
+1. **Type column shows the kind, colored, delivery → icon.** Every row shows its kind
+   (Text/DateTime/Macro/Raw), each a distinct color including Text (violet). Clipboard delivery
+   becomes a small icon, not the chip label.
+2. **Categories get an auto OKLCH palette**, outlined chips — a *distinct visual channel* from the
+   filled Type chips. No schema change: 8 default categories hand-mapped to hues, custom categories
+   hash into the same ring.
+3. **Two color channels, deliberately different** (impeccable): Type = **filled** semantic/violet
+   (the chip carries its own hue background, so it reads in both themes); Categories = **outlined**
+   custom hues (border+text sit on the page background, so those hues must be dual-theme legible).
+
+## Approach
+
+### 1. Type column: kind label, colored, delivery as icon
+
+`RenderTypeChip` (`Pages/Hotstrings.razor:959-965`) currently branches Text→delivery chip,
+else→kind chip. Replace with: **always render a kind chip** via `KindLabel` (already exists, 947-954),
+colored per kind, plus a small delivery icon when `DeliveryDisplay.IsClipboard(item.EffectiveDelivery)`.
+
+Kind colors — one coherent 4-hue OKLCH set applied as **inline `Style`** on the filled chip (inline
+style reliably overrides MudBlazor's filled background; a filled chip's own hue background reads in
+both themes):
+
+| Kind | Hue (approx OKLCH, tune at build) | Note |
+|---|---|---|
+| Text | violet `oklch(0.55 0.16 300)` | new distinct color, replaces grey |
+| DateTime | blue `oklch(0.58 0.14 240)` | matches prior Info intent |
+| Macro | green `oklch(0.56 0.13 150)` | matches prior Success intent |
+| Raw | amber `oklch(0.62 0.14 70)` | + keep the existing `Warning` icon |
+
+Foreground text near-white `oklch(0.98 0 0)` for contrast on all four. Keep the Raw warning icon and
+its aria-label (`ScriptWarningText`, lines 994/1015-1018). Add the clipboard icon
+(`Icons.Material.Filled.ContentPaste`, small, muted) only for Text-clipboard rows, inside the existing
+Type-cell composition (chip + `.option-glyphs` + context icon, lines 168-179); mention delivery in the
+per-row Type tooltip so the info stays discoverable. The dialog toggle
+(`HotstringEditDialog.razor:22-44`) already colors kinds via icons — optionally align those icon hues
+to the same set; not required.
+
+### 2. Category color palette (auto, outlined, dual-theme)
+
+New `CategoryPalette` helper (Frontend, e.g. `Components/Common/CategoryPalette.cs`):
+
+```csharp
+internal static class CategoryPalette
+{
+    private static readonly string[] Ring =
+        ["cat-hue-0","cat-hue-1","cat-hue-2","cat-hue-3","cat-hue-4","cat-hue-5","cat-hue-6","cat-hue-7"];
+
+    private static readonly Dictionary<string, string> Defaults = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Autocorrect"] = "cat-hue-0", ["Communication"] = "cat-hue-1", ["DateTime"] = "cat-hue-2",
+        ["Email"] = "cat-hue-3", ["Code"] = "cat-hue-4", ["Symbols"] = "cat-hue-5",
+        ["Window Management"] = "cat-hue-6", ["App Launcher"] = "cat-hue-7",
+    };
+
+    public static string ClassFor(string name) =>
+        Defaults.TryGetValue(name, out string? c) ? c : Ring[StableHash(name) % Ring.Length];
+
+    // Stable across sessions/platforms (string.GetHashCode is not) — FNV-1a, non-negative.
+    private static int StableHash(string s) { /* ... */ }
+}
+```
+
+Add an optional pass-through to the shared component — `Components/Common/EntityChips.razor`:
+
+```razor
+[Parameter] public Func<Guid, string?>? ColorClassFor { get; set; }
+...
+<MudChip T="string" Size="Size.Small" Variant="Variant" Class="@ColorClassFor?.Invoke(id)">@NameFor(id)</MudChip>
+```
+
+Profiles and every other caller pass nothing → unchanged. `RenderCategories`
+(`Pages/Hotstrings.razor:944-945`) and `HotstringMobileList.razor:108` pass
+`ColorClassFor="@(id => CategoryPalette.ClassFor(nameFor(id)))"` (resolve name via `_categoryOptions`).
+
+Global CSS in `wwwroot/css/app.css` (not scoped — the chips render in two different components):
+`.cat-hue-0` … `.cat-hue-7`, each setting **border-color + text color** to a mid-tone OKLCH hue chosen
+to read on both light and dark page backgrounds. Selector specificity must beat MudBlazor's default
+outlined-chip color (likely needs `.mud-chip.cat-hue-N` or a cascade layer) — verify live. Add a dark
+override only for any hue that fails contrast in the live both-theme check.
+
+### 3. Inline category editor: stop the "C..." clip
+
+Two changes in `Hotstrings.razor.css`:
+- **Un-clip editing rows.** The blanket clip (39-47) is meant for read-only text columns. Exclude the
+  in-edit cell: `::deep .hotstrings-grid .edit-row .mud-table-cell,
+  ::deep .hotstrings-grid .draft-row .mud-table-cell { overflow: visible; white-space: normal; }`
+  (the `edit-row`/`draft-row` classes are already attached by `GetRowClass`, 427-428).
+- **Give the editor room.** Modestly widen the Categories column (`nth-child(7)`, 87-90) from `10%`
+  (rebalance a couple of the other `%` columns so the row still sums sanely), and ensure
+  `EntityMultiSelect`'s `MudSelect` fills the cell (add a `FullWidth`/min-width via a class param, or a
+  `.category-select` rule). Optionally set MudSelect `MultiSelectionTextFunc` to a compact
+  "N selected" so multiple picks don't overflow. Verify live that the selected category name is fully
+  readable.
+
+### 4. Seed: +2 Macro, +2 Raw, fill empty categories, de-dupe the array
+
+Add four samples. The seed tuple needs **no new fields** (Kind + Replacement carry Macro/Raw):
+
+| Trigger | Replacement | Kind | Category |
+|---|---|---|---|
+| `htag` | `<b>{{cursor}}</b>` | Macro | Code |
+| `alink` | `<a href="{{cursor}}"></a>` | Macro | Code |
+| `/np` | `:X:/np::Run("notepad.exe")` | Raw | App Launcher |
+| `/wmax` | `:X:/wmax::WinMaximize("A")` | Raw | Window Management |
+
+Macro replacements use the documented token vocabulary (`{{cursor}}` with text but no keys after —
+valid per `ahk-v2-syntax.md`). Raw replacements are the entire verbatim `:X:trigger::` definition with
+the `X` execute flag. **Risk to resolve at build:** the seed path constructs `HotstringDefinition`
+directly and bypasses `RawHotstringDefinitionParser.Prepare`. For Raw seeds, run the replacement
+through `RawHotstringDefinitionParser.Prepare` (same as `CreateHotstringCommand`) so stored
+`Replacement` = `NormalizedDefinition` and Trigger is consistent; Macro stores the token string
+directly. Verify a seeded Raw/Macro row renders and its generated `.ahk` is valid.
+
+**De-dupe while here:** extract the sample array to one shared static (e.g.
+`Application/.../HotstringSeedSamples.cs`) and have both `SeedHotstringsCommand` and
+`ListHotstringsQuery` consume it — removes the "update both files" hazard the current comment warns of.
+
+### 5. Grid loading indicator
+
+`_loading` is set around every load (`LoadServerData` 335/354, `LoadMobileAsync` 637/649) but bound to
+nothing visible. Bind `Loading="_loading"` on the desktop `MudDataGrid` (70-77) with a `LoadingContent`;
+add a `MudProgressLinear`/skeleton on the mobile branch gated on `_loading`.
+
+### 6. "No results for filter" empty state
+
+Both the grid `NoRecordsContent` (line 197) and the mobile empty block say "No hotstrings yet."
+regardless of active filters. Add a computed `_hasActiveFilters` (search non-empty OR `_selectedKind`
+set OR `_selectedCategoryIds` non-empty) and branch: filtered-empty → "No hotstrings match these
+filters." plus a **Clear filters** action; true-empty → keep "No hotstrings yet." Apply to both
+desktop and mobile.
+
+### 7. Complete the glyph legend + confirm selection highlight
+
+- Header legend tooltip (`Pages/Hotstrings.razor:161`) documents only `* ? C`. Add `O` (omit ending
+  char) and the window-context icon meaning, matching what the cell actually renders (`OptionGlyphs`
+  978-990) and the per-row `OptionsTooltip` (996-1013).
+- Selection highlighting (`.selected-row`) already shipped in the first plan. Verify it's actually
+  visible in both themes at the current 12% tint; bump the mix if too subtle.
+
+## Test blast radius
+
+- **bUnit** (`tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs`): any assertion that the
+  Type column shows delivery text ("Hotstring"/"Clipboard") for Text rows now expects the kind label
+  "Text"; the first plan's chip-color assertions change from semantic `Color` classes to the new
+  inline-style / kind-class scheme. Add: a category chip carries a `cat-hue-*` class; the filtered-empty
+  state renders distinct text; the grid exposes a loading state.
+- **E2E** (`HotstringsCrudFlowTests.cs`, `RawHotstringFlowTests.cs`, `VersionHistoryFlowTests.cs`):
+  category-editor selector unaffected (`data-test="category-select"` preserved by `EntityMultiSelect`);
+  re-check any assertion reading the Type column's text.
+- **Backend**: a seeding test (if present) that counts samples per kind updates to expect Macro=2,
+  Raw=2; the shared-array extraction must keep both seed paths byte-identical (assert they reference the
+  same source).
+
+## Verification
+
+- `dotnet build` + `dotnet test` (UI.Blazor, then E2E, then the seed/backend tests touched).
+- Playwright (`playwright-cli` skill) against the no-auth dev stack (`Docker SQL (No Auth)` API +
+  `http (No Auth)` frontend). **Reset the PWA cache / hard-reload first** to rule out stale assets.
+  1. Trigger a seed reset; confirm the grid shows Macro rows (`htag`, `alink`) and Raw rows
+     (`/np`, `/wmax`), and that `Window Management` + `App Launcher` category filters now return rows.
+  2. Type column: Text=violet, DateTime=blue, Macro=green, Raw=amber+warning icon — four visibly
+     distinct filled chips; a Text-clipboard row shows the clipboard icon.
+  3. Category chips: outlined, each category a distinct hue, clearly a different channel from Type
+     chips. Toggle the theme switch — confirm both Type and Category colors stay legible in light and
+     dark; fix any failing category hue.
+  4. Inline-edit a row's categories: the `MudSelect` is fully readable (no "C..."), selected names
+     visible.
+  5. Force a load (reload) and confirm the loading indicator shows; apply a filter with no matches and
+     confirm the filtered-empty text + Clear filters; clear it and confirm rows return.
+  6. Hover the Type header help icon: legend lists `* ? C O` and the window-context icon.
+  7. Select rows via checkboxes: highlight visible in both themes.
+- Generate/download a profile `.ahk` (or use the preview) to confirm the seeded Macro/Raw emit valid
+  AHK v2.
+
+## Unresolved questions
+
+1. Kind hues — violet/blue/green/amber ok, or swap any? (green Macro sits near the app's green Primary.)
+2. Custom (non-default) categories: hash-into-8-hues acceptable, or only color the 8 defaults and leave
+   custom ones neutral?
+3. Inline multi-category editor: keep per-name chips in the closed anchor, or switch to "N selected"?

--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/HotstringSeedSamples.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/HotstringSeedSamples.cs
@@ -1,0 +1,57 @@
+using AHKFlowApp.Domain.Enums;
+
+namespace AHKFlowApp.Application.Commands.Dev;
+
+/// <summary>
+/// The curated dev seed set. Shared by <c>SeedHotstringsCommandHandler</c> (the explicit
+/// <c>POST /dev/hotstrings/seed</c> path) and the lazy auto-seed in <c>ListHotstringsQuery</c>,
+/// which previously held byte-identical copies that had to be updated in lockstep.
+/// </summary>
+internal static class HotstringSeedSamples
+{
+    /// <param name="Trigger"></param>
+    /// <param name="Replacement">
+    /// Kind-dependent, matching <see cref="Domain.Entities.HotstringDefinition"/>: literal text for
+    /// Text, the token string for Macro, and the entire verbatim <c>:options:trigger::</c> definition
+    /// for Raw.
+    /// </param>
+    /// <param name="Description"></param>
+    /// <param name="Ending"></param>
+    /// <param name="InsideWord"></param>
+    /// <param name="Categories"></param>
+    /// <param name="Kind"></param>
+    /// <param name="DateTimeFormat"></param>
+    internal sealed record Sample(
+        string Trigger,
+        string Replacement,
+        string Description,
+        bool Ending,
+        bool InsideWord,
+        string[] Categories,
+        HotstringKind Kind,
+        string? DateTimeFormat = null);
+
+    // Raw samples are deliberately single-line: this path constructs HotstringDefinition directly
+    // rather than going through RawHotstringDefinitionParser.Prepare, so nothing here normalizes
+    // CRLF to LF or checks brace balance. Both use the X (execute) flag, which is the thing no
+    // structured kind can express — the honest reason to reach for Raw.
+    internal static readonly Sample[] All =
+    [
+        new("recieve", "receive", "Fixes a common typo.", true, true, ["Autocorrect"], HotstringKind.Text),
+        new("btw", "by the way", "Expands a chat abbreviation.", true, false, ["Communication"], HotstringKind.Text),
+        new("brb", "be right back", "Expands a chat abbreviation.", true, false, ["Communication"], HotstringKind.Text),
+        new("fyi", "for your information", "Expands a chat abbreviation.", true, false, ["Communication"], HotstringKind.Text),
+        new("/today", "", "Inserts today's date.", false, false, ["DateTime"], HotstringKind.DateTime, "yyyy-MM-dd"),
+        new("/now", "", "Inserts the current time.", false, false, ["DateTime"], HotstringKind.DateTime, "HH:mm"),
+        new("@sig", "Example User\nuser@example.com\nExample Company", "Inserts a plain-text email signature.", false, false, ["Email"], HotstringKind.Text),
+        new(";arrow", "→", "Inserts a right arrow.", false, false, ["Symbols"], HotstringKind.Text),
+        new(";check", "✓", "Inserts a check mark.", false, false, ["Symbols"], HotstringKind.Text),
+        new(";shrug", "¯\\_(ツ)_/¯", "Inserts the shrug emoticon.", false, false, ["Symbols"], HotstringKind.Text),
+        new(";e:", "ë", "Inserts e with diaeresis.", false, false, ["Symbols"], HotstringKind.Text),
+        new(";todo", "TODO(name): ", "Inserts a TODO marker.", false, false, ["Code"], HotstringKind.Text),
+        new("htag", "<b>{{cursor}}</b>", "Wraps the cursor in bold tags.", false, false, ["Code"], HotstringKind.Macro),
+        new("alink", "<a href=\"{{cursor}}\"></a>", "Inserts an anchor tag with the cursor in the href.", false, false, ["Code"], HotstringKind.Macro),
+        new("/user", ":X:/user::SendText(A_UserName)", "Inserts the current Windows username.", false, false, ["Code"], HotstringKind.Raw),
+        new("/ghub", ":X:/ghub::Run(\"https://github.com\")", "Opens GitHub in the default browser.", false, false, ["Code"], HotstringKind.Raw),
+    ];
+}

--- a/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotstringsCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/Dev/SeedHotstringsCommand.cs
@@ -20,29 +20,6 @@ internal sealed class SeedHotstringsCommandHandler(
     AppEnvironment env)
     : IUseCaseHandler<SeedHotstringsCommand, Result<PagedList<HotstringDto>>>
 {
-    private static readonly (
-        string Trigger,
-        string Replacement,
-        bool Ending,
-        bool InsideWord,
-        string[] Categories,
-        HotstringKind Kind,
-        string? DateTimeFormat)[] s_samples =
-    [
-        ("recieve", "receive",              true,  true,  ["Autocorrect"],  HotstringKind.Text,     null),
-        ("btw",     "by the way",           true,  false, ["Communication"], HotstringKind.Text,    null),
-        ("brb",     "be right back",        true,  false, ["Communication"], HotstringKind.Text,    null),
-        ("fyi",     "for your information", true,  false, ["Communication"], HotstringKind.Text,    null),
-        ("/today",  "",                     false, false, ["DateTime"],     HotstringKind.DateTime, "yyyy-MM-dd"),
-        ("/now",    "",                     false, false, ["DateTime"],     HotstringKind.DateTime, "HH:mm"),
-        ("@sig",    "Example User\nuser@example.com\nExample Company", false, false, ["Email"], HotstringKind.Text, null),
-        (";arrow",  "→",               false, false, ["Symbols"], HotstringKind.Text, null),
-        (";check",  "✓",               false, false, ["Symbols"], HotstringKind.Text, null),
-        (";shrug",  "¯\\_(ツ)_/¯", false, false, ["Symbols"], HotstringKind.Text, null),
-        (";e:",     "ë",               false, false, ["Symbols"], HotstringKind.Text, null),
-        (";todo",   "TODO(name): ",         false, false, ["Code"], HotstringKind.Text, null),
-    ];
-
     public async Task<Result<PagedList<HotstringDto>>> ExecuteAsync(SeedHotstringsCommand request, CancellationToken ct)
     {
         if (!env.IsDevelopment)
@@ -77,8 +54,9 @@ internal sealed class SeedHotstringsCommandHandler(
                 .Select(x => (x.HotstringId, x.CategoryId))
                 .ToHashSet();
 
-        foreach ((string trigger, string replacement, bool ending, bool inside, string[] cats, HotstringKind kind, string? dateTimeFormat) in s_samples)
+        foreach (HotstringSeedSamples.Sample sample in HotstringSeedSamples.All)
         {
+            string trigger = sample.Trigger;
             Hotstring? existing = request.Reset
                 ? null
                 : await db.Hotstrings.FirstOrDefaultAsync(
@@ -94,15 +72,15 @@ internal sealed class SeedHotstringsCommandHandler(
                 var entity = Hotstring.Create(
                     ownerOid,
                     new HotstringDefinition(
-                        trigger, replacement, Description: null, AppliesToAllProfiles: true,
-                        IsEndingCharacterRequired: ending, IsTriggerInsideWord: inside,
-                        Kind: kind, DateTimeFormat: dateTimeFormat),
+                        sample.Trigger, sample.Replacement, sample.Description, AppliesToAllProfiles: true,
+                        IsEndingCharacterRequired: sample.Ending, IsTriggerInsideWord: sample.InsideWord,
+                        Kind: sample.Kind, DateTimeFormat: sample.DateTimeFormat),
                     clock);
                 db.Hotstrings.Add(entity);
                 hotstringId = entity.Id;
             }
 
-            foreach (string categoryName in cats)
+            foreach (string categoryName in sample.Categories)
             {
                 if (!categoryByName.TryGetValue(categoryName, out Guid categoryId)) continue;
                 if (!existingLinks.Add((hotstringId, categoryId))) continue;

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotstrings/ListHotstringsQuery.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.Commands.Dev;
 using AHKFlowApp.Application.Common;
 using AHKFlowApp.Application.DTOs;
 using AHKFlowApp.Domain.Constants;
@@ -64,30 +65,6 @@ internal sealed class ListHotstringsQueryHandler(
     : IUseCaseHandler<ListHotstringsQuery, Result<PagedList<HotstringDto>>>
 {
     internal const int ListReplacementPreviewLength = 200;
-
-    // Mirrors SeedHotstringsCommand.s_samples — update both if seed set changes.
-    private static readonly (
-        string Trigger,
-        string Replacement,
-        bool Ending,
-        bool InsideWord,
-        string[] Categories,
-        HotstringKind Kind,
-        string? DateTimeFormat)[] s_lazySeed =
-    [
-        ("recieve", "receive",              true,  true,  ["Autocorrect"],  HotstringKind.Text,     null),
-        ("btw",     "by the way",           true,  false, ["Communication"], HotstringKind.Text,    null),
-        ("brb",     "be right back",        true,  false, ["Communication"], HotstringKind.Text,    null),
-        ("fyi",     "for your information", true,  false, ["Communication"], HotstringKind.Text,    null),
-        ("/today",  "",                     false, false, ["DateTime"],     HotstringKind.DateTime, "yyyy-MM-dd"),
-        ("/now",    "",                     false, false, ["DateTime"],     HotstringKind.DateTime, "HH:mm"),
-        ("@sig",    "Example User\nuser@example.com\nExample Company", false, false, ["Email"], HotstringKind.Text, null),
-        (";arrow",  "→",               false, false, ["Symbols"], HotstringKind.Text, null),
-        (";check",  "✓",               false, false, ["Symbols"], HotstringKind.Text, null),
-        (";shrug",  "¯\\_(ツ)_/¯", false, false, ["Symbols"], HotstringKind.Text, null),
-        (";e:",     "ë",               false, false, ["Symbols"], HotstringKind.Text, null),
-        (";todo",   "TODO(name): ",         false, false, ["Code"], HotstringKind.Text, null),
-    ];
 
     // Shared, EF-translatable "searchable replacement" selector: DateTime-kind hotstrings store
     // Replacement = "" and carry their format string in DateTimeFormat instead. Search/filter/sort
@@ -295,17 +272,17 @@ internal sealed class ListHotstringsQueryHandler(
                     .ToDictionary(c => c.Name, c => c.Id, StringComparer.OrdinalIgnoreCase);
             }
 
-            foreach ((string trigger, string replacement, bool ending, bool inside, string[] cats, HotstringKind kind, string? dateTimeFormat) in s_lazySeed)
+            foreach (HotstringSeedSamples.Sample sample in HotstringSeedSamples.All)
             {
                 var hs = Hotstring.Create(
                     ownerOid,
                     new HotstringDefinition(
-                        trigger, replacement, Description: null,
-                        AppliesToAllProfiles: true, ending, inside,
-                        Kind: kind, DateTimeFormat: dateTimeFormat),
+                        sample.Trigger, sample.Replacement, sample.Description,
+                        AppliesToAllProfiles: true, sample.Ending, sample.InsideWord,
+                        Kind: sample.Kind, DateTimeFormat: sample.DateTimeFormat),
                     clock);
                 db.Hotstrings.Add(hs);
-                foreach (string catName in cats)
+                foreach (string catName in sample.Categories)
                 {
                     if (catByName.TryGetValue(catName, out Guid catId))
                         db.HotstringCategories.Add(HotstringCategory.Create(hs.Id, catId));

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Common/EntityChips.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Common/EntityChips.razor
@@ -2,13 +2,13 @@
 
 @if (Any)
 {
-    <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant">Any</MudChip>
+    <MudChip T="string" Size="Size.Small" Color="MudBlazor.Color.Info" Variant="Variant">Any</MudChip>
 }
 else
 {
     @foreach (Guid id in Ids)
     {
-        <MudChip T="string" Size="Size.Small" Variant="Variant">@NameFor(id)</MudChip>
+        <MudChip T="string" Size="Size.Small" Variant="Variant" Color="@(Color ?? MudBlazor.Color.Default)">@NameFor(id)</MudChip>
     }
 }
 
@@ -20,6 +20,9 @@ else
     [Parameter] public bool Any { get; set; }
 
     [Parameter] public Variant Variant { get; set; } = Variant.Filled;
+
+    /// <summary>Color for the id chips. Null keeps MudBlazor's default (grey). Does not affect the "Any" chip.</summary>
+    [Parameter] public MudBlazor.Color? Color { get; set; }
 
     private string NameFor(Guid id) =>
         Options.FirstOrDefault(o => o.Id == id)?.Name ?? id.ToString()[..8];

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Common/EntityChips.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Common/EntityChips.razor
@@ -2,13 +2,13 @@
 
 @if (Any)
 {
-    <MudChip T="string" Size="Size.Small" Color="Color.Info">Any</MudChip>
+    <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant">Any</MudChip>
 }
 else
 {
     @foreach (Guid id in Ids)
     {
-        <MudChip T="string" Size="Size.Small">@NameFor(id)</MudChip>
+        <MudChip T="string" Size="Size.Small" Variant="Variant">@NameFor(id)</MudChip>
     }
 }
 
@@ -18,6 +18,8 @@ else
 
     /// <summary>When true, renders a single "Any" chip instead of the id list (profiles case).</summary>
     [Parameter] public bool Any { get; set; }
+
+    [Parameter] public Variant Variant { get; set; } = Variant.Filled;
 
     private string NameFor(Guid id) =>
         Options.FirstOrDefault(o => o.Id == id)?.Name ?? id.ToString()[..8];

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Common/EntityMultiSelect.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Common/EntityMultiSelect.razor
@@ -4,6 +4,7 @@
            SelectedValues="SelectedIds"
            SelectedValuesChanged="OnSelectedValuesChanged"
            ToStringFunc="NameFor"
+           MultiSelectionTextFunc="SelectionText"
            Dense="Dense" Placeholder="@Placeholder"
            Clearable="true" SelectAll="true"
            UserAttributes="@_userAttributes">
@@ -30,6 +31,16 @@
         _userAttributes = DataTest is null
             ? []
             : new Dictionary<string, object?> { ["data-test"] = DataTest };
+
+    // Joined names cannot fit the narrow grid cell this renders in — that is what clipped the
+    // category editor to "C...". One selection shows its name; more collapse to a count, which
+    // can never overflow. The open dropdown still shows exactly what is checked.
+    private static string SelectionText(IReadOnlyList<string?>? selected) => selected switch
+    {
+        null or { Count: 0 } => "",
+        { Count: 1 } => selected[0] ?? "",
+        _ => $"{selected.Count} selected",
+    };
 
     private string NameFor(Guid id) =>
         Options.FirstOrDefault(o => o.Id == id)?.Name ?? id.ToString();

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Common/EntityMultiSelect.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Common/EntityMultiSelect.razor
@@ -4,9 +4,9 @@
            SelectedValues="SelectedIds"
            SelectedValuesChanged="OnSelectedValuesChanged"
            ToStringFunc="NameFor"
-           MultiSelectionTextFunc="SelectionText"
+           MultiSelectionTextFunc="SelectionTextFunc"
            Dense="Dense" Placeholder="@Placeholder"
-           Clearable="true" SelectAll="true"
+           Clearable="@(!Compact)" SelectAll="true"
            UserAttributes="@_userAttributes">
     @foreach (EntityOption option in Options)
     {
@@ -32,9 +32,19 @@
             ? []
             : new Dictionary<string, object?> { ["data-test"] = DataTest };
 
-    // Joined names cannot fit the narrow grid cell this renders in — that is what clipped the
-    // category editor to "C...". One selection shows its name; more collapse to a count, which
-    // can never overflow. The open dropdown still shows exactly what is checked.
+    /// <summary>
+    /// Fits the control into a narrow container: collapses a multi-selection to "N selected"
+    /// instead of joined names, and drops the clear button, whose adornment costs more width than
+    /// it earns when unchecking in the dropdown does the same job. Opt-in — every other caller has
+    /// room for the full names and keeps the clear button.
+    /// </summary>
+    [Parameter] public bool Compact { get; set; }
+
+    private Func<IReadOnlyList<string?>?, string>? SelectionTextFunc =>
+        Compact ? SelectionText : null;
+
+    // One selection shows its name; more collapse to a count, which can never overflow.
+    // The open dropdown still shows exactly what is checked.
     private static string SelectionText(IReadOnlyList<string?>? selected) => selected switch
     {
         null or { Count: 0 } => "",

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -22,8 +22,18 @@
             <MudToggleGroup T="HotstringKind" Value="Item.Kind" ValueChanged="OnKindChangedAsync"
                              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "kind-selector" })">
                 <MudToggleItem Value="HotstringKind.Text" Text="Text" />
-                <MudToggleItem Value="HotstringKind.DateTime" Text="Date & time" />
-                <MudToggleItem Value="HotstringKind.Macro" Text="Macro" />
+                <MudToggleItem Value="HotstringKind.DateTime">
+                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                        <MudIcon Icon="@Icons.Material.Filled.Schedule" Color="Color.Info" Size="Size.Small" />
+                        <MudText>Date & time</MudText>
+                    </MudStack>
+                </MudToggleItem>
+                <MudToggleItem Value="HotstringKind.Macro">
+                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                        <MudIcon Icon="@Icons.Material.Filled.Bolt" Color="Color.Success" Size="Size.Small" />
+                        <MudText>Macro</MudText>
+                    </MudStack>
+                </MudToggleItem>
                 <MudToggleItem Value="HotstringKind.Raw">
                     <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
                         <MudIcon Icon="@Icons.Material.Filled.Warning" Color="Color.Warning" Size="Size.Small"

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringKindChip.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringKindChip.razor
@@ -1,0 +1,35 @@
+@using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Helpers
+@using MudBlazor
+
+@* Every row shows its own kind, so a column titled "Type" actually reports the type. Delivery is
+   surfaced only for the clipboard exception — clipboard delivery has a real side effect (it
+   overwrites the user's clipboard), whereas keystroke delivery is the unremarkable default and
+   labelling it on every row was noise. Lives in its own component so the desktop grid and the
+   mobile list cannot drift apart; the tints ride along in the scoped CSS. *@
+<span class="kind-chip-host">
+    <MudChip T="string" Size="Size.Small" Variant="Variant.Text"
+             Class="@HotstringKindDisplay.ChipClass(Kind)"
+             Icon="@(Kind == HotstringKind.Raw ? Icons.Material.Filled.Warning : null)"
+             UserAttributes="@ChipAttributes()">@HotstringKindDisplay.Label(Kind)</MudChip>
+    @if (Kind == HotstringKind.Text && DeliveryDisplay.IsClipboard(EffectiveDelivery))
+    {
+        <MudIcon Icon="@Icons.Material.Filled.ContentPaste" Size="Size.Small" Class="delivery-icon"
+                 UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = DeliveryDisplay.ClipboardDataTest })" />
+    }
+</span>
+
+@code {
+    [Parameter, EditorRequired] public HotstringKind Kind { get; set; }
+
+    /// <summary>Only read for <see cref="HotstringKind.Text"/> — the sole kind with a delivery choice.</summary>
+    [Parameter] public HotstringDelivery EffectiveDelivery { get; set; }
+
+    private Dictionary<string, object?> ChipAttributes() => Kind == HotstringKind.Raw
+        ? new Dictionary<string, object?>
+        {
+            ["aria-label"] = $"{HotstringKindDisplay.Label(Kind)}. {HotstringKindDisplay.ScriptWarningText}",
+            ["data-test"] = "raw-kind-chip",
+        }
+        : [];
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringKindChip.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringKindChip.razor.css
@@ -1,0 +1,33 @@
+/* Type chips read as data, not actions. The toolbar already owns saturated fill in the brand
+   triad (Primary green #6AA84F, Secondary blue #3B8FC2, Tertiary brick #8C3A3A), so these hues
+   are picked off that triad and kept as soft tints. Mixing against theme variables tracks
+   light/dark without needing a dark-mode selector.
+
+   These live here rather than in Hotstrings.razor.css because the mobile list is a separate
+   component: page-scoped rules keyed on .hotstrings-grid never reached it, which is why mobile
+   Type chips rendered grey. */
+.kind-chip-host ::deep .mud-chip.kind-chip--text {
+    background-color: color-mix(in oklch, var(--mud-palette-surface) 84%, oklch(0.62 0.19 300));
+    color: color-mix(in oklch, var(--mud-palette-text-primary) 35%, oklch(0.52 0.19 300));
+}
+
+.kind-chip-host ::deep .mud-chip.kind-chip--datetime {
+    background-color: color-mix(in oklch, var(--mud-palette-surface) 84%, oklch(0.65 0.13 200));
+    color: color-mix(in oklch, var(--mud-palette-text-primary) 35%, oklch(0.52 0.13 200));
+}
+
+.kind-chip-host ::deep .mud-chip.kind-chip--macro {
+    background-color: color-mix(in oklch, var(--mud-palette-surface) 84%, oklch(0.63 0.20 350));
+    color: color-mix(in oklch, var(--mud-palette-text-primary) 35%, oklch(0.52 0.20 350));
+}
+
+.kind-chip-host ::deep .mud-chip.kind-chip--raw {
+    background-color: color-mix(in oklch, var(--mud-palette-surface) 84%, oklch(0.70 0.15 70));
+    color: color-mix(in oklch, var(--mud-palette-text-primary) 35%, oklch(0.50 0.15 70));
+}
+
+.kind-chip-host ::deep .delivery-icon {
+    opacity: 0.6;
+    margin-left: 4px;
+    vertical-align: middle;
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
@@ -13,7 +13,18 @@
 
     @if (Items.Count == 0)
     {
-        <MudText Class="pa-4 text-center" Typo="Typo.body2">No hotstrings yet.</MudText>
+        @if (HasActiveFilters)
+        {
+            <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="pa-4">
+                <MudText Typo="Typo.body2">No hotstrings match these filters.</MudText>
+                <MudButton Variant="Variant.Text" Color="Color.Primary" Class="clear-filters"
+                           OnClick="OnClearFilters">Clear filters</MudButton>
+            </MudStack>
+        }
+        else
+        {
+            <MudText Class="pa-4 text-center" Typo="Typo.body2">No hotstrings yet.</MudText>
+        }
     }
     else
     {
@@ -105,7 +116,7 @@
                                         <EntityChips Ids="item.ProfileIds" Options="_profileOptions" Any="item.AppliesToAllProfiles" />
                                     </MudText>
                                     <MudText Typo="Typo.body2"><strong>Categories:</strong>
-                                        <EntityChips Ids="item.CategoryIds" Options="_categoryOptions" Variant="Variant.Outlined" />
+                                        <EntityChips Ids="item.CategoryIds" Options="_categoryOptions" Variant="Variant.Outlined" Color="Color.Primary" />
                                     </MudText>
                                     @if (item.Kind != HotstringKind.Raw)
                                     {
@@ -153,6 +164,10 @@
     [Parameter] public EventCallback<HotstringEditModel> OnEdit { get; set; }
     [Parameter] public EventCallback<HotstringEditModel> OnDelete { get; set; }
     [Parameter] public EventCallback<IReadOnlyList<Guid>> OnBulkDelete { get; set; }
+
+    /// <summary>Drives the empty state: filtered-empty offers a way out, true-empty does not.</summary>
+    [Parameter] public bool HasActiveFilters { get; set; }
+    [Parameter] public EventCallback OnClearFilters { get; set; }
 
     private Guid? _expandedId;
     private bool _selectMode;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
@@ -11,7 +11,7 @@
         <MudText Typo="Typo.subtitle2">@(_selectMode ? $"{_selectedIds.Count} selected" : "")</MudText>
     </MudStack>
 
-    @if (Items.Count == 0)
+    @if (Items.Count == 0 && !Loading)
     {
         @if (HasActiveFilters)
         {
@@ -168,6 +168,10 @@
     /// <summary>Drives the empty state: filtered-empty offers a way out, true-empty does not.</summary>
     [Parameter] public bool HasActiveFilters { get; set; }
     [Parameter] public EventCallback OnClearFilters { get; set; }
+
+    /// <summary>Suppresses the empty state while a load is in flight — an empty list mid-load is
+    /// not yet known to be empty, and "No hotstrings yet" under a progress bar reads as a result.</summary>
+    [Parameter] public bool Loading { get; set; }
 
     private Guid? _expandedId;
     private bool _selectMode;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
@@ -53,22 +53,15 @@
                                        @onchange="e => OnRowCheckboxChanged(item, IsChecked(e))" />
                             </td>
                         }
-                        <td class="trigger-cell"><code>@item.Trigger</code></td>
-                        <td class="replacement-cell">
-                            @if (item.Kind == HotstringKind.Raw)
-                            {
-                                <MudIcon Icon="@Icons.Material.Filled.Warning" Color="Color.Warning" Size="Size.Small" Class="script-badge"
-                                         title="Raw — verbatim AutoHotkey definition"
-                                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "script-badge-collapsed" })" />
-                            }
-                            @if (item.Kind == HotstringKind.Text)
-                            {
-                                <MudChip T="string" Size="Size.Small"
-                                         Color="@(DeliveryDisplay.IsClipboard(item.EffectiveDelivery) ? Color.Info : Color.Default)"
-                                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = DeliveryDisplay.DataTest(item.EffectiveDelivery) })">@DeliveryDisplay.Label(item.EffectiveDelivery)</MudChip>
-                            }
-                            @RenderReplacementCell(item)
+                        @* Same chip as the desktop grid's Type column — kind for every row, tinted per
+                           kind, with Raw's warning icon riding on the chip. It sits under the trigger
+                           rather than beside the replacement: at 390px a word-width chip in the
+                           replacement cell left that column only wide enough for an ellipsis. *@
+                        <td class="trigger-cell">
+                            <code>@item.Trigger</code>
+                            <HotstringKindChip Kind="item.Kind" EffectiveDelivery="item.EffectiveDelivery" />
                         </td>
+                        <td class="replacement-cell">@RenderReplacementCell(item)</td>
                         <td class="chevron-cell">@(expanded ? "▾" : "▸")</td>
                     </tr>
                     @if (expanded)

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
@@ -105,7 +105,7 @@
                                         <EntityChips Ids="item.ProfileIds" Options="_profileOptions" Any="item.AppliesToAllProfiles" />
                                     </MudText>
                                     <MudText Typo="Typo.body2"><strong>Categories:</strong>
-                                        <EntityChips Ids="item.CategoryIds" Options="_categoryOptions" />
+                                        <EntityChips Ids="item.CategoryIds" Options="_categoryOptions" Variant="Variant.Outlined" />
                                     </MudText>
                                     @if (item.Kind != HotstringKind.Raw)
                                     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor.css
@@ -30,9 +30,15 @@
     vertical-align: middle;
 }
 
+/* Trigger and its kind chip stack, so the replacement column keeps the full remaining width
+   instead of collapsing to an ellipsis at phone widths. */
 .mobile-list .trigger-cell {
-    width: 30%;
+    width: 34%;
     white-space: nowrap;
+}
+
+.mobile-list .trigger-cell code {
+    display: block;
 }
 
 .mobile-list .replacement-cell {
@@ -61,9 +67,11 @@
     text-align: center;
 }
 
-.mobile-list .script-badge {
-    vertical-align: middle;
-    margin-right: 4px;
+/* The kind chip is a child component, so its root carries a different scope — reach into it with
+   ::deep, anchored on .mobile-list, which is this component's own markup. */
+.mobile-list ::deep .kind-chip-host {
+    display: block;
+    margin-top: 2px;
 }
 
 .script-body {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/DeliveryDisplay.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/DeliveryDisplay.cs
@@ -6,14 +6,12 @@ namespace AHKFlowApp.UI.Blazor.Helpers;
 internal static class DeliveryDisplay
 {
     public const string ClipboardDataTest = "clipboard-delivery";
-    public const string HotstringDataTest = "hotstring-delivery";
 
     public static bool IsClipboard(HotstringDelivery effectiveDelivery) =>
         effectiveDelivery == HotstringDelivery.ClipboardPaste;
 
+    /// <summary>Only reached from the Type tooltip now — the chip itself reports the kind, and
+    /// keystroke delivery is the unremarkable default, so only clipboard gets a visual marker.</summary>
     public static string Label(HotstringDelivery effectiveDelivery) =>
         IsClipboard(effectiveDelivery) ? "Clipboard" : "Hotstring";
-
-    public static string DataTest(HotstringDelivery effectiveDelivery) =>
-        IsClipboard(effectiveDelivery) ? ClipboardDataTest : HotstringDataTest;
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotstringKindDisplay.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotstringKindDisplay.cs
@@ -1,0 +1,29 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+
+namespace AHKFlowApp.UI.Blazor.Helpers;
+
+/// <summary>Single-sourced label and tint class for a hotstring's kind chip, shared by the
+/// desktop grid and the mobile list so both branches show the same Type coding.</summary>
+internal static class HotstringKindDisplay
+{
+    /// <summary>Warning conveyed to assistive tech and sighted users alike — the chip's warning
+    /// color and icon alone are not exposed to screen readers.</summary>
+    public const string ScriptWarningText = "Verbatim AutoHotkey definition — review before running.";
+
+    public static string Label(HotstringKind kind) => kind switch
+    {
+        HotstringKind.Text => "Text",
+        HotstringKind.DateTime => "Date & time",
+        HotstringKind.Macro => "Macro",
+        HotstringKind.Raw => "Raw",
+        _ => kind.ToString(),
+    };
+
+    public static string ChipClass(HotstringKind kind) => kind switch
+    {
+        HotstringKind.DateTime => "kind-chip--datetime",
+        HotstringKind.Macro => "kind-chip--macro",
+        HotstringKind.Raw => "kind-chip--raw",
+        _ => "kind-chip--text",
+    };
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -74,6 +74,7 @@
                          Dense="true" Hover="true" RowsPerPage="_rowsPerPage"
                          Filterable="true" FilterMode="DataGridFilterMode.ColumnFilterMenu"
                          SortMode="SortMode.Single" ReadOnly="true"
+                         Loading="_loading"
                          RowClassFunc="@GetRowClass">
                 <Columns>
                     @* SelectColumn defaults to an inline width:0% (sized to content under the
@@ -158,10 +159,10 @@
                         <HeaderTemplate>
                             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="0">
                                 <MudText>Type</MudText>
-                                <MudTooltip Text="* = expands immediately · ? = triggers inside words · C = case sensitive">
+                                <MudTooltip Text="* = expands immediately · ? = triggers inside words · C = case sensitive · O = omits ending character · window icon = only in a specific app · clipboard icon = pasted via clipboard">
                                     <MudIconButton Icon="@Icons.Material.Filled.HelpOutline" Size="Size.Small"
                                                    Class="type-legend-help"
-                                                   UserAttributes="@(new Dictionary<string, object?> { ["aria-label"] = "Glyph legend: * expands immediately, ? triggers inside words, C case sensitive" })" />
+                                                   UserAttributes="@(new Dictionary<string, object?> { ["aria-label"] = "Glyph legend: * expands immediately, ? triggers inside words, C case sensitive, O omits ending character, window icon only in a specific app, clipboard icon pasted via clipboard" })" />
                                 </MudTooltip>
                             </MudStack>
                         </HeaderTemplate>
@@ -194,7 +195,20 @@
                         <CellTemplate>@RenderActions(context.Item)</CellTemplate>
                     </TemplateColumn>
                 </Columns>
-                <NoRecordsContent><MudText>No hotstrings yet.</MudText></NoRecordsContent>
+                <NoRecordsContent>
+                    @if (HasActiveFilters)
+                    {
+                        <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="pa-4">
+                            <MudText>No hotstrings match these filters.</MudText>
+                            <MudButton Variant="Variant.Text" Color="Color.Primary" Class="clear-filters"
+                                       OnClick="ClearFiltersAsync">Clear filters</MudButton>
+                        </MudStack>
+                    }
+                    else
+                    {
+                        <MudText>No hotstrings yet.</MudText>
+                    }
+                </NoRecordsContent>
                 <PagerContent>
                     <MudDataGridPager T="HotstringEditModel" PageSizeOptions="UserPreferences.AllowedRowsPerPage" />
                 </PagerContent>
@@ -242,9 +256,16 @@
                 <MudAlert Severity="Severity.Error" Class="mb-3">@_loadError</MudAlert>
             }
 
+            @if (_loading)
+            {
+                <MudProgressLinear Indeterminate="true" Color="Color.Primary" Class="mb-2" />
+            }
+
             <HotstringMobileList Items="_mobileItems"
                                  Profiles="_profiles"
                                  Categories="_categories"
+                                 HasActiveFilters="HasActiveFilters"
+                                 OnClearFilters="ClearFiltersAsync"
                                  OnEdit="OpenEditDialogAsync"
                                  OnDelete="DeleteAsync"
                                  OnBulkDelete="MobileBulkDeleteAsync" />
@@ -908,6 +929,21 @@
         await LoadMobileAsync();
     }
 
+    // Separates "you have no hotstrings" from "your filters matched nothing" — the two empty
+    // states need different copy, and only the second one can offer a way out.
+    private bool HasActiveFilters =>
+        !string.IsNullOrWhiteSpace(_search) || _selectedKind is not null || _selectedCategoryIds.Count > 0;
+
+    private async Task ClearFiltersAsync()
+    {
+        _search = "";
+        _selectedKind = null;
+        _selectedCategoryIds = [];
+        if (_grid is not null) await _grid.ReloadServerData();
+        _mobilePage = 1;
+        await LoadMobileAsync();
+    }
+
     private RenderFragment RenderProfiles(bool appliesToAllProfiles, IReadOnlyCollection<Guid> profileIds) =>
         @<EntityChips Ids="profileIds" Options="_profileOptions" Any="appliesToAllProfiles" />;
 
@@ -942,7 +978,7 @@
                             DataTest="category-select" />;
 
     private RenderFragment RenderCategories(IReadOnlyCollection<Guid> categoryIds) =>
-        @<EntityChips Ids="categoryIds" Options="_categoryOptions" Variant="Variant.Outlined" />;
+        @<EntityChips Ids="categoryIds" Options="_categoryOptions" Variant="Variant.Outlined" Color="Color.Primary" />;
 
     private static string KindLabel(HotstringKind kind) => kind switch
     {
@@ -953,23 +989,28 @@
         _ => kind.ToString(),
     };
 
-    // Text rows show the resolved delivery chip (Hotstring/Clipboard) instead of a "Text" kind
-    // chip — the delivery is the more useful signal once Auto resolves per-row. Non-Text kinds
-    // keep their existing kind chip.
-    private RenderFragment RenderTypeChip(HotstringEditModel item) => item.Kind == HotstringKind.Text
-        ? @<MudChip T="string" Size="Size.Small"
-                    Color="@(DeliveryDisplay.IsClipboard(item.EffectiveDelivery) ? Color.Info : Color.Default)"
-                    UserAttributes="@DeliveryChipAttributes(item.EffectiveDelivery)">@DeliveryDisplay.Label(item.EffectiveDelivery)</MudChip>
-        : @<MudChip T="string" Size="Size.Small" Color="@KindColor(item.Kind)"
-                    Icon="@(item.Kind == HotstringKind.Raw ? Icons.Material.Filled.Warning : null)"
-                    UserAttributes="@KindChipAttributes(item.Kind)">@KindLabel(item.Kind)</MudChip>;
+    // Every row shows its own kind, so a column titled "Type" actually reports the type. Delivery
+    // is surfaced only for the clipboard exception — clipboard delivery has a real side effect (it
+    // overwrites the user's clipboard), whereas keystroke delivery is the unremarkable default and
+    // labelling it on every row was noise. Tints live in Hotstrings.razor.css.
+    private RenderFragment RenderTypeChip(HotstringEditModel item) => @<text>
+        <MudChip T="string" Size="Size.Small" Variant="Variant.Text"
+                 Class="@KindChipClass(item.Kind)"
+                 Icon="@(item.Kind == HotstringKind.Raw ? Icons.Material.Filled.Warning : null)"
+                 UserAttributes="@KindChipAttributes(item.Kind)">@KindLabel(item.Kind)</MudChip>
+        @if (item.Kind == HotstringKind.Text && DeliveryDisplay.IsClipboard(item.EffectiveDelivery))
+        {
+            <MudIcon Icon="@Icons.Material.Filled.ContentPaste" Size="Size.Small" Class="delivery-icon"
+                     UserAttributes="@DeliveryChipAttributes(item.EffectiveDelivery)" />
+        }
+    </text>;
 
-    private static Color KindColor(HotstringKind kind) => kind switch
+    private static string KindChipClass(HotstringKind kind) => kind switch
     {
-        HotstringKind.DateTime => Color.Info,
-        HotstringKind.Macro => Color.Success,
-        HotstringKind.Raw => Color.Warning,
-        _ => Color.Default,
+        HotstringKind.DateTime => "kind-chip--datetime",
+        HotstringKind.Macro => "kind-chip--macro",
+        HotstringKind.Raw => "kind-chip--raw",
+        _ => "kind-chip--text",
     };
 
     private static Dictionary<string, object?> DeliveryChipAttributes(HotstringDelivery effectiveDelivery) =>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -998,41 +998,8 @@
     private RenderFragment RenderCategories(IReadOnlyCollection<Guid> categoryIds) =>
         @<EntityChips Ids="categoryIds" Options="_categoryOptions" Variant="Variant.Outlined" Color="Color.Primary" />;
 
-    private static string KindLabel(HotstringKind kind) => kind switch
-    {
-        HotstringKind.Text => "Text",
-        HotstringKind.DateTime => "Date & time",
-        HotstringKind.Macro => "Macro",
-        HotstringKind.Raw => "Raw",
-        _ => kind.ToString(),
-    };
-
-    // Every row shows its own kind, so a column titled "Type" actually reports the type. Delivery
-    // is surfaced only for the clipboard exception — clipboard delivery has a real side effect (it
-    // overwrites the user's clipboard), whereas keystroke delivery is the unremarkable default and
-    // labelling it on every row was noise. Tints live in Hotstrings.razor.css.
-    private RenderFragment RenderTypeChip(HotstringEditModel item) => @<text>
-        <MudChip T="string" Size="Size.Small" Variant="Variant.Text"
-                 Class="@KindChipClass(item.Kind)"
-                 Icon="@(item.Kind == HotstringKind.Raw ? Icons.Material.Filled.Warning : null)"
-                 UserAttributes="@KindChipAttributes(item.Kind)">@KindLabel(item.Kind)</MudChip>
-        @if (item.Kind == HotstringKind.Text && DeliveryDisplay.IsClipboard(item.EffectiveDelivery))
-        {
-            <MudIcon Icon="@Icons.Material.Filled.ContentPaste" Size="Size.Small" Class="delivery-icon"
-                     UserAttributes="@DeliveryChipAttributes(item.EffectiveDelivery)" />
-        }
-    </text>;
-
-    private static string KindChipClass(HotstringKind kind) => kind switch
-    {
-        HotstringKind.DateTime => "kind-chip--datetime",
-        HotstringKind.Macro => "kind-chip--macro",
-        HotstringKind.Raw => "kind-chip--raw",
-        _ => "kind-chip--text",
-    };
-
-    private static Dictionary<string, object?> DeliveryChipAttributes(HotstringDelivery effectiveDelivery) =>
-        new() { ["data-test"] = DeliveryDisplay.DataTest(effectiveDelivery) };
+    private RenderFragment RenderTypeChip(HotstringEditModel item) =>
+        @<HotstringKindChip Kind="item.Kind" EffectiveDelivery="item.EffectiveDelivery" />;
 
     private static string OptionGlyphs(HotstringEditModel item)
     {
@@ -1048,17 +1015,15 @@
         return glyphs;
     }
 
-    // Warning conveyed to assistive tech and sighted users alike — the chip's warning color and
-    // icon alone are not exposed to screen readers.
-    private const string ScriptWarningText = "Verbatim AutoHotkey definition — review before running.";
-
     private static string OptionsTooltip(HotstringEditModel item)
     {
-        List<string> parts = [item.Kind == HotstringKind.Text ? DeliveryDisplay.Label(item.EffectiveDelivery) : KindLabel(item.Kind)];
+        List<string> parts = [item.Kind == HotstringKind.Text
+            ? DeliveryDisplay.Label(item.EffectiveDelivery)
+            : HotstringKindDisplay.Label(item.Kind)];
         if (item.Kind == HotstringKind.Raw)
         {
             // Raw's structured flags are meaningless (options live in the verbatim text) — skip them.
-            parts.Add(ScriptWarningText);
+            parts.Add(HotstringKindDisplay.ScriptWarningText);
         }
         else
         {
@@ -1070,11 +1035,6 @@
         if (item.ContextMatchType is not null) parts.Add($"Only in {item.ContextSummary}");
         return string.Join(" · ", parts);
     }
-
-    private static Dictionary<string, object?> KindChipAttributes(HotstringKind kind) =>
-        kind == HotstringKind.Raw
-            ? new Dictionary<string, object?> { ["aria-label"] = $"{KindLabel(kind)}. {ScriptWarningText}" }
-            : [];
 
     private RenderFragment RenderActions(HotstringEditModel item) => @<text>
         @if (IsEditing(item))

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -150,7 +150,17 @@
                             }
                         </CellTemplate>
                     </TemplateColumn>
-                    <TemplateColumn Title="Type" Sortable="true" SortBy="x => x.Kind" Filterable="false">
+                    <TemplateColumn Sortable="true" SortBy="x => x.Kind" Filterable="false">
+                        <HeaderTemplate>
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="0">
+                                <MudText>Type</MudText>
+                                <MudTooltip Text="* = expands immediately · ? = triggers inside words · C = case sensitive">
+                                    <MudIconButton Icon="@Icons.Material.Filled.HelpOutline" Size="Size.Small"
+                                                   Class="type-legend-help"
+                                                   UserAttributes="@(new Dictionary<string, object?> { ["aria-label"] = "Glyph legend: * expands immediately, ? triggers inside words, C case sensitive" })" />
+                                </MudTooltip>
+                            </MudStack>
+                        </HeaderTemplate>
                         <CellTemplate>
                             <MudTooltip Text="@OptionsTooltip(context.Item)">
                                 <span class="type-badge">
@@ -425,7 +435,14 @@
         };
 
     private string GetRowClass(HotstringEditModel item, int _)
-        => IsEditing(item) ? (ReferenceEquals(item, _pendingCreate) ? "draft-row" : "edit-row") : string.Empty;
+    {
+        List<string> classes = [];
+        if (IsEditing(item))
+            classes.Add(ReferenceEquals(item, _pendingCreate) ? "draft-row" : "edit-row");
+        if (_selected.Contains(item))
+            classes.Add("selected-row");
+        return string.Join(" ", classes);
+    }
 
     private async Task ReloadAsync()
     {
@@ -768,14 +785,9 @@
         }
     }
 
-    private Task OpenEditDialogAsync(HotstringEditModel item) =>
-        OpenEditDialogCoreAsync(item, new DialogOptions { FullScreen = true, CloseButton = false });
-
-    private Task OpenEditDetailsDialogAsync(HotstringEditModel item) =>
-        OpenEditDialogCoreAsync(item, new DialogOptions { FullScreen = false, MaxWidth = MaxWidth.Medium, CloseButton = false });
-
-    private async Task OpenEditDialogCoreAsync(HotstringEditModel item, DialogOptions options)
+    private async Task OpenEditDialogAsync(HotstringEditModel item)
     {
+        DialogOptions options = new() { FullScreen = true, CloseButton = false };
         if (_dialogOpen || item.Id is null)
             return;
 
@@ -926,7 +938,7 @@
                             DataTest="category-select" />;
 
     private RenderFragment RenderCategories(IReadOnlyCollection<Guid> categoryIds) =>
-        @<EntityChips Ids="categoryIds" Options="_categoryOptions" />;
+        @<EntityChips Ids="categoryIds" Options="_categoryOptions" Variant="Variant.Outlined" />;
 
     private static string KindLabel(HotstringKind kind) => kind switch
     {
@@ -944,9 +956,17 @@
         ? @<MudChip T="string" Size="Size.Small"
                     Color="@(DeliveryDisplay.IsClipboard(item.EffectiveDelivery) ? Color.Info : Color.Default)"
                     UserAttributes="@DeliveryChipAttributes(item.EffectiveDelivery)">@DeliveryDisplay.Label(item.EffectiveDelivery)</MudChip>
-        : @<MudChip T="string" Size="Size.Small" Color="@(item.Kind == HotstringKind.Raw ? Color.Warning : Color.Default)"
+        : @<MudChip T="string" Size="Size.Small" Color="@KindColor(item.Kind)"
                     Icon="@(item.Kind == HotstringKind.Raw ? Icons.Material.Filled.Warning : null)"
                     UserAttributes="@KindChipAttributes(item.Kind)">@KindLabel(item.Kind)</MudChip>;
+
+    private static Color KindColor(HotstringKind kind) => kind switch
+    {
+        HotstringKind.DateTime => Color.Info,
+        HotstringKind.Macro => Color.Success,
+        HotstringKind.Raw => Color.Warning,
+        _ => Color.Default,
+    };
 
     private static Dictionary<string, object?> DeliveryChipAttributes(HotstringDelivery effectiveDelivery) =>
         new() { ["data-test"] = DeliveryDisplay.DataTest(effectiveDelivery) };
@@ -1006,17 +1026,12 @@
         }
         else
         {
-            <MudIconButton Class="edit-details" Icon="@Icons.Material.Filled.EditNote"
-                           OnClick="() => OpenEditDetailsDialogAsync(item)" />
+            <MudIconButton Class="edit" Icon="@Icons.Material.Filled.Edit"
+                           OnClick="() => (item.IsInlineEditable ? StartEditAsync(item) : OpenEditDialogAsync(item))" />
             <MudIconButton Class="show-history" Icon="@Icons.Material.Filled.History"
                            OnClick="() => ShowHistoryAsync(item)" />
             <MudIconButton Class="delete" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
                            OnClick="() => DeleteAsync(item)" />
-            @if (item.IsInlineEditable)
-            {
-                <MudIconButton Class="start-edit" Icon="@Icons.Material.Filled.Edit"
-                               OnClick="() => StartEditAsync(item)" />
-            }
         }
     </text>;
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -76,7 +76,11 @@
                          SortMode="SortMode.Single" ReadOnly="true"
                          RowClassFunc="@GetRowClass">
                 <Columns>
-                    <SelectColumn T="HotstringEditModel" />
+                    @* SelectColumn defaults to an inline width:0% (sized to content under the
+                       default auto table layout). The grid uses table-layout:fixed, where 0% is
+                       taken literally — the column collapses and the Trigger cell covers the
+                       checkbox, making row selection unclickable. Pin an explicit width. *@
+                    <SelectColumn T="HotstringEditModel" HeaderStyle="width:56px" />
                     <PropertyColumn Property="x => x.Trigger" Title="Trigger">
                         <CellTemplate>
                             @if (IsEditing(context.Item))

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -266,6 +266,7 @@
                                  Categories="_categories"
                                  HasActiveFilters="HasActiveFilters"
                                  OnClearFilters="ClearFiltersAsync"
+                                 Loading="_loading"
                                  OnEdit="OpenEditDialogAsync"
                                  OnDelete="DeleteAsync"
                                  OnBulkDelete="MobileBulkDeleteAsync" />
@@ -312,6 +313,7 @@
     private bool _loading;
     private string? _loadError;
     private string _search = "";
+    private bool _hasColumnFilters;
     private int _rowsPerPage = UserPreferences.Default.RowsPerPage;
     private readonly CancellationTokenSource _cts = new();
 
@@ -358,6 +360,15 @@
 
         (string? sortField, bool sortDescending) = GetSort(state);
 
+        // Column filters live in the grid's state, not in page fields — capture them here so the
+        // empty state can tell "no hotstrings" from "no matches" for these too.
+        string? triggerFilter = StringFilter(state, "trigger");
+        string? replacementFilter = StringFilter(state, "replacement");
+        string? descriptionFilter = StringFilter(state, "description");
+        _hasColumnFilters = !string.IsNullOrWhiteSpace(triggerFilter)
+            || !string.IsNullOrWhiteSpace(replacementFilter)
+            || !string.IsNullOrWhiteSpace(descriptionFilter);
+
         ApiResult<PagedList<HotstringDto>> result = await ListAsync(
             new HotstringListRequest(
                 Page: state.Page + 1,
@@ -365,9 +376,9 @@
                 Search: string.IsNullOrWhiteSpace(_search) ? null : _search,
                 SortField: sortField,
                 SortDescending: sortDescending,
-                TriggerFilter: StringFilter(state, "trigger"),
-                ReplacementFilter: StringFilter(state, "replacement"),
-                DescriptionFilter: StringFilter(state, "description"),
+                TriggerFilter: triggerFilter,
+                ReplacementFilter: replacementFilter,
+                DescriptionFilter: descriptionFilter,
                 CategoryIds: _selectedCategoryIds.Count > 0 ? _selectedCategoryIds : null,
                 Kind: _selectedKind),
             ct);
@@ -930,15 +941,21 @@
     }
 
     // Separates "you have no hotstrings" from "your filters matched nothing" — the two empty
-    // states need different copy, and only the second one can offer a way out.
+    // states need different copy, and only the second one can offer a way out. Column filters
+    // count too: they reach the API, so they can produce an empty result on their own.
     private bool HasActiveFilters =>
-        !string.IsNullOrWhiteSpace(_search) || _selectedKind is not null || _selectedCategoryIds.Count > 0;
+        !string.IsNullOrWhiteSpace(_search)
+        || _selectedKind is not null
+        || _selectedCategoryIds.Count > 0
+        || _hasColumnFilters;
 
     private async Task ClearFiltersAsync()
     {
         _search = "";
         _selectedKind = null;
         _selectedCategoryIds = [];
+        _grid?.FilterDefinitions.Clear();
+        _hasColumnFilters = false;
         if (_grid is not null) await _grid.ReloadServerData();
         _mobilePage = 1;
         await LoadMobileAsync();
@@ -975,6 +992,7 @@
                             SelectedIds="edit.CategoryIds"
                             SelectedIdsChanged="@(ids => edit.CategoryIds = [.. ids])"
                             Dense="true" Placeholder="Select categories"
+                            Compact="true"
                             DataTest="category-select" />;
 
     private RenderFragment RenderCategories(IReadOnlyCollection<Guid> categoryIds) =>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
@@ -91,7 +91,17 @@
 
 ::deep .hotstrings-grid th:nth-child(8),
 ::deep .hotstrings-grid td:nth-child(8) {
-    width: 132px;
+    width: 108px;
+}
+
+/* Actions column holds icon buttons, not text — the shared ellipsis rule above would clip
+   them behind a fake "..." once the fixed-width column can't fit all icons at higher zoom. */
+::deep .hotstrings-grid td:nth-child(8) {
+    overflow: visible;
+}
+
+::deep .hotstrings-grid .selected-row {
+    background-color: color-mix(in srgb, var(--mud-palette-primary) 12%, transparent);
 }
 
 ::deep .hotstrings-grid .option-glyphs {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
@@ -73,11 +73,12 @@
     width: 13%;
 }
 
-/* Profiles renders one short chip ("Any" for most rows) and never needed 10%. The reclaimed
-   width goes to Categories, which has to host the inline multi-select editor. */
+/* Profiles renders one short chip ("Any" for most rows), so it can give a little width to
+   Categories — but not much: at high zoom the fixed layout squeezes percentage columns hard,
+   and below ~9% the "Any" chip clips. */
 ::deep .hotstrings-grid th:nth-child(5),
 ::deep .hotstrings-grid td:nth-child(5) {
-    width: 7%;
+    width: 9%;
 }
 
 ::deep .hotstrings-grid th:nth-child(6),
@@ -86,9 +87,11 @@
     text-align: center;
 }
 
+/* Wider than the original 10% so the inline editor is comfortable, but it no longer needs to fit
+   joined category names — MultiSelectionTextFunc collapses multi-selection to "N selected". */
 ::deep .hotstrings-grid th:nth-child(7),
 ::deep .hotstrings-grid td:nth-child(7) {
-    width: 14%;
+    width: 12%;
 }
 
 /* Actions column holds icon buttons, not text — the shared ellipsis rule above would clip
@@ -99,8 +102,10 @@
     overflow: visible;
 }
 
+/* 12% read as barely-there against the dark surface; 18% stays subtle in light while being
+   unambiguous in dark. */
 ::deep .hotstrings-grid .selected-row {
-    background-color: color-mix(in srgb, var(--mud-palette-primary) 12%, transparent);
+    background-color: color-mix(in srgb, var(--mud-palette-primary) 18%, transparent);
 }
 
 /* Inline editors must not inherit the read-only cell clipping above — that rule is what

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
@@ -89,13 +89,10 @@
     width: 10%;
 }
 
-::deep .hotstrings-grid th:nth-child(8),
-::deep .hotstrings-grid td:nth-child(8) {
-    width: 108px;
-}
-
 /* Actions column holds icon buttons, not text — the shared ellipsis rule above would clip
-   them behind a fake "..." once the fixed-width column can't fit all icons at higher zoom. */
+   them behind a fake "..." once the fixed-width column can't fit all icons at higher zoom.
+   Its width comes from the column's HeaderStyle in Hotstrings.razor: under table-layout:fixed
+   the header row sizes the column, so an inline header width beats any rule set here. */
 ::deep .hotstrings-grid td:nth-child(8) {
     overflow: visible;
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
@@ -70,12 +70,14 @@
 
 ::deep .hotstrings-grid th:nth-child(4),
 ::deep .hotstrings-grid td:nth-child(4) {
-    width: 14%;
+    width: 13%;
 }
 
+/* Profiles renders one short chip ("Any" for most rows) and never needed 10%. The reclaimed
+   width goes to Categories, which has to host the inline multi-select editor. */
 ::deep .hotstrings-grid th:nth-child(5),
 ::deep .hotstrings-grid td:nth-child(5) {
-    width: 10%;
+    width: 7%;
 }
 
 ::deep .hotstrings-grid th:nth-child(6),
@@ -86,7 +88,7 @@
 
 ::deep .hotstrings-grid th:nth-child(7),
 ::deep .hotstrings-grid td:nth-child(7) {
-    width: 10%;
+    width: 14%;
 }
 
 /* Actions column holds icon buttons, not text — the shared ellipsis rule above would clip
@@ -99,6 +101,45 @@
 
 ::deep .hotstrings-grid .selected-row {
     background-color: color-mix(in srgb, var(--mud-palette-primary) 12%, transparent);
+}
+
+/* Inline editors must not inherit the read-only cell clipping above — that rule is what
+   truncated the category MudSelect to "C...". The edit-row/draft-row classes come from
+   GetRowClass, so this only relaxes the row currently being edited. */
+::deep .hotstrings-grid .edit-row .mud-table-cell,
+::deep .hotstrings-grid .draft-row .mud-table-cell {
+    overflow: visible;
+    white-space: normal;
+}
+
+/* Type chips read as data, not actions. The toolbar already owns saturated fill in the brand
+   triad (Primary green #6AA84F, Secondary blue #3B8FC2, Tertiary brick #8C3A3A), so these hues
+   are picked off that triad and kept as soft tints. Mixing against theme variables tracks
+   light/dark without needing a dark-mode selector. */
+::deep .hotstrings-grid .mud-chip.kind-chip--text {
+    background-color: color-mix(in oklch, var(--mud-palette-surface) 84%, oklch(0.62 0.19 300));
+    color: color-mix(in oklch, var(--mud-palette-text-primary) 35%, oklch(0.52 0.19 300));
+}
+
+::deep .hotstrings-grid .mud-chip.kind-chip--datetime {
+    background-color: color-mix(in oklch, var(--mud-palette-surface) 84%, oklch(0.65 0.13 200));
+    color: color-mix(in oklch, var(--mud-palette-text-primary) 35%, oklch(0.52 0.13 200));
+}
+
+::deep .hotstrings-grid .mud-chip.kind-chip--macro {
+    background-color: color-mix(in oklch, var(--mud-palette-surface) 84%, oklch(0.63 0.20 350));
+    color: color-mix(in oklch, var(--mud-palette-text-primary) 35%, oklch(0.52 0.20 350));
+}
+
+::deep .hotstrings-grid .mud-chip.kind-chip--raw {
+    background-color: color-mix(in oklch, var(--mud-palette-surface) 84%, oklch(0.70 0.15 70));
+    color: color-mix(in oklch, var(--mud-palette-text-primary) 35%, oklch(0.50 0.15 70));
+}
+
+::deep .hotstrings-grid .delivery-icon {
+    opacity: 0.6;
+    margin-left: 4px;
+    vertical-align: middle;
 }
 
 ::deep .hotstrings-grid .option-glyphs {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
@@ -120,35 +120,7 @@
     white-space: normal;
 }
 
-/* Type chips read as data, not actions. The toolbar already owns saturated fill in the brand
-   triad (Primary green #6AA84F, Secondary blue #3B8FC2, Tertiary brick #8C3A3A), so these hues
-   are picked off that triad and kept as soft tints. Mixing against theme variables tracks
-   light/dark without needing a dark-mode selector. */
-::deep .hotstrings-grid .mud-chip.kind-chip--text {
-    background-color: color-mix(in oklch, var(--mud-palette-surface) 84%, oklch(0.62 0.19 300));
-    color: color-mix(in oklch, var(--mud-palette-text-primary) 35%, oklch(0.52 0.19 300));
-}
-
-::deep .hotstrings-grid .mud-chip.kind-chip--datetime {
-    background-color: color-mix(in oklch, var(--mud-palette-surface) 84%, oklch(0.65 0.13 200));
-    color: color-mix(in oklch, var(--mud-palette-text-primary) 35%, oklch(0.52 0.13 200));
-}
-
-::deep .hotstrings-grid .mud-chip.kind-chip--macro {
-    background-color: color-mix(in oklch, var(--mud-palette-surface) 84%, oklch(0.63 0.20 350));
-    color: color-mix(in oklch, var(--mud-palette-text-primary) 35%, oklch(0.52 0.20 350));
-}
-
-::deep .hotstrings-grid .mud-chip.kind-chip--raw {
-    background-color: color-mix(in oklch, var(--mud-palette-surface) 84%, oklch(0.70 0.15 70));
-    color: color-mix(in oklch, var(--mud-palette-text-primary) 35%, oklch(0.50 0.15 70));
-}
-
-::deep .hotstrings-grid .delivery-icon {
-    opacity: 0.6;
-    margin-left: 4px;
-    vertical-align: middle;
-}
+/* Kind chip tints live in HotstringKindChip.razor.css so the mobile list gets them too. */
 
 ::deep .hotstrings-grid .option-glyphs {
     opacity: 0.6;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
@@ -58,7 +58,7 @@
 
 ::deep .hotstrings-grid th:nth-child(3),
 ::deep .hotstrings-grid td:nth-child(3) {
-    width: 24%;
+    width: 19%;
 }
 
 /* Replacement column: multi-line imports (continuation sections, converted Send
@@ -87,11 +87,14 @@
     text-align: center;
 }
 
-/* Wider than the original 10% so the inline editor is comfortable, but it no longer needs to fit
-   joined category names — MultiSelectionTextFunc collapses multi-selection to "N selected". */
+/* Hosts the inline MudSelect. Its dropdown adornment plus cell padding cost a fixed ~40px before
+   any value shows, and the percentage shrinks with the window, so 10% left room for about one
+   character at 1280px. Sized to fit "N selected" there; the width comes from Replacement, which
+   had the most slack and ellipsizes anyway. Below roughly 1150px every column in this grid
+   truncates — a pre-existing limit of fitting 8 fixed-layout columns, not specific to this one. */
 ::deep .hotstrings-grid th:nth-child(7),
 ::deep .hotstrings-grid td:nth-child(7) {
-    width: 12%;
+    width: 17%;
 }
 
 /* Actions column holds icon buttons, not text — the shared ellipsis rule above would clip

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
@@ -17,6 +17,9 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 // override the cached copies for both validation and MSAL.
 if (builder.HostEnvironment.IsDevelopment())
 {
+    // This await blocks before RunAsync, so nothing is mounted and the Blazor boot indicator is
+    // frozen at ~99% for its whole duration. AddCacheBustedDevConfigAsync bounds each fetch with a
+    // cancellation token — a slow or restarting dev host used to park the app there indefinitely.
     using HttpClient configHttp = new() { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) };
     await builder.Configuration.AddCacheBustedDevConfigAsync(configHttp);
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Startup/DevConfig.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Startup/DevConfig.cs
@@ -10,23 +10,48 @@ internal static class DevConfig
 {
     private static readonly string[] Files = ["appsettings.json", "appsettings.Development.json"];
 
+    /// <summary>Two local static files; anything slower means the dev host is not healthy, and
+    /// waiting longer only extends the frozen boot indicator.</summary>
+    private static readonly TimeSpan DefaultPerFileTimeout = TimeSpan.FromSeconds(3);
+
     /// <summary>
     /// Fetches the dev appsettings cache-busted and adds them to <paramref name="builder"/> (later
-    /// providers win, so these override any cached copies). A missing optional file is skipped.
+    /// providers win, so these override any cached copies). A file that is missing, slow, or
+    /// unreachable is skipped — the cached copy WebAssemblyHostBuilder already loaded stays in effect.
     /// </summary>
+    /// <remarks>
+    /// This runs before <c>RunAsync()</c>, so nothing is mounted while it is in flight and the Blazor
+    /// boot indicator is frozen at ~99%. Every failure mode must therefore be caught and bounded: an
+    /// escaping exception leaves that spinner up forever with no message, which reads as a hung app.
+    /// </remarks>
     public static async Task AddCacheBustedDevConfigAsync(
-        this IConfigurationBuilder builder, HttpClient http, CancellationToken ct = default)
+        this IConfigurationBuilder builder,
+        HttpClient http,
+        TimeSpan? perFileTimeout = null,
+        CancellationToken ct = default)
     {
+        // The timeout rides on a token rather than HttpClient.Timeout: under WebAssembly the browser
+        // HTTP handler does not enforce HttpClient.Timeout, so a stalled fetch would hang forever
+        // regardless of what the client is configured with. Cancelling the token aborts the fetch.
         foreach (string file in Files)
         {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(perFileTimeout ?? DefaultPerFileTimeout);
+
             try
             {
-                byte[] json = await http.GetByteArrayAsync($"{file}?reloadcheck={Guid.NewGuid():N}", ct);
+                byte[] json = await http.GetByteArrayAsync($"{file}?reloadcheck={Guid.NewGuid():N}", timeoutCts.Token);
                 builder.AddJsonStream(new MemoryStream(json));
             }
             catch (HttpRequestException)
             {
                 // File may legitimately be absent (e.g. appsettings.Development.json not created yet) — skip.
+            }
+            catch (OperationCanceledException)
+            {
+                // HttpClient surfaces its timeout as TaskCanceledException. A dev host that is
+                // restarting or still warming up can stall these fetches; boot with the cached
+                // config rather than dying before the app mounts.
             }
         }
     }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Startup/StartupErrorRoot.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Startup/StartupErrorRoot.razor
@@ -64,7 +64,7 @@ else
     {
         // Re-read the same files the host loads at boot, cache-busted, and validate the merged result.
         ConfigurationBuilder configBuilder = new();
-        await configBuilder.AddCacheBustedDevConfigAsync(Http, ct);
+        await configBuilder.AddCacheBustedDevConfigAsync(Http, ct: ct);
         return StartupConfigValidator.Check(configBuilder.Build()) is null;
     }
 

--- a/tests/AHKFlowApp.API.Tests/Dev/DevSeedEndpointTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Dev/DevSeedEndpointTests.cs
@@ -51,7 +51,7 @@ public sealed class DevSeedEndpointTests(ApiTestFixture fixture)
         SeedAllResultDto? result = await resp.Content.ReadFromJsonAsync<SeedAllResultDto>();
         result.Should().NotBeNull();
         result!.CategoriesCount.Should().Be(8);
-        result.HotstringsCount.Should().Be(12);
+        result.HotstringsCount.Should().Be(16);
         result.HotkeysCount.Should().Be(12);
     }
 
@@ -67,7 +67,7 @@ public sealed class DevSeedEndpointTests(ApiTestFixture fixture)
         SeedAllResultDto? result = await resp.Content.ReadFromJsonAsync<SeedAllResultDto>();
         result.Should().NotBeNull();
         result!.CategoriesCount.Should().Be(8);
-        result.HotstringsCount.Should().Be(12);
+        result.HotstringsCount.Should().Be(16);
         result.HotkeysCount.Should().Be(12);
     }
 

--- a/tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs
@@ -237,7 +237,7 @@ public sealed class HotstringsEndpointsTests(ApiTestFixture fixture)
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         PagedList<HotstringDto>? pagedBody = await response.Content.ReadFromJsonAsync<PagedList<HotstringDto>>();
-        pagedBody!.TotalCount.Should().Be(17);  // 5 created + 12 lazy-seeded in dev
+        pagedBody!.TotalCount.Should().Be(21);  // 5 created + 16 lazy-seeded in dev
         pagedBody.Items.Should().HaveCount(2);
         pagedBody.Page.Should().Be(2);
     }

--- a/tests/AHKFlowApp.Application.Tests/Dev/SeedAllCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Dev/SeedAllCommandHandlerTests.cs
@@ -52,11 +52,12 @@ public sealed class SeedAllCommandHandlerTests(DevDbFixture fx)
 
         result.IsSuccess.Should().BeTrue();
         result.Value.CategoriesCount.Should().Be(8);
-        result.Value.HotstringsCount.Should().Be(12);
+        result.Value.HotstringsCount.Should().Be(HotstringSeedSamples.All.Length);
         result.Value.HotkeysCount.Should().Be(12);
 
         await using AppDbContext verify = fx.CreateContext();
-        (await verify.HotstringCategories.CountAsync(hc => hc.Hotstring.OwnerOid == _ownerOid)).Should().Be(12);
+        // Every sample carries exactly one category, so the junction count tracks the sample count.
+        (await verify.HotstringCategories.CountAsync(hc => hc.Hotstring.OwnerOid == _ownerOid)).Should().Be(HotstringSeedSamples.All.Length);
         (await verify.HotkeyCategories.CountAsync(hc => hc.Hotkey.OwnerOid == _ownerOid)).Should().Be(12);
     }
 
@@ -78,7 +79,7 @@ public sealed class SeedAllCommandHandlerTests(DevDbFixture fx)
 
         result.IsSuccess.Should().BeTrue();
         result.Value.CategoriesCount.Should().Be(8);
-        result.Value.HotstringsCount.Should().Be(12);
+        result.Value.HotstringsCount.Should().Be(HotstringSeedSamples.All.Length);
         result.Value.HotkeysCount.Should().Be(12);
     }
 

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsLazySeedTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/ListHotstringsLazySeedTests.cs
@@ -18,11 +18,13 @@ namespace AHKFlowApp.Application.Tests.Hotstrings;
 public sealed class ListHotstringsLazySeedTests(HotstringDbFixture fx)
 {
     private readonly FakeTimeProvider _clock = new(DateTimeOffset.Parse("2026-05-23T10:00:00Z"));
+    // Derived from the shared seed set so adding a sample doesn't break every count assertion.
+    private static readonly int SampleCount = Application.Commands.Dev.HotstringSeedSamples.All.Length;
     private static readonly AppEnvironment s_dev = new(IsDevelopment: true);
     private static readonly AppEnvironment s_prod = new(IsDevelopment: false);
 
     [Fact]
-    public async Task Handle_FirstCallInDev_Seeds12Hotstrings()
+    public async Task Handle_FirstCallInDev_SeedsAllHotstrings()
     {
         var owner = Guid.NewGuid();
         await using AppDbContext ctx = fx.CreateContext();
@@ -31,7 +33,7 @@ public sealed class ListHotstringsLazySeedTests(HotstringDbFixture fx)
         Result<PagedList<HotstringDto>> result = await sut.ExecuteAsync(new ListHotstringsQuery(), CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.TotalCount.Should().Be(12);
+        result.Value.TotalCount.Should().Be(SampleCount);
     }
 
     [Fact]
@@ -62,7 +64,7 @@ public sealed class ListHotstringsLazySeedTests(HotstringDbFixture fx)
         Result<PagedList<HotstringDto>> result = await sut2.ExecuteAsync(new ListHotstringsQuery(), CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.TotalCount.Should().Be(12);
+        result.Value.TotalCount.Should().Be(SampleCount);
     }
 
     [Fact]
@@ -141,7 +143,7 @@ public sealed class ListHotstringsLazySeedTests(HotstringDbFixture fx)
         Result<PagedList<HotstringDto>> result = await sut.ExecuteAsync(new ListHotstringsQuery(), CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.TotalCount.Should().Be(12);
+        result.Value.TotalCount.Should().Be(SampleCount);
 
         // Marker persisted (the bug: lazy-seed would have detached pref on duplicate-key)
         await using AppDbContext verify = fx.CreateContext();
@@ -231,10 +233,10 @@ public sealed class ListHotstringsLazySeedTests(HotstringDbFixture fx)
         int hotstringCount = await verify.Hotstrings.CountAsync(h => h.OwnerOid == owner);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.TotalCount.Should().Be(12);
+        result.Value.TotalCount.Should().Be(SampleCount);
         pref!.CategoriesSeededAt.Should().NotBeNull();
         pref.HotstringsSeededAt.Should().NotBeNull();
-        hotstringCount.Should().Be(12);
+        hotstringCount.Should().Be(SampleCount);
     }
 
     [Fact]
@@ -261,7 +263,7 @@ public sealed class ListHotstringsLazySeedTests(HotstringDbFixture fx)
         int hotstringCount = await verify.Hotstrings.CountAsync(h => h.OwnerOid == owner);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.TotalCount.Should().Be(12);
-        hotstringCount.Should().Be(12);
+        result.Value.TotalCount.Should().Be(SampleCount);
+        hotstringCount.Should().Be(SampleCount);
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/Hotstrings/SeedHotstringsCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Hotstrings/SeedHotstringsCommandHandlerTests.cs
@@ -16,7 +16,8 @@ namespace AHKFlowApp.Application.Tests.Hotstrings;
 [Trait("Category", "Integration")]
 public sealed class SeedHotstringsCommandHandlerTests(HotstringDbFixture fx)
 {
-    private const int SampleCount = 12;
+    // Derived from the shared seed set so adding a sample doesn't break every count assertion.
+    private static readonly int SampleCount = HotstringSeedSamples.All.Length;
 
     private static AppEnvironment DevEnv(bool isDev) => new(isDev);
 
@@ -28,7 +29,7 @@ public sealed class SeedHotstringsCommandHandlerTests(HotstringDbFixture fx)
     }
 
     [Fact]
-    public async Task Handle_InDevelopment_SeedsTwelveSamples()
+    public async Task Handle_InDevelopment_SeedsAllSamples()
     {
         var owner = Guid.NewGuid();
         await using AppDbContext db = fx.CreateContext();
@@ -127,7 +128,7 @@ public sealed class SeedHotstringsCommandHandlerTests(HotstringDbFixture fx)
     }
 
     [Fact]
-    public async Task Handle_WithReset_AfterFullSeed_KeepsTwelveSamples()
+    public async Task Handle_WithReset_AfterFullSeed_KeepsAllSamples()
     {
         var owner = Guid.NewGuid();
         await SeedCategoriesAsync(owner);
@@ -177,7 +178,7 @@ public sealed class SeedHotstringsCommandHandlerTests(HotstringDbFixture fx)
     }
 
     [Fact]
-    public async Task Handle_BeforeCategoriesSeeded_CreatesTwelveWithNoJunctions()
+    public async Task Handle_BeforeCategoriesSeeded_CreatesAllWithNoJunctions()
     {
         var owner = Guid.NewGuid();
         await using AppDbContext db = fx.CreateContext();

--- a/tests/AHKFlowApp.E2E.Tests/HotstringsCrudFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/HotstringsCrudFlowTests.cs
@@ -33,7 +33,7 @@ public sealed class HotstringsCrudFlowTests(StackFixture fixture) : IAsyncLifeti
 
         Assert.True(await page.IsVisibleAsync("text=by the way"));
 
-        await page.ClickAsync("button.start-edit");
+        await page.ClickAsync("button.edit");
         await page.WaitForSelectorAsync("tr.edit-row");
         await page.FillAsync("textarea[data-test=\"replacement-input\"]", "by the way!");
         await page.ClickAsync("button.commit-edit");

--- a/tests/AHKFlowApp.E2E.Tests/RawHotstringFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/RawHotstringFlowTests.cs
@@ -101,10 +101,11 @@ public sealed class RawHotstringFlowTests(StackFixture fixture) : IAsyncLifetime
         await page.ClickAsync("button.commit-edit");
         await page.WaitForSelectorAsync("text=Hotstring created.");
 
-        // Collapsed mobile row (keyed by the derived trigger) shows the Raw warning badge.
+        // Collapsed mobile row (keyed by the derived trigger) shows the Raw kind chip, which carries
+        // the warning icon and the accessible warning text.
         await page.WaitForSelectorAsync("tr.mobile-row:has-text(\"ftw\")");
         await Assertions.Expect(
-            page.Locator("tr.mobile-row:has-text(\"ftw\") [data-test=\"script-badge-collapsed\"]")).ToBeVisibleAsync();
+            page.Locator("tr.mobile-row:has-text(\"ftw\") [data-test=\"raw-kind-chip\"]")).ToBeVisibleAsync();
 
         // Byte-match the downloaded profile script — the verbatim Raw line must appear exactly.
         await page.GotoAsync($"{fixture.Spa.BaseUrl}/downloads");

--- a/tests/AHKFlowApp.E2E.Tests/VersionHistoryFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/VersionHistoryFlowTests.cs
@@ -138,7 +138,7 @@ public sealed class VersionHistoryFlowTests(StackFixture fixture) : IAsyncLifeti
     private static async Task UpdateHotstringReplacementAsync(IPage page, string trigger, string replacement)
     {
         await page.Locator("tbody tr", new() { HasTextString = trigger })
-            .Locator("button.start-edit")
+            .Locator("button.edit")
             .ClickAsync();
         await page.WaitForSelectorAsync("tr.edit-row");
         await page.FillAsync("tr.edit-row textarea[data-test=\"replacement-input\"]", replacement);

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
@@ -211,7 +211,9 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
             .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
             .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
 
-        cut.Find("td.replacement-cell").TextContent.Should().Be("yyyy-MM-dd");
+        // The cell leads with the kind chip, so the summary is what trails it — EndWith still proves
+        // nothing else is appended after the format.
+        cut.Find("td.replacement-cell").TextContent.Trim().Should().EndWith("yyyy-MM-dd");
     }
 
     [Fact]
@@ -241,8 +243,8 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
             .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
             .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
 
-        cut.Find("td.replacement-cell").TextContent
-            .Should().Be("Dear {{{{first_name}}}},{{key:Enter}}{{cursor}}Alex");
+        cut.Find("td.replacement-cell").TextContent.Trim()
+            .Should().EndWith("Dear {{{{first_name}}}},{{key:Enter}}{{cursor}}Alex");
         cut.FindAll("td.replacement-cell .macro-token-chip").Should().BeEmpty();
     }
 
@@ -297,19 +299,40 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public void TextRow_CollapsedCell_ShowsHotstringChipByDefault()
+    public void TextRow_CollapsedCell_ShowsTintedKindChipNotDelivery()
     {
         IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
             .Add(c => c.Items, [Item("btw", "by the way")])
             .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
             .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
 
-        cut.Find("[data-test=\"hotstring-delivery\"]").TextContent.Should().Contain("Hotstring");
+        AngleSharp.Dom.IElement chip = cut.Find("td.trigger-cell .mud-chip");
+        chip.TextContent.Should().Contain("Text");
+        chip.ClassList.Should().Contain("kind-chip--text");
         cut.FindAll("[data-test=\"clipboard-delivery\"]").Should().BeEmpty();
     }
 
+    [Theory]
+    [InlineData(HotstringKind.DateTime, "Date", "kind-chip--datetime")]
+    [InlineData(HotstringKind.Macro, "Macro", "kind-chip--macro")]
+    public void CollapsedCell_NonTextKinds_ShowTheirOwnTintedChip(
+        HotstringKind kind, string expectedLabel, string expectedClass)
+    {
+        HotstringEditModel item = Item();
+        item.Kind = kind;
+
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [item])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        AngleSharp.Dom.IElement chip = cut.Find("td.trigger-cell .mud-chip");
+        chip.TextContent.Should().Contain(expectedLabel);
+        chip.ClassList.Should().Contain(expectedClass);
+    }
+
     [Fact]
-    public void TextRow_CollapsedCell_ShowsClipboardChipFromEffectiveDelivery()
+    public void TextRow_CollapsedCell_ShowsClipboardIconFromEffectiveDelivery()
     {
         HotstringEditModel item = Item("long", "replacement text");
         item.EffectiveDelivery = HotstringDelivery.ClipboardPaste;
@@ -319,8 +342,8 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
             .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
             .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
 
-        cut.Find("[data-test=\"clipboard-delivery\"]").TextContent.Should().Contain("Clipboard");
-        cut.FindAll("[data-test=\"hotstring-delivery\"]").Should().BeEmpty();
+        cut.FindAll("[data-test=\"clipboard-delivery\"]").Should().HaveCount(1);
+        cut.Find("td.trigger-cell .mud-chip").ClassList.Should().Contain("kind-chip--text");
     }
 
     [Fact]
@@ -381,7 +404,13 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
             .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
             .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
 
-        cut.FindAll("[data-test=\"script-badge-collapsed\"]").Should().HaveCount(1);
+        // The warning now rides on the Raw kind chip itself rather than a separate icon, so only
+        // the Raw row carries it — and it is labelled for screen readers, not color-only.
+        AngleSharp.Dom.IElement badge = cut.Find("[data-test=\"raw-kind-chip\"]");
+        badge.TextContent.Should().Contain("Raw");
+        badge.ClassList.Should().Contain("kind-chip--raw");
+        badge.GetAttribute("aria-label").Should().Contain("Verbatim AutoHotkey definition");
+        cut.FindAll("[data-test=\"raw-kind-chip\"]").Should().HaveCount(1);
     }
 
     [Fact]

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringMobileListTests.cs
@@ -59,6 +59,52 @@ public sealed class HotstringMobileListTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public void EmptyState_WhileLoading_ShowsNoEmptyMessage()
+    {
+        // An empty list mid-load is not yet known to be empty — "No hotstrings yet." rendered
+        // under the progress bar reads as a result the user does not actually have.
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [])
+            .Add(c => c.Loading, true)
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        cut.Markup.Should().NotContain("No hotstrings yet.");
+        cut.Markup.Should().NotContain("No hotstrings match these filters.");
+    }
+
+    [Fact]
+    public void EmptyState_WithActiveFilters_OffersClearFilters()
+    {
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [])
+            .Add(c => c.HasActiveFilters, true)
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        cut.Markup.Should().Contain("No hotstrings match these filters.");
+        cut.Markup.Should().NotContain("No hotstrings yet.");
+        cut.FindAll("button.clear-filters").Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task EmptyState_ClearFiltersButton_RaisesCallback()
+    {
+        bool cleared = false;
+
+        IRenderedComponent<HotstringMobileList> cut = Render<HotstringMobileList>(p => p
+            .Add(c => c.Items, [])
+            .Add(c => c.HasActiveFilters, true)
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[])
+            .Add(c => c.OnClearFilters, EventCallback.Factory.Create(this, () => cleared = true)));
+
+        await cut.InvokeAsync(() => cut.Find("button.clear-filters").Click());
+
+        cleared.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task EditButton_RaisesOnEdit()
     {
         HotstringEditModel item = Item();

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -221,14 +221,14 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         IRenderedComponent<Hotstrings> cut = RenderPage();
         cut.WaitForAssertion(() => cut.Find(".mobile-row"));
         cut.Find(".mobile-row").Click();
-        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
+        cut.WaitForAssertion(() => cut.Find("button.edit"));
 
         cut.Find("button.reload-hotstrings-mobile").Click();
 
         cut.WaitForAssertion(() => _api.Received(2).ListAsync(Arg.Any<HotstringListRequest>(), Arg.Any<CancellationToken>()));
         cut.WaitForAssertion(() =>
         {
-            cut.Find("button.start-edit").Should().NotBeNull();
+            cut.Find("button.edit").Should().NotBeNull();
             cut.Markup.Should().Contain("by the way");
         });
     }
@@ -279,8 +279,8 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
             .Returns(ApiResult<HotstringDto>.Ok(dto with { Replacement = "by the way!" }));
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
-        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
-        cut.Find("button.start-edit").Click();
+        cut.WaitForAssertion(() => cut.Find("button.edit"));
+        cut.Find("button.edit").Click();
         cut.WaitForAssertion(() => cut.Find("textarea[data-test=\"replacement-input\"]"));
         cut.Find("textarea[data-test=\"replacement-input\"]").Input("by the way!");
         cut.Find("button.commit-edit").Click();
@@ -323,8 +323,8 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
             .Returns(ApiResult<HotstringDto>.Ok(dto with { Replacement = replacement }));
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
-        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
-        cut.Find("button.start-edit").Click();
+        cut.WaitForAssertion(() => cut.Find("button.edit"));
+        cut.Find("button.edit").Click();
         cut.WaitForAssertion(() => cut.Find("textarea[data-test=\"replacement-input\"]"));
         cut.Find("textarea[data-test=\"replacement-input\"]").Input(replacement);
         cut.Find("button.commit-edit").Click();
@@ -347,8 +347,8 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         _api.GetAsync(summary.Id, Arg.Any<CancellationToken>()).Returns(ApiResult<HotstringDto>.Ok(detail));
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
-        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
-        cut.Find("button.start-edit").Click();
+        cut.WaitForAssertion(() => cut.Find("button.edit"));
+        cut.Find("button.edit").Click();
 
         cut.WaitForAssertion(() =>
         {
@@ -368,7 +368,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         preferences.GetAsync(Arg.Any<CancellationToken>()).Returns(new UserPreferences(25, false));
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
-        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
+        cut.WaitForAssertion(() => cut.Find("button.edit"));
         _api.ClearReceivedCalls();
         cut.Find("button.reload-hotstrings-mobile").Click();
         cut.WaitForAssertion(() =>
@@ -382,7 +382,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         });
         _api.ClearReceivedCalls();
 
-        cut.Find("button.start-edit").Click();
+        cut.Find("button.edit").Click();
 
         cut.WaitForAssertion(() => cut.Find("textarea[data-test=\"replacement-input\"]"));
         _ = _api.DidNotReceive().ListAsync(
@@ -400,8 +400,8 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
         IRenderedComponent<Hotstrings> cut = Render<Hotstrings>(p => p.AddCascadingValue(AuthenticatedState));
 
-        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
-        cut.Find("button.start-edit").Click();
+        cut.WaitForAssertion(() => cut.Find("button.edit"));
+        cut.Find("button.edit").Click();
 
         // Carry a typed edit into the promotion.
         cut.WaitForAssertion(() => cut.Find("textarea[data-test=\"replacement-input\"]"));
@@ -489,8 +489,8 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
             .Returns(ApiResult<HotstringDto>.Ok(dto with { Description = "updated filler" }));
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
-        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
-        cut.Find("button.start-edit").Click();
+        cut.WaitForAssertion(() => cut.Find("button.edit"));
+        cut.Find("button.edit").Click();
         cut.WaitForAssertion(() =>
             cut.Find("input[data-test=\"description-input\"]").GetAttribute("value").Should().Be("polite filler"));
 
@@ -534,8 +534,8 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         StubList(Page(dto));
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
-        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
-        cut.Find("button.start-edit").Click();
+        cut.WaitForAssertion(() => cut.Find("button.edit"));
+        cut.Find("button.edit").Click();
 
         cut.WaitForAssertion(() => cut.FindAll("[data-test=\"category-select\"]").Should().NotBeEmpty());
     }
@@ -654,25 +654,26 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public Task Page_EditDetails_OpensDialogWithItem()
+    public Task Page_Edit_NonInlineEditableRow_OpensDialogWithItem()
     {
         // MudDialogProvider renders dialog content into its own root, not into the component that
         // called ShowAsync — so the dialog markup must be queried on `provider`, not on `cut`
         // (RenderPage() discards its MudDialogProvider reference; render it manually here instead,
         // matching the pattern in HotstringEditDialogTests.cs).
-        var dto = new HotstringDto(Guid.NewGuid(), [], true, "btw", "by the way", null,
-            true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        // Raw is not inline-editable, so the single Edit button must route to the dialog.
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "btw", ":*:btw::by the way", null,
+            true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, Kind: HotstringKind.Raw);
         StubList(Page(dto));
 
         Render<MudPopoverProvider>();
         IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
         IRenderedComponent<Hotstrings> cut = Render<Hotstrings>(p => p.AddCascadingValue(AuthenticatedState));
 
-        cut.WaitForAssertion(() => cut.Find("button.edit-details"));
-        cut.Find("button.edit-details").Click();
+        cut.WaitForAssertion(() => cut.Find("button.edit"));
+        cut.Find("button.edit").Click();
 
         provider.WaitForAssertion(() =>
-            provider.Find("input[data-test=\"trigger-input\"]").GetAttribute("value").Should().Be("btw"));
+            provider.Find("textarea[data-test=\"replacement-input\"]").TextContent.Should().Contain("by the way"));
         return Task.CompletedTask;
     }
 
@@ -749,8 +750,10 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public Task Page_DateTimeRow_HidesStartEditPencil_TextRowKeepsIt()
+    public Task Page_EveryKind_RendersExactlyOneEditButtonPerRow()
     {
+        // Every row gets exactly one Edit button regardless of kind — its behavior branches
+        // internally (inline for Text with no context, dialog otherwise), it's not two buttons.
         var dateTimeDto = new HotstringDto(Guid.NewGuid(), [], true, "now", "", null, true, true,
             DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.DateTime,
             DateTimeFormat: "yyyy-MM-dd");
@@ -760,7 +763,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
 
-        cut.WaitForAssertion(() => cut.FindAll("button.start-edit").Count.Should().Be(1));
+        cut.WaitForAssertion(() => cut.FindAll("button.edit").Count.Should().Be(2));
         return Task.CompletedTask;
     }
 
@@ -820,6 +823,89 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
                 .Contain("Raw").And.Contain("Verbatim AutoHotkey definition");
         });
         return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task Page_DateTimeRow_ShowsInfoColoredBadge()
+    {
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "now", "", null, true, true,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.DateTime,
+            DateTimeFormat: "yyyy-MM-dd");
+        StubList(Page(dto));
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+
+        cut.WaitForAssertion(() =>
+        {
+            AngleSharp.Dom.IElement badge = cut.Find(".type-badge .mud-chip");
+            badge.TextContent.Should().Contain("Date");
+            badge.ClassList.Should().Contain(c => c.Contains("info", StringComparison.OrdinalIgnoreCase));
+        });
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task Page_MacroRow_ShowsSuccessColoredBadge()
+    {
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "greet", "hello", null, true, true,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, HotstringKind.Macro);
+        StubList(Page(dto));
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+
+        cut.WaitForAssertion(() =>
+        {
+            AngleSharp.Dom.IElement badge = cut.Find(".type-badge .mud-chip");
+            badge.TextContent.Should().Contain("Macro");
+            badge.ClassList.Should().Contain(c => c.Contains("success", StringComparison.OrdinalIgnoreCase));
+        });
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task Page_Categories_RenderOutlinedChips()
+    {
+        var categoryId = Guid.NewGuid();
+        StubCategories(new CategoryDto(categoryId, "Work", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "btw", "by the way", null, true, true,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, CategoryIds: [categoryId]);
+        StubList(Page(dto));
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+
+        cut.WaitForAssertion(() =>
+        {
+            IReadOnlyList<AngleSharp.Dom.IElement> categoryChips = [.. cut.FindAll(".mud-table-cell .mud-chip")
+                .Where(chip => chip.TextContent.Contains("Work"))];
+            categoryChips.Should().NotBeEmpty();
+            categoryChips.Should().OnlyContain(chip => chip.ClassList.Contains("mud-chip-outlined"));
+        });
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public void Page_TypeColumnHeader_ShowsGlyphLegendHelpIcon()
+    {
+        StubList(Page());
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+
+        cut.WaitForAssertion(() => cut.Find(".type-legend-help").Should().NotBeNull());
+    }
+
+    [Fact]
+    public async Task Page_SelectedRow_GetsSelectedRowClass()
+    {
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "btw", "by the way", null, true, true,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        StubList(Page(dto));
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find("tbody tr"));
+
+        await cut.InvokeAsync(() => cut.Find("tbody tr input[type=\"checkbox\"]").Change(true));
+
+        cut.WaitForAssertion(() => cut.Find("tbody tr.selected-row").Should().NotBeNull());
     }
 
     [Fact]

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -588,8 +588,10 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
 
         cut.WaitForAssertion(() =>
         {
-            cut.Find(".desktop-branch .type-badge").TextContent.Should().Contain("Hotstring");
-            cut.Find(".desktop-branch [data-test=\"hotstring-delivery\"]").Should().NotBeNull();
+            // The Type column reports the kind. Keystroke delivery is the unremarkable default and
+            // is deliberately left unmarked — only clipboard delivery, which overwrites the user's
+            // clipboard, earns an icon.
+            cut.Find(".desktop-branch .type-badge").TextContent.Should().Contain("Text");
             cut.FindAll(".desktop-branch [data-test=\"clipboard-delivery\"]").Should().BeEmpty();
             cut.Find(".option-glyphs").TextContent.Should().Be("*?C");
         });
@@ -597,7 +599,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public Task Page_ExplicitClipboardDelivery_ShowsSingleClipboardChip()
+    public Task Page_ExplicitClipboardDelivery_ShowsClipboardIcon()
     {
         HotstringDto dto = new(Guid.NewGuid(), [], true, "long", "replacement", null,
             true, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow,
@@ -608,9 +610,9 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
 
         cut.WaitForAssertion(() =>
         {
+            // Kind chip plus a clipboard icon beside it; the icon carries the marker, not text.
+            cut.Find(".desktop-branch .type-badge .mud-chip").TextContent.Should().Contain("Text");
             cut.FindAll(".desktop-branch [data-test=\"clipboard-delivery\"]").Should().HaveCount(1);
-            cut.FindAll(".desktop-branch [data-test=\"hotstring-delivery\"]").Should().BeEmpty();
-            cut.Find(".desktop-branch [data-test=\"clipboard-delivery\"]").TextContent.Should().Contain("Clipboard");
         });
         return Task.CompletedTask;
     }
@@ -816,7 +818,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         {
             AngleSharp.Dom.IElement badge = cut.Find(".type-badge .mud-chip");
             badge.TextContent.Should().Contain("Raw");
-            badge.ClassList.Should().Contain(c => c.Contains("warning", StringComparison.OrdinalIgnoreCase));
+            badge.ClassList.Should().Contain("kind-chip--raw");
             // Warning must be conveyed semantically, not just via color — screen readers read the
             // aria-label, not the CSS warning color.
             badge.GetAttribute("aria-label").Should()
@@ -839,7 +841,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         {
             AngleSharp.Dom.IElement badge = cut.Find(".type-badge .mud-chip");
             badge.TextContent.Should().Contain("Date");
-            badge.ClassList.Should().Contain(c => c.Contains("info", StringComparison.OrdinalIgnoreCase));
+            badge.ClassList.Should().Contain("kind-chip--datetime");
         });
         return Task.CompletedTask;
     }
@@ -857,13 +859,13 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         {
             AngleSharp.Dom.IElement badge = cut.Find(".type-badge .mud-chip");
             badge.TextContent.Should().Contain("Macro");
-            badge.ClassList.Should().Contain(c => c.Contains("success", StringComparison.OrdinalIgnoreCase));
+            badge.ClassList.Should().Contain("kind-chip--macro");
         });
         return Task.CompletedTask;
     }
 
     [Fact]
-    public Task Page_Categories_RenderOutlinedChips()
+    public Task Page_Categories_RenderOutlinedAccentChips()
     {
         var categoryId = Guid.NewGuid();
         StubCategories(new CategoryDto(categoryId, "Work", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
@@ -879,6 +881,10 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
                 .Where(chip => chip.TextContent.Contains("Work"))];
             categoryChips.Should().NotBeEmpty();
             categoryChips.Should().OnlyContain(chip => chip.ClassList.Contains("mud-chip-outlined"));
+            // Categories carry the brand accent, not MudBlazor's default grey. Outlined + accent is
+            // a deliberately separate channel from the tinted, filled kind chips in the Type column.
+            categoryChips.Should().OnlyContain(chip =>
+                chip.ClassList.Any(c => c.Contains("primary", StringComparison.OrdinalIgnoreCase)));
         });
         return Task.CompletedTask;
     }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -60,6 +60,32 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         _api.ListAsync(Arg.Any<HotstringListRequest>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult<PagedList<HotstringDto>>.Ok(page));
 
+    [Fact]
+    public async Task Page_WhileReloadIsInFlight_RendersLoadingIndicator()
+    {
+        // The indicator is only observable mid-flight, which no other test covers: ComponentBase
+        // renders once before awaiting a suspending event handler and again on completion, so a
+        // gated API call is the only way to catch the page in its loading state.
+        StubList(Page());
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+        cut.WaitForAssertion(() =>
+            cut.FindAll(".mobile-branch .mud-progress-linear").Should().BeEmpty());
+
+        var gate = new TaskCompletionSource<ApiResult<PagedList<HotstringDto>>>();
+        _api.ListAsync(Arg.Any<HotstringListRequest>(), Arg.Any<CancellationToken>())
+            .Returns(gate.Task);
+
+        await cut.InvokeAsync(() => cut.Find("button.reload-hotstrings-mobile").Click());
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll(".mobile-branch .mud-progress-linear").Should().NotBeEmpty());
+
+        gate.SetResult(ApiResult<PagedList<HotstringDto>>.Ok(Page()));
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll(".mobile-branch .mud-progress-linear").Should().BeEmpty());
+    }
+
     private void StubListFailure(ApiResultStatus status, ApiProblemDetails? problem = null) =>
         _api.ListAsync(Arg.Any<HotstringListRequest>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult<PagedList<HotstringDto>>.Failure(status, problem));

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Startup/DevConfigTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Startup/DevConfigTests.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics;
+using System.Net;
+using AHKFlowApp.UI.Blazor.Startup;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Startup;
+
+public sealed class DevConfigTests
+{
+    private static HttpClient Client(HttpMessageHandler handler) =>
+        new(handler) { BaseAddress = new Uri("http://localhost/") };
+
+    [Fact]
+    public async Task AddCacheBustedDevConfigAsync_WhenFetchTimesOut_DoesNotThrow()
+    {
+        // Regression: HttpClient reports its timeout as TaskCanceledException, which was not caught.
+        // This runs before RunAsync, so an escaping exception leaves the Blazor boot indicator frozen
+        // at ~99% forever with nothing on screen — the app never mounts to report anything.
+        var builder = new ConfigurationBuilder();
+        using HttpClient http = Client(new ThrowingHandler(new TaskCanceledException()));
+
+        Func<Task> act = () => builder.AddCacheBustedDevConfigAsync(http);
+
+        await act.Should().NotThrowAsync();
+        builder.Sources.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AddCacheBustedDevConfigAsync_WhenFetchNeverCompletes_GivesUpAndReturns()
+    {
+        // The live failure: a dev host that accepts the connection but never answers. HttpClient.Timeout
+        // does not help here — WebAssembly's browser handler ignores it — so the bound has to come from
+        // the cancellation token. Without it the app never mounts and the boot spinner sits at ~99%.
+        var builder = new ConfigurationBuilder();
+        using var handler = new NeverCompletingHandler();
+        using HttpClient http = Client(handler);
+
+        Func<Task> act = () => builder.AddCacheBustedDevConfigAsync(http, TimeSpan.FromMilliseconds(150));
+
+        await act.Should().CompleteWithinAsync(TimeSpan.FromSeconds(5));
+        builder.Sources.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AddCacheBustedDevConfigAsync_WhenFileMissing_SkipsIt()
+    {
+        var builder = new ConfigurationBuilder();
+        using HttpClient http = Client(new StatusHandler(HttpStatusCode.NotFound));
+
+        await builder.AddCacheBustedDevConfigAsync(http);
+
+        builder.Sources.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AddCacheBustedDevConfigAsync_WhenFilesLoad_AddsBothAndValuesWin()
+    {
+        var builder = new ConfigurationBuilder();
+        builder.AddInMemoryCollection(new Dictionary<string, string?> { ["Auth:UseTestProvider"] = "false" });
+        using HttpClient http = Client(new StatusHandler(HttpStatusCode.OK, """{"Auth":{"UseTestProvider":"true"}}"""));
+
+        await builder.AddCacheBustedDevConfigAsync(http);
+
+        // Later providers win — the fetched copy overrides whatever the cached load produced.
+        builder.Build().GetValue<bool>("Auth:UseTestProvider").Should().BeTrue();
+    }
+
+    /// <summary>Accepts the request and never answers — only the caller's token ends it.</summary>
+    private sealed class NeverCompletingHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+            throw new UnreachableException();
+        }
+    }
+
+    private sealed class ThrowingHandler(Exception exception) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            Task.FromException<HttpResponseMessage>(exception);
+    }
+
+    private sealed class StatusHandler(HttpStatusCode status, string? body = null) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var response = new HttpResponseMessage(status);
+            if (body is not null)
+            {
+                response.Content = new StringContent(body);
+            }
+
+            // GetByteArrayAsync throws HttpRequestException on a non-success status.
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
Three passes on the Hotstrings page. Each later pass exists because live testing showed the previous one had not actually landed.

## Pass 1 — edit affordances

- Collapse the two edit affordances (pencil + EditNote popup) into one Edit button per row, branching internally: inline row editor for Text-kind hotstrings with no window context, fullscreen dialog for everything else (removes the cramped Medium-width dialog that hid the profile selector).
- Add a glyph legend (help icon + tooltip) to the Type column header.
- Fix a CSS bug where the Actions column clipped icons behind a fake "..." at higher browser zoom.
- Add selected-row highlighting via the existing RowClassFunc mechanism.

## Pass 2 — color coding, truncation, seed coverage

Root causes, verified in code rather than assumed:

- **Categories were never color-coded.** `EntityChips` assigned no `Color`, so every chip fell back to MudBlazor's default grey. Pass 1 added an outline *shape*, not a color.
- **Type chips were grey for the common case.** The column showed *delivery* ("Hotstring"/"Clipboard") for Text rows, so a column titled Type never showed "Text" — and every seeded row is Text-kind.
- **Pass 1's palette collided with the brand.** It claimed to avoid Primary/Secondary/Tertiary, then used Info (blue) and Success (green) — which are exactly the Reload and Add buttons.
- **"C..." truncation** came from a 10% fixed column inheriting the read-only cell clipping and then having to host a `MudSelect`, not from the select-column width pin.

Changes:

- Type column now shows the **kind** for every row, tinted per kind (violet / teal / rose / amber), with clipboard delivery demoted to an icon since it is the only delivery worth flagging. Hues sit off the brand triad and stay soft tints so data does not compete with the saturated toolbar buttons; `color-mix` against theme variables tracks light/dark with no dark-mode selector.
- Categories carry the brand accent, outlined — a channel deliberately distinct from the filled kind chips.
- Category editor: un-clip editing rows, rebalance column widths, and collapse multi-selection to "N selected" so the anchor cannot truncate.
- Seed: add 2 Macro + 2 Raw examples (both kinds previously had **zero**), a Description on every row, and extract the sample array into `HotstringSeedSamples` — it was duplicated byte-for-byte across the seed command and the lazy auto-seed, kept in sync by a comment.
- Grid loading indicator, distinct filtered-empty state with a Clear filters action, completed glyph legend.

Dropped from the plan: seeding App Launcher / Window Management. `SeedHotkeysCommand` already fills those with 10 hotkeys — they are hotkey categories, and pressing Ctrl+Alt+N is the AHK idiom, not typing `/np`.

## Pass 3 — mobile parity

Pass 2 only ever touched the desktop grid. Mobile still rendered a grey "Hotstring" delivery chip, and copying the desktop markup across would not have fixed it: the tints were written as `::deep .hotstrings-grid .mud-chip.kind-chip--*` in the page stylesheet, keyed on the desktop grid, so a page-scoped rule could never reach a separate component.

- Extract `HotstringKindChip` owning the markup **and** the tints in its own scoped CSS, used by both branches so they cannot drift apart again.
- Place it under the trigger on mobile: at 390px a word-width chip beside the replacement left that column only wide enough for an ellipsis.
- Drop the standalone Raw warning icon — the Raw chip already carries the icon, label, tint, and `aria-label`; two warning icons side by side was noise.

## Also fixed: dev boot hanging at 99%

Unrelated to the page, found while verifying the above, and **arguably belongs on its own branch** — say so and I will move it.

`AddCacheBustedDevConfigAsync` is awaited before `RunAsync()`, so nothing is mounted while it runs and the Blazor boot indicator is frozen at ~99%. It had no bound at all: a dev host that accepts the connection but never answers parked the app there indefinitely with no message on screen. This is Development-only and bites whenever the dev host is restarting or still warming up.

`HttpClient.Timeout` does not help — WebAssembly's browser HTTP handler ignores it — so the bound rides on a linked `CancellationToken` that aborts the fetch, with timeouts caught alongside `HttpRequestException` and the file skipped. The cached config the host already loaded stays in effect.

Reproduced by stalling the cache-busted fetch: **99.2% and an empty body indefinitely** before, **mounts in ~7s** (2 files × 3s) after. Normal path unchanged at ~1.5s.

## Verification

- [x] `dotnet build` — full solution, 0 warnings/errors
- [x] `dotnet format --verify-no-changes` — clean
- [x] **1657 tests passing** — UI.Blazor 476, Application 946, API 169, Domain 32, Infrastructure 19, E2E 15
- [x] Live Playwright pass against the no-auth dev stack, **both themes**: four distinct kind tints on desktop *and* mobile, green category chips, category editor readable (none/one/many → placeholder / name / "N selected"), filtered-empty + Clear filters, complete legend tooltip, selection highlight, no column overflow at 175% zoom
- [x] Boot-hang fix verified live by stalling the config fetch, before and after

Two things live review corrected that static planning could not see: the selection tint was invisible at 12% against the dark surface, and cutting Profiles to 7% clipped the "Any" chip once the fixed table layout compressed at zoom.

One correction to an earlier claim in this PR: Pass 2 listed a "grid loading indicator" as a fix. Investigating a report that it never appears, I found it was never broken — `ComponentBase` already calls `StateHasChanged()` before awaiting a suspending event handler, so Blazor renders mid-flight on its own. Local API calls simply return in ~20ms. A regression test now covers the mid-flight state via a gated API call.

Plan: `docs/superpowers/plans/2026-07-20-hotstring-page-ux-followup-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
