### PR TITLE
docs: add root-cause, smoke-test, and laptop-key rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,13 @@ Frameworks: xUnit, FluentAssertions (over raw `Assert`), NSubstitute, Testcontai
 - NSubstitute for third-party boundaries only — don't mock what you own
 - Test behavior (HTTP response, DB state, Result status), not implementation details
 - `FakeTimeProvider` (from `Microsoft.Extensions.TimeProvider.Testing`) for time-dependent tests
+- Derive expected seed keys and row counts from the seed source — never hard-code them, or a catalog change breaks unrelated suites
+- Rebuild in Release **and restart the API/UI** before any live smoke test; a stale Debug build has served old seed data and produced a false failure
+
+## Debugging
+
+- State the root cause with `file:line` evidence before editing. Can't point to it — say so and keep investigating instead of shipping a plausible guess.
+- If a fix fails ("it still does not work"), stop patching. Go back to instrumentation or docs research rather than guessing again at the same shape.
 
 ## Plans
 

--- a/docs/development/ahk-v2-syntax.md
+++ b/docs/development/ahk-v2-syntax.md
@@ -310,6 +310,13 @@ plainly:
   lower-casing and zero-padding (`vk1` → `vk01`, `sc1` → `sc001`), so one physical key
   cannot survive as two rows.
 
+### Keys to avoid in examples
+
+`CapsLock`, `ScrollLock`, `RAlt`, and `Pause` are all valid registry keys, but don't reach for them
+when writing samples, seeded catalog rows, or doc examples — they are absent or already remapped on a
+laptop keyboard, so the example can't be tried as written. Prefer a modifier plus a key that is
+physically present. (`Pause` is separately excluded as a remap destination; see `HotkeyKeys`.)
+
 ### Right-hand side per action
 
 Each `HotkeyActionKind` owns its own stored field(s) and exactly one emitted form:


### PR DESCRIPTION
## Summary

Three recurring friction points from a Claude Code usage review, none of which were written down anywhere.

**Root cause before fix** — new `## Debugging` section in `AGENTS.md`. State the cause with `file:line` evidence before editing; if a fix fails, go back to instrumentation rather than guessing again at the same shape. This was the single largest friction category in the review.

**Release build before live smoke tests** — added to `AGENTS.md` Testing. A stale Debug build once served old seed data (12 samples instead of 17) and read as a genuine failure. Also: derive expected seed keys and row counts from the seed source instead of hard-coding them, so a catalog change stops breaking unrelated suites.

**Laptop-unavailable keys** — new `### Keys to avoid in examples` in `docs/development/ahk-v2-syntax.md`. `CapsLock`, `ScrollLock`, `RAlt`, and `Pause` are absent or already remapped on a laptop keyboard, so examples using them cannot be tried as written.

## Note on the third one

Those four keys are **valid** registry entries — `HotkeyKeys.cs:77` and `:103` — so the guidance is "don't reach for these in examples", not "these are invalid". Framing it as invalid would have been wrong. `Pause` is separately excluded as a remap destination, which the doc already covers.

## Verification

Docs-only, no code compiled. Verified the key claim against source before writing it rather than asserting it. No `dotnet` build or test run.

Note `ci.yml`'s `paths-filter` skips build, test, and coverage for docs-only PRs, so CI will not exercise anything here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)