### PR TITLE
fix: worktree hooks not substituting CLAUDE_PROJECT_DIR in shell form

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -175,7 +175,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\scripts\\new-worktree.ps1\""
+            "command": "pwsh",
+            "args": ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", "${CLAUDE_PROJECT_DIR}/scripts/new-worktree.ps1"]
           }
         ]
       }
@@ -185,7 +186,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\scripts\\remove-worktree-local-dev.ps1\" -TimeoutSeconds 300"
+            "command": "pwsh",
+            "args": ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", "${CLAUDE_PROJECT_DIR}/scripts/remove-worktree-local-dev.ps1", "-TimeoutSeconds", "300"]
           }
         ]
       }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
           ./tests/AgentWorktreeGuard.Tests.ps1
           ./tests/AgentPreCommitHook.Tests.ps1
           ./tests/WorktreePowerShellHost.Tests.ps1
+          ./tests/WorktreeBranchName.Tests.ps1
           ./tests/WorktreeMergedCleanup.Tests.ps1
           ./tests/WorktreeRemoveHook.Tests.ps1
           ./tests/WorktreeLocalDevSetup.Tests.ps1

--- a/scripts/new-worktree.ps1
+++ b/scripts/new-worktree.ps1
@@ -219,6 +219,11 @@ if (-not $Name) {
 $safeName = ConvertTo-SafeName $Name
 if (-not $BranchName) {
     $BranchName = $safeName
+    # AGENTS.md: worktree-born branches must carry a 'wt-' marker for grepping/cleanup.
+    # An explicit -BranchName is trusted as-is; only the derived default is normalized.
+    if ($BranchName -notmatch '(^|/)wt-') {
+        $BranchName = "wt-$BranchName"
+    }
 }
 
 if (-not $Path) {

--- a/scripts/new-worktree.ps1
+++ b/scripts/new-worktree.ps1
@@ -218,12 +218,9 @@ if (-not $Name) {
 
 $safeName = ConvertTo-SafeName $Name
 if (-not $BranchName) {
-    $BranchName = $safeName
-    # AGENTS.md: worktree-born branches must carry a 'wt-' marker for grepping/cleanup.
-    # An explicit -BranchName is trusted as-is; only the derived default is normalized.
-    if ($BranchName -notmatch '(^|/)wt-') {
-        $BranchName = "wt-$BranchName"
-    }
+    # Derived from the raw name, not $safeName: the directory name has already lost the '/'
+    # that separates a type prefix from the topic. An explicit -BranchName is trusted as-is.
+    $BranchName = ConvertTo-WorktreeBranchName $Name
 }
 
 if (-not $Path) {

--- a/scripts/worktree-git.common.ps1
+++ b/scripts/worktree-git.common.ps1
@@ -23,3 +23,31 @@ function Test-LinkedWorktree {
     $commonDir = Resolve-GitPath $Root '--git-common-dir'
     return $gitDir.TrimEnd('\') -ine $commonDir.TrimEnd('\')
 }
+
+# AGENTS.md: worktree-born branches are '<type>/wt-<topic>'. The Claude WorktreeCreate hook
+# only ever supplies a worktree name, so an untyped name cannot express intent and falls back
+# to the 'fix/' type; a type prefix the caller did supply is preserved.
+function ConvertTo-WorktreeBranchName {
+    param([string] $Value)
+
+    # Same sanitization as the worktree directory name, except '/' survives so a type prefix
+    # can be expressed. Collapsed and trimmed because git rejects '//' and a trailing '/'.
+    $safe = ($Value.Trim() -replace '[^A-Za-z0-9._/-]+', '-') -replace '/{2,}', '/'
+    $safe = $safe.Trim([char[]] @('-', '/'))
+    if (-not $safe) {
+        throw 'Worktree branch name cannot be empty.'
+    }
+
+    $type = 'fix'
+    $topic = $safe
+    if ($safe -match '^(?<type>fix|feature|hotfix|refactor|test|docs|chore)/(?<topic>.+)$') {
+        $type = $Matches.type
+        $topic = $Matches.topic
+    }
+
+    if ($topic -notmatch '^wt-') {
+        $topic = "wt-$topic"
+    }
+
+    return "$type/$topic"
+}

--- a/scripts/worktree-git.common.ps1
+++ b/scripts/worktree-git.common.ps1
@@ -38,9 +38,12 @@ function ConvertTo-WorktreeBranchName {
         throw 'Worktree branch name cannot be empty.'
     }
 
+    # The branch prefixes from AGENTS.md 'Git Workflow' — deliberately NOT the conventional
+    # commit types listed alongside them ('refactor:', 'test:', 'docs:', 'chore:'), which name
+    # commits rather than branches. An unrecognized leading segment is topic text, not a type.
     $type = 'fix'
     $topic = $safe
-    if ($safe -match '^(?<type>fix|feature|hotfix|refactor|test|docs|chore)/(?<topic>.+)$') {
+    if ($safe -match '^(?<type>feature|fix|hotfix)/(?<topic>.+)$') {
         $type = $Matches.type
         $topic = $Matches.topic
     }

--- a/tests/WorktreeBranchName.Tests.ps1
+++ b/tests/WorktreeBranchName.Tests.ps1
@@ -1,0 +1,70 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Assert-BranchName {
+    param([string] $Value, [string] $Expected)
+
+    $actual = ConvertTo-WorktreeBranchName $Value
+    Assert-True ($actual -ceq $Expected) "ConvertTo-WorktreeBranchName '$Value': expected '$Expected', got '$actual'."
+}
+
+. (Join-Path $repoRoot 'scripts\worktree-git.common.ps1')
+
+# Bare name: no type prefix to preserve, so it falls back to 'fix/'.
+Assert-BranchName 'foo' 'fix/wt-foo'
+Assert-BranchName 'worktree-hook-exec-form' 'fix/wt-worktree-hook-exec-form'
+
+# Already carrying the wt- marker but untyped: keep the marker, add the fallback type once.
+Assert-BranchName 'wt-foo' 'fix/wt-foo'
+
+# Typed names keep their type and gain the marker.
+Assert-BranchName 'feature/123-thing' 'feature/wt-123-thing'
+Assert-BranchName 'hotfix/456-thing' 'hotfix/wt-456-thing'
+Assert-BranchName 'chore/tidy' 'chore/wt-tidy'
+
+# Fully conventional names are already correct and must round-trip unchanged.
+Assert-BranchName 'fix/wt-foo' 'fix/wt-foo'
+Assert-BranchName 'feature/wt-123-thing' 'feature/wt-123-thing'
+
+# Unsafe characters collapse to '-', but '/' survives so the type prefix is not destroyed.
+Assert-BranchName 'fix/some topic!' 'fix/wt-some-topic'
+Assert-BranchName '  feature/spaced  ' 'feature/wt-spaced'
+
+# git rejects '//' and a trailing '/', so both are normalized away.
+Assert-BranchName 'fix//foo' 'fix/wt-foo'
+Assert-BranchName 'fix/foo/' 'fix/wt-foo'
+
+# An unrecognized leading segment is topic text, not a type.
+Assert-BranchName 'bart/foo' 'fix/wt-bart/foo'
+
+$threw = $false
+try {
+    ConvertTo-WorktreeBranchName '---' | Out-Null
+} catch {
+    $threw = $true
+}
+Assert-True $threw 'Expected a name with no usable characters to throw.'
+
+# An explicit -BranchName must bypass normalization entirely; only the name-derived default
+# is rewritten. Asserted on the source because exercising the parameter for real would
+# require creating a worktree and mutating git state.
+$newWorktreeContent = Get-Content -LiteralPath (Join-Path $repoRoot 'scripts\new-worktree.ps1') -Raw
+Assert-True ($newWorktreeContent -match '(?m)if\s*\(-not\s+\$BranchName\)\s*\{[^}]*\$BranchName\s*=\s*ConvertTo-WorktreeBranchName\s+\$Name') 'new-worktree.ps1 must derive BranchName via ConvertTo-WorktreeBranchName only when -BranchName was not supplied.'
+Assert-True (([regex]::Matches($newWorktreeContent, 'ConvertTo-WorktreeBranchName')).Count -eq 1) 'new-worktree.ps1 should normalize the branch name in exactly one place.'
+
+Write-Host 'Worktree branch name tests passed.'

--- a/tests/WorktreeBranchName.Tests.ps1
+++ b/tests/WorktreeBranchName.Tests.ps1
@@ -32,10 +32,15 @@ Assert-BranchName 'worktree-hook-exec-form' 'fix/wt-worktree-hook-exec-form'
 # Already carrying the wt- marker but untyped: keep the marker, add the fallback type once.
 Assert-BranchName 'wt-foo' 'fix/wt-foo'
 
-# Typed names keep their type and gain the marker.
+# The three branch prefixes from AGENTS.md keep their type and gain the marker.
 Assert-BranchName 'feature/123-thing' 'feature/wt-123-thing'
-Assert-BranchName 'hotfix/456-thing' 'hotfix/wt-456-thing'
-Assert-BranchName 'chore/tidy' 'chore/wt-tidy'
+Assert-BranchName 'fix/456-thing' 'fix/wt-456-thing'
+Assert-BranchName 'hotfix/789-thing' 'hotfix/wt-789-thing'
+
+# Conventional commit types are not branch prefixes: they name commits, not branches, so they
+# are topic text and pick up the 'fix/' fallback like any other unrecognized leading segment.
+Assert-BranchName 'chore/tidy' 'fix/wt-chore/tidy'
+Assert-BranchName 'docs/readme' 'fix/wt-docs/readme'
 
 # Fully conventional names are already correct and must round-trip unchanged.
 Assert-BranchName 'fix/wt-foo' 'fix/wt-foo'

--- a/tests/WorktreePowerShellHost.Tests.ps1
+++ b/tests/WorktreePowerShellHost.Tests.ps1
@@ -55,4 +55,41 @@ $claudeSettingsPath = Join-Path $repoRoot '.claude\settings.json'
 $claudeSettingsContent = Get-Content -LiteralPath $claudeSettingsPath -Raw
 Assert-DoesNotMatch $claudeSettingsContent '"command":\s*"powershell\s+-NoProfile\s+-ExecutionPolicy\s+Bypass\s+-File\s+\\"?\$\{CLAUDE_PROJECT_DIR\}\\scripts\\(?:new-worktree|remove-worktree-local-dev)\.ps1' 'Claude Worktree hooks should not hard-code Windows PowerShell.'
 
+# Shell form leaves ${CLAUDE_PROJECT_DIR} unsubstituted on the Claude Desktop worktree path,
+# so pwsh receives the literal placeholder as -File. Assert the documented exec form
+# structurally: shape, not just the absence of one bad spelling.
+$claudeSettings = $claudeSettingsContent | ConvertFrom-Json
+
+function Assert-ExecFormWorktreeHook {
+    param([string] $EventName, [string] $ScriptName)
+
+    Assert-True ($claudeSettings.hooks.PSObject.Properties.Name -contains $EventName) "Expected a $EventName hook in .claude/settings.json."
+
+    $entries = @($claudeSettings.hooks.$EventName.hooks)
+    Assert-True ($entries.Count -eq 1) "Expected exactly one $EventName hook handler, got $($entries.Count)."
+
+    $handler = $entries[0]
+    Assert-True ($handler.type -eq 'command') "$EventName handler must be a command hook."
+    Assert-True ($handler.command -eq 'pwsh') "$EventName must invoke 'pwsh' as the bare command in exec form, got '$($handler.command)'."
+    Assert-True ($handler.PSObject.Properties.Name -contains 'args') "$EventName must use exec form (command plus args): shell form leaves the path placeholder unsubstituted."
+
+    $hookArgs = @($handler.args)
+    $fileIndex = [array]::IndexOf($hookArgs, '-File')
+    Assert-True ($fileIndex -ge 0) "$EventName args must pass -File."
+    Assert-True ($fileIndex + 1 -lt $hookArgs.Count) "$EventName args must pass a script path after -File."
+
+    # The placeholder must be present and spelled exactly; a malformed one would resolve to a
+    # path that does not exist, which the substitution check below catches.
+    $scriptArg = [string] $hookArgs[$fileIndex + 1]
+    $placeholder = '${CLAUDE_PROJECT_DIR}'
+    Assert-True ($scriptArg.StartsWith($placeholder)) "$EventName -File argument must start with $placeholder, got '$scriptArg'."
+
+    $resolved = $scriptArg.Replace($placeholder, $repoRoot)
+    Assert-True (Test-Path -LiteralPath $resolved) "$EventName -File argument does not resolve to an existing script: '$resolved'."
+    Assert-True ((Split-Path -Leaf $resolved) -eq $ScriptName) "$EventName must run $ScriptName, got '$(Split-Path -Leaf $resolved)'."
+}
+
+Assert-ExecFormWorktreeHook -EventName 'WorktreeCreate' -ScriptName 'new-worktree.ps1'
+Assert-ExecFormWorktreeHook -EventName 'WorktreeRemove' -ScriptName 'remove-worktree-local-dev.ps1'
+
 Write-Host 'Worktree PowerShell host tests passed.'


### PR DESCRIPTION
## Summary

Two related worktree-tooling fixes, plus the regression coverage that was missing for both.

**1. WorktreeCreate/WorktreeRemove hooks used shell form.** `${CLAUDE_PROJECT_DIR}` was left unsubstituted on the Claude Desktop worktree-checkbox path, so pwsh received the literal placeholder as `-File`:

```
The argument '${CLAUDE_PROJECT_DIR}\scripts\new-worktree.ps1' is not recognized as the name of a script file.
```

Switched both hooks to exec form (`command` + `args`), which the [Claude Code hooks reference](https://code.claude.com/docs/en/hooks) recommends for any hook referencing a path placeholder.

**2. Derived branch names did not follow the documented convention.** `scripts/new-worktree.ps1` had no naming logic at all, so a name supplied by the hook (or `EnterWorktree`) became the branch verbatim. The first attempt at a fix normalized the *sanitized directory name*, which has already collapsed `/` to `-` — so `fix/wt-foo` became `wt-fix-wt-foo`, and a bare name became `wt-foo`. Neither matches `<type>/wt-<topic>`.

Normalization now runs on the raw name and lives in `scripts/worktree-git.common.ps1` as `ConvertTo-WorktreeBranchName`:

| Input | Branch | Why |
| --- | --- | --- |
| `foo` | `fix/wt-foo` | untyped, so the `fix/` fallback applies |
| `wt-foo` | `fix/wt-foo` | marker kept, type added once |
| `feature/123-thing` | `feature/wt-123-thing` | documented branch prefix, preserved |
| `hotfix/456-thing` | `hotfix/wt-456-thing` | documented branch prefix, preserved |
| `fix/wt-foo` | `fix/wt-foo` | already conventional, round-trips unchanged |
| `chore/tidy` | `fix/wt-chore/tidy` | `chore` is a commit type, not a branch prefix |

The recognized prefixes are exactly the three in AGENTS.md "Git Workflow" — `feature`, `fix`, `hotfix`. The conventional commit types listed in the sentence below them (`refactor:`, `test:`, `docs:`, `chore:`) name *commits*, not branches, and are deliberately not accepted; an unrecognized leading segment is treated as topic text.

The fallback for an untyped name is `fix/`, because the WorktreeCreate hook only ever supplies a worktree name and cannot express intent. An explicit `-BranchName` bypasses normalization entirely. The worktree *directory* name is unaffected — it still uses the slash-free `ConvertTo-SafeName`.

It moved to the common file because `new-worktree.ps1` executes top-level code on dot-source and so cannot be unit-tested; the common file is already dot-sourced by both scripts.

## Coverage

The exec-form hooks were previously guarded only by a negative text match, which would still pass if `args` vanished, the placeholder were malformed, or shell form returned. `tests/WorktreePowerShellHost.Tests.ps1` now asserts the parsed shape of both hooks: exec form present, `command` is bare `pwsh`, `-File` present with a following argument, placeholder spelled exactly, and the substituted path resolving to the expected script on disk.

`tests/WorktreeBranchName.Tests.ps1` (new, registered in `ci.yml`) covers bare, already-prefixed, all three typed prefixes, commit-types-as-topic-text, fully-conventional, unsafe-character, `//`, trailing-`/`, and empty-after-sanitization inputs.

## Test plan

- [x] Every assertion mutation-tested rather than merely observed green:
  - reverting the hook to shell form fails with `WorktreeCreate must invoke 'pwsh' as the bare command in exec form`
  - restoring the old branch logic fails with `expected 'fix/wt-foo', got 'wt-foo'`
  - re-adding the commit types to the branch-type list fails with `expected 'fix/wt-chore/tidy', got 'chore/wt-tidy'`
  - all mutations reverted and the working tree confirmed clean afterwards
- [x] All five worktree PowerShell suites pass under pwsh 7 **and** Windows PowerShell 5.1
- [x] `dotnet build` + fast test slice green (pre-push hook)
- [x] `git diff --check` clean
- [x] Manually verified: creating a worktree via `EnterWorktree` succeeds after the hook fix (previously failed with the error quoted above)

## Notes for the reviewer

Two deliberate limits, both to avoid side effects in a test suite:

- The hook configuration is **not executed**. Running `new-worktree.ps1` for real creates a worktree, prunes Docker, and mutates git state. The test substitutes the placeholder and asserts the resolved path exists, which catches a malformed placeholder without those side effects.
- The explicit `-BranchName` bypass is asserted at source level for the same reason; the other cases are true unit tests.

No documentation changed: `.claude/skills/worktrees/SKILL.md` already defers to AGENTS.md, so restricting the helper aligned the code to the existing contract rather than widening it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)