### PR TITLE
feat: add -BaseRef to new-worktree.ps1

### DIFF
--- a/.agents/worktrees/SKILL.md
+++ b/.agents/worktrees/SKILL.md
@@ -21,6 +21,14 @@ It creates the branch, places the worktree under `.claude/worktrees/<name>/`, co
 
 **Branch naming:** worktree branches insert `wt-` after the type prefix — `fix/wt-<topic>`, `feature/wt-NNN-<topic>` (see AGENTS.md Git Workflow). Pass it explicitly (`-BranchName fix/wt-<topic>`) or name the worktree so the derived branch matches.
 
+**Stacking on unmerged work:** the `WorktreeCreate` hook contract carries only a worktree name, so the native Claude Code path can express no base ref and always branches from the main checkout's current HEAD. When the work builds on a branch that has not merged yet, **skip native creation** and run the script directly with `-BaseRef`:
+
+```bash
+pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name> -BranchName feature/wt-<topic> -BaseRef feature/wt-<prerequisite>
+```
+
+Then enter it with the native worktree tool by path. `-BaseRef` accepts a branch, tag, or SHA, and is rejected if the branch or the worktree already exists — the base of existing history cannot be changed after the fact.
+
 **Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
 
 ### Cleanup of merged worktrees on create

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
           ./tests/PreCommitAntiPatternHook.Tests.ps1
           ./tests/WorktreePowerShellHost.Tests.ps1
           ./tests/WorktreeBranchName.Tests.ps1
+          ./tests/WorktreeBaseRef.Tests.ps1
           ./tests/WorktreeMergedCleanup.Tests.ps1
           ./tests/WorktreeRemoveHook.Tests.ps1
           ./tests/WorktreeLocalDevSetup.Tests.ps1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,12 @@ Atomic commits: one logical change per commit; feature + its tests = one commit.
 Never force-push to main/master. Run `dotnet build` + `dotnet test` before creating a PR.
 Keep PRs focused on a single concern; split large changes into stacked PRs.
 
+Confirm the base before branching. A new branch starts from the main checkout's current HEAD, so
+work that builds on unmerged work must say so explicitly: pass `-BaseRef <branch>` to
+`scripts/new-worktree.ps1`. Check which branch actually contains the spec, plan, or code you are
+building on rather than defaulting to `main` — branching from `main` while the prerequisite sits on
+an open branch produces a diff full of unrelated commits after the first rebase.
+
 The AHKFlowApp main checkout is human-owned for Git mutations. Agents may inspect, edit, build,
 test, and format there, but must branch, add, commit, merge, rebase, and push for this repository
 only from a managed linked worktree. Use `scripts/new-worktree.ps1` or the `WorktreeCreate` tool.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,7 +204,9 @@ Confirm the base before branching. A new branch starts from the main checkout's 
 work that builds on unmerged work must say so explicitly: pass `-BaseRef <branch>` to
 `scripts/new-worktree.ps1`. Check which branch actually contains the spec, plan, or code you are
 building on rather than defaulting to `main` — branching from `main` while the prerequisite sits on
-an open branch produces a diff full of unrelated commits after the first rebase.
+an open branch produces a diff full of unrelated commits after the first rebase. Claude Code's native
+worktree creation cannot pass a base ref, so stacked work must call the script directly; see the
+`worktrees` skill.
 
 The AHKFlowApp main checkout is human-owned for Git mutations. Agents may inspect, edit, build,
 test, and format there, but must branch, add, commit, merge, rebase, and push for this repository

--- a/plugins/ahkflowapp/.codex-plugin/plugin.json
+++ b/plugins/ahkflowapp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ahkflowapp",
-  "version": "0.1.0+codex.25c51d5d88d6",
+  "version": "0.1.0+codex.7ec4118de2f4",
   "description": "Repo-local Codex plugin exposing focused AHKFlowApp project skills.",
   "author": {
     "name": "AHKFlowApp maintainers",

--- a/plugins/ahkflowapp/skills/worktrees/SKILL.md
+++ b/plugins/ahkflowapp/skills/worktrees/SKILL.md
@@ -21,6 +21,14 @@ It creates the branch, places the worktree under `.claude/worktrees/<name>/`, co
 
 **Branch naming:** worktree branches insert `wt-` after the type prefix — `fix/wt-<topic>`, `feature/wt-NNN-<topic>` (see AGENTS.md Git Workflow). Pass it explicitly (`-BranchName fix/wt-<topic>`) or name the worktree so the derived branch matches.
 
+**Stacking on unmerged work:** the `WorktreeCreate` hook contract carries only a worktree name, so the native Claude Code path can express no base ref and always branches from the main checkout's current HEAD. When the work builds on a branch that has not merged yet, **skip native creation** and run the script directly with `-BaseRef`:
+
+```bash
+pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name> -BranchName feature/wt-<topic> -BaseRef feature/wt-<prerequisite>
+```
+
+Then enter it with the native worktree tool by path. `-BaseRef` accepts a branch, tag, or SHA, and is rejected if the branch or the worktree already exists — the base of existing history cannot be changed after the fact.
+
 **Do NOT** run bare `git worktree add` — it checks out files but skips isolation setup, leaving a broken worktree.
 
 ### Cleanup of merged worktrees on create

--- a/scripts/new-worktree.ps1
+++ b/scripts/new-worktree.ps1
@@ -9,6 +9,10 @@
     output on stderr) to sweep worktrees whose branch is already merged into main. That
     sweep is opt-in via `git config --local ahkflow.worktreeCleanup true`; -Cleanup forces
     it for this run. See cleanup-merged-worktrees.ps1 for the full precedence.
+
+    A new branch is created from the main checkout's current HEAD unless -BaseRef names another
+    starting point. Pass -BaseRef when the work builds on an unmerged branch, so the new worktree
+    stacks on that branch instead of silently picking up whatever main happens to be on.
 #>
 
 [CmdletBinding()]
@@ -16,6 +20,7 @@ param(
     [string] $Name,
     [string] $BranchName,
     [string] $Path,
+    [string] $BaseRef,
 
     [Alias('c')]
     [switch] $Cleanup
@@ -246,7 +251,12 @@ Invoke-OrphanDockerPrune $repoRoot
 
 if (-not $worktreeExists) {
     $branchExists = Test-BranchExists $repoRoot $BranchName
-    $sourceRef = if ($branchExists) { $BranchName } else { 'HEAD' }
+
+    if ($BaseRef -and -not (Test-RefExists $repoRoot $BaseRef)) {
+        throw "-BaseRef '$BaseRef' does not resolve to a commit in this repository. Fetch it first, or pass a local branch, tag, or SHA."
+    }
+
+    $sourceRef = Resolve-WorktreeSourceRef -BranchName $BranchName -BranchExists $branchExists -BaseRef $BaseRef
     Assert-SetupScriptCommitted -RepoRoot $repoRoot -Ref $sourceRef
 
     New-Item -ItemType Directory -Path (Split-Path -Parent $worktreePath) -Force | Out-Null
@@ -254,7 +264,7 @@ if (-not $worktreeExists) {
     if ($branchExists) {
         Invoke-Git $repoRoot @('worktree', 'add', $worktreePath, $BranchName)
     } else {
-        Invoke-Git $repoRoot @('worktree', 'add', $worktreePath, '-b', $BranchName)
+        Invoke-Git $repoRoot @('worktree', 'add', $worktreePath, '-b', $BranchName, $sourceRef)
     }
 }
 

--- a/scripts/new-worktree.ps1
+++ b/scripts/new-worktree.ps1
@@ -236,6 +236,12 @@ $worktreePath = [System.IO.Path]::GetFullPath($Path)
 Assert-WorktreeLocation -RepoRoot $repoRoot -WorktreePath $worktreePath
 $worktreeExists = Test-Path -LiteralPath (Join-Path $worktreePath '.git')
 
+# -BaseRef only affects branch creation. Reusing an existing worktree cannot honor it, and
+# rerunning setup while ignoring the flag would imply the requested base had been applied.
+if ($BaseRef -and $worktreeExists) {
+    throw "Worktree '$worktreePath' already exists, so -BaseRef '$BaseRef' cannot apply. Remove that worktree first, or omit -BaseRef to reuse it as-is."
+}
+
 # Sweep other worktrees whose branch is already merged into main before creating/reusing
 # this one. -ExcludePath protects $worktreePath itself: without it a same-named create/reuse
 # could race the async removal. -IsHook passes the RAW hook context; the cleanup script's
@@ -261,11 +267,8 @@ if (-not $worktreeExists) {
 
     New-Item -ItemType Directory -Path (Split-Path -Parent $worktreePath) -Force | Out-Null
 
-    if ($branchExists) {
-        Invoke-Git $repoRoot @('worktree', 'add', $worktreePath, $BranchName)
-    } else {
-        Invoke-Git $repoRoot @('worktree', 'add', $worktreePath, '-b', $BranchName, $sourceRef)
-    }
+    $addArguments = Get-WorktreeAddArguments -WorktreePath $worktreePath -BranchName $BranchName -BranchExists $branchExists -SourceRef $sourceRef
+    Invoke-Git $repoRoot $addArguments
 }
 
 Copy-WorktreeIncludeEntries $repoRoot $worktreePath

--- a/scripts/worktree-git.common.ps1
+++ b/scripts/worktree-git.common.ps1
@@ -64,6 +64,24 @@ function Resolve-WorktreeSourceRef {
     return 'HEAD'
 }
 
+# The exact 'git worktree add' argv. Kept separate from the call so a test can assert the start
+# point is really passed through: dropping $SourceRef would still produce a working script and
+# would be invisible to a test that only checked the resolver's return value.
+function Get-WorktreeAddArguments {
+    param(
+        [string] $WorktreePath,
+        [string] $BranchName,
+        [bool] $BranchExists,
+        [string] $SourceRef
+    )
+
+    if ($BranchExists) {
+        return , @('worktree', 'add', $WorktreePath, $BranchName)
+    }
+
+    return , @('worktree', 'add', $WorktreePath, '-b', $BranchName, $SourceRef)
+}
+
 # AGENTS.md: worktree-born branches are '<type>/wt-<topic>'. The Claude WorktreeCreate hook
 # only ever supplies a worktree name, so an untyped name cannot express intent and falls back
 # to the 'fix/' type; a type prefix the caller did supply is preserved.

--- a/scripts/worktree-git.common.ps1
+++ b/scripts/worktree-git.common.ps1
@@ -24,6 +24,46 @@ function Test-LinkedWorktree {
     return $gitDir.TrimEnd('\') -ine $commonDir.TrimEnd('\')
 }
 
+function Test-RefExists {
+    param(
+        [string] $Root,
+        [string] $Ref
+    )
+
+    # Deliberately broader than a branch probe: a base ref may legitimately be a local branch, a
+    # remote-tracking ref, a tag, or a raw SHA. The '^{commit}' suffix rejects a ref that resolves
+    # to something that cannot be branched from.
+    & git -C $Root rev-parse --verify --quiet "$Ref^{commit}" *> $null
+    return $LASTEXITCODE -eq 0
+}
+
+# Which ref a new worktree's branch starts from. Pure so the precedence is testable without a
+# repo: an existing branch owns its own history, an explicit -BaseRef stacks on unmerged work,
+# and HEAD is the default that preserves the historical behavior.
+function Resolve-WorktreeSourceRef {
+    param(
+        [string] $BranchName,
+        [bool] $BranchExists,
+        [string] $BaseRef
+    )
+
+    # Silently ignoring -BaseRef here would hand back a worktree based on something other than
+    # what was asked for — the exact confusion the parameter exists to prevent.
+    if ($BaseRef -and $BranchExists) {
+        throw "Branch '$BranchName' already exists, so -BaseRef '$BaseRef' cannot apply. Omit -BaseRef to check out the existing branch, or pick a new -BranchName."
+    }
+
+    if ($BranchExists) {
+        return $BranchName
+    }
+
+    if ($BaseRef) {
+        return $BaseRef
+    }
+
+    return 'HEAD'
+}
+
 # AGENTS.md: worktree-born branches are '<type>/wt-<topic>'. The Claude WorktreeCreate hook
 # only ever supplies a worktree name, so an untyped name cannot express intent and falls back
 # to the 'fix/' type; a type prefix the caller did supply is preserved.

--- a/tests/WorktreeBaseRef.Tests.ps1
+++ b/tests/WorktreeBaseRef.Tests.ps1
@@ -1,0 +1,73 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Assert-SourceRef {
+    param(
+        [string] $BranchName,
+        [bool] $BranchExists,
+        [string] $BaseRef,
+        [string] $Expected
+    )
+
+    $actual = Resolve-WorktreeSourceRef -BranchName $BranchName -BranchExists $BranchExists -BaseRef $BaseRef
+    Assert-True ($actual -ceq $Expected) "Resolve-WorktreeSourceRef('$BranchName', exists=$BranchExists, base='$BaseRef'): expected '$Expected', got '$actual'."
+}
+
+function Assert-Throws {
+    param([scriptblock] $Action, [string] $ExpectedSubstring, [string] $Message)
+
+    try {
+        & $Action
+    } catch {
+        Assert-True ($_.Exception.Message -like "*$ExpectedSubstring*") "$Message (message was '$($_.Exception.Message)')"
+        return
+    }
+
+    throw "$Message (no exception was thrown)"
+}
+
+. (Join-Path $repoRoot 'scripts\worktree-git.common.ps1')
+
+# Default: no base ref supplied and a new branch, so the main checkout's HEAD is the start point.
+# This is the historical behavior and must not change when -BaseRef is absent.
+Assert-SourceRef -BranchName 'fix/wt-thing' -BranchExists $false -BaseRef '' -Expected 'HEAD'
+
+# Explicit base ref on a new branch: stack on that ref instead of whatever main is sitting on.
+# This is the whole point of the parameter — the report's incident was branching from main while
+# the required spec docs lived on an unmerged branch.
+Assert-SourceRef -BranchName 'feature/wt-w2-ui' -BranchExists $false -BaseRef 'feature/wt-w1-backend' -Expected 'feature/wt-w1-backend'
+
+# A base ref may be any committish, not just a local branch.
+Assert-SourceRef -BranchName 'fix/wt-thing' -BranchExists $false -BaseRef 'origin/main' -Expected 'origin/main'
+Assert-SourceRef -BranchName 'fix/wt-thing' -BranchExists $false -BaseRef 'v1.2.3' -Expected 'v1.2.3'
+Assert-SourceRef -BranchName 'fix/wt-thing' -BranchExists $false -BaseRef '3b35668' -Expected '3b35668'
+
+# Existing branch with no base ref: check it out as-is. Its history is already fixed.
+Assert-SourceRef -BranchName 'fix/wt-existing' -BranchExists $true -BaseRef '' -Expected 'fix/wt-existing'
+
+# Existing branch plus a base ref is a contradiction. It must fail loudly rather than silently
+# ignore the flag, or the caller gets a worktree based on something they did not ask for.
+Assert-Throws {
+    Resolve-WorktreeSourceRef -BranchName 'fix/wt-existing' -BranchExists $true -BaseRef 'main'
+} 'already exists' 'An existing branch combined with -BaseRef must throw.'
+
+# Ref probing is broader than a branch probe: HEAD of this repo resolves, gibberish does not.
+Assert-True (Test-RefExists $repoRoot 'HEAD') 'Test-RefExists should resolve HEAD.'
+Assert-True (-not (Test-RefExists $repoRoot 'refs/heads/definitely-not-a-real-branch-xyz')) 'Test-RefExists should reject a nonexistent ref.'
+
+Write-Host 'Worktree base-ref tests passed.'

--- a/tests/WorktreeBaseRef.Tests.ps1
+++ b/tests/WorktreeBaseRef.Tests.ps1
@@ -70,4 +70,85 @@ Assert-Throws {
 Assert-True (Test-RefExists $repoRoot 'HEAD') 'Test-RefExists should resolve HEAD.'
 Assert-True (-not (Test-RefExists $repoRoot 'refs/heads/definitely-not-a-real-branch-xyz')) 'Test-RefExists should reject a nonexistent ref.'
 
+# The argv itself, not just the resolved string. A wiring change that dropped the start point
+# would leave every assertion above passing, so assert the exact arguments git receives.
+function Assert-AddArguments {
+    param(
+        [bool] $BranchExists,
+        [string] $SourceRef,
+        [string] $Expected
+    )
+
+    $actual = (Get-WorktreeAddArguments -WorktreePath 'C:\wt\x' -BranchName 'fix/wt-x' -BranchExists $BranchExists -SourceRef $SourceRef) -join ' '
+    Assert-True ($actual -ceq $Expected) "Get-WorktreeAddArguments(exists=$BranchExists, source='$SourceRef'): expected '$Expected', got '$actual'."
+}
+
+Assert-AddArguments -BranchExists $false -SourceRef 'HEAD' -Expected 'worktree add C:\wt\x -b fix/wt-x HEAD'
+Assert-AddArguments -BranchExists $false -SourceRef 'feature/wt-upstream' -Expected 'worktree add C:\wt\x -b fix/wt-x feature/wt-upstream'
+# An existing branch takes no start point: git rejects 'add <path> <branch> <ref>'.
+Assert-AddArguments -BranchExists $true -SourceRef 'HEAD' -Expected 'worktree add C:\wt\x fix/wt-x'
+
+# End-to-end against real git. The unit assertions prove the argv is shaped as intended; only a
+# real 'git worktree add' proves that shape yields the intended ancestry. Drives the same helper
+# the script calls, in a throwaway repo, for both the default and the stacked case.
+function New-AncestryFixture {
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ('wtbase-' + [guid]::NewGuid().ToString('N').Substring(0, 8))
+    $repo = Join-Path $root 'repo'
+    New-Item -ItemType Directory -Path $repo -Force | Out-Null
+
+    & git -C $repo init --quiet
+    & git -C $repo symbolic-ref HEAD refs/heads/main
+    & git -C $repo config user.email 'test@example.com'
+    & git -C $repo config user.name 'Worktree BaseRef Test'
+
+    Set-Content -LiteralPath (Join-Path $repo 'on-main.txt') -Value 'main' -Encoding utf8
+    & git -C $repo add -A
+    & git -C $repo commit --quiet -m 'seed main'
+
+    # A file that exists only on the unmerged branch: its presence is the ancestry assertion.
+    & git -C $repo checkout --quiet -b feature/upstream
+    Set-Content -LiteralPath (Join-Path $repo 'only-upstream.txt') -Value 'upstream' -Encoding utf8
+    & git -C $repo add -A
+    & git -C $repo commit --quiet -m 'only on upstream'
+    & git -C $repo checkout --quiet main
+
+    return (Resolve-Path -LiteralPath $repo).Path
+}
+
+$fixtureRepo = New-AncestryFixture
+try {
+    $marker = 'only-upstream.txt'
+
+    # Default: no base ref, so the new branch starts at main's HEAD and must NOT carry the marker.
+    $defaultPath = Join-Path (Split-Path -Parent $fixtureRepo) 'wt-default'
+    $defaultArgs = Get-WorktreeAddArguments -WorktreePath $defaultPath -BranchName 'fix/wt-default' -BranchExists $false -SourceRef (Resolve-WorktreeSourceRef -BranchName 'fix/wt-default' -BranchExists $false -BaseRef '')
+    & git -C $fixtureRepo @defaultArgs *> $null
+    Assert-True ($LASTEXITCODE -eq 0) 'Default worktree add should succeed.'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $defaultPath $marker))) "Default base should be main's HEAD, so '$marker' must be absent."
+
+    # Explicit base ref: the new branch stacks on the unmerged branch and MUST carry the marker.
+    $stackedPath = Join-Path (Split-Path -Parent $fixtureRepo) 'wt-stacked'
+    $stackedArgs = Get-WorktreeAddArguments -WorktreePath $stackedPath -BranchName 'feature/wt-stacked' -BranchExists $false -SourceRef (Resolve-WorktreeSourceRef -BranchName 'feature/wt-stacked' -BranchExists $false -BaseRef 'feature/upstream')
+    & git -C $fixtureRepo @stackedArgs *> $null
+    Assert-True ($LASTEXITCODE -eq 0) 'Stacked worktree add should succeed.'
+    Assert-True (Test-Path -LiteralPath (Join-Path $stackedPath $marker)) "-BaseRef should stack on feature/upstream, so '$marker' must be present."
+
+    # Ancestry, not just file presence: the stacked branch descends from the base ref.
+    & git -C $fixtureRepo merge-base --is-ancestor 'feature/upstream' 'feature/wt-stacked'
+    Assert-True ($LASTEXITCODE -eq 0) 'feature/upstream must be an ancestor of the stacked branch.'
+    & git -C $fixtureRepo merge-base --is-ancestor 'feature/upstream' 'fix/wt-default'
+    Assert-True ($LASTEXITCODE -ne 0) 'feature/upstream must NOT be an ancestor of the default branch.'
+} finally {
+    $fixtureRoot = Split-Path -Parent $fixtureRepo
+    for ($attempt = 1; $attempt -le 3; $attempt++) {
+        try {
+            Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction Stop
+            break
+        } catch {
+            if ($attempt -eq 3) { break }
+            Start-Sleep -Milliseconds 200
+        }
+    }
+}
+
 Write-Host 'Worktree base-ref tests passed.'


### PR DESCRIPTION
## Summary

A new worktree branch was always created from the main checkout's current HEAD, and `new-worktree.ps1` had no parameter to say otherwise. Stacking a worktree on an unmerged branch was therefore inexpressible through the sanctioned script, so an agent told to stack either could not comply or stepped outside policy — which is how a branch once got cut from `main` while its prerequisite spec sat on an open branch, pulling unrelated commits in on the first rebase.

`-BaseRef` accepts a branch, tag, or SHA:

```bash
pwsh -NoProfile -File scripts/new-worktree.ps1 -Name w2-ui -BranchName feature/wt-w2-ui -BaseRef feature/wt-w1-backend
```

Omitted, behavior is unchanged — `$sourceRef` defaults to `HEAD`, so the git call is identical to before.

## Design notes

- Precedence (`Resolve-WorktreeSourceRef`) and the git argv (`Get-WorktreeAddArguments`) live in `scripts/worktree-git.common.ps1` as pure functions. Inline versions were not unit-testable: `new-worktree.ps1` executes on dot-source, and dropping the start point from an inline argv would have been invisible to tests.
- Rejected when the branch **or** the worktree already exists, rather than silently ignored. The base of existing history cannot be changed after the fact, and quietly ignoring the flag hands back a worktree based on something the caller did not ask for.
- `tests/WorktreeBaseRef.Tests.ps1` is registered in `ci.yml` — that job enumerates test files explicitly, with no glob, so a new file would otherwise run locally forever and never in CI.

## Known limitation — documented, not fixed

Claude Code's `WorktreeCreate` hook contract carries only a worktree name, so the native worktree path cannot pass a base ref and always branches from HEAD. Stacked work must call the script directly. The repo cannot add a field to what the hook sends, so this is documented in the `worktrees` skill and cross-referenced from `AGENTS.md` instead of plumbed.

## Verification

- `WorktreeBaseRef.Tests.ps1` — precedence, exact argv, ref probing, plus a throwaway-repo end-to-end asserting ancestry with `merge-base --is-ancestor` in both directions (present for stacked, absent for default).
- Mutation-checked: dropping `$SourceRef` from the argv makes the suite fail. Restored, green.
- Passing: `WorktreeBaseRef`, `WorktreeBranchName`, `WorktreeLocalDevSetup`, `WorktreeMergedCleanup`, `WorktreeRemoveHook`, `WorktreePowerShellHost`, `SkillParity`. The last three matter because this touches a shared helper that `setup-worktree-local-dev.ps1` also dot-sources.
- Pre-push hook passed on push.
- **Not covered:** `new-worktree.ps1` is never invoked end-to-end. It calls `Invoke-OrphanDockerPrune` and the full local-dev setup, which would add a Docker dependency and minutes to a suite that runs in seconds. The repo already tests those pieces separately. The top-level orchestration remains untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)