### PR TITLE
docs: require builder pattern for test data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ HTTP Request -> Controller (thin, maps Result to HTTP)
 - AAA pattern (Arrange/Act/Assert) with blank line separation; one assertion concept per test
 - Assert on `Result.IsSuccess` / `Result.Status` in handler unit tests
 - FluentAssertions over raw `Assert` — better failure messages
+- Builder pattern for test data and scenarios — `new HotstringBuilder().WithTrigger("btw").Build()`, not raw construction or many-parameter factories. Builders live in `tests/AHKFlowApp.TestUtilities/Builders/`; add one there for new entities.
 - Shared fixtures: `IClassFixture<T>`, `ICollectionFixture<T>` for expensive setup (containers)
 - NSubstitute for third-party boundaries only — don't mock what you own
 - Test behavior (HTTP response, DB state, Result status), not implementation details


### PR DESCRIPTION
Codifies the builder-pattern convention for test data in the Testing section of `AGENTS.md`.

## Why

The preference existed only in agent memory (`feedback_test_builders.md`), so it applied to whichever assistant session happened to load that memory and was invisible to human contributors and to other tools reading `AGENTS.md`. The convention is already the de facto standard in the repo — `tests/AHKFlowApp.TestUtilities/Builders/` holds `CategoryBuilder`, `HealthResponseBuilder`, `HotkeyBuilder`, `HotstringBuilder`, and `ProfileBuilder`, plus `Auth/TestUserBuilder` — so this documents existing practice rather than introducing anything new.

## What changes

One bullet in the Testing section:

> Builder pattern for test data and scenarios — `new HotstringBuilder().WithTrigger("btw").Build()`, not raw construction or many-parameter factories. Builders live in `tests/AHKFlowApp.TestUtilities/Builders/`; add one there for new entities.

The example is verified against the real `HotstringBuilder` API (`WithTrigger` exists at `tests/AHKFlowApp.TestUtilities/Builders/HotstringBuilder.cs:54`), so it compiles as written.

## Scope

Docs only — no code, no tests, no build impact. The memory file this replaces has been deleted from the local agent memory store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
