### PR TITLE
fix: stop CLI retrying unsafe HTTP methods on ambiguous failures

### DIFF
--- a/.claude/backlog/done/033-cli-retry-unsafe-http-methods.md
+++ b/.claude/backlog/done/033-cli-retry-unsafe-http-methods.md
@@ -46,12 +46,12 @@ write commands: `ahkflow hotstring new` against a cold app would fail instead of
 
 ## Acceptance criteria
 
-- [ ] `ahkflow hotstring new` never creates more than one hotstring, even when the first attempt
+- [x] `ahkflow hotstring new` never creates more than one hotstring, even when the first attempt
       returns 504 or the connection drops after send.
-- [ ] Warm-up against a stopped/cold App Service still succeeds for write commands (no regression
+- [x] Warm-up against a stopped/cold App Service still succeeds for write commands (no regression
       of the 10 × 2s wake behaviour).
-- [ ] Read-only commands (`list`, downloads) keep their current retry behaviour unchanged.
-- [ ] Chosen approach is covered by tests in `AHKFlowApp.CLI.Tests`, asserting behaviour (request
+- [x] Read-only commands (`list`, downloads) keep their current retry behaviour unchanged.
+- [x] Chosen approach is covered by tests in `AHKFlowApp.CLI.Tests`, asserting behaviour (request
       count reaching the API) rather than pipeline wiring.
 
 ## Candidate approaches
@@ -66,6 +66,24 @@ write commands: `ahkflow hotstring new` against a cold app would fail instead of
    leaves 504 correctly un-retried but relies on distinguishing pre- from post-send exceptions.
 
 Approach 2 is the smallest correct change if no API work is in scope; approach 1 is the durable fix.
+
+## Resolution
+
+Approach 3. `ShouldRetry` now takes the request method and splits into two failure sets:
+
+- **Idempotent** (`GET`/`HEAD`/`OPTIONS`/`TRACE`) — unchanged transient set.
+- **Everything else** — only failures that prove the origin never ran: the App Service 403 HTML
+  stopped-app page (served by the front end), DNS / TLS / proxy-tunnel `HttpRequestException`, and
+  a refused connect (`SocketError.ConnectionRefused`). An unknown method is treated as unsafe.
+
+`HttpRequestError.ConnectionError` alone is *not* enough — it also covers mid-flight drops, which
+is exactly the post-send case this item is about. Timeouts, 408, 429, 502, 503 and 504 no longer
+retry for writes: none of them prove the write was rejected.
+
+Warm-up survives because a stopped App Service answers with the 403 page rather than failing the
+connection, so `ahkflow hotstring new` still waits out the 10 × 2s wake.
+
+Approach 1 (idempotency key) remains the durable fix if the CLI grows more write commands.
 
 ## Out of scope
 

--- a/.claude/hooks/pre-commit-antipattern.ps1
+++ b/.claude/hooks/pre-commit-antipattern.ps1
@@ -110,7 +110,8 @@ foreach ($file in $filesToCheck) {
     if (Test-AntiPattern $file $addedLines 'DateTime\.(Now|UtcNow)'                                    'Use TimeProvider instead of DateTime.Now/UtcNow')                   { $errors++ }
     if (Test-AntiPattern $file $addedLines 'new HttpClient\(\)'                                        'Use IHttpClientFactory instead of new HttpClient()')                { $errors++ }
     if (Test-AntiPattern $file ($addedLines | Where-Object { $_.Text -notmatch 'EventArgs' }) 'async void' 'async void is dangerous, use async Task instead')                { $errors++ }
-    if (Test-AntiPattern $file $addedLines '\.Result\b|\.GetAwaiter\(\)\.GetResult\(\)'                'Avoid sync-over-async (.Result / .GetAwaiter().GetResult())')       { $errors++ }
+    # Polly's Outcome<T>.Result is the resilience outcome value, not a blocking Task.Result.
+    if (Test-AntiPattern $file ($addedLines | Where-Object { $_.Text -notmatch 'Outcome\.Result' }) '\.Result\b|\.GetAwaiter\(\)\.GetResult\(\)' 'Avoid sync-over-async (.Result / .GetAwaiter().GetResult())') { $errors++ }
 }
 
 if ($errors -gt 0) {

--- a/.claude/hooks/pre-commit-antipattern.ps1
+++ b/.claude/hooks/pre-commit-antipattern.ps1
@@ -111,7 +111,10 @@ foreach ($file in $filesToCheck) {
     if (Test-AntiPattern $file $addedLines 'new HttpClient\(\)'                                        'Use IHttpClientFactory instead of new HttpClient()')                { $errors++ }
     if (Test-AntiPattern $file ($addedLines | Where-Object { $_.Text -notmatch 'EventArgs' }) 'async void' 'async void is dangerous, use async Task instead')                { $errors++ }
     # Polly's Outcome<T>.Result is the resilience outcome value, not a blocking Task.Result.
-    if (Test-AntiPattern $file ($addedLines | Where-Object { $_.Text -notmatch 'Outcome\.Result' }) '\.Result\b|\.GetAwaiter\(\)\.GetResult\(\)' 'Avoid sync-over-async (.Result / .GetAwaiter().GetResult())') { $errors++ }
+    # Strip only that exact expression from each line before scanning, so a real task.Result
+    # sharing a line with Outcome.Result is still caught.
+    $resultScan = $addedLines | ForEach-Object { [PSCustomObject]@{ LineNumber = $_.LineNumber; Text = ($_.Text -replace '\bOutcome\.Result\b', '') } }
+    if (Test-AntiPattern $file $resultScan '\.Result\b|\.GetAwaiter\(\)\.GetResult\(\)' 'Avoid sync-over-async (.Result / .GetAwaiter().GetResult())') { $errors++ }
 }
 
 if ($errors -gt 0) {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,7 +43,7 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="System.CommandLine" Version="3.0.0-preview.3.26207.106" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/Tools/AHKFlowApp.CLI/Services/CliApiFailureDetector.cs
+++ b/src/Tools/AHKFlowApp.CLI/Services/CliApiFailureDetector.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Sockets;
 using Polly.Timeout;
 
 namespace AHKFlowApp.CLI.Services;
@@ -7,7 +8,31 @@ internal static class CliApiFailureDetector
 {
     private const string HtmlContentType = "text/html";
 
-    public static bool ShouldRetry(Exception? exception, HttpResponseMessage? response) =>
+    /// <summary>
+    /// Decides whether a failed attempt may be retried. Retrying a non-idempotent request is only
+    /// safe when the failure proves the API never received it — a gateway timeout or a dropped
+    /// connection can both follow a write the origin already committed, so replaying them would
+    /// create duplicates. Idempotent requests keep the broad retry set that wakes a cold API.
+    /// </summary>
+    public static bool ShouldRetry(Exception? exception, HttpResponseMessage? response, HttpMethod? requestMethod) =>
+        IsIdempotent(requestMethod)
+            ? IsTransientFailure(exception, response)
+            : NeverReachedOrigin(exception, response);
+
+    public static bool IsStoppedWebAppResponse(ApiException exception) =>
+        exception.StatusCode == (int)HttpStatusCode.Forbidden
+        && IsHtmlContentType(exception.ContentType)
+        && LooksLikeStoppedWebAppPage(exception.Body);
+
+    // Unknown method is treated as unsafe: better to fail a retryable read than to duplicate a write.
+    private static bool IsIdempotent(HttpMethod? requestMethod) =>
+        requestMethod is not null
+        && (requestMethod == HttpMethod.Get
+            || requestMethod == HttpMethod.Head
+            || requestMethod == HttpMethod.Options
+            || requestMethod == HttpMethod.Trace);
+
+    private static bool IsTransientFailure(Exception? exception, HttpResponseMessage? response) =>
         exception is HttpRequestException or TimeoutRejectedException
         || response?.StatusCode is HttpStatusCode.RequestTimeout
             or HttpStatusCode.TooManyRequests
@@ -16,10 +41,18 @@ internal static class CliApiFailureDetector
             or HttpStatusCode.GatewayTimeout
         || IsStoppedWebAppResponse(response);
 
-    public static bool IsStoppedWebAppResponse(ApiException exception) =>
-        exception.StatusCode == (int)HttpStatusCode.Forbidden
-        && IsHtmlContentType(exception.ContentType)
-        && LooksLikeStoppedWebAppPage(exception.Body);
+    private static bool NeverReachedOrigin(Exception? exception, HttpResponseMessage? response) =>
+        // The App Service front end serves the stopped-app page itself; the origin never ran.
+        IsStoppedWebAppResponse(response)
+        || (exception is HttpRequestException request && FailedBeforeSending(request));
+
+    private static bool FailedBeforeSending(HttpRequestException exception) =>
+        exception.HttpRequestError is HttpRequestError.NameResolutionError
+            or HttpRequestError.SecureConnectionError
+            or HttpRequestError.ProxyTunnelError
+        // ConnectionError also covers mid-flight drops, so only a refused connect qualifies —
+        // nothing was transmitted. A reset or abort may follow a fully sent request.
+        || exception.InnerException is SocketException { SocketErrorCode: SocketError.ConnectionRefused };
 
     private static bool IsStoppedWebAppResponse(HttpResponseMessage? response) =>
         response?.StatusCode == HttpStatusCode.Forbidden

--- a/src/Tools/AHKFlowApp.CLI/Services/CliApiFailureDetector.cs
+++ b/src/Tools/AHKFlowApp.CLI/Services/CliApiFailureDetector.cs
@@ -14,10 +14,14 @@ internal static class CliApiFailureDetector
     /// connection can both follow a write the origin already committed, so replaying them would
     /// create duplicates. Idempotent requests keep the broad retry set that wakes a cold API.
     /// </summary>
-    public static bool ShouldRetry(Exception? exception, HttpResponseMessage? response, HttpMethod? requestMethod) =>
+    public static bool ShouldRetry(
+        Exception? exception,
+        HttpResponseMessage? response,
+        string? forbiddenBody,
+        HttpMethod? requestMethod) =>
         IsIdempotent(requestMethod)
-            ? IsTransientFailure(exception, response)
-            : NeverReachedOrigin(exception, response);
+            ? IsTransientFailure(exception, response, forbiddenBody)
+            : NeverReachedOrigin(exception, response, forbiddenBody);
 
     public static bool IsStoppedWebAppResponse(ApiException exception) =>
         exception.StatusCode == (int)HttpStatusCode.Forbidden
@@ -32,18 +36,18 @@ internal static class CliApiFailureDetector
             || requestMethod == HttpMethod.Options
             || requestMethod == HttpMethod.Trace);
 
-    private static bool IsTransientFailure(Exception? exception, HttpResponseMessage? response) =>
+    private static bool IsTransientFailure(Exception? exception, HttpResponseMessage? response, string? forbiddenBody) =>
         exception is HttpRequestException or TimeoutRejectedException
         || response?.StatusCode is HttpStatusCode.RequestTimeout
             or HttpStatusCode.TooManyRequests
             or HttpStatusCode.BadGateway
             or HttpStatusCode.ServiceUnavailable
             or HttpStatusCode.GatewayTimeout
-        || IsStoppedWebAppResponse(response);
+        || IsStoppedWebAppResponse(response, forbiddenBody);
 
-    private static bool NeverReachedOrigin(Exception? exception, HttpResponseMessage? response) =>
+    private static bool NeverReachedOrigin(Exception? exception, HttpResponseMessage? response, string? forbiddenBody) =>
         // The App Service front end serves the stopped-app page itself; the origin never ran.
-        IsStoppedWebAppResponse(response)
+        IsStoppedWebAppResponse(response, forbiddenBody)
         || (exception is HttpRequestException request && FailedBeforeSending(request));
 
     private static bool FailedBeforeSending(HttpRequestException exception) =>
@@ -54,9 +58,13 @@ internal static class CliApiFailureDetector
         // nothing was transmitted. A reset or abort may follow a fully sent request.
         || exception.InnerException is SocketException { SocketErrorCode: SocketError.ConnectionRefused };
 
-    private static bool IsStoppedWebAppResponse(HttpResponseMessage? response) =>
+    // Mirrors the ApiException overload: a bare 403 + text/html is not enough — the stopped-app
+    // marker in the body must be present, or an unrelated HTML 403 (WAF, auth page) would be
+    // mistaken for a cold App Service and retried.
+    private static bool IsStoppedWebAppResponse(HttpResponseMessage? response, string? forbiddenBody) =>
         response?.StatusCode == HttpStatusCode.Forbidden
-        && IsHtmlContentType(response.Content.Headers.ContentType?.MediaType);
+        && IsHtmlContentType(response.Content.Headers.ContentType?.MediaType)
+        && LooksLikeStoppedWebAppPage(forbiddenBody);
 
     private static bool IsHtmlContentType(string? contentType) =>
         contentType?.StartsWith(HtmlContentType, StringComparison.OrdinalIgnoreCase) == true;

--- a/src/Tools/AHKFlowApp.CLI/Services/CliHttpClientBuilderExtensions.cs
+++ b/src/Tools/AHKFlowApp.CLI/Services/CliHttpClientBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
 using Polly;
@@ -30,11 +31,12 @@ public static class CliHttpClientBuilderExtensions
                     BackoffType = DelayBackoffType.Constant,
                     Delay = RetryDelay,
                     UseJitter = false,
-                    ShouldHandle = static args => ValueTask.FromResult(
+                    ShouldHandle = static async args =>
                         CliApiFailureDetector.ShouldRetry(
                             args.Outcome.Exception,
                             args.Outcome.Result,
-                            GetRequestMethod(args))),
+                            await ReadForbiddenHtmlBodyAsync(args.Outcome.Result),
+                            GetRequestMethod(args)),
                     OnRetry = args =>
                     {
                         retryStatusWriter.WriteRetrying(
@@ -56,4 +58,18 @@ public static class CliHttpClientBuilderExtensions
     private static HttpMethod? GetRequestMethod(RetryPredicateArguments<HttpResponseMessage> args) =>
         args.Outcome.Result?.RequestMessage?.Method
         ?? args.Context.GetRequestMessage()?.Method;
+
+    // Buffer the body only for a 403 so the stopped-app marker can be confirmed; every other
+    // outcome decides on status or exception alone. LoadIntoBufferAsync keeps the content
+    // re-readable for the caller when the retry decision is not to retry.
+    private static async ValueTask<string?> ReadForbiddenHtmlBodyAsync(HttpResponseMessage? response)
+    {
+        if (response?.StatusCode != HttpStatusCode.Forbidden)
+        {
+            return null;
+        }
+
+        await response.Content.LoadIntoBufferAsync();
+        return await response.Content.ReadAsStringAsync();
+    }
 }

--- a/src/Tools/AHKFlowApp.CLI/Services/CliHttpClientBuilderExtensions.cs
+++ b/src/Tools/AHKFlowApp.CLI/Services/CliHttpClientBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
 using Polly;
+using Polly.Retry;
 
 namespace AHKFlowApp.CLI.Services;
 
@@ -30,7 +31,10 @@ public static class CliHttpClientBuilderExtensions
                     Delay = RetryDelay,
                     UseJitter = false,
                     ShouldHandle = static args => ValueTask.FromResult(
-                        CliApiFailureDetector.ShouldRetry(args.Outcome.Exception, args.Outcome.Result)),
+                        CliApiFailureDetector.ShouldRetry(
+                            args.Outcome.Exception,
+                            args.Outcome.Result,
+                            GetRequestMethod(args))),
                     OnRetry = args =>
                     {
                         retryStatusWriter.WriteRetrying(
@@ -46,4 +50,10 @@ public static class CliHttpClientBuilderExtensions
 
         return httpClientBuilder;
     }
+
+    // The response carries the request on a failed status; on a transport exception there is no
+    // response, so fall back to the request the resilience handler stashed in the context.
+    private static HttpMethod? GetRequestMethod(RetryPredicateArguments<HttpResponseMessage> args) =>
+        args.Outcome.Result?.RequestMessage?.Method
+        ?? args.Context.GetRequestMessage()?.Method;
 }

--- a/tests/AHKFlowApp.CLI.Tests/Services/CliHttpClientBuilderExtensionsTests.cs
+++ b/tests/AHKFlowApp.CLI.Tests/Services/CliHttpClientBuilderExtensionsTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using AHKFlowApp.CLI.Services;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Polly.Timeout;
 using Xunit;
 
 namespace AHKFlowApp.CLI.Tests.Services;
@@ -48,6 +49,75 @@ public sealed class CliHttpClientBuilderExtensionsTests
 
         ApiException ex = (await act.Should().ThrowAsync<ApiException>()).Which;
         ex.StatusCode.Should().Be(403);
+        handler.RequestCount.Should().Be(1);
+        retryStatusWriter.Messages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListAsync_UnrelatedHtml403_DoesNotRetry()
+    {
+        SequenceHandler handler = new(CreateUnrelatedHtml403Response());
+        RecordingRetryStatusWriter retryStatusWriter = new();
+
+        using ServiceProvider provider = CreateServices(handler, retryStatusWriter);
+        IHotstringsApiClient sut = provider.GetRequiredService<IHotstringsApiClient>();
+
+        Func<Task> act = async () => await sut.ListAsync(null, null, 1, 50, CancellationToken.None);
+
+        ApiException ex = (await act.Should().ThrowAsync<ApiException>()).Which;
+        ex.StatusCode.Should().Be(403);
+        handler.RequestCount.Should().Be(1);
+        retryStatusWriter.Messages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateAsync_UnrelatedHtml403_DoesNotRetry()
+    {
+        SequenceHandler handler = new(CreateUnrelatedHtml403Response());
+        RecordingRetryStatusWriter retryStatusWriter = new();
+
+        using ServiceProvider provider = CreateServices(handler, retryStatusWriter);
+        IHotstringsApiClient sut = provider.GetRequiredService<IHotstringsApiClient>();
+
+        Func<Task> act = async () => await sut.CreateAsync(CreateInput(), CancellationToken.None);
+
+        ApiException ex = (await act.Should().ThrowAsync<ApiException>()).Which;
+        ex.StatusCode.Should().Be(403);
+        handler.RequestCount.Should().Be(1);
+        retryStatusWriter.Messages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListAsync_Timeout_RetriesUntilSuccess()
+    {
+        SequenceHandler handler = new(
+            new TimeoutRejectedException(),
+            CreateSuccessfulListResponse());
+        RecordingRetryStatusWriter retryStatusWriter = new();
+
+        using ServiceProvider provider = CreateServices(handler, retryStatusWriter);
+        IHotstringsApiClient sut = provider.GetRequiredService<IHotstringsApiClient>();
+
+        PagedList<HotstringDto> result = await sut.ListAsync(null, null, 1, 50, CancellationToken.None);
+
+        result.Items.Should().BeEmpty();
+        handler.RequestCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CreateAsync_Timeout_DoesNotRetry()
+    {
+        SequenceHandler handler = new(
+            new TimeoutRejectedException(),
+            CreateSuccessfulCreateResponse());
+        RecordingRetryStatusWriter retryStatusWriter = new();
+
+        using ServiceProvider provider = CreateServices(handler, retryStatusWriter);
+        IHotstringsApiClient sut = provider.GetRequiredService<IHotstringsApiClient>();
+
+        Func<Task> act = async () => await sut.CreateAsync(CreateInput(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<TimeoutRejectedException>();
         handler.RequestCount.Should().Be(1);
         retryStatusWriter.Messages.Should().BeEmpty();
     }
@@ -195,6 +265,23 @@ public sealed class CliHttpClientBuilderExtensionsTests
                 <html>
                 <head><title>Web App - Unavailable</title></head>
                 <body><h1>Error 403 - This web app is stopped.</h1></body>
+                </html>
+                """,
+                Encoding.UTF8,
+                "text/html"),
+        };
+
+    // A 403 with an HTML body that is NOT the App Service stopped-app page — e.g. a WAF or
+    // gateway auth block. Must not be mistaken for a cold origin and retried.
+    private static HttpResponseMessage CreateUnrelatedHtml403Response() =>
+        new(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent(
+                """
+                <!DOCTYPE html>
+                <html>
+                <head><title>403 Forbidden</title></head>
+                <body><h1>Access denied by web application firewall.</h1></body>
                 </html>
                 """,
                 Encoding.UTF8,

--- a/tests/AHKFlowApp.CLI.Tests/Services/CliHttpClientBuilderExtensionsTests.cs
+++ b/tests/AHKFlowApp.CLI.Tests/Services/CliHttpClientBuilderExtensionsTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Net.Sockets;
 using System.Text;
 using AHKFlowApp.CLI.Services;
 using FluentAssertions;
@@ -51,6 +52,126 @@ public sealed class CliHttpClientBuilderExtensionsTests
         retryStatusWriter.Messages.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task ListAsync_GatewayTimeout_RetriesUntilSuccess()
+    {
+        SequenceHandler handler = new(
+            new HttpResponseMessage(HttpStatusCode.GatewayTimeout),
+            CreateSuccessfulListResponse());
+        RecordingRetryStatusWriter retryStatusWriter = new();
+
+        using ServiceProvider provider = CreateServices(handler, retryStatusWriter);
+        IHotstringsApiClient sut = provider.GetRequiredService<IHotstringsApiClient>();
+
+        PagedList<HotstringDto> result = await sut.ListAsync(null, null, 1, 50, CancellationToken.None);
+
+        result.Items.Should().BeEmpty();
+        handler.RequestCount.Should().Be(2);
+    }
+
+    // No response means the method can only come from the resilience context; if that lookup broke,
+    // the request would be treated as unsafe and this read would stop retrying.
+    [Fact]
+    public async Task ListAsync_ConnectionDroppedAfterSend_RetriesUntilSuccess()
+    {
+        SequenceHandler handler = new(
+            new HttpRequestException(
+                HttpRequestError.ConnectionError,
+                "connection reset",
+                new SocketException((int)SocketError.ConnectionReset)),
+            CreateSuccessfulListResponse());
+        RecordingRetryStatusWriter retryStatusWriter = new();
+
+        using ServiceProvider provider = CreateServices(handler, retryStatusWriter);
+        IHotstringsApiClient sut = provider.GetRequiredService<IHotstringsApiClient>();
+
+        PagedList<HotstringDto> result = await sut.ListAsync(null, null, 1, 50, CancellationToken.None);
+
+        result.Items.Should().BeEmpty();
+        handler.RequestCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CreateAsync_GatewayTimeout_DoesNotRetry()
+    {
+        SequenceHandler handler = new(
+            new HttpResponseMessage(HttpStatusCode.GatewayTimeout),
+            CreateSuccessfulCreateResponse());
+        RecordingRetryStatusWriter retryStatusWriter = new();
+
+        using ServiceProvider provider = CreateServices(handler, retryStatusWriter);
+        IHotstringsApiClient sut = provider.GetRequiredService<IHotstringsApiClient>();
+
+        Func<Task> act = async () => await sut.CreateAsync(CreateInput(), CancellationToken.None);
+
+        ApiException ex = (await act.Should().ThrowAsync<ApiException>()).Which;
+        ex.StatusCode.Should().Be(504);
+        handler.RequestCount.Should().Be(1);
+        retryStatusWriter.Messages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateAsync_ConnectionDroppedAfterSend_DoesNotRetry()
+    {
+        SequenceHandler handler = new(
+            new HttpRequestException(
+                HttpRequestError.ConnectionError,
+                "connection reset",
+                new SocketException((int)SocketError.ConnectionReset)),
+            CreateSuccessfulCreateResponse());
+        RecordingRetryStatusWriter retryStatusWriter = new();
+
+        using ServiceProvider provider = CreateServices(handler, retryStatusWriter);
+        IHotstringsApiClient sut = provider.GetRequiredService<IHotstringsApiClient>();
+
+        Func<Task> act = async () => await sut.CreateAsync(CreateInput(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        handler.RequestCount.Should().Be(1);
+        retryStatusWriter.Messages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateAsync_StoppedWebAppHtml_RetriesUntilSuccess()
+    {
+        SequenceHandler handler = new(
+            CreateStoppedWebAppResponse(),
+            CreateSuccessfulCreateResponse());
+        RecordingRetryStatusWriter retryStatusWriter = new();
+
+        using ServiceProvider provider = CreateServices(handler, retryStatusWriter);
+        IHotstringsApiClient sut = provider.GetRequiredService<IHotstringsApiClient>();
+
+        HotstringDto result = await sut.CreateAsync(CreateInput(), CancellationToken.None);
+
+        result.Trigger.Should().Be("btw");
+        handler.RequestCount.Should().Be(2);
+        retryStatusWriter.Messages.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ConnectionRefused_RetriesUntilSuccess()
+    {
+        SequenceHandler handler = new(
+            new HttpRequestException(
+                HttpRequestError.ConnectionError,
+                "connection refused",
+                new SocketException((int)SocketError.ConnectionRefused)),
+            CreateSuccessfulCreateResponse());
+        RecordingRetryStatusWriter retryStatusWriter = new();
+
+        using ServiceProvider provider = CreateServices(handler, retryStatusWriter);
+        IHotstringsApiClient sut = provider.GetRequiredService<IHotstringsApiClient>();
+
+        HotstringDto result = await sut.CreateAsync(CreateInput(), CancellationToken.None);
+
+        result.Trigger.Should().Be("btw");
+        handler.RequestCount.Should().Be(2);
+        retryStatusWriter.Messages.Should().HaveCount(1);
+    }
+
+    private static CreateHotstringDto CreateInput() => new("btw", "by the way");
+
     private static ServiceProvider CreateServices(
         HttpMessageHandler handler,
         IHttpRetryStatusWriter retryStatusWriter)
@@ -80,6 +201,21 @@ public sealed class CliHttpClientBuilderExtensionsTests
                 "text/html"),
         };
 
+    private static HttpResponseMessage CreateSuccessfulCreateResponse() =>
+        new(HttpStatusCode.Created)
+        {
+            Content = JsonContent.Create(new HotstringDto(
+                Guid.NewGuid(),
+                [],
+                true,
+                "btw",
+                "by the way",
+                true,
+                true,
+                DateTimeOffset.UnixEpoch,
+                DateTimeOffset.UnixEpoch)),
+        };
+
     private static HttpResponseMessage CreateSuccessfulListResponse() =>
         new(HttpStatusCode.OK)
         {
@@ -104,9 +240,11 @@ public sealed class CliHttpClientBuilderExtensionsTests
         }
     }
 
-    private sealed class SequenceHandler(params HttpResponseMessage[] responses) : HttpMessageHandler
+    // Each outcome is either an HttpResponseMessage to return or an Exception to throw, replayed
+    // in order so a test can script transport failures alongside responses.
+    private sealed class SequenceHandler(params object[] outcomes) : HttpMessageHandler
     {
-        private readonly Queue<HttpResponseMessage> _responses = new(responses);
+        private readonly Queue<object> _outcomes = new(outcomes);
 
         public int RequestCount { get; private set; }
 
@@ -115,7 +253,12 @@ public sealed class CliHttpClientBuilderExtensionsTests
             CancellationToken cancellationToken)
         {
             RequestCount++;
-            return Task.FromResult(_responses.Dequeue());
+            return _outcomes.Dequeue() switch
+            {
+                HttpResponseMessage response => Task.FromResult(response),
+                Exception exception => Task.FromException<HttpResponseMessage>(exception),
+                var outcome => throw new InvalidOperationException($"Unsupported outcome: {outcome}"),
+            };
         }
     }
 }


### PR DESCRIPTION
## What

Non-idempotent CLI requests (POST/PUT/PATCH/DELETE) only retry when the failure proves the origin never received them; idempotent requests keep the broad cold-start retry set.

## Changes

- **Stopped-app 403 detection**: the retry predicate now confirms the App Service stopped-app body marker (not just `403` + `text/html`), matching the existing `ApiException` path. Body is buffered only for 403s. An unrelated HTML 403 (WAF, gateway auth) no longer triggers retries.
- **Coverage**: added unrelated-HTML-403 no-retry tests (GET + POST) and timeout retry/no-retry tests (GET retries, POST doesn't).
- **Anti-pattern hook**: strip only the exact `Outcome.Result` Polly token before scanning, so a real `.Result` sharing a line is still caught.
- **Security**: bump `System.Security.Cryptography.Xml` 10.0.7 → 10.0.10 (NU1903, high-severity advisory; was blocking restore).

## Verification

- 207/207 CLI tests pass
- Build 0 warnings/0 errors, restore clean, format clean
- Pre-push quick checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)