### PR TITLE
feat: window snap operations + Win-in-Send guardrail

### DIFF
--- a/docs/development/ahk-v2-syntax.md
+++ b/docs/development/ahk-v2-syntax.md
@@ -336,13 +336,21 @@ F1::return
 `Window`'s two snap ops (`SnapLeft`, `SnapRight`) are the only non-one-line emit: each is a
 brace block that restores the window, reads the **primary** monitor's work area
 (`MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)`), then `WinMove`s to the left or right
-half. SnapRight's width is `r - (l + (r-l)//2)` so an odd work-area width still reaches `r`:
+half. SnapRight's width is measured back from `r` rather than repeating the left half's
+`(r - l) // 2`, so an odd work-area width still reaches `r` instead of leaving an uncovered column
+at the far-right edge. Both bodies in full — these are the emitted strings verbatim:
 
 ```ahk
 ^!Left::{
     WinRestore("A")
     MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)
     WinMove(l, t, (r - l) // 2, b - t, "A")
+}
+
+^!Right::{
+    WinRestore("A")
+    MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)
+    WinMove(l + (r - l) // 2, t, r - (l + (r - l) // 2), b - t, "A")
 }
 ```
 

--- a/docs/development/ahk-v2-syntax.md
+++ b/docs/development/ahk-v2-syntax.md
@@ -319,7 +319,7 @@ Each `HotkeyActionKind` owns its own stored field(s) and exactly one emitted for
 | `SendText` | `Text` | `SendText("<escaped>")` |
 | `SendKeys` | `SendKeysContent` | `Send("<escaped>")` — plus the `$` prefix |
 | `Run` | `RunTarget`, `RunTargetKind` | `Run("<escaped>")` — `RunTargetKind` is a display label and changes nothing |
-| `Window` | `WindowOp` | `WinMinimize("A")`, `WinMaximize("A")`, `WinRestore("A")`, `WinClose("A")`, `WinSetAlwaysOnTop(-1, "A")` |
+| `Window` | `WindowOp` | five one-line ops — `WinMinimize("A")`, `WinMaximize("A")`, `WinRestore("A")`, `WinClose("A")`, `WinSetAlwaysOnTop(-1, "A")` — plus two block-bodied snap ops (see below) |
 | `Remap` | `RemapDest` | the destination key name, bare |
 | `Disable` | — | `return` |
 | `Raw` | `Body` | `Body`, verbatim |
@@ -331,6 +331,19 @@ $#p::Send("{Media_Play_Pause}")
 ^Space::WinSetAlwaysOnTop(-1, "A")
 CapsLock::Ctrl
 F1::return
+```
+
+`Window`'s two snap ops (`SnapLeft`, `SnapRight`) are the only non-one-line emit: each is a
+brace block that restores the window, reads the **primary** monitor's work area
+(`MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)`), then `WinMove`s to the left or right
+half. SnapRight's width is `r - (l + (r-l)//2)` so an odd work-area width still reaches `r`:
+
+```ahk
+^!Left::{
+    WinRestore("A")
+    MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)
+    WinMove(l, t, (r - l) // 2, b - t, "A")
+}
 ```
 
 Only the three kinds that embed user text in a quoted literal — `SendText`, `SendKeys`, `Run` — pass

--- a/docs/superpowers/plans/2026-07-25-window-snap-ops-plan.md
+++ b/docs/superpowers/plans/2026-07-25-window-snap-ops-plan.md
@@ -1,6 +1,6 @@
 # Window snap operations + Win-in-Send guardrail — implementation plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task — the tasks are small, sequential, and repeatedly touch the same files, so inline execution beats a fresh subagent per task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add `SnapLeft` / `SnapRight` as first-class `Window` operations, move the two seeded snap samples off Raw bodies, and warn (non-blocking) when a SendKeys hotkey sends Win + an arrow key.
 
@@ -16,8 +16,8 @@
 - **Enum values are wire contract.** `SnapLeft = 5`, `SnapRight = 6` in *both* `AHKFlowApp.Domain/Enums/WindowOp.cs` and `AHKFlowApp.UI.Blazor/DTOs/WindowOp.cs`, with identical numeric values.
 - **Catalog count stays 19.** The snap conversion is in-place — no row is added or removed by this plan. Do not touch any seed-count assertion.
 - **Spec §5 is already implemented** on this branch's base (`feat: seed two SendKeys sample hotkeys`, catalog rows `Play / pause media` + `Select to end of line`, counts already 17 → 19). This plan does **not** re-do it.
-- **Deviation from spec §2 — read this before Task 2.** The spec claims the emitted output is byte-identical so golden assertions do not change. That holds for SnapLeft but **not** SnapRight: the existing catalog constant emits width `(r - l) // 2`, while spec §1's formula emits `r - (l + (r - l) // 2)` (the fix for odd work-area widths). Task 2 therefore updates one existing assertion in `AhkScriptGeneratorIntegrationTests`. This is intentional — the new formula is the spec's, and it is what closes the uncovered-strip gap.
-- `dotnet format` runs via hook after edits — do not revert its changes.
+- **SnapRight's emitted width changes.** The retired catalog constant emits width `(r - l) // 2`; spec §1's formula emits `r - (l + (r - l) // 2)`, so on an odd work-area width the right half reaches `r` instead of leaving an uncovered column at the far-right edge. Task 2 updates the one existing golden assertion in `AhkScriptGeneratorIntegrationTests`. The spec has been corrected to say so — its earlier "byte-identical / assertions do not change" wording was true only for SnapLeft.
+- `dotnet format` runs via hook after edits — do not revert its changes. The repo root holds both `AHKFlowApp.csproj` and `AHKFlowApp.slnx`, so bare `dotnet format` aborts with `Both a MSBuild project file and solution file found` — always pass the workspace: `dotnet format AHKFlowApp.slnx`.
 - Run `dotnet build` and `dotnet test` before opening a PR.
 
 ---
@@ -27,6 +27,7 @@
 **Files:**
 - Modify: `src/Backend/AHKFlowApp.Domain/Enums/WindowOp.cs:19`
 - Modify: `src/Backend/AHKFlowApp.Application/Services/HotkeyEmitter.cs:41-49`
+- Create: `tests/AHKFlowApp.Domain.Tests/Enums/WindowOpTests.cs`
 - Test: `tests/AHKFlowApp.Application.Tests/Services/HotkeyEmitterTests.cs`
 - Test: `tests/AHKFlowApp.Application.Tests/Validation/HotkeyKindConditionalRulesTests.cs`
 
@@ -52,7 +53,7 @@ Add after the `Emit_Window_Restore` test in `tests/AHKFlowApp.Application.Tests/
                 "}");
 
     // SnapRight's width is measured back from r rather than repeating (r - l) // 2, so an odd
-    // work-area width leaves no uncovered strip between the two halves.
+    // work-area width still reaches the right edge instead of leaving an uncovered column there.
     [Fact]
     public void Emit_Window_SnapRight() =>
         Line(new HotkeyBuilder().WithKey("Right").WithCtrl().WithAlt().WithWindow(WindowOp.SnapRight))
@@ -97,8 +98,9 @@ Then add this private helper directly below the `WindowCall` method (above `Rema
 ```csharp
     // Snap to one half of the PRIMARY monitor's work area (which excludes the taskbar). WinRestore
     // first so a maximized window can be moved; `//` is AHK integer division. The right half's width
-    // is measured back from r instead of reusing the left half's, so an odd work-area width leaves
-    // no uncovered strip. Resolving the window's own monitor is a later refinement (design non-goal).
+    // is measured back from r instead of reusing the left half's, so an odd work-area width still
+    // reaches the right edge instead of leaving an uncovered column there. Resolving the window's
+    // own monitor is a later refinement (design non-goal).
     private static string SnapBody(string x, string width) =>
         "{\n" +
         $"    WinRestore({ActiveWindow})\n" +
@@ -133,10 +135,47 @@ Run: `dotnet test tests/AHKFlowApp.Application.Tests --filter "FullyQualifiedNam
 
 Expected: PASS.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 8: Pin the domain ordinals**
+
+`WindowOp` is persisted as an `int` and hand-mirrored in the frontend (Task 3), so both sides pin their ordinals — the same pairing `HotstringImportRowStatusTests` uses in `AHKFlowApp.Application.Tests/Hotstrings/` and `AHKFlowApp.UI.Blazor.Tests/DTOs/`. Create `tests/AHKFlowApp.Domain.Tests/Enums/WindowOpTests.cs`:
+
+```csharp
+using AHKFlowApp.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Domain.Tests.Enums;
+
+public sealed class WindowOpTests
+{
+    [Theory]
+    [InlineData(WindowOp.Minimize, 0)]
+    [InlineData(WindowOp.Maximize, 1)]
+    [InlineData(WindowOp.Restore, 2)]
+    [InlineData(WindowOp.Close, 3)]
+    [InlineData(WindowOp.ToggleAlwaysOnTop, 4)]
+    [InlineData(WindowOp.SnapLeft, 5)]
+    [InlineData(WindowOp.SnapRight, 6)]
+    public void OrdinalValue_MatchesUiMirror(WindowOp op, int expected)
+    {
+        // WindowOp is persisted as an int and hand-mirrored in
+        // AHKFlowApp.UI.Blazor.DTOs.WindowOp — these ordinals must stay in lockstep with
+        // that file's WindowOpTests. Renumbering here silently rewrites stored rows.
+        ((int)op).Should().Be(expected);
+    }
+}
+```
+
+- [ ] **Step 9: Run the ordinal test**
+
+Run: `dotnet test tests/AHKFlowApp.Domain.Tests --filter "FullyQualifiedName~WindowOpTests"`
+
+Expected: PASS, 7 cases.
+
+- [ ] **Step 10: Commit**
 
 ```bash
-git add src/Backend/AHKFlowApp.Domain/Enums/WindowOp.cs src/Backend/AHKFlowApp.Application/Services/HotkeyEmitter.cs tests/AHKFlowApp.Application.Tests/Services/HotkeyEmitterTests.cs tests/AHKFlowApp.Application.Tests/Validation/HotkeyKindConditionalRulesTests.cs
+git add src/Backend/AHKFlowApp.Domain/Enums/WindowOp.cs src/Backend/AHKFlowApp.Application/Services/HotkeyEmitter.cs tests/AHKFlowApp.Domain.Tests/Enums/WindowOpTests.cs tests/AHKFlowApp.Application.Tests/Services/HotkeyEmitterTests.cs tests/AHKFlowApp.Application.Tests/Validation/HotkeyKindConditionalRulesTests.cs
 git commit -m "feat: emit SnapLeft/SnapRight WindowOp block bodies"
 ```
 
@@ -152,9 +191,11 @@ git commit -m "feat: emit SnapLeft/SnapRight WindowOp block bodies"
 - Consumes: `WindowOp.SnapLeft` / `WindowOp.SnapRight` and the emitter block bodies from Task 1.
 - Produces: no new API. `DefaultHotkeyCatalog.All` keeps 19 rows; the two snap rows now report `HotkeyActionKind.Window` instead of `Raw`.
 
-- [ ] **Step 1: Update the integration-test assertion to the new SnapRight width**
+- [ ] **Step 1: Update the SnapRight width assertion and assert the rows' kind**
 
-This is the one place the emitted text changes (see the Global Constraints deviation note). In `tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorIntegrationTests.cs`, replace line 140:
+Two edits in `tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorIntegrationTests.cs`.
+
+First, replace line 140 (the one place the emitted text changes — see Global Constraints):
 
 ```csharp
         output.Should().Contain("    WinMove(l + (r - l) // 2, t, (r - l) // 2, b - t, \"A\")");
@@ -168,11 +209,27 @@ with:
 
 Leave lines 137-139 exactly as they are — SnapLeft's emit and both `::{\n    WinRestore("A")` prefixes are unchanged.
 
+Second, output assertions alone would still pass if the rows stayed `Raw` bodies emitting the same text, so pin the kind too. Add after the last SendKeys assertion (line 152), using the `forProfile` list already materialized at line 127:
+
+```csharp
+        // The snap rows are Window-kind samples now, not Raw bodies that merely emit the same
+        // text — assert the stored kind, or a regression to Raw would pass on output alone.
+        Hotkey snapLeft = forProfile.Single(h => h.Description == "Snap window left");
+        snapLeft.ActionKind.Should().Be(HotkeyActionKind.Window);
+        snapLeft.WindowOp.Should().Be(WindowOp.SnapLeft);
+
+        Hotkey snapRight = forProfile.Single(h => h.Description == "Snap window right");
+        snapRight.ActionKind.Should().Be(HotkeyActionKind.Window);
+        snapRight.WindowOp.Should().Be(WindowOp.SnapRight);
+```
+
+`AHKFlowApp.Domain.Enums` and `AHKFlowApp.Domain.Entities` are already imported at lines 4-5.
+
 - [ ] **Step 2: Run the integration test to verify it fails**
 
 Run: `dotnet test tests/AHKFlowApp.Application.Tests --filter "FullyQualifiedName~AhkScriptGeneratorIntegrationTests.Generate_FromSeededCatalog_EmitsCorrectedAndNewLines"`
 
-Expected: FAIL — the catalog still seeds the old Raw constant, so the output contains the old width string, not the new one. (Requires Docker: this test uses the SQL Server Testcontainer fixture.)
+Expected: FAIL on the width assertion — the catalog still seeds the old Raw constant, so the output contains the old width string. The kind assertions would fail too (`ActionKind` is still `Raw`). (Requires Docker: this test uses the SQL Server Testcontainer fixture.)
 
 - [ ] **Step 3: Convert the two catalog rows**
 
@@ -319,25 +376,26 @@ Expected: PASS.
 
 - [ ] **Step 7: Add the dialog dropdown test**
 
-The op `MudSelect` lives in a popover, so asserting on rendered `MudSelectItem`s is brittle in bUnit. Instead drive the select's `ValueChanged` with a snap value — the same technique `CorrectingWindowOp_ClearsItsStaleSaveError` uses at line 422 — which proves the dropdown is typed to carry it and the dialog stores it. Add to `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs`, after `CorrectingWindowOp_ClearsItsStaleSaveError` (currently ends at line 427):
+Assert on the rendered items, not on `ValueChanged`: driving `ValueChanged` with an enum value passes even when no item for it was ever rendered, so it would not catch a missing dropdown entry. `MudSelectItem`s render without opening the popover — `HotstringsPageTests.Page_KindFilter_ListsAllFourKinds` (line 962) already does exactly this. Add to `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs`, after `CorrectingWindowOp_ClearsItsStaleSaveError` (currently ends at line 427):
 
 ```csharp
-    // The op dropdown enumerates the frontend WindowOp, so a value missing there is a value the
-    // user cannot pick. Driving ValueChanged is what selecting the item does, minus the popover.
-    [Theory]
-    [InlineData(WindowOp.SnapLeft)]
-    [InlineData(WindowOp.SnapRight)]
-    public async Task WindowPanel_AcceptsSnapOps(WindowOp op)
+    // The op dropdown enumerates Enum.GetValues<WindowOp>(), so an op absent from the frontend
+    // mirror is an op the user cannot pick. Asserting the rendered items — rather than driving
+    // ValueChanged, which passes whether or not the item exists — is what catches that.
+    [Fact]
+    public async Task WindowPanel_OpDropdown_ListsEveryWindowOp()
     {
-        HotkeyEditModel item = new() { Description = "d", Key = "n", ActionKind = HotkeyActionKind.Window };
-        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(item);
+        IRenderedComponent<MudDialogProvider> provider =
+            await ShowDialogAsync(new HotkeyEditModel { ActionKind = HotkeyActionKind.Window });
 
-        await provider.InvokeAsync(() => provider.FindComponent<MudSelect<WindowOp?>>()
-            .Instance.ValueChanged.InvokeAsync(op));
+        IReadOnlyList<WindowOp?> items = [.. provider.FindComponents<MudSelectItem<WindowOp?>>()
+            .Select(c => c.Instance.Value)];
 
-        item.WindowOp.Should().Be(op);
+        items.Should().BeEquivalentTo(Enum.GetValues<WindowOp>().Cast<WindowOp?>());
     }
 ```
+
+If `FindComponents<MudSelectItem<WindowOp?>>()` comes back empty, the dialog's select renders its items lazily — in that case assert `provider.Markup` contains `Snap left` and `Snap right` instead, and say so in the step's notes. Do **not** fall back to the `ValueChanged` form.
 
 - [ ] **Step 8: Run the dialog test suite**
 
@@ -362,10 +420,10 @@ git commit -m "feat: snap ops in frontend WindowOp mirror and labels"
 - Test: `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs`
 
 **Interfaces:**
-- Consumes: `HotkeyActionDisplay.WindowOpLabel` wording from Task 3 (the warning text names "Snap left / Snap right").
-- Produces: `HotkeyActionDisplay.SendWinArrowWarningText` (const string) and a `data-test="send-win-arrow-warning"` element in the SendKeys panel.
+- Consumes: `HotkeyActionDisplay.WindowOpLabel` wording from Task 3 (the warning text names the four Window ops by their labels).
+- Produces: `HotkeyActionDisplay.SendWinArrowWarningText` (const string) and a `data-test="send-win-arrow-warning"` element in the SendKeys panel. The `data-test` id stays a string literal in markup and tests, matching every other `data-test` in the codebase including the Raw warning — the spec's §4 bullet was amended to say so.
 
-- [ ] **Step 1: Add an arrow key to the test catalog**
+- [ ] **Step 1: Add the four arrow keys to the test catalog**
 
 The dialog's test double (`CatalogKeys`, line 20-25) has no arrow key, so no test can select one. Replace the array with:
 
@@ -375,11 +433,14 @@ The dialog's test double (`CatalogKeys`, line 20-25) has no arrow key, so no tes
         new("F1", "Function keys", ["HotkeyKey", "RemapDest", "SendToken"], true),
         new("c", "Letters & digits", ["HotkeyKey", "RemapDest", "SendToken"], false),
         new("Volume_Up", "Media & browser", ["SendToken"], true),
+        new("Up", "Navigation & editing", ["HotkeyKey", "RemapDest", "SendToken"], true),
+        new("Down", "Navigation & editing", ["HotkeyKey", "RemapDest", "SendToken"], true),
         new("Left", "Navigation & editing", ["HotkeyKey", "RemapDest", "SendToken"], true),
+        new("Right", "Navigation & editing", ["HotkeyKey", "RemapDest", "SendToken"], true),
     ];
 ```
 
-`Left` is a named key in the real registry (`HotkeyKeys.s_namedKeys`), carries all roles, and has `RequiresBracesInSend: true` — this mirrors it.
+All four are named keys in the real registry (`HotkeyKeys.s_namedKeys`), carry every role, and have `RequiresBracesInSend: true` — this mirrors them.
 
 - [ ] **Step 2: Write the three failing warning tests**
 
@@ -387,18 +448,23 @@ Add to `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTest
 
 ```csharp
     // Injected Win is not honoured by the shell's Aero-Snap handler, so Send("#{Left}") silently
-    // does nothing. The warning is advisory only — see SendKeysPanel_WinArrowWarning_DoesNotBlockSave.
-    [Fact]
-    public async Task SendKeysPanel_WinPlusArrow_ShowsTheSnapWarning()
+    // does nothing. All four arrows are the same gesture — Win+Up/Down maximize and minimize, and
+    // fail the same way. Advisory only — see SendKeysPanel_WinArrowWarning_DoesNotBlockSave.
+    [Theory]
+    [InlineData("Up")]
+    [InlineData("Down")]
+    [InlineData("Left")]
+    [InlineData("Right")]
+    public async Task SendKeysPanel_WinPlusArrow_ShowsTheSnapWarning(string arrow)
     {
         HotkeyEditModel item = new() { ActionKind = HotkeyActionKind.SendKeys };
         IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(item);
 
         provider.Find("input[data-test=\"send-win-checkbox\"]").Change(true);
-        await SetKeyAsync(provider, "send-key-picker", "Left");
+        await SetKeyAsync(provider, "send-key-picker", arrow);
 
         provider.WaitForAssertion(() => provider.Find("[data-test=\"send-win-arrow-warning\"]")
-            .TextContent.Should().Contain("won't snap the window"));
+            .TextContent.Should().Contain("won't snap or resize the window"));
     }
 
     // Send "#e" really does open Explorer, so a blanket all-Win warning would be wrong: only the
@@ -467,12 +533,14 @@ In `src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs`, directly 
     /// Advisory shown when a SendKeys row sends Win + an arrow. Injected LWin (SendInput's atomic
     /// batch, flagged LLKHF_INJECTED) is not honoured by the shell's Aero-Snap handler, so the send
     /// silently does nothing. Non-blocking: the token is valid AHK and Save is unaffected. Scoped to
-    /// arrows only — injected Win *does* fire some shortcuts (Send "#e" opens Explorer).
+    /// arrows only — injected Win *does* fire some shortcuts (Send "#e" opens Explorer). Names all
+    /// four Window ops because the warning covers all four arrows: Win+Up/Down are maximize and
+    /// minimize. Plain text, no Markdown — MudAlert renders the constant verbatim.
     /// </summary>
     public const string SendWinArrowWarningText =
-        "Sending Win + Arrow won't snap the window — Windows ignores injected Win for Aero Snap. " +
-        "To snap the active window, use a Window action (Snap left / Snap right). " +
-        "For other Win shortcuts, use Raw.";
+        "Sending Win + Arrow won't snap or resize the window — Windows ignores injected Win for " +
+        "Aero Snap. Use the matching Window action instead (Minimize, Maximize, Snap left, or " +
+        "Snap right). For other Win shortcuts, use Raw.";
 ```
 
 - [ ] **Step 5: Add the arrow-detection helper to the dialog**
@@ -555,14 +623,15 @@ brace block that restores the window, reads the **primary** monitor's work area
 half. SnapRight's width is `r - (l + (r-l)//2)` so an odd work-area width still reaches `r`:
 
 ```ahk
-^!Left::
-{
+^!Left::{
     WinRestore("A")
     MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)
     WinMove(l, t, (r - l) // 2, b - t, "A")
 }
 ```
 ````
+
+The `::{` on one line is not a style choice — the emitter concatenates the body straight after `::`, so that is the literal output, and it matches how this document already shows the `Raw` block example (`^+v::{`, line 363).
 
 - [ ] **Step 3: Verify the doc matches the emitter**
 
@@ -597,9 +666,9 @@ Expected: all green. Docker must be running — the Application and API integrat
 
 - [ ] **Step 3: Check formatting**
 
-Run: `dotnet format --verify-no-changes`
+Run: `dotnet format AHKFlowApp.slnx --verify-no-changes --no-restore`
 
-Expected: no diff. If it reports changes, run `dotnet format` and amend the owning commit.
+Expected: no diff. If it reports changes, run `dotnet format AHKFlowApp.slnx` and amend the owning commit. The workspace argument is required — the repo root holds both `AHKFlowApp.csproj` and `AHKFlowApp.slnx`, and bare `dotnet format` aborts with `Both a MSBuild project file and solution file found`.
 
 - [ ] **Step 4: Report**
 
@@ -607,7 +676,12 @@ State the actual `dotnet test` summary line (passed/failed/skipped counts). If a
 
 ---
 
+## Resolved decisions
+
+1. **SnapRight width** — approved. `r - (l + (r - l) // 2)` replaces `(r - l) // 2`; on an odd work-area width the old formula left an uncovered column at the far-right edge. Spec §2 and the golden assertion updated to match.
+2. **Warning copy** — plain text, no Markdown bold. `MudAlert`'s warning styling supplies the emphasis, and a literal constant stays single-sourced and easy to assert. Spec §4 updated.
+3. **Execution mode** — inline (`superpowers:executing-plans`), not a subagent per task: the tasks are small, sequential, and repeatedly touch the same files.
+
 ## Unresolved questions
 
-1. SnapRight width changes from `(r-l)//2` to `r-(l+(r-l)//2)` — spec's formula, breaks §2's "byte-identical" claim. Confirm OK?
-2. Warning copy: spec has bold markdown (`**Window**`, `**Raw**`); `MudAlert` renders plain text. Plan drops the asterisks. Want bold via markup instead?
+None.

--- a/docs/superpowers/plans/2026-07-25-window-snap-ops-plan.md
+++ b/docs/superpowers/plans/2026-07-25-window-snap-ops-plan.md
@@ -1,0 +1,613 @@
+# Window snap operations + Win-in-Send guardrail — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `SnapLeft` / `SnapRight` as first-class `Window` operations, move the two seeded snap samples off Raw bodies, and warn (non-blocking) when a SendKeys hotkey sends Win + an arrow key.
+
+**Architecture:** Two enum values in the domain `WindowOp` plus its frontend numeric mirror; the half-work-area `WinMove` AHK moves from two catalog string constants into the emitter's `WindowCall` switch, so the block body lives once. The catalog's snap rows convert from `Raw(…)` to `Typed(… WindowOp.SnapLeft/SnapRight)`. The UI gains two dropdown labels (enum-driven, no markup change) and a `MudAlert` in the SendKeys panel gated on `_sendWin && arrow key`.
+
+**Tech Stack:** .NET 10, EF Core (no migration needed), Blazor WebAssembly + MudBlazor 9.x, xUnit + FluentAssertions + bUnit + Testcontainers.
+
+**Source spec:** `docs/superpowers/specs/2026-07-24-window-snap-and-win-send-guardrail-design.md`
+
+## Global Constraints
+
+- **No DB migration.** `WindowOp` persists as `int`; new enum values add no schema change and leave existing rows untouched.
+- **Enum values are wire contract.** `SnapLeft = 5`, `SnapRight = 6` in *both* `AHKFlowApp.Domain/Enums/WindowOp.cs` and `AHKFlowApp.UI.Blazor/DTOs/WindowOp.cs`, with identical numeric values.
+- **Catalog count stays 19.** The snap conversion is in-place — no row is added or removed by this plan. Do not touch any seed-count assertion.
+- **Spec §5 is already implemented** on this branch's base (`feat: seed two SendKeys sample hotkeys`, catalog rows `Play / pause media` + `Select to end of line`, counts already 17 → 19). This plan does **not** re-do it.
+- **Deviation from spec §2 — read this before Task 2.** The spec claims the emitted output is byte-identical so golden assertions do not change. That holds for SnapLeft but **not** SnapRight: the existing catalog constant emits width `(r - l) // 2`, while spec §1's formula emits `r - (l + (r - l) // 2)` (the fix for odd work-area widths). Task 2 therefore updates one existing assertion in `AhkScriptGeneratorIntegrationTests`. This is intentional — the new formula is the spec's, and it is what closes the uncovered-strip gap.
+- `dotnet format` runs via hook after edits — do not revert its changes.
+- Run `dotnet build` and `dotnet test` before opening a PR.
+
+---
+
+### Task 1: Domain enum values + emitter snap bodies
+
+**Files:**
+- Modify: `src/Backend/AHKFlowApp.Domain/Enums/WindowOp.cs:19`
+- Modify: `src/Backend/AHKFlowApp.Application/Services/HotkeyEmitter.cs:41-49`
+- Test: `tests/AHKFlowApp.Application.Tests/Services/HotkeyEmitterTests.cs`
+- Test: `tests/AHKFlowApp.Application.Tests/Validation/HotkeyKindConditionalRulesTests.cs`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `AHKFlowApp.Domain.Enums.WindowOp.SnapLeft` (= 5) and `.SnapRight` (= 6). `HotkeyEmitter.Emit(Hotkey)` returns a multi-line brace block for those two ops; every other op keeps its one-line form.
+
+- [ ] **Step 1: Write the two failing emitter tests**
+
+Add after the `Emit_Window_Restore` test in `tests/AHKFlowApp.Application.Tests/Services/HotkeyEmitterTests.cs` (currently ends at line 51):
+
+```csharp
+    // Snap is the only Window op with a block body: the half-work-area WinMove needs three
+    // statements. Pinned byte-for-byte because this string is what lands in the user's script.
+    [Fact]
+    public void Emit_Window_SnapLeft() =>
+        Line(new HotkeyBuilder().WithKey("Left").WithCtrl().WithAlt().WithWindow(WindowOp.SnapLeft))
+            .Should().Be(
+                "^!Left::{\n" +
+                "    WinRestore(\"A\")\n" +
+                "    MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)\n" +
+                "    WinMove(l, t, (r - l) // 2, b - t, \"A\")\n" +
+                "}");
+
+    // SnapRight's width is measured back from r rather than repeating (r - l) // 2, so an odd
+    // work-area width leaves no uncovered strip between the two halves.
+    [Fact]
+    public void Emit_Window_SnapRight() =>
+        Line(new HotkeyBuilder().WithKey("Right").WithCtrl().WithAlt().WithWindow(WindowOp.SnapRight))
+            .Should().Be(
+                "^!Right::{\n" +
+                "    WinRestore(\"A\")\n" +
+                "    MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)\n" +
+                "    WinMove(l + (r - l) // 2, t, r - (l + (r - l) // 2), b - t, \"A\")\n" +
+                "}");
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/AHKFlowApp.Application.Tests --filter "FullyQualifiedName~HotkeyEmitterTests.Emit_Window_Snap"`
+
+Expected: **compile error** — `'WindowOp' does not contain a definition for 'SnapLeft'`. A compile failure is the correct red here; the enum member does not exist yet.
+
+- [ ] **Step 3: Add the two enum values**
+
+In `src/Backend/AHKFlowApp.Domain/Enums/WindowOp.cs`, after `ToggleAlwaysOnTop = 4,`:
+
+```csharp
+
+    /// <summary>Left half of the primary monitor's work area — a <c>WinMove</c> block body.</summary>
+    SnapLeft = 5,
+
+    /// <summary>Right half of the primary monitor's work area — a <c>WinMove</c> block body.</summary>
+    SnapRight = 6,
+```
+
+- [ ] **Step 4: Add the emitter cases**
+
+In `src/Backend/AHKFlowApp.Application/Services/HotkeyEmitter.cs`, add two arms to `WindowCall` immediately after the `ToggleAlwaysOnTop` arm (before the `_ =>` default):
+
+```csharp
+        WindowOp.SnapLeft => SnapBody("l", "(r - l) // 2"),
+        WindowOp.SnapRight => SnapBody("l + (r - l) // 2", "r - (l + (r - l) // 2)"),
+```
+
+Then add this private helper directly below the `WindowCall` method (above `RemapRhs`):
+
+```csharp
+    // Snap to one half of the PRIMARY monitor's work area (which excludes the taskbar). WinRestore
+    // first so a maximized window can be moved; `//` is AHK integer division. The right half's width
+    // is measured back from r instead of reusing the left half's, so an odd work-area width leaves
+    // no uncovered strip. Resolving the window's own monitor is a later refinement (design non-goal).
+    private static string SnapBody(string x, string width) =>
+        "{\n" +
+        $"    WinRestore({ActiveWindow})\n" +
+        "    MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)\n" +
+        $"    WinMove({x}, t, {width}, b - t, {ActiveWindow})\n" +
+        "}";
+```
+
+- [ ] **Step 5: Run the emitter tests to verify they pass**
+
+Run: `dotnet test tests/AHKFlowApp.Application.Tests --filter "FullyQualifiedName~HotkeyEmitterTests"`
+
+Expected: PASS, all tests in the class.
+
+- [ ] **Step 6: Write the validator test**
+
+`HotkeyRules` gates `Window` with `d.WindowOp is not WindowOp op || !Enum.IsDefined(op)`, so the new values are accepted automatically — this test pins that. Add to `tests/AHKFlowApp.Application.Tests/Validation/HotkeyKindConditionalRulesTests.cs`, after the existing `Raw` body tests (around line 223):
+
+```csharp
+    // Enum.IsDefined is the whole Window gate, so new WindowOp values need no validator change.
+    // Pinned so a future "allowed ops" list cannot silently drop snap.
+    [Theory]
+    [InlineData(WindowOp.SnapLeft)]
+    [InlineData(WindowOp.SnapRight)]
+    public void Window_AcceptsSnapOps(WindowOp op) =>
+        Validate(Base(HotkeyActionKind.Window) with { WindowOp = op }).IsValid.Should().BeTrue();
+```
+
+- [ ] **Step 7: Run the validator test**
+
+Run: `dotnet test tests/AHKFlowApp.Application.Tests --filter "FullyQualifiedName~HotkeyKindConditionalRulesTests"`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Backend/AHKFlowApp.Domain/Enums/WindowOp.cs src/Backend/AHKFlowApp.Application/Services/HotkeyEmitter.cs tests/AHKFlowApp.Application.Tests/Services/HotkeyEmitterTests.cs tests/AHKFlowApp.Application.Tests/Validation/HotkeyKindConditionalRulesTests.cs
+git commit -m "feat: emit SnapLeft/SnapRight WindowOp block bodies"
+```
+
+---
+
+### Task 2: Catalog snap samples become `Window` kind
+
+**Files:**
+- Modify: `src/Backend/AHKFlowApp.Application/Constants/DefaultHotkeyCatalog.cs:35-45` (rows + comment) and `:88-105` (delete two constants)
+- Test: `tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorIntegrationTests.cs:139-140`
+
+**Interfaces:**
+- Consumes: `WindowOp.SnapLeft` / `WindowOp.SnapRight` and the emitter block bodies from Task 1.
+- Produces: no new API. `DefaultHotkeyCatalog.All` keeps 19 rows; the two snap rows now report `HotkeyActionKind.Window` instead of `Raw`.
+
+- [ ] **Step 1: Update the integration-test assertion to the new SnapRight width**
+
+This is the one place the emitted text changes (see the Global Constraints deviation note). In `tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorIntegrationTests.cs`, replace line 140:
+
+```csharp
+        output.Should().Contain("    WinMove(l + (r - l) // 2, t, (r - l) // 2, b - t, \"A\")");
+```
+
+with:
+
+```csharp
+        output.Should().Contain("    WinMove(l + (r - l) // 2, t, r - (l + (r - l) // 2), b - t, \"A\")");
+```
+
+Leave lines 137-139 exactly as they are — SnapLeft's emit and both `::{\n    WinRestore("A")` prefixes are unchanged.
+
+- [ ] **Step 2: Run the integration test to verify it fails**
+
+Run: `dotnet test tests/AHKFlowApp.Application.Tests --filter "FullyQualifiedName~AhkScriptGeneratorIntegrationTests.Generate_FromSeededCatalog_EmitsCorrectedAndNewLines"`
+
+Expected: FAIL — the catalog still seeds the old Raw constant, so the output contains the old width string, not the new one. (Requires Docker: this test uses the SQL Server Testcontainer fixture.)
+
+- [ ] **Step 3: Convert the two catalog rows**
+
+In `src/Backend/AHKFlowApp.Application/Constants/DefaultHotkeyCatalog.cs`, replace lines 44-45:
+
+```csharp
+        Raw("Snap window left",  true, true, false, false, "Left",  SnapLeftBody,  ["Window Management"]),
+        Raw("Snap window right", true, true, false, false, "Right", SnapRightBody, ["Window Management"]),
+```
+
+with:
+
+```csharp
+        Typed("Snap window left",  "Left",  HotkeyActionKind.Window, ["Window Management"],
+            ctrl: true, alt: true, windowOp: WindowOp.SnapLeft),
+        Typed("Snap window right", "Right", HotkeyActionKind.Window, ["Window Management"],
+            ctrl: true, alt: true, windowOp: WindowOp.SnapRight),
+```
+
+- [ ] **Step 4: Update the comment above those rows**
+
+The comment block at lines 35-39 still says snap needs a Raw body. Replace its last sentence — `Max/Min use the typed Window kind; snap L/R need a half-work-area WinMove that no WindowOp expresses, so they are Raw bodies.` — with:
+
+```
+        // window functions are deterministic. All four use the typed Window kind; the snap pair's
+        // half-work-area WinMove block lives in the emitter, not here.
+```
+
+Keep the preceding sentences (the `LLKHF_INJECTED` / Aero-Snap explanation) verbatim — they are still the reason these rows are not SendKeys.
+
+- [ ] **Step 5: Delete the two Raw body constants**
+
+Remove lines 88-105 of the same file in full — the `// Snap the active window to the left/right half…` comment block plus both `SnapLeftBody` and `SnapRightBody` constants. Leave `PastePlainTextBody` (lines 75-86) untouched.
+
+- [ ] **Step 6: Run the integration test to verify it passes**
+
+Run: `dotnet test tests/AHKFlowApp.Application.Tests --filter "FullyQualifiedName~AhkScriptGeneratorIntegrationTests"`
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the seed-count suites to prove the count is unchanged**
+
+Run:
+
+```bash
+dotnet test tests/AHKFlowApp.Application.Tests --filter "FullyQualifiedName~SeedHotkeysCommandHandlerTests|FullyQualifiedName~ListHotkeysLazySeedTests|FullyQualifiedName~SeedAllCommandHandlerTests"
+```
+
+Expected: PASS with no edits — the catalog is still 19 rows.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Backend/AHKFlowApp.Application/Constants/DefaultHotkeyCatalog.cs tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorIntegrationTests.cs
+git commit -m "refactor: seed snap samples as Window kind, drop Raw bodies"
+```
+
+---
+
+### Task 3: Frontend enum mirror + snap labels
+
+**Files:**
+- Modify: `src/Frontend/AHKFlowApp.UI.Blazor/DTOs/WindowOp.cs:10`
+- Modify: `src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs:60-68`
+- Create: `tests/AHKFlowApp.UI.Blazor.Tests/DTOs/WindowOpTests.cs`
+- Test: `tests/AHKFlowApp.UI.Blazor.Tests/Helpers/HotkeyActionDisplayTests.cs`
+- Test: `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs`
+
+**Interfaces:**
+- Consumes: the numeric values fixed in Task 1 (`SnapLeft = 5`, `SnapRight = 6`) — the frontend enum must match them exactly.
+- Produces: `AHKFlowApp.UI.Blazor.DTOs.WindowOp.SnapLeft` / `.SnapRight`, and `HotkeyActionDisplay.WindowOpLabel` returning `"Snap left"` / `"Snap right"`. The `HotkeyEditDialog` op dropdown enumerates this frontend enum via `Enum.GetValues<WindowOp>()`, so it picks the entries up with no markup change.
+
+- [ ] **Step 1: Write the wire-value pin test**
+
+The frontend enum is deserialized from an int and hand-mirrors the domain enum, so its ordinals are contract. This mirrors the existing `HotstringImportRowStatusTests` precedent. Create `tests/AHKFlowApp.UI.Blazor.Tests/DTOs/WindowOpTests.cs`:
+
+```csharp
+using AHKFlowApp.UI.Blazor.DTOs;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.DTOs;
+
+public sealed class WindowOpTests
+{
+    [Theory]
+    [InlineData(WindowOp.Minimize, 0)]
+    [InlineData(WindowOp.Maximize, 1)]
+    [InlineData(WindowOp.Restore, 2)]
+    [InlineData(WindowOp.Close, 3)]
+    [InlineData(WindowOp.ToggleAlwaysOnTop, 4)]
+    [InlineData(WindowOp.SnapLeft, 5)]
+    [InlineData(WindowOp.SnapRight, 6)]
+    public void OrdinalValue_MatchesBackendMirror(WindowOp op, int expected)
+    {
+        // WindowOp is deserialized from an int and hand-mirrors
+        // AHKFlowApp.Domain.Enums.WindowOp — these ordinals must stay in lockstep with that file.
+        ((int)op).Should().Be(expected);
+    }
+}
+```
+
+- [ ] **Step 2: Write the two failing label tests**
+
+Add to `tests/AHKFlowApp.UI.Blazor.Tests/Helpers/HotkeyActionDisplayTests.cs`, after `Summary_Window_IsOperationLabel` (currently ends at line 81):
+
+```csharp
+    [Theory]
+    [InlineData(WindowOp.SnapLeft, "Snap left")]
+    [InlineData(WindowOp.SnapRight, "Snap right")]
+    public void WindowOpLabel_Snap_IsHumanReadable(WindowOp op, string expected) =>
+        HotkeyActionDisplay.WindowOpLabel(op).Should().Be(expected);
+```
+
+- [ ] **Step 3: Run both tests to verify they fail**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "FullyQualifiedName~WindowOpTests|FullyQualifiedName~WindowOpLabel_Snap"`
+
+Expected: **compile error** — `'WindowOp' does not contain a definition for 'SnapLeft'` (the frontend mirror, not the domain one).
+
+- [ ] **Step 4: Add the frontend enum values**
+
+In `src/Frontend/AHKFlowApp.UI.Blazor/DTOs/WindowOp.cs`, after `ToggleAlwaysOnTop = 4,`:
+
+```csharp
+    SnapLeft = 5,
+    SnapRight = 6,
+```
+
+- [ ] **Step 5: Add the two labels**
+
+In `src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs`, add two arms to `WindowOpLabel` after the `ToggleAlwaysOnTop` arm:
+
+```csharp
+        DTOs.WindowOp.SnapLeft => "Snap left",
+        DTOs.WindowOp.SnapRight => "Snap right",
+```
+
+- [ ] **Step 6: Run both tests to verify they pass**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "FullyQualifiedName~WindowOpTests|FullyQualifiedName~WindowOpLabel_Snap"`
+
+Expected: PASS.
+
+- [ ] **Step 7: Add the dialog dropdown test**
+
+The op `MudSelect` lives in a popover, so asserting on rendered `MudSelectItem`s is brittle in bUnit. Instead drive the select's `ValueChanged` with a snap value — the same technique `CorrectingWindowOp_ClearsItsStaleSaveError` uses at line 422 — which proves the dropdown is typed to carry it and the dialog stores it. Add to `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs`, after `CorrectingWindowOp_ClearsItsStaleSaveError` (currently ends at line 427):
+
+```csharp
+    // The op dropdown enumerates the frontend WindowOp, so a value missing there is a value the
+    // user cannot pick. Driving ValueChanged is what selecting the item does, minus the popover.
+    [Theory]
+    [InlineData(WindowOp.SnapLeft)]
+    [InlineData(WindowOp.SnapRight)]
+    public async Task WindowPanel_AcceptsSnapOps(WindowOp op)
+    {
+        HotkeyEditModel item = new() { Description = "d", Key = "n", ActionKind = HotkeyActionKind.Window };
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(item);
+
+        await provider.InvokeAsync(() => provider.FindComponent<MudSelect<WindowOp?>>()
+            .Instance.ValueChanged.InvokeAsync(op));
+
+        item.WindowOp.Should().Be(op);
+    }
+```
+
+- [ ] **Step 8: Run the dialog test suite**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "FullyQualifiedName~HotkeyEditDialogTests"`
+
+Expected: PASS, all tests in the class.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Frontend/AHKFlowApp.UI.Blazor/DTOs/WindowOp.cs src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs tests/AHKFlowApp.UI.Blazor.Tests/DTOs/WindowOpTests.cs tests/AHKFlowApp.UI.Blazor.Tests/Helpers/HotkeyActionDisplayTests.cs tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
+git commit -m "feat: snap ops in frontend WindowOp mirror and labels"
+```
+
+---
+
+### Task 4: Win + Arrow warning in the SendKeys panel
+
+**Files:**
+- Modify: `src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs:18-19` (add a second constant beside `RawWarningText`)
+- Modify: `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor:83-99` (alert) and the `@code` block near `:307`
+- Test: `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs`
+
+**Interfaces:**
+- Consumes: `HotkeyActionDisplay.WindowOpLabel` wording from Task 3 (the warning text names "Snap left / Snap right").
+- Produces: `HotkeyActionDisplay.SendWinArrowWarningText` (const string) and a `data-test="send-win-arrow-warning"` element in the SendKeys panel.
+
+- [ ] **Step 1: Add an arrow key to the test catalog**
+
+The dialog's test double (`CatalogKeys`, line 20-25) has no arrow key, so no test can select one. Replace the array with:
+
+```csharp
+    private static readonly HotkeyKeyDto[] CatalogKeys =
+    [
+        new("F1", "Function keys", ["HotkeyKey", "RemapDest", "SendToken"], true),
+        new("c", "Letters & digits", ["HotkeyKey", "RemapDest", "SendToken"], false),
+        new("Volume_Up", "Media & browser", ["SendToken"], true),
+        new("Left", "Navigation & editing", ["HotkeyKey", "RemapDest", "SendToken"], true),
+    ];
+```
+
+`Left` is a named key in the real registry (`HotkeyKeys.s_namedKeys`), carries all roles, and has `RequiresBracesInSend: true` — this mirrors it.
+
+- [ ] **Step 2: Write the three failing warning tests**
+
+Add to `tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs`, after `SendKeysPanel_StoredTokenDecomposesIntoCheckboxesAndKey` (currently ends at line 500):
+
+```csharp
+    // Injected Win is not honoured by the shell's Aero-Snap handler, so Send("#{Left}") silently
+    // does nothing. The warning is advisory only — see SendKeysPanel_WinArrowWarning_DoesNotBlockSave.
+    [Fact]
+    public async Task SendKeysPanel_WinPlusArrow_ShowsTheSnapWarning()
+    {
+        HotkeyEditModel item = new() { ActionKind = HotkeyActionKind.SendKeys };
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(item);
+
+        provider.Find("input[data-test=\"send-win-checkbox\"]").Change(true);
+        await SetKeyAsync(provider, "send-key-picker", "Left");
+
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"send-win-arrow-warning\"]")
+            .TextContent.Should().Contain("won't snap the window"));
+    }
+
+    // Send "#e" really does open Explorer, so a blanket all-Win warning would be wrong: only the
+    // arrow gesture is documented to fail.
+    [Fact]
+    public async Task SendKeysPanel_WinPlusNonArrow_ShowsNoWarning()
+    {
+        HotkeyEditModel item = new() { ActionKind = HotkeyActionKind.SendKeys };
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(item);
+
+        provider.Find("input[data-test=\"send-win-checkbox\"]").Change(true);
+        await SetKeyAsync(provider, "send-key-picker", "c");
+
+        provider.FindAll("[data-test=\"send-win-arrow-warning\"]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SendKeysPanel_ArrowWithoutWin_ShowsNoWarning()
+    {
+        HotkeyEditModel item = new() { ActionKind = HotkeyActionKind.SendKeys };
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(item);
+
+        await SetKeyAsync(provider, "send-key-picker", "Left");
+
+        provider.FindAll("[data-test=\"send-win-arrow-warning\"]").Should().BeEmpty();
+    }
+
+    // Non-blocking by design: the token is valid AHK and the user may have a reason.
+    [Fact]
+    public async Task SendKeysPanel_WinArrowWarning_DoesNotBlockSave()
+    {
+        HotkeyDto created = new(Guid.NewGuid(), [], true, "Snap attempt", "n", true, false, false, false,
+            HotkeyActionKind.SendKeys, null, "#{Left}", null, null, null, null, null,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        _api.CreateAsync(Arg.Any<CreateHotkeyDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotkeyDto>.Ok(created));
+
+        HotkeyEditModel item = new() { Description = "Snap attempt", Key = "n", ActionKind = HotkeyActionKind.SendKeys };
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(item);
+
+        provider.Find("input[data-test=\"send-win-checkbox\"]").Change(true);
+        await SetKeyAsync(provider, "send-key-picker", "Left");
+        provider.Find("button.commit-edit").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).CreateAsync(
+            Arg.Is<CreateHotkeyDto>(d => d.SendKeysContent == "#{Left}"),
+            Arg.Any<CancellationToken>()));
+    }
+```
+
+The `HotkeyDto` positional argument list follows `HotkeyDto.cs`: id, profile ids, applies-to-all, description, key, ctrl, alt, shift, win, kind, then the seven payload slots (`Text`, `SendKeysContent`, `RunTarget`, `RunTargetKind`, `WindowOp`, `RemapDest`, `Body`), then the two timestamps. `"#{Left}"` sits in the second payload slot, `SendKeysContent`.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "FullyQualifiedName~SendKeysPanel_Win|FullyQualifiedName~SendKeysPanel_Arrow"`
+
+Expected: FAIL — `SendKeysPanel_WinPlusArrow_ShowsTheSnapWarning` throws `ElementNotFoundException` for `[data-test="send-win-arrow-warning"]`. The three negative/save tests pass already (nothing renders yet); that is fine — they are regression guards for the next step.
+
+- [ ] **Step 4: Add the warning constant**
+
+In `src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs`, directly below `RawWarningText` (line 19):
+
+```csharp
+
+    /// <summary>
+    /// Advisory shown when a SendKeys row sends Win + an arrow. Injected LWin (SendInput's atomic
+    /// batch, flagged LLKHF_INJECTED) is not honoured by the shell's Aero-Snap handler, so the send
+    /// silently does nothing. Non-blocking: the token is valid AHK and Save is unaffected. Scoped to
+    /// arrows only — injected Win *does* fire some shortcuts (Send "#e" opens Explorer).
+    /// </summary>
+    public const string SendWinArrowWarningText =
+        "Sending Win + Arrow won't snap the window — Windows ignores injected Win for Aero Snap. " +
+        "To snap the active window, use a Window action (Snap left / Snap right). " +
+        "For other Win shortcuts, use Raw.";
+```
+
+- [ ] **Step 5: Add the arrow-detection helper to the dialog**
+
+In `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor`, add this computed property to the `@code` block, directly below the `_sendKey` field declaration (line 307):
+
+```csharp
+    // The four arrow canonicals from the key registry. Compared case-insensitively because a stored
+    // token is decomposed back into _sendKey verbatim, and AHK itself is case-insensitive on key names.
+    private static readonly string[] s_arrowKeys = ["Up", "Down", "Left", "Right"];
+
+    private bool ShowSendWinArrowWarning =>
+        _sendWin && _sendKey is not null && s_arrowKeys.Contains(_sendKey, StringComparer.OrdinalIgnoreCase);
+```
+
+- [ ] **Step 6: Render the alert**
+
+In the same file, inside the SendKeys panel `<div data-test="sendkeys-panel">`, after the closing `</MudStack>` of the modifier row and before the `<KeyPicker …>` (i.e. between lines 93 and 94):
+
+```razor
+                        @if (ShowSendWinArrowWarning)
+                        {
+                            <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-2"
+                                      UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "send-win-arrow-warning" })">
+                                @HotkeyActionDisplay.SendWinArrowWarningText
+                            </MudAlert>
+                        }
+```
+
+This mirrors the Raw panel's alert at line 155-158 exactly, minus the `@if` gate.
+
+- [ ] **Step 7: Run the four tests to verify they pass**
+
+Run: `dotnet test tests/AHKFlowApp.UI.Blazor.Tests --filter "FullyQualifiedName~SendKeysPanel"`
+
+Expected: PASS, including the two pre-existing `SendKeysPanel_*` compose/decompose tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
+git commit -m "feat: warn on SendKeys Win+Arrow, steer to Window snap"
+```
+
+---
+
+### Task 5: Document the snap emit in the AHK v2 syntax reference
+
+**Files:**
+- Modify: `docs/development/ahk-v2-syntax.md:322` (the `Window` row of the per-action table) and `:334-335` (insert after the example block)
+
+**Interfaces:**
+- Consumes: the exact emitted strings pinned by Task 1's emitter tests. The doc must quote them verbatim.
+- Produces: nothing consumed by other tasks.
+
+The base branch deliberately reverted these rows (`docs: revert snap doc rows, keep snap out of this PR`) so the doc never described ops the code lacked. This task restores them now that the code exists.
+
+- [ ] **Step 1: Extend the `Window` row of the per-action table**
+
+In `docs/development/ahk-v2-syntax.md`, replace line 322:
+
+```markdown
+| `Window` | `WindowOp` | `WinMinimize("A")`, `WinMaximize("A")`, `WinRestore("A")`, `WinClose("A")`, `WinSetAlwaysOnTop(-1, "A")` |
+```
+
+with:
+
+```markdown
+| `Window` | `WindowOp` | five one-line ops — `WinMinimize("A")`, `WinMaximize("A")`, `WinRestore("A")`, `WinClose("A")`, `WinSetAlwaysOnTop(-1, "A")` — plus two block-bodied snap ops (see below) |
+```
+
+- [ ] **Step 2: Add the snap paragraph**
+
+Insert immediately after the fenced `ahk` example block that ends with `F1::return` (line 334) and before the `Only the three kinds that embed user text…` paragraph:
+
+````markdown
+`Window`'s two snap ops (`SnapLeft`, `SnapRight`) are the only non-one-line emit: each is a
+brace block that restores the window, reads the **primary** monitor's work area
+(`MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)`), then `WinMove`s to the left or right
+half. SnapRight's width is `r - (l + (r-l)//2)` so an odd work-area width still reaches `r`:
+
+```ahk
+^!Left::
+{
+    WinRestore("A")
+    MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)
+    WinMove(l, t, (r - l) // 2, b - t, "A")
+}
+```
+````
+
+- [ ] **Step 3: Verify the doc matches the emitter**
+
+Run: `dotnet test tests/AHKFlowApp.Application.Tests --filter "FullyQualifiedName~HotkeyEmitterTests.Emit_Window_Snap" --verbosity normal`
+
+Expected: PASS. Then read the two expected strings in those tests and confirm the `WinMove` lines quoted in the doc are character-identical.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/development/ahk-v2-syntax.md
+git commit -m "docs: document block-bodied snap ops"
+```
+
+---
+
+### Task 6: Full verification
+
+**Files:** none modified — this task only runs and reports.
+
+- [ ] **Step 1: Build the solution**
+
+Run: `dotnet build --configuration Release`
+
+Expected: 0 errors, 0 new warnings.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `dotnet test --configuration Release --no-build`
+
+Expected: all green. Docker must be running — the Application and API integration suites use SQL Server Testcontainers.
+
+- [ ] **Step 3: Check formatting**
+
+Run: `dotnet format --verify-no-changes`
+
+Expected: no diff. If it reports changes, run `dotnet format` and amend the owning commit.
+
+- [ ] **Step 4: Report**
+
+State the actual `dotnet test` summary line (passed/failed/skipped counts). If anything failed, quote the shortest decisive failure line — do not claim completion.
+
+---
+
+## Unresolved questions
+
+1. SnapRight width changes from `(r-l)//2` to `r-(l+(r-l)//2)` — spec's formula, breaks §2's "byte-identical" claim. Confirm OK?
+2. Warning copy: spec has bold markdown (`**Window**`, `**Raw**`); `MudAlert` renders plain text. Plan drops the asterisks. Want bold via markup instead?

--- a/docs/superpowers/specs/2026-07-24-window-snap-and-win-send-guardrail-design.md
+++ b/docs/superpowers/specs/2026-07-24-window-snap-and-win-send-guardrail-design.md
@@ -54,7 +54,8 @@ The emitter's `WindowCall` returns a block body for them:
 ```
 
 SnapRight differs only in the `WinMove` X/Width. Its X is the left window's right edge, and its
-width spans from there to `r` so an odd work-area width leaves no uncovered strip:
+width spans from there to `r` so an odd work-area width still reaches the right edge instead of
+leaving an uncovered column there:
 `WinMove(l + (r - l) // 2, t, r - (l + (r - l) // 2), b - t, "A")`.
 
 `WinRestore("A")` first so a maximized window can be moved. `//` is AHK integer division.
@@ -76,9 +77,12 @@ undefined value the validator would already have rejected).
 The two snap samples (currently `Raw` bodies from the sibling spec) become
 `Typed(… WindowOp.SnapLeft / SnapRight)` on Ctrl+Alt+Left / Ctrl+Alt+Right. The Raw
 `SnapLeftBody` / `SnapRightBody` string constants are removed — the WinMove AHK now lives
-once, in the emitter. Emitted output is byte-identical, so the golden integration-test
-assertions do not change. The snap conversion is in-place, so it alone keeps the count at 17;
-§5 then adds two SendKeys rows, taking the catalog to **19**.
+once, in the emitter. SnapLeft's emitted output is byte-identical; **SnapRight's is not** — the
+retired constant emitted width `(r - l) // 2`, while §1's formula emits `r - (l + (r - l) // 2)`
+so an odd work-area width reaches the right edge. That is a deliberate fix, and it changes one
+existing golden assertion in `AhkScriptGeneratorIntegrationTests`. The snap conversion is
+in-place, so it alone keeps the count at 17; §5 then adds two SendKeys rows, taking the catalog
+to **19**.
 
 ## 3. Labels
 
@@ -93,16 +97,21 @@ In the SendKeys panel of `HotkeyEditDialog`, when the Win modifier checkbox (`_s
 checked **and an arrow key is the sent key**, render a `MudAlert` (`Severity.Warning`,
 `Dense`), mirroring the existing Raw-panel warning:
 
-> ⚠ Sending Win + Arrow won't snap the window — Windows ignores injected Win for Aero Snap.
-> To snap the active window, use a **Window** action (Snap left / Snap right). For other Win
-> shortcuts, use **Raw**.
+> ⚠ Sending Win + Arrow won't snap or resize the window — Windows ignores injected Win for Aero
+> Snap. Use the matching Window action instead (Minimize, Maximize, Snap left, or Snap right).
+> For other Win shortcuts, use Raw.
 
 - **Non-blocking**: Save is unaffected; the token still validates and persists.
 - **Trigger**: Win + arrow only — that is the sole gesture documented to fail (Aero Snap;
   companion spec §2b). Injected Win *does* fire some OS shortcuts (`Send "#e"` = Win+E per the
   AHK v2 Send docs), so a blanket "all Win+key" warning would be wrong.
-- The message string and its `data-test` id are constants beside `RawWarningText` in
-  `HotkeyActionDisplay`, so markup and tests share one source.
+- **All four arrows**, not just left/right: Win+Up/Down are the same Aero-Snap gesture, which is
+  why the copy names Minimize and Maximize alongside the snap ops.
+- Plain text, no Markdown bold: `MudAlert` renders the constant verbatim, and the alert's warning
+  styling already carries the emphasis.
+- The message string is a constant beside `RawWarningText` in `HotkeyActionDisplay`, so markup and
+  tests share one source. The `data-test` id stays a literal, matching every other `data-test` in
+  the codebase (the Raw warning included).
 
 ## 5. SendKeys samples
 
@@ -133,16 +142,22 @@ token converts to `HotkeyActionKind.SendKeys` and emits `$key::Send("<token>")` 
 ## Testing
 
 - **Emitter** (`HotkeyEmitterTests`): a case per snap op asserting the exact WinMove block.
+- **Enum ordinals**: the two new values are wire contract, so both sides pin them —
+  `AHKFlowApp.Domain.Tests/Enums/WindowOpTests` and `AHKFlowApp.UI.Blazor.Tests/DTOs/WindowOpTests`,
+  mirroring the existing `HotstringImportRowStatusTests` pair.
 - **Catalog SendKeys** (`AhkScriptGeneratorIntegrationTests`): the two new rows emit
   `$^!p::Send("{Media_Play_Pause}")` / `$^!k::Send("+{End}")` and report `SendKeys` kind.
 - **Validator** (`HotkeyKindConditionalRulesTests`): `Window` accepts `SnapLeft` / `SnapRight`
   (guards `Enum.IsDefined`).
-- **UI** (`HotkeyEditDialog` bUnit): the warning renders when the Send Win checkbox is checked
-  **and an arrow key is chosen**, is absent for Win + a non-arrow key and for arrow-without-Win,
-  and Save is not blocked while it shows. The op dropdown lists the two new frontend `WindowOp`
-  values.
-- **Catalog** (`AhkScriptGeneratorIntegrationTests`): existing snap-line assertions stand
-  (same emit); the two samples now report `Window` kind.
+- **UI** (`HotkeyEditDialog` bUnit): the warning renders for each of the four arrows when the Send
+  Win checkbox is checked, is absent for Win + a non-arrow key and for arrow-without-Win, and Save
+  is not blocked while it shows. The op dropdown is asserted by enumerating its rendered
+  `MudSelectItem<WindowOp?>` values against `Enum.GetValues<WindowOp>()` — the technique
+  `HotstringsPageTests.Page_KindFilter_ListsAllFourKinds` already uses — not by driving
+  `ValueChanged`, which would pass even if the item never rendered.
+- **Catalog** (`AhkScriptGeneratorIntegrationTests`): the SnapLeft line assertion stands unchanged
+  and the SnapRight one moves to the §1 width; both samples are asserted to carry
+  `ActionKind.Window` plus their `WindowOp`, so a Raw row emitting equivalent text cannot pass.
 - **Seed counts**: the two SendKeys rows move the catalog 17 → **19**. Update every count
   assertion the sibling spec inventoried — `SeedHotkeysCommandHandlerTests`,
   `ListHotkeysLazySeedTests`, `SeedAllCommandHandlerTests`, `DevSeedEndpointTests`,

--- a/src/Backend/AHKFlowApp.Application/Constants/DefaultHotkeyCatalog.cs
+++ b/src/Backend/AHKFlowApp.Application/Constants/DefaultHotkeyCatalog.cs
@@ -35,14 +35,16 @@ internal static class DefaultHotkeyCatalog
         // Window resize/snap on Ctrl+Alt+Arrow. These do NOT Send Win+Arrow: injected LWin (the
         // LLKHF_INJECTED flag + SendInput's atomic batch) is not reliably recognized by the shell's
         // Aero-Snap / Win-hotkey handler, so `Send("#{Left}")` fails to snap (design §2b). Native
-        // window functions are deterministic. Max/Min use the typed Window kind; snap L/R need a
-        // half-work-area WinMove that no WindowOp expresses, so they are Raw bodies.
+        // window functions are deterministic. All four use the typed Window kind; the snap pair's
+        // half-work-area WinMove block lives in the emitter, not here.
         Typed("Maximize window", "Up",   HotkeyActionKind.Window, ["Window Management"],
             ctrl: true, alt: true, windowOp: WindowOp.Maximize),
         Typed("Minimize window", "Down", HotkeyActionKind.Window, ["Window Management"],
             ctrl: true, alt: true, windowOp: WindowOp.Minimize),
-        Raw("Snap window left",  true, true, false, false, "Left",  SnapLeftBody,  ["Window Management"]),
-        Raw("Snap window right", true, true, false, false, "Right", SnapRightBody, ["Window Management"]),
+        Typed("Snap window left",  "Left",  HotkeyActionKind.Window, ["Window Management"],
+            ctrl: true, alt: true, windowOp: WindowOp.SnapLeft),
+        Typed("Snap window right", "Right", HotkeyActionKind.Window, ["Window Management"],
+            ctrl: true, alt: true, windowOp: WindowOp.SnapRight),
 
         // Fixed → Raw: legacy shape could not express a function call or block body (design §2).
         Raw("Reload AHK script",   true, true, false, false, "r", "Reload()", ["App Launcher"]),
@@ -83,25 +85,6 @@ internal static class DefaultHotkeyCatalog
         "    Sleep(150)                   ; let the paste consume the clipboard first\n" +
         "    A_Clipboard := saved         ; restore the original formatting\n" +
         "    saved := \"\"\n" +
-        "}";
-
-    // Snap the active window to the left/right half of the primary monitor's work area (excludes the
-    // taskbar). WinRestore first so a maximized window can be moved. `//` is AHK integer division.
-    // Deterministic native positioning — see the resize/snap comment above for why Send("#{Left}") is
-    // not used. Primary monitor keeps the sample readable; a real multi-monitor snap would resolve the
-    // window's own monitor first.
-    private const string SnapLeftBody =
-        "{\n" +
-        "    WinRestore(\"A\")\n" +
-        "    MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)\n" +
-        "    WinMove(l, t, (r - l) // 2, b - t, \"A\")\n" +
-        "}";
-
-    private const string SnapRightBody =
-        "{\n" +
-        "    WinRestore(\"A\")\n" +
-        "    MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)\n" +
-        "    WinMove(l + (r - l) // 2, t, (r - l) // 2, b - t, \"A\")\n" +
         "}";
 
     /// <summary>Legacy-shaped row: converted to typed columns at build time, pinned all-profiles.</summary>

--- a/src/Backend/AHKFlowApp.Application/Services/HotkeyEmitter.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/HotkeyEmitter.cs
@@ -45,8 +45,22 @@ internal static class HotkeyEmitter
         WindowOp.Restore => $"WinRestore({ActiveWindow})",
         WindowOp.Close => $"WinClose({ActiveWindow})",
         WindowOp.ToggleAlwaysOnTop => $"WinSetAlwaysOnTop(-1, {ActiveWindow})",
+        WindowOp.SnapLeft => SnapBody("l", "(r - l) // 2"),
+        WindowOp.SnapRight => SnapBody("l + (r - l) // 2", "r - (l + (r - l) // 2)"),
         _ => throw new InvalidOperationException($"Unsupported WindowOp: {op}"),
     };
+
+    // Snap to one half of the PRIMARY monitor's work area (which excludes the taskbar). WinRestore
+    // first so a maximized window can be moved; `//` is AHK integer division. The right half's width
+    // is measured back from r instead of reusing the left half's, so an odd work-area width still
+    // reaches the right edge instead of leaving an uncovered column there. Resolving the window's
+    // own monitor is a later refinement (design non-goal).
+    private static string SnapBody(string x, string width) =>
+        "{\n" +
+        $"    WinRestore({ActiveWindow})\n" +
+        "    MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)\n" +
+        $"    WinMove({x}, t, {width}, b - t, {ActiveWindow})\n" +
+        "}";
 
     private static string RemapRhs(string? dest) =>
         dest ?? throw new InvalidOperationException("Remap requires a RemapDest");

--- a/src/Backend/AHKFlowApp.Domain/Enums/WindowOp.cs
+++ b/src/Backend/AHKFlowApp.Domain/Enums/WindowOp.cs
@@ -17,4 +17,10 @@ public enum WindowOp
 
     /// <summary><c>WinSetAlwaysOnTop(-1, "A")</c>.</summary>
     ToggleAlwaysOnTop = 4,
+
+    /// <summary>Left half of the primary monitor's work area — a <c>WinMove</c> block body.</summary>
+    SnapLeft = 5,
+
+    /// <summary>Right half of the primary monitor's work area — a <c>WinMove</c> block body.</summary>
+    SnapRight = 6,
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
@@ -91,6 +91,13 @@
                             <MudCheckBox T="bool" Value="_sendWin" ValueChanged="@((bool v) => { _sendWin = v; ComposeSendKeys(); })" Label="Win"
                                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "send-win-checkbox" })" />
                         </MudStack>
+                        @if (ShowSendWinArrowWarning)
+                        {
+                            <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-2"
+                                      UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "send-win-arrow-warning" })">
+                                @HotkeyActionDisplay.SendWinArrowWarningText
+                            </MudAlert>
+                        }
                         <KeyPicker Role="SendToken" Label="Key to press"
                                    Value="@_sendKey" ValueChanged="OnSendKeyChanged"
                                    Error="@(FieldError(nameof(HotkeyEditModel.SendKeysContent)) is not null)"
@@ -305,6 +312,13 @@
     // canonical token the server validates.
     private bool _sendCtrl, _sendAlt, _sendShift, _sendWin;
     private string? _sendKey;
+
+    // The four arrow canonicals from the key registry. Compared case-insensitively because a stored
+    // token is decomposed back into _sendKey verbatim, and AHK itself is case-insensitive on key names.
+    private static readonly string[] s_arrowKeys = ["Up", "Down", "Left", "Right"];
+
+    private bool ShowSendWinArrowWarning =>
+        _sendWin && _sendKey is not null && s_arrowKeys.Contains(_sendKey, StringComparer.OrdinalIgnoreCase);
 
     private bool _previewExpanded;
     private bool _previewPending;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/WindowOp.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/WindowOp.cs
@@ -8,4 +8,6 @@ public enum WindowOp
     Restore = 2,
     Close = 3,
     ToggleAlwaysOnTop = 4,
+    SnapLeft = 5,
+    SnapRight = 6,
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs
@@ -24,12 +24,15 @@ internal static class HotkeyActionDisplay
     /// silently does nothing. Non-blocking: the token is valid AHK and Save is unaffected. Scoped to
     /// arrows only — injected Win *does* fire some shortcuts (Send "#e" opens Explorer). Names all
     /// four Window ops because the warning covers all four arrows: Win+Up/Down are maximize and
-    /// minimize. Plain text, no Markdown — MudAlert renders the constant verbatim.
+    /// minimize. Those four names come from <see cref="WindowOpLabel"/> rather than being spelled
+    /// out, so renaming a dropdown label cannot leave this advisory pointing at a control name the
+    /// user no longer sees. Plain text, no Markdown — MudAlert renders the string verbatim.
     /// </summary>
-    public const string SendWinArrowWarningText =
+    public static readonly string SendWinArrowWarningText =
         "Sending Win + Arrow won't snap or resize the window — Windows ignores injected Win for " +
-        "Aero Snap. Use the matching Window action instead (Minimize, Maximize, Snap left, or " +
-        "Snap right). For other Win shortcuts, use Raw.";
+        $"Aero Snap. Use the matching Window action instead ({WindowOpLabel(DTOs.WindowOp.Minimize)}, " +
+        $"{WindowOpLabel(DTOs.WindowOp.Maximize)}, {WindowOpLabel(DTOs.WindowOp.SnapLeft)}, or " +
+        $"{WindowOpLabel(DTOs.WindowOp.SnapRight)}). For other Win shortcuts, use Raw.";
 
     /// <summary>Stands in for the kind of a pre-typed-action history snapshot, which has none.</summary>
     public const string LegacyLabel = "Legacy";

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs
@@ -18,6 +18,19 @@ internal static class HotkeyActionDisplay
     public const string RawWarningText =
         "Raw is unchecked AutoHotkey. A mistake here can stop the whole profile script from loading.";
 
+    /// <summary>
+    /// Advisory shown when a SendKeys row sends Win + an arrow. Injected LWin (SendInput's atomic
+    /// batch, flagged LLKHF_INJECTED) is not honoured by the shell's Aero-Snap handler, so the send
+    /// silently does nothing. Non-blocking: the token is valid AHK and Save is unaffected. Scoped to
+    /// arrows only — injected Win *does* fire some shortcuts (Send "#e" opens Explorer). Names all
+    /// four Window ops because the warning covers all four arrows: Win+Up/Down are maximize and
+    /// minimize. Plain text, no Markdown — MudAlert renders the constant verbatim.
+    /// </summary>
+    public const string SendWinArrowWarningText =
+        "Sending Win + Arrow won't snap or resize the window — Windows ignores injected Win for " +
+        "Aero Snap. Use the matching Window action instead (Minimize, Maximize, Snap left, or " +
+        "Snap right). For other Win shortcuts, use Raw.";
+
     /// <summary>Stands in for the kind of a pre-typed-action history snapshot, which has none.</summary>
     public const string LegacyLabel = "Legacy";
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs
@@ -64,6 +64,8 @@ internal static class HotkeyActionDisplay
         DTOs.WindowOp.Restore => "Restore",
         DTOs.WindowOp.Close => "Close",
         DTOs.WindowOp.ToggleAlwaysOnTop => "Toggle always on top",
+        DTOs.WindowOp.SnapLeft => "Snap left",
+        DTOs.WindowOp.SnapRight => "Snap right",
         _ => op.ToString(),
     };
 

--- a/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorIntegrationTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/AhkScriptGeneratorIntegrationTests.cs
@@ -137,7 +137,7 @@ public sealed class AhkScriptGeneratorIntegrationTests(ScriptGeneratorDbFixture 
         output.Should().Contain("^!Left::{\n    WinRestore(\"A\")");
         output.Should().Contain("    WinMove(l, t, (r - l) // 2, b - t, \"A\")");
         output.Should().Contain("^!Right::{\n    WinRestore(\"A\")");
-        output.Should().Contain("    WinMove(l + (r - l) // 2, t, (r - l) // 2, b - t, \"A\")");
+        output.Should().Contain("    WinMove(l + (r - l) // 2, t, r - (l + (r - l) // 2), b - t, \"A\")");
         // Paste-as-plain-text Raw block: keeps its own braces, save/strip/paste/restore.
         output.Should().Contain("^+v::{\n    saved := ClipboardAll()");
         output.Should().Contain("    A_Clipboard := saved         ; restore the original formatting");
@@ -150,5 +150,15 @@ public sealed class AhkScriptGeneratorIntegrationTests(ScriptGeneratorDbFixture 
         // SendKeys samples ($ prefix per emitter).
         output.Should().Contain("$^!p::Send(\"{Media_Play_Pause}\")");
         output.Should().Contain("$^!k::Send(\"+{End}\")");
+
+        // The snap rows are Window-kind samples now, not Raw bodies that merely emit the same
+        // text — assert the stored kind, or a regression to Raw would pass on output alone.
+        Hotkey snapLeft = forProfile.Single(h => h.Description == "Snap window left");
+        snapLeft.ActionKind.Should().Be(HotkeyActionKind.Window);
+        snapLeft.WindowOp.Should().Be(WindowOp.SnapLeft);
+
+        Hotkey snapRight = forProfile.Single(h => h.Description == "Snap window right");
+        snapRight.ActionKind.Should().Be(HotkeyActionKind.Window);
+        snapRight.WindowOp.Should().Be(WindowOp.SnapRight);
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/Services/HotkeyEmitterTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/HotkeyEmitterTests.cs
@@ -50,6 +50,30 @@ public sealed class HotkeyEmitterTests
         Line(new HotkeyBuilder().WithKey("r").WithWin().WithWindow(WindowOp.Restore))
             .Should().Be("#r::WinRestore(\"A\")");
 
+    // Snap is the only Window op with a block body: the half-work-area WinMove needs three
+    // statements. Pinned byte-for-byte because this string is what lands in the user's script.
+    [Fact]
+    public void Emit_Window_SnapLeft() =>
+        Line(new HotkeyBuilder().WithKey("Left").WithCtrl().WithAlt().WithWindow(WindowOp.SnapLeft))
+            .Should().Be(
+                "^!Left::{\n" +
+                "    WinRestore(\"A\")\n" +
+                "    MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)\n" +
+                "    WinMove(l, t, (r - l) // 2, b - t, \"A\")\n" +
+                "}");
+
+    // SnapRight's width is measured back from r rather than repeating (r - l) // 2, so an odd
+    // work-area width still reaches the right edge instead of leaving an uncovered column there.
+    [Fact]
+    public void Emit_Window_SnapRight() =>
+        Line(new HotkeyBuilder().WithKey("Right").WithCtrl().WithAlt().WithWindow(WindowOp.SnapRight))
+            .Should().Be(
+                "^!Right::{\n" +
+                "    WinRestore(\"A\")\n" +
+                "    MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)\n" +
+                "    WinMove(l + (r - l) // 2, t, r - (l + (r - l) // 2), b - t, \"A\")\n" +
+                "}");
+
     [Fact] // golden 9 — SendText escapes free text (backtick-n from a newline)
     public void Emit_SendText_EscapesMultiline() =>
         Line(new HotkeyBuilder().WithKey("s").WithCtrl().WithAlt().WithSendText("Jane Smith\nAcme"))

--- a/tests/AHKFlowApp.Application.Tests/Validation/HotkeyKindConditionalRulesTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Validation/HotkeyKindConditionalRulesTests.cs
@@ -222,6 +222,14 @@ public sealed class HotkeyKindConditionalRulesTests
     public void Raw_IndentedHashDirective_IsInvalid() =>
         Validate(Base(HotkeyActionKind.Raw) with { Body = "{\n    #Requires AutoHotkey v2\n}" }).IsValid.Should().BeFalse();
 
+    // Enum.IsDefined is the whole Window gate, so new WindowOp values need no validator change.
+    // Pinned so a future "allowed ops" list cannot silently drop snap.
+    [Theory]
+    [InlineData(WindowOp.SnapLeft)]
+    [InlineData(WindowOp.SnapRight)]
+    public void Window_AcceptsSnapOps(WindowOp op) =>
+        Validate(Base(HotkeyActionKind.Window) with { WindowOp = op }).IsValid.Should().BeTrue();
+
     // --- Free-text limits carried over from the retired ValidParameters rule ---------------
 
     [Theory]

--- a/tests/AHKFlowApp.Domain.Tests/Enums/WindowOpTests.cs
+++ b/tests/AHKFlowApp.Domain.Tests/Enums/WindowOpTests.cs
@@ -1,0 +1,24 @@
+using AHKFlowApp.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Domain.Tests.Enums;
+
+public sealed class WindowOpTests
+{
+    [Theory]
+    [InlineData(WindowOp.Minimize, 0)]
+    [InlineData(WindowOp.Maximize, 1)]
+    [InlineData(WindowOp.Restore, 2)]
+    [InlineData(WindowOp.Close, 3)]
+    [InlineData(WindowOp.ToggleAlwaysOnTop, 4)]
+    [InlineData(WindowOp.SnapLeft, 5)]
+    [InlineData(WindowOp.SnapRight, 6)]
+    public void OrdinalValue_MatchesUiMirror(WindowOp op, int expected)
+    {
+        // WindowOp is persisted as an int and hand-mirrored in
+        // AHKFlowApp.UI.Blazor.DTOs.WindowOp — these ordinals must stay in lockstep with
+        // that file's WindowOpTests. Renumbering here silently rewrites stored rows.
+        ((int)op).Should().Be(expected);
+    }
+}

--- a/tests/AHKFlowApp.Domain.Tests/Enums/WindowOpTests.cs
+++ b/tests/AHKFlowApp.Domain.Tests/Enums/WindowOpTests.cs
@@ -16,9 +16,11 @@ public sealed class WindowOpTests
     [InlineData(WindowOp.SnapRight, 6)]
     public void OrdinalValue_MatchesUiMirror(WindowOp op, int expected)
     {
-        // WindowOp is persisted as an int and hand-mirrored in
-        // AHKFlowApp.UI.Blazor.DTOs.WindowOp — these ordinals must stay in lockstep with
-        // that file's WindowOpTests. Renumbering here silently rewrites stored rows.
+        // WindowOp is persisted as an int, so renumbering here silently rewrites stored rows.
+        // AHKFlowApp.UI.Blazor.DTOs.WindowOp hand-mirrors it; that the two agree on every name and
+        // ordinal is enforced by WindowOpTests.MirrorsDomainEnum_NameAndOrdinal in
+        // AHKFlowApp.UI.Blazor.Tests, which can see both enums. This table pins the numbers
+        // themselves, which a mirror comparison alone cannot.
         ((int)op).Should().Be(expected);
     }
 }

--- a/tests/AHKFlowApp.E2E.Tests/WindowSnapFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/WindowSnapFlowTests.cs
@@ -1,0 +1,155 @@
+using AHKFlowApp.E2E.Tests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace AHKFlowApp.E2E.Tests;
+
+/// <summary>
+/// Covers the two surfaces the snap work added that unit and bUnit tests structurally cannot reach:
+/// a Window action whose emitted body is multi-line (every other kind is one line), and the Win+Arrow
+/// advisory, whose whole job is to appear and disappear as the user toggles controls in a real browser.
+/// The preview here is served by the API, so a green run also proves HotkeyEmitter's snap block
+/// survives the round trip over HTTP and into the DOM unmangled.
+/// </summary>
+[Collection(E2ETestCollection.Name)]
+public sealed class WindowSnapFlowTests(StackFixture fixture) : IAsyncLifetime
+{
+    public Task InitializeAsync() =>
+        fixture.ResetDataAsync();
+
+    public Task DisposeAsync() =>
+        Task.CompletedTask;
+
+    [Fact]
+    public async Task CreateSnapLeftHotkey_PreviewKeepsBlockBodyLines_ThenGridShowsWindowAction()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync();
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotkeys");
+        await page.WaitForSelectorAsync("button.add-hotkey");
+
+        await page.ClickAsync("button.add-hotkey");
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog");
+
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"description-input\"]", "E2E snap left");
+        await CommitKeyAsync(page, ".hotkey-edit-dialog input[data-test=\"key-picker\"]", "Left");
+
+        await page.ClickAsync(".hotkey-edit-dialog [data-test=\"action-kind-Window\"]");
+        await SelectWindowOpAsync(page, "Snap left", expectedValue: "SnapLeft");
+        await page.CheckAsync(".hotkey-edit-dialog input[data-test=\"ctrl-checkbox\"]");
+        await page.CheckAsync(".hotkey-edit-dialog input[data-test=\"alt-checkbox\"]");
+
+        await page.ClickAsync(".hotkey-edit-dialog [data-test=\"ahk-preview\"] .mud-expand-panel-header");
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog [data-test=\"preview-snippet\"]");
+
+        // InnerText, not TextContent or ToContainTextAsync: those two would pass on a single collapsed
+        // line. InnerText is rendered text, so the newlines only survive it while the snippet really
+        // lays out as four lines — which is what makes this assertion worth running in a browser at
+        // all. Regressing .preview-snippet to white-space: normal, or the <pre> to a <div>, fails here
+        // and nowhere else in the suite.
+        ILocator snippet = page.Locator(".hotkey-edit-dialog [data-test=\"preview-snippet\"]");
+        string rendered = (await snippet.InnerTextAsync()).ReplaceLineEndings("\n");
+
+        rendered.Should().Contain(
+            "^!Left::{\n" +
+            "    WinRestore(\"A\")\n" +
+            "    MonitorGetWorkArea(MonitorGetPrimary(), &l, &t, &r, &b)\n" +
+            "    WinMove(l, t, (r - l) // 2, b - t, \"A\")\n" +
+            "}");
+
+        await page.ClickAsync(".hotkey-edit-dialog button.commit-edit");
+        await page.WaitForSelectorAsync("text=Hotkey created.");
+
+        // Scoped to the desktop branch: both branches are in the DOM and the mobile one is hidden by
+        // CSS alone, so an unscoped selector matches twice.
+        ILocator row = page.Locator(".desktop-branch tr", new() { HasTextString = "E2E snap left" });
+        await row.WaitForAsync();
+
+        (await row.Locator("[data-test=\"action-chip\"]").InnerTextAsync()).Should().Contain("Window");
+        await Assertions.Expect(row).ToContainTextAsync("Snap left");
+    }
+
+    [Fact]
+    public async Task SendKeysWinPlusArrow_ShowsAdvisoryUntilWinCleared_AndStillSaves()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync();
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotkeys");
+        await page.WaitForSelectorAsync("button.add-hotkey");
+
+        await page.ClickAsync("button.add-hotkey");
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog");
+
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"description-input\"]", "E2E win arrow send");
+        await CommitKeyAsync(page, ".hotkey-edit-dialog input[data-test=\"key-picker\"]", "n");
+
+        await page.ClickAsync(".hotkey-edit-dialog [data-test=\"action-kind-SendKeys\"]");
+        await page.CheckAsync(".hotkey-edit-dialog input[data-test=\"send-win-checkbox\"]");
+        await CommitKeyAsync(page, ".hotkey-edit-dialog input[data-test=\"send-key-picker\"]", "Left");
+
+        ILocator warning = page.Locator(".hotkey-edit-dialog [data-test=\"send-win-arrow-warning\"]");
+        await Assertions.Expect(warning).ToBeVisibleAsync();
+        await Assertions.Expect(warning).ToContainTextAsync("won't snap or resize the window");
+        await Assertions.Expect(warning).ToContainTextAsync("Snap left");
+
+        // Clearing Win must retract the advisory, not just stop adding it — the alert occupies flow
+        // above the key picker, so a stuck alert permanently displaces the control beneath it.
+        await page.UncheckAsync(".hotkey-edit-dialog input[data-test=\"send-win-checkbox\"]");
+        await Assertions.Expect(warning).ToBeHiddenAsync();
+
+        await page.CheckAsync(".hotkey-edit-dialog input[data-test=\"send-win-checkbox\"]");
+        await Assertions.Expect(warning).ToBeVisibleAsync();
+
+        // Advisory only. Save has to go through with the warning on screen, or it has quietly become
+        // a validation rule.
+        await page.ClickAsync(".hotkey-edit-dialog button.commit-edit");
+        await page.WaitForSelectorAsync("text=Hotkey created.");
+
+        ILocator row = page.Locator(".desktop-branch tr", new() { HasTextString = "E2E win arrow send" });
+        await row.WaitForAsync();
+
+        (await row.Locator("[data-test=\"action-chip\"]").InnerTextAsync()).Should().Contain("Send keys");
+        await Assertions.Expect(row).ToContainTextAsync("#{Left}");
+    }
+
+    // Fills a MudAutocomplete key picker and commits the typed value by blurring (CoerceValue).
+    private static async Task CommitKeyAsync(IPage page, string selector, string key)
+    {
+        ILocator input = page.Locator(selector);
+        await input.ClickAsync();
+        await input.FillAsync(key);
+        await input.PressAsync("Tab");
+    }
+
+    // Opens the Window op MudSelect and picks the named option from its body-level popover. MudSelect
+    // can drop the first click while the popover animates in, leaving the value silently unset, so
+    // the open+pick is retried until the value commits.
+    //
+    // Two MudSelect details this has to work around, both learned the hard way:
+    //  - UserAttributes land on MudSelect's *hidden* input, which can never be clicked. The click has
+    //    to target the enclosing .mud-input-control instead.
+    //  - That hidden input's value is the enum name ("SnapLeft"), not the item label ("Snap left"), so
+    //    the commit check compares against `expectedValue`. HotkeysCrudFlowTests gets away with
+    //    comparing to a label only because RunTargetKind.Application's name and label are identical.
+    private static async Task SelectWindowOpAsync(IPage page, string label, string expectedValue)
+    {
+        ILocator hidden = page.Locator(".hotkey-edit-dialog [data-test=\"window-op-select\"]");
+        ILocator control = page.Locator(".hotkey-edit-dialog .mud-input-control:has([data-test=\"window-op-select\"])");
+        ILocator option = page.Locator($".mud-list-item:has-text(\"{label}\")");
+
+        for (int attempt = 0; attempt < 5; attempt++)
+        {
+            await control.ClickAsync();
+            await option.WaitForAsync(new() { State = WaitForSelectorState.Visible });
+            await option.ClickAsync();
+
+            if (await hidden.GetAttributeAsync("value") == expectedValue)
+                return;
+        }
+
+        (await hidden.GetAttributeAsync("value")).Should().Be(expectedValue, "the Window op must commit");
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
@@ -426,6 +426,21 @@ public sealed class HotkeyEditDialogTests : BunitContext, IAsyncLifetime
             dialog.SaveFieldErrors.Should().NotContainKey(nameof(HotkeyEditModel.WindowOp)));
     }
 
+    // The op dropdown enumerates Enum.GetValues<WindowOp>(), so an op absent from the frontend
+    // mirror is an op the user cannot pick. Asserting the rendered items — rather than driving
+    // ValueChanged, which passes whether or not the item exists — is what catches that.
+    [Fact]
+    public async Task WindowPanel_OpDropdown_ListsEveryWindowOp()
+    {
+        IRenderedComponent<MudDialogProvider> provider =
+            await ShowDialogAsync(new HotkeyEditModel { ActionKind = HotkeyActionKind.Window });
+
+        IReadOnlyList<WindowOp?> items = [.. provider.FindComponents<MudSelectItem<WindowOp?>>()
+            .Select(c => c.Instance.Value)];
+
+        items.Should().BeEquivalentTo(Enum.GetValues<WindowOp>().Cast<WindowOp?>());
+    }
+
     [Fact]
     public async Task EmptyKey_BlocksSubmitClientSide()
     {

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
@@ -22,6 +22,10 @@ public sealed class HotkeyEditDialogTests : BunitContext, IAsyncLifetime
         new("F1", "Function keys", ["HotkeyKey", "RemapDest", "SendToken"], true),
         new("c", "Letters & digits", ["HotkeyKey", "RemapDest", "SendToken"], false),
         new("Volume_Up", "Media & browser", ["SendToken"], true),
+        new("Up", "Navigation & editing", ["HotkeyKey", "RemapDest", "SendToken"], true),
+        new("Down", "Navigation & editing", ["HotkeyKey", "RemapDest", "SendToken"], true),
+        new("Left", "Navigation & editing", ["HotkeyKey", "RemapDest", "SendToken"], true),
+        new("Right", "Navigation & editing", ["HotkeyKey", "RemapDest", "SendToken"], true),
     ];
 
     private readonly IHotkeysApiClient _api = Substitute.For<IHotkeysApiClient>();
@@ -512,6 +516,73 @@ public sealed class HotkeyEditDialogTests : BunitContext, IAsyncLifetime
         IsChecked(provider, "send-alt-checkbox").Should().BeTrue();
         IsChecked(provider, "send-shift-checkbox").Should().BeFalse();
         provider.Find("input[data-test=\"send-key-picker\"]").GetAttribute("value").Should().Be("Volume_Up");
+    }
+
+    // Injected Win is not honoured by the shell's Aero-Snap handler, so Send("#{Left}") silently
+    // does nothing. All four arrows are the same gesture — Win+Up/Down maximize and minimize, and
+    // fail the same way. Advisory only — see SendKeysPanel_WinArrowWarning_DoesNotBlockSave.
+    [Theory]
+    [InlineData("Up")]
+    [InlineData("Down")]
+    [InlineData("Left")]
+    [InlineData("Right")]
+    public async Task SendKeysPanel_WinPlusArrow_ShowsTheSnapWarning(string arrow)
+    {
+        HotkeyEditModel item = new() { ActionKind = HotkeyActionKind.SendKeys };
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(item);
+
+        provider.Find("input[data-test=\"send-win-checkbox\"]").Change(true);
+        await SetKeyAsync(provider, "send-key-picker", arrow);
+
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"send-win-arrow-warning\"]")
+            .TextContent.Should().Contain("won't snap or resize the window"));
+    }
+
+    // Send "#e" really does open Explorer, so a blanket all-Win warning would be wrong: only the
+    // arrow gesture is documented to fail.
+    [Fact]
+    public async Task SendKeysPanel_WinPlusNonArrow_ShowsNoWarning()
+    {
+        HotkeyEditModel item = new() { ActionKind = HotkeyActionKind.SendKeys };
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(item);
+
+        provider.Find("input[data-test=\"send-win-checkbox\"]").Change(true);
+        await SetKeyAsync(provider, "send-key-picker", "c");
+
+        provider.FindAll("[data-test=\"send-win-arrow-warning\"]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SendKeysPanel_ArrowWithoutWin_ShowsNoWarning()
+    {
+        HotkeyEditModel item = new() { ActionKind = HotkeyActionKind.SendKeys };
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(item);
+
+        await SetKeyAsync(provider, "send-key-picker", "Left");
+
+        provider.FindAll("[data-test=\"send-win-arrow-warning\"]").Should().BeEmpty();
+    }
+
+    // Non-blocking by design: the token is valid AHK and the user may have a reason.
+    [Fact]
+    public async Task SendKeysPanel_WinArrowWarning_DoesNotBlockSave()
+    {
+        HotkeyDto created = new(Guid.NewGuid(), [], true, "Snap attempt", "n", true, false, false, false,
+            HotkeyActionKind.SendKeys, null, "#{Left}", null, null, null, null, null,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        _api.CreateAsync(Arg.Any<CreateHotkeyDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotkeyDto>.Ok(created));
+
+        HotkeyEditModel item = new() { Description = "Snap attempt", Key = "n", ActionKind = HotkeyActionKind.SendKeys };
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(item);
+
+        provider.Find("input[data-test=\"send-win-checkbox\"]").Change(true);
+        await SetKeyAsync(provider, "send-key-picker", "Left");
+        provider.Find("button.commit-edit").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).CreateAsync(
+            Arg.Is<CreateHotkeyDto>(d => d.SendKeysContent == "#{Left}"),
+            Arg.Any<CancellationToken>()));
     }
 
     [Fact]

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
@@ -430,9 +430,12 @@ public sealed class HotkeyEditDialogTests : BunitContext, IAsyncLifetime
             dialog.SaveFieldErrors.Should().NotContainKey(nameof(HotkeyEditModel.WindowOp)));
     }
 
-    // The op dropdown enumerates Enum.GetValues<WindowOp>(), so an op absent from the frontend
-    // mirror is an op the user cannot pick. Asserting the rendered items — rather than driving
-    // ValueChanged, which passes whether or not the item exists — is what catches that.
+    // Expected ops are listed literally, not as Enum.GetValues<WindowOp>(): the dropdown builds its
+    // items from that same call, so comparing against it could never fail. The literal catches the
+    // dropdown narrowing its source — a hardcoded subset, or a .Where(...) filter over the enum.
+    // Mirror completeness is a different failure, covered by WindowOpTests.MirrorsDomainEnum.
+    // Asserting rendered items, rather than driving ValueChanged (which passes whether or not the
+    // item exists), is what makes an unpickable op visible at all.
     [Fact]
     public async Task WindowPanel_OpDropdown_ListsEveryWindowOp()
     {
@@ -442,7 +445,9 @@ public sealed class HotkeyEditDialogTests : BunitContext, IAsyncLifetime
         IReadOnlyList<WindowOp?> items = [.. provider.FindComponents<MudSelectItem<WindowOp?>>()
             .Select(c => c.Instance.Value)];
 
-        items.Should().BeEquivalentTo(Enum.GetValues<WindowOp>().Cast<WindowOp?>());
+        items.Should().BeEquivalentTo<WindowOp?>([
+            WindowOp.Minimize, WindowOp.Maximize, WindowOp.Restore, WindowOp.Close,
+            WindowOp.ToggleAlwaysOnTop, WindowOp.SnapLeft, WindowOp.SnapRight]);
     }
 
     [Fact]

--- a/tests/AHKFlowApp.UI.Blazor.Tests/DTOs/WindowOpTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/DTOs/WindowOpTests.cs
@@ -1,0 +1,23 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.DTOs;
+
+public sealed class WindowOpTests
+{
+    [Theory]
+    [InlineData(WindowOp.Minimize, 0)]
+    [InlineData(WindowOp.Maximize, 1)]
+    [InlineData(WindowOp.Restore, 2)]
+    [InlineData(WindowOp.Close, 3)]
+    [InlineData(WindowOp.ToggleAlwaysOnTop, 4)]
+    [InlineData(WindowOp.SnapLeft, 5)]
+    [InlineData(WindowOp.SnapRight, 6)]
+    public void OrdinalValue_MatchesBackendMirror(WindowOp op, int expected)
+    {
+        // WindowOp is deserialized from an int and hand-mirrors
+        // AHKFlowApp.Domain.Enums.WindowOp — these ordinals must stay in lockstep with that file.
+        ((int)op).Should().Be(expected);
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/DTOs/WindowOpTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/DTOs/WindowOpTests.cs
@@ -20,4 +20,14 @@ public sealed class WindowOpTests
         // AHKFlowApp.Domain.Enums.WindowOp — these ordinals must stay in lockstep with that file.
         ((int)op).Should().Be(expected);
     }
+
+    // The literal table above only catches renumbering of a value both enums already have; a value
+    // added to one side alone leaves every hand-written table green while the wire silently
+    // mismatches. This compares the two enums directly — the domain assembly is a transitive
+    // reference here — so neither side can grow, shrink, or rename without the other.
+    [Fact]
+    public void MirrorsDomainEnum_NameAndOrdinal() =>
+        Enum.GetValues<WindowOp>().Select(op => (op.ToString(), (int)op))
+            .Should().BeEquivalentTo(
+                Enum.GetValues<AHKFlowApp.Domain.Enums.WindowOp>().Select(op => (op.ToString(), (int)op)));
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/HotkeyActionDisplayTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/HotkeyActionDisplayTests.cs
@@ -86,6 +86,18 @@ public sealed class HotkeyActionDisplayTests
     public void WindowOpLabel_Snap_IsHumanReadable(WindowOp op, string expected) =>
         HotkeyActionDisplay.WindowOpLabel(op).Should().Be(expected);
 
+    // The advisory tells the user to reach for a specific dropdown entry, so it must name that entry
+    // as the dropdown labels it. Composed from WindowOpLabel for exactly this reason — pinned so a
+    // future edit cannot re-inline the wording and let the two drift apart.
+    [Theory]
+    [InlineData(WindowOp.Minimize)]
+    [InlineData(WindowOp.Maximize)]
+    [InlineData(WindowOp.SnapLeft)]
+    [InlineData(WindowOp.SnapRight)]
+    public void SendWinArrowWarningText_NamesTheWindowOpByItsDropdownLabel(WindowOp op) =>
+        HotkeyActionDisplay.SendWinArrowWarningText
+            .Should().Contain(HotkeyActionDisplay.WindowOpLabel(op));
+
     [Fact]
     public void Summary_Remap_ShowsDestination()
     {

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/HotkeyActionDisplayTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/HotkeyActionDisplayTests.cs
@@ -80,6 +80,12 @@ public sealed class HotkeyActionDisplayTests
         HotkeyActionDisplay.Summary(model).Should().Be("Toggle always on top");
     }
 
+    [Theory]
+    [InlineData(WindowOp.SnapLeft, "Snap left")]
+    [InlineData(WindowOp.SnapRight, "Snap right")]
+    public void WindowOpLabel_Snap_IsHumanReadable(WindowOp op, string expected) =>
+        HotkeyActionDisplay.WindowOpLabel(op).Should().Be(expected);
+
     [Fact]
     public void Summary_Remap_ShowsDestination()
     {


### PR DESCRIPTION
Adds `SnapLeft` / `SnapRight` as first-class `Window` operations, moves the two seeded snap samples off `Raw` bodies, and warns (non-blocking) when a SendKeys hotkey sends Win + an arrow key.

Implements `docs/superpowers/specs/2026-07-24-window-snap-and-win-send-guardrail-design.md` per `docs/superpowers/plans/2026-07-25-window-snap-ops-plan.md`.

## What changed

- **Domain + emitter** — `WindowOp.SnapLeft = 5` / `SnapRight = 6`. These are the only Window ops with a block body: the half-work-area `WinMove` needs three statements, so it lives once in `HotkeyEmitter.SnapBody` instead of twice as catalog string constants.
- **Catalog** — the two snap rows convert from `Raw(…)` to `Typed(… WindowOp.SnapLeft/SnapRight)`. Row count unchanged at 19; the two retired `SnapLeftBody` / `SnapRightBody` constants are deleted.
- **Frontend** — the numeric mirror gains both values, `WindowOpLabel` gains "Snap left" / "Snap right". The op dropdown enumerates the enum, so it picks them up with no markup change.
- **Guardrail** — a `MudAlert` in the SendKeys panel when Win + an arrow key is selected. Advisory only: the token is valid AHK and Save is unaffected.
- **Docs** — `docs/development/ahk-v2-syntax.md` describes the block-bodied snap emit and quotes both bodies verbatim.

**No DB migration.** `WindowOp` persists as `int`; new enum values add no schema change and leave existing rows untouched.

## Behavior change worth a look

`SnapRight`'s emitted width changed. The retired constant emitted `(r - l) // 2`; the emitter now measures back from `r`:

```ahk
WinMove(l + (r - l) // 2, t, r - (l + (r - l) // 2), b - t, "A")
```

On an odd work-area width the right half now reaches `r` instead of leaving an uncovered column at the far-right edge. One golden assertion in `AhkScriptGeneratorIntegrationTests` was updated to match. `SnapLeft`'s emit is byte-identical to before.

## Reviewer notes

- **Already-seeded dev databases keep the old `Raw` snap rows**, including the old width. Seeding is idempotent on (owner, key, modifiers) and never rewrites an existing row, so the conversion only reaches fresh users or a `reset=true` re-seed. Both seed paths are `env.IsDevelopment`-gated, so there is no TEST/PROD impact.
- **The premise of this change cannot be tested in-repo.** Runtime AutoHotkey execution is deliberately out of scope, so "injected Win does not trigger Aero Snap, but `WinMove` does snap" is asserted by comments and verified only by hand. Worth two minutes on a real machine: generate a profile, load it, press Ctrl+Alt+Left, then add a SendKeys `#{Left}` row and watch it do nothing.
- Emitted AHK was checked against the official v2 docs: `::{` OTB is valid ("The opening brace may also be specified on the same line as the double-colon"), and `MonitorGetWorkArea(N, &Left, &Top, &Right, &Bottom)` matches the documented signature. `MonitorGetPrimary()` is technically redundant (omitting `N` defaults to primary) but was kept — it is inherited verbatim from the retired constants and changing it would churn two golden strings plus the doc for no behavior gain.

## Testing

- **Emitter** — both snap bodies pinned byte-for-byte; this string is what lands in the user's script.
- **Validator** — `Enum.IsDefined` is the whole `Window` gate, so the new values need no validator change; pinned so a future "allowed ops" list cannot silently drop snap.
- **Enum ordinals** — literal tables on both sides, plus `WindowOpTests.MirrorsDomainEnum_NameAndOrdinal`, which compares the domain enum against the UI mirror directly. Mutation-checked: adding a value to one enum alone turns it red while both hand-written tables stay green.
- **bUnit** — dropdown lists every op (asserted against a literal list, not `Enum.GetValues`, which would be circular); warning shows for all four arrows, stays hidden for Win + non-arrow and arrow-without-Win, and does not block Save.
- **E2E (new, `WindowSnapFlowTests`)** — creates a snap hotkey through the dialog and asserts the preview's rendered text keeps all four body lines (`InnerText`, not `TextContent`, which normalizes whitespace and would pass on one collapsed line); then the Win+Arrow advisory appearing, retracting when Win is cleared, and Save still succeeding.
- Screenshot review at 1280px and 430px: the block body renders with indentation intact, and the advisory wraps without overflow.

Full suite green: 3019 passed, 0 failed, 0 skipped. `dotnet format AHKFlowApp.slnx --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
