### PR TITLE
docs: route verification by surface after implementation

### DIFF
--- a/.agents/dck-verify/SKILL.md
+++ b/.agents/dck-verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dck-verify
-description: Use when verifying AHKFlowApp build, tests, formatting, diagnostics, security, or readiness before commit, push, or PR.
+description: Use when verifying AHKFlowApp build, tests, formatting, diagnostics, security, runtime behavior, or readiness — after implementing a change, and before commit, push, or PR.
 ---
 
 # Verify
@@ -13,8 +13,8 @@ Verification is evidence, not confidence. Report PASS, WARN, FAIL, or SKIP for e
 
 | Change | Phases |
 |---|---|
-| Feature, refactor, pre-PR | All 7 |
-| Bug fix | Build, diagnostics, tests, diff |
+| Feature, refactor, pre-PR | All 8 |
+| Bug fix | Build, diagnostics, tests, diff — **plus runtime when the bug had an observable symptom** |
 | Dependency update | Build, tests, vulnerable packages, format |
 | EF migration | Build, migration SQL review, tests, format, diff |
 | Skill/docs only | Targeted text checks, setup script if skill surface changed, diff |
@@ -22,7 +22,7 @@ Verification is evidence, not confidence. Report PASS, WARN, FAIL, or SKIP for e
 
 When unsure, run the full pipeline.
 
-## 7-Phase Pipeline
+## 8-Phase Pipeline
 
 ### 1. Build
 
@@ -55,18 +55,18 @@ Look especially for sync-over-async, `DateTime.Now`/`UtcNow`, missing `Cancellat
 
 ### 4. Tests
 
-```bash
-dotnet test --configuration Release --no-build --verbosity normal
-```
-
-For narrow changes, run affected test projects first, then broaden if risk warrants:
+Pick the slice that covers what changed. `docs/development/testing-workflow.md` owns the mode
+definitions and the canonical pre-PR gate — follow it rather than restating commands here.
 
 ```bash
-dotnet test tests/AHKFlowApp.Application.Tests --configuration Release --verbosity normal
-dotnet test tests/AHKFlowApp.API.Tests --configuration Release --verbosity normal
+pwsh .\scripts\test-fast.ps1 -Mode Fast          # domain, validators, bUnit
+pwsh .\scripts\test-fast.ps1 -Mode Integration   # EF Core, API, CLI flows
+pwsh .\scripts\test-fast.ps1 -Mode E2E           # browser, PWA, mobile viewport
+pwsh .\scripts\test-fast.ps1 -Mode Coverage      # full gate before a PR
 ```
 
-Any failing test is FAIL.
+The script manages one disposable shared SQL container; plain `dotnet test` falls back to slower
+per-project Testcontainers. Any failing test is FAIL.
 
 ### 5. Security and Packages
 
@@ -101,6 +101,29 @@ git diff --check
 
 Inspect the diff for accidental files, debug leftovers, secrets, stale references, and changes outside the task.
 
+### 8. Runtime Verification
+
+The other seven phases prove the code compiles and the existing suite still passes. None of them
+exercise the change. This phase does.
+
+Route on what surface changed — the table in `AGENTS.md` under **Verification After Implementation**
+is authoritative. In short:
+
+| Changed | Evidence |
+|---|---|
+| Blazor UI flow | A new or extended `*FlowTests.cs` in `tests/AHKFlowApp.E2E.Tests`, green under `-Mode E2E` |
+| UI, visual only | A `playwright-cli` drive of the running app plus a screenshot |
+| API, use case, EF Core | An integration test covering the new behavior, green under `-Mode Integration` |
+| CLI | A `CLI.Tests` integration flow, green under `-Mode Integration` |
+| Emitted `.ahk` | An assertion on the generated text; manual AHK steps only for a construct never shipped before |
+| Bug fix with an observable symptom | The original repro re-run, showing the symptom gone |
+
+Prefer a durable test over a one-off drive — a test keeps proving the behavior after this session.
+
+Report the artifact by path, not as a claim. SKIP is allowed only for one of the three exemptions in
+`AGENTS.md`, and the exemption must be named. For the refactor exemption, name the covering tests and
+paste their fresh output.
+
 ## Skill Surface Verification
 
 When `.agents/*` skills change:
@@ -130,8 +153,12 @@ For renamed skills, confirm no stale `.agents/cck-*` directories remain and the 
 | Tests | PASS | Failed: 0 |
 | Format | PASS | verify-no-changes exit 0 |
 | Diff | WARN | docs-only changes plus plugin cache refresh |
+| Runtime | PASS | HotkeysCrudFlowTests.CreateRunHotkey_... green under -Mode E2E |
 
 Verdict: READY / NEEDS FIXES
 ```
 
 Do not claim ready until the evidence is fresh.
+
+`Runtime = SKIP` blocks `READY` unless the Evidence cell names one of the three `AGENTS.md`
+exemptions. Green build and green tests are not runtime evidence.

--- a/.agents/playwright-cli/SKILL.md
+++ b/.agents/playwright-cli/SKILL.md
@@ -1,10 +1,30 @@
 ---
 name: playwright-cli
-description: Use when testing local web pages, browser behavior, screenshots, or Playwright flows from the CLI.
+description: Use when driving the AHKFlowApp UI in a browser for a visual or exploratory check, or when testing local web pages, screenshots, or Playwright flows from the CLI.
 allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
 ---
 
 # Browser Automation with playwright-cli
+
+## In this project, first
+
+**Prefer an E2E flow test over an ad-hoc drive.** If the check can be asserted, add or extend a
+`*FlowTests.cs` in `tests/AHKFlowApp.E2E.Tests` and run `pwsh .\scripts\test-fast.ps1 -Mode E2E` — the
+test keeps proving the behavior after this session ends, a drive proves it once. Reach for this skill
+when the check is visual or exploratory, or when you need to see the page to work out what is wrong.
+See **Verification After Implementation** in `AGENTS.md` for the routing, and
+`docs/development/testing-workflow.md#writing-a-flow-test` for the test template.
+
+**Get the ports from `launchSettings.json`, not from memory.** The main checkout runs the frontend on
+5601 and the API on 5600, but every agent worktree gets its own offset pair (e.g. 5603 / 5602) so it can
+run alongside. Driving 5601 from a worktree silently hits the main checkout or a dead port, and it looks
+like a broken app rather than a wrong URL.
+
+**Worktrees are already signed in.** They run no-auth (`Auth:UseTestProvider=true`, user "Test User"),
+so full CRUD is reachable with no login step. The main checkout runs real MSAL unless started on its
+`http (No Auth)` profile.
+
+Setup and troubleshooting: `docs/development/playwright-setup.md`.
 
 ## Quick start
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,7 @@ Be concise in all interactions. Optimize for readability when writing documentat
 ## Workflow Preferences
 
 - When asked to store instructions or rules, put them in CLAUDE.md (not memory files) unless explicitly told otherwise.
-- Browser/UI verification: use the `playwright-cli` skill for any task needing visual confirmation in a browser (frontend changes, UI smoke tests). Invoke it via the Skill tool.
+- Verifying finished work is governed by **Verification After Implementation** in AGENTS.md. Invoke the `playwright-cli` skill via the Skill tool when that routing calls for a browser drive.
 - Before claiming a tool or capability is unavailable, check `.claude/skills/` and available skills. Never assume browser automation is missing — `playwright-cli` is installed.
 
 ## Out of Scope

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,11 @@ Brief description of changes.
 
 ## Checklist
 
-- [ ] Tests pass (`dotnet test`)
-- [ ] Build succeeds (`dotnet build`)
+- [ ] [Canonical pre-PR gate](../docs/development/testing-workflow.md#canonical-pre-pr-gate) passes (build, format, coverage, `git diff --check`)
+- [ ] The change was exercised, not just compiled — name the test or verification below
 - [ ] No new warnings introduced
 - [ ] Breaking changes documented (if any)
+
+## Verification
+
+How this was exercised — test path, screenshot, or the exemption claimed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ Branch naming: `feature/NNN-short-description`, `fix/short-description`, `hotfix
 Branches created in agent git worktrees insert `wt-` after the type prefix: `fix/wt-<topic>`, `feature/wt-NNN-<topic>` — marks worktree-born branches for grepping/cleanup.
 Conventional commits: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:` — body explains "why", not "what".
 Atomic commits: one logical change per commit; feature + its tests = one commit. Don't bundle unrelated changes.
-Never force-push to main/master. Run `dotnet build` + `dotnet test` before creating a PR.
+Never force-push to main/master. Run the canonical pre-PR gate before creating a PR — [`docs/development/testing-workflow.md`](docs/development/testing-workflow.md#canonical-pre-pr-gate).
 Keep PRs focused on a single concern; split large changes into stacked PRs.
 
 The AHKFlowApp main checkout is human-owned for Git mutations. Agents may inspect, edit, build,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,11 +112,35 @@ When finalizing a plan or spec (right before presenting the final plan for appro
 
 Only commit plans/specs to `docs/superpowers/` when they relate to project improvements — code, features, infra, deployment, tests, repo tooling that affects contributors. Skip writing (or keep out-of-repo) plans for agent optimization, personal workflow tuning, agent housekeeping, or one-off context/config cleanups.
 
-## Manual Testing Requests
+## Verification After Implementation
 
-Prefer verifying yourself with browser automation (Playwright preferred; Claude in Chrome as fallback) over asking the user to test manually. Asking is fine when automation can't cover it (e.g. real Azure AD login, visual judgment calls) or when asking is clearly easier or faster.
+This fires when implementation of a feature, fix, or plan task completes — **before reporting it done**, not only before commit, push, or PR. A change that has never been exercised is not finished. Don't leave defects for a review agent to find.
 
-When asking the user to manually test or verify anything (UI flows, commands, acceptance checks), always provide:
+Default to a **durable test** as the verification artifact. Driving the app by hand proves it once; a test keeps proving it.
+
+| Surface changed | Verification artifact | Command |
+|---|---|---|
+| Blazor UI flow, assertable | Add or extend a `*FlowTests.cs` in `tests/AHKFlowApp.E2E.Tests` | `pwsh .\scripts\test-fast.ps1 -Mode E2E` |
+| UI, visual or exploratory only | Drive the running app with the `playwright-cli` skill, capture a screenshot | Read the worktree's own `launchSettings.json` for ports |
+| API, use case, EF Core | Integration test (`Category=Integration` trait, or `API.Tests`) | `pwsh .\scripts\test-fast.ps1 -Mode Integration` |
+| CLI behavior | `CLI.Tests` integration flow | `pwsh .\scripts\test-fast.ps1 -Mode Integration` |
+| Emitted `.ahk` output | Assert the generated text. Add manual steps **only when the change emits a construct the repo has not shipped before** — new option flag, new escaping path, new action kind. Running `.ahk` is out of scope, so for proven constructs the assertion is the contract | `pwsh .\scripts\test-fast.ps1 -Mode Fast` |
+| Domain rule, validator | Unit test | `pwsh .\scripts\test-fast.ps1 -Mode Fast` |
+| Real Azure AD login, visual judgment call | Numbered manual steps for the user | — |
+
+Which slice to run, test templates, and the canonical pre-PR gate: [`docs/development/testing-workflow.md`](docs/development/testing-workflow.md).
+
+### The only exemptions
+
+1. **Docs, skills, or plan files only** — nothing compiled. Targeted text checks plus diff review.
+2. **Internal-only, no observable surface** — no UI, no API contract, no emitted `.ahk` change, no schema change.
+3. **Pure refactor, no behavior change** — to claim this, name the existing tests that cover the changed code and paste their fresh pass output. No named coverage, no exemption; verify at runtime instead.
+
+State the verdict either way. Naming an exemption is fine; saying nothing is not.
+
+### When manual steps are the answer
+
+Ask the user only for the cases the table sends to them. Then always provide:
 
 - **Preconditions first** — what must be running, exact URL, login/profile, starting state
 - **Numbered steps, one action each** — never combine actions in one step

--- a/docs/development/coverage.md
+++ b/docs/development/coverage.md
@@ -38,7 +38,7 @@ git config core.hooksPath .githooks
 
 The canonical gate also requires `python` on `PATH`.
 
-That `core.hooksPath` setting enables the repo-managed `.githooks/pre-push` hook, which runs `pwsh .\scripts\pre-push-quick-checks.ps1` automatically before each push — an incremental build plus the container-free fast test slice, not full coverage. CI runs the full coverage + format gate on every PR, so the hook is a quick local sanity check rather than the authoritative gate. Run `pwsh .\scripts\run-coverage.ps1` yourself before opening a PR if you want the full local confidence check.
+That `core.hooksPath` setting enables the repo-managed `.githooks/pre-push` hook, which runs `pwsh .\scripts\pre-push-quick-checks.ps1` automatically before each push — an incremental build plus the container-free fast test slice, not full coverage. CI runs the full coverage + format gate on every non-docs PR, so the hook is a quick local sanity check rather than the authoritative gate. Run `pwsh .\scripts\run-coverage.ps1` yourself before opening a PR if you want the full local confidence check.
 
 The hook adds well under two minutes per push. Skip it for WIP pushes with either:
 

--- a/docs/development/coverage.md
+++ b/docs/development/coverage.md
@@ -1,8 +1,8 @@
 # Code coverage
 
-## Canonical local verification
+## The coverage step
 
-For day-to-day development, prefer the targeted test slices in [Local testing workflow](testing-workflow.md). The coverage command below remains the full pre-PR confidence gate; CI runs it on every PR. The pre-push hook itself only runs quick checks (see below), not full coverage.
+The canonical pre-PR gate lives in [Local testing workflow](testing-workflow.md#canonical-pre-pr-gate). This page documents only its coverage step and the thresholds behind it.
 
 From the repo root, run:
 
@@ -10,7 +10,7 @@ From the repo root, run:
 pwsh .\scripts\run-coverage.ps1
 ```
 
-That command is the recommended pre-push / pre-PR coverage check. It:
+`test-fast.ps1 -Mode Coverage` delegates to this script. It:
 
 1. runs the test suite with `XPlat Code Coverage`
 2. merges the per-project coverage files into `CoverageReport\Cobertura.xml`

--- a/docs/development/playwright-setup.md
+++ b/docs/development/playwright-setup.md
@@ -33,10 +33,16 @@ Once installed, Claude Code can drive the browser during a session. Common uses 
 
 ## Ports
 
+These are the **main checkout** ports only:
+
 | Service | URL |
 |---------|-----|
 | Blazor UI | http://localhost:5601 |
 | API | http://localhost:5600 |
+
+**In an agent worktree these are the wrong ports.** Each worktree gets its own offset pair (e.g. API 5602 / frontend 5603) so it can run alongside the main checkout — read the worktree's own `launchSettings.json` rather than assuming. Driving 5601 from a worktree hits the main checkout or a dead port, and the failure looks like a broken app rather than a wrong URL.
+
+Worktrees also run no-auth automatically (`Auth:UseTestProvider=true`, always signed in as "Test User"), so a browser drive gets full CRUD with no login.
 
 ## Notes
 

--- a/docs/development/playwright-setup.md
+++ b/docs/development/playwright-setup.md
@@ -28,7 +28,7 @@ Once installed, Claude Code can drive the browser during a session. Common uses 
 ```
 "Open the health page in headed mode so I can see it"
 "Take a screenshot of the home page"
-"Check if the UI is loading correctly on localhost:5601"
+"Read this worktree's launchSettings.json for the frontend port, then check the UI loads"
 ```
 
 ## Ports

--- a/docs/development/testing-workflow.md
+++ b/docs/development/testing-workflow.md
@@ -1,6 +1,6 @@
 # Local testing workflow
 
-Use the fastest test slice that still covers the code you changed. The pre-push hook runs an incremental build plus the fast slice automatically; run the full coverage gate yourself before opening a PR (CI enforces it on every PR regardless).
+Use the fastest test slice that still covers the code you changed. The pre-push hook runs an incremental build plus the fast slice automatically; run the full coverage gate yourself before opening a PR (CI enforces it on every non-docs PR regardless).
 
 This file is the single source for which tests to run and when. Other docs link here rather than restating commands.
 
@@ -12,12 +12,14 @@ Four steps, in order. Nothing else counts as the gate.
 dotnet build AHKFlowApp.slnx --configuration Release
 dotnet format AHKFlowApp.slnx --verify-no-changes
 pwsh .\scripts\test-fast.ps1 -Mode Coverage
-git diff --check
+git diff --check main...HEAD
 ```
+
+Pass the `main...HEAD` range to `git diff --check`. The bare form inspects only uncommitted work, so on a clean branch it passes without ever looking at the commits you are about to propose. Run the bare form as well if you have changes still in flight.
 
 Then verify the change actually works — see **Verification After Implementation** in [`AGENTS.md`](../../AGENTS.md). A green gate proves nothing regressed; it does not prove the new behavior happened.
 
-CI enforces the same build, format, and coverage-threshold steps on every PR. The pre-push hook is a faster subset (incremental build + fast slice, `scripts/pre-push-quick-checks.ps1`), not this gate.
+CI enforces the same build, format, and coverage-threshold steps on every **non-docs** PR. A PR touching only `**/*.md`, `docs/**`, or `.claude/**` skips build, test, and coverage entirely — see the `dorny/paths-filter` step in `ci.yml`. On a docs-only branch CI proves nothing, so this local gate is the only gate. The pre-push hook is a faster subset (incremental build + fast slice, `scripts/pre-push-quick-checks.ps1`), not this gate.
 
 ## Fast inner loop
 
@@ -106,7 +108,7 @@ Assert on something a user would see — rendered text, a grid cell, a snackbar 
 pwsh .\scripts\test-fast.ps1 -Mode Coverage
 ```
 
-Coverage mode delegates to `scripts/run-coverage.ps1`. Run it before opening a PR; CI enforces the same coverage + threshold gate on every PR. The pre-push hook itself only runs quick checks (incremental build + fast slice, see `scripts/pre-push-quick-checks.ps1`), not this full coverage path. The local coverage script uses the same disposable shared SQL container behavior as Integration mode for the SQL-backed suites.
+Coverage mode delegates to `scripts/run-coverage.ps1`. Run it before opening a PR; CI enforces the same coverage + threshold gate on every non-docs PR. The pre-push hook itself only runs quick checks (incremental build + fast slice, see `scripts/pre-push-quick-checks.ps1`), not this full coverage path. The local coverage script uses the same disposable shared SQL container behavior as Integration mode for the SQL-backed suites.
 
 ## Trait contract
 

--- a/docs/development/testing-workflow.md
+++ b/docs/development/testing-workflow.md
@@ -2,6 +2,23 @@
 
 Use the fastest test slice that still covers the code you changed. The pre-push hook runs an incremental build plus the fast slice automatically; run the full coverage gate yourself before opening a PR (CI enforces it on every PR regardless).
 
+This file is the single source for which tests to run and when. Other docs link here rather than restating commands.
+
+## Canonical pre-PR gate
+
+Four steps, in order. Nothing else counts as the gate.
+
+```bash
+dotnet build AHKFlowApp.slnx --configuration Release
+dotnet format AHKFlowApp.slnx --verify-no-changes
+pwsh .\scripts\test-fast.ps1 -Mode Coverage
+git diff --check
+```
+
+Then verify the change actually works — see **Verification After Implementation** in [`AGENTS.md`](../../AGENTS.md). A green gate proves nothing regressed; it does not prove the new behavior happened.
+
+CI enforces the same build, format, and coverage-threshold steps on every PR. The pre-push hook is a faster subset (incremental build + fast slice, `scripts/pre-push-quick-checks.ps1`), not this gate.
+
 ## Fast inner loop
 
 ```bash
@@ -46,6 +63,42 @@ pwsh .\scripts\test-fast.ps1 -Mode E2E
 E2E mode runs `AHKFlowApp.E2E.Tests`. Use it for browser flows, Playwright-covered UI behavior, mobile viewport behavior, service-worker/PWA behavior, and changes to the E2E fixture or published Blazor output. The script starts the same disposable shared SQL Server container used by Integration mode, and the E2E API fixture uses an isolated per-assembly database on that server.
 
 The first E2E run after frontend source changes publishes the Blazor app before Playwright starts. Unchanged reruns reuse the cached publish output through the E2E project target, so the publish step is skipped while the browser tests still run normally. E2E flow classes share one API/Spa/browser stack, and each test resets mutable database rows before it starts.
+
+### Writing a flow test
+
+A UI change is verified by adding or extending a `*FlowTests.cs`. The shape — copy it from a neighbour such as `HotkeysCrudFlowTests.cs`:
+
+```csharp
+[Collection(E2ETestCollection.Name)]
+public sealed class MyFeatureFlowTests(StackFixture fixture) : IAsyncLifetime
+{
+    public Task InitializeAsync() => fixture.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task DoingTheThing_ProducesTheVisibleResult()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync();
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotkeys");
+        await page.ClickAsync("[data-test=\"some-control\"]");
+
+        await Assertions.Expect(page.Locator("[data-test=\"result\"]"))
+            .ToContainTextAsync("expected");
+    }
+}
+```
+
+Four rules that are easy to get wrong:
+
+- **Select on `data-test`**, not MudBlazor's generated classes — they change between MudBlazor versions.
+- **Scope grid assertions to `.desktop-branch` or the mobile branch.** Both render into the DOM; the mobile one is hidden by CSS only, so an unscoped selector can match twice.
+- **`MudAutocomplete` with `CoerceValue` needs a blur to commit.** `FillAsync` sets the text but not the bound value — follow it with `PressAsync("Tab")`.
+- **Debounced fields only refresh a preview while the panel is already open.** Expand first, then fill, or the preview stays stale.
+
+Assert on something a user would see — rendered text, a grid cell, a snackbar — not on internal component state.
 
 ## Full coverage gate
 

--- a/docs/superpowers/plans/2026-07-26-post-implementation-verification-plan.md
+++ b/docs/superpowers/plans/2026-07-26-post-implementation-verification-plan.md
@@ -1,0 +1,229 @@
+# Post-Implementation Verification — plan
+
+## Context
+
+Agents in this repo finish implementing a feature and report done without ever exercising it. Bugs
+then get found by a review agent, or by you. The rule meant to prevent this exists but does not fire.
+
+Three concrete reasons, all found by audit:
+
+1. **The rule cancels itself.** `AGENTS.md:117` ends `…or when asking is clearly easier or faster.`
+   Asking you is always faster for the agent, so the clause licenses skipping verification in every
+   case the sentence was written to prevent. Git history shows a stronger draft (`Don't ask the user
+   to test manually what you can verify yourself`) was added in `ae19f0d` and deleted minutes later
+   by the dedupe commit `00216db`. The weak version survived.
+2. **`dck-verify` never runs the app.** Its 7 phases are build, diagnostics, antipatterns, tests,
+   security, format, diff. No runtime, no browser, no mention of Playwright or `AHKFlowApp.E2E.Tests`.
+   An agent that runs "all 7 phases" prints `Verdict: READY` with zero runtime evidence. Its trigger
+   is also strictly `before commit, push, or PR` — it never fires on "implementation finished".
+3. **No routing rule exists.** Nothing anywhere branches on what surface changed to pick a
+   verification mode. The strongest version of the rule lives in an untracked user memory file
+   (`feedback_branch_completion_pr_default.md:17`) which Codex and Copilot never see, and it says
+   *offer* a smoke pass, not *perform* one.
+
+Compounding it: `AGENTS.md` stopped naming `AHKFlowApp.E2E.Tests` two days ago (`2e888e5`), so
+"Playwright" in agent instructions now means only ad-hoc `playwright-cli` driving — while the repo
+actually has 11 mature E2E flow classes. And five documents define five different pre-PR gates with
+no cross-references.
+
+**Outcome wanted:** verification happens as part of implementing, routed by surface, with a durable
+test as the default artifact — so regressions are caught by the suite, not by a reviewer.
+
+## Assets to reuse (do not build new)
+
+| Asset | Path | Use |
+|---|---|---|
+| E2E flow suite | `tests/AHKFlowApp.E2E.Tests/*FlowTests.cs` (11 classes) | Template for new flow tests |
+| E2E stack fixture | `tests/AHKFlowApp.E2E.Tests/Fixtures/StackFixture.cs` | API+SPA+browser, `ResetDataAsync()` per test |
+| E2E test shape | `HotkeysCrudFlowTests.cs` | `[Collection(E2ETestCollection.Name)]`, `data-test` selectors, `.desktop-branch` scoping |
+| Test slice runner | `scripts/test-fast.ps1` (`-Mode Fast\|Integration\|E2E\|Coverage`) | Every command in the routing table |
+| Layer→slice routing | `docs/development/testing-workflow.md` | Becomes canonical gate owner |
+| Manual-steps format | `AGENTS.md:119-125` | Absorbed, not rewritten |
+| Skill parity tests | `tests/SkillParity.Tests.ps1`, `tests/CodexSkillsHashParity.Tests.ps1` | Verifies this plan's own `.agents/` edits |
+
+## Task 1 — `AGENTS.md`: replace `## Manual Testing Requests`
+
+Rename to `## Verification After Implementation`. Same slot in the file.
+
+- **Trigger, stated explicitly:** fires when implementation of a feature, fix, or plan task
+  completes — *before reporting it done*, not only before commit/push/PR.
+- **Delete** the clause `or when asking is clearly easier or faster.`
+- **Add the routing table** (below).
+- **Add the three exemptions** and the refactor fence (below).
+- **Absorb** the existing manual-steps checklist (preconditions / numbered steps / verbatim input /
+  expected result / per-step feedback) as the sub-block for when manual steps *are* the answer.
+- **Re-name `AHKFlowApp.E2E.Tests`** — it went missing in `2e888e5` and this rule depends on agents
+  knowing it exists.
+- **Link** `docs/development/testing-workflow.md` as the canonical gate.
+
+Routing table — the default artifact is a **durable test**, ad-hoc driving is the fallback:
+
+| Surface changed | Verification artifact | Command |
+|---|---|---|
+| Blazor UI flow, assertable | Add/extend a `*FlowTests.cs` in `tests/AHKFlowApp.E2E.Tests` | `pwsh .\scripts\test-fast.ps1 -Mode E2E` |
+| UI, visual or exploratory only | Drive the running app with the `playwright-cli` skill, capture a screenshot | Worktree ports — read the worktree's `launchSettings.json` |
+| API, use case, EF Core | Integration test (`Category=Integration` trait, or `API.Tests`) | `-Mode Integration` |
+| CLI behavior | `CLI.Tests` integration flow | `-Mode Integration` |
+| Emitted `.ahk` output | Emitter assertion on the generated text. Numbered manual steps for the user **only when the change emits a construct the repo has not shipped before** — new option flag, new escaping path, new action kind. Running `.ahk` is out of scope, so the assertion is the contract for already-proven constructs | `-Mode Fast`, plus manual steps for new constructs |
+| Domain rule, validator | Unit test | `-Mode Fast` |
+| Real Azure AD login, visual judgment call | Numbered manual steps for the user | — |
+
+Exemptions — the only cases that skip runtime verification:
+
+1. Docs, skills, or plan files only — no code compiled. Targeted text checks + diff review.
+2. Internal-only change with no observable surface — no UI, no API contract, no emitted `.ahk`
+   change, no schema change.
+3. Pure refactor with no behavior change — **fenced**: to claim this the agent must name which
+   existing tests cover the changed code and paste their fresh pass output. No named coverage, no
+   exemption; runtime verification is required instead.
+
+State the verdict either way. Naming an exemption is allowed; silence is not.
+
+## Task 2 — `.agents/dck-verify/SKILL.md`: add the runtime phase
+
+- **`description`** — add "after implementing a change" alongside `before commit, push, or PR`, so
+  the skill fires at the point the gap exists.
+- **New Phase 8 — Runtime / UI Verification.** Routes via the Task 1 table; for UI that means an
+  E2E flow test run through `test-fast.ps1 -Mode E2E`, not an ad-hoc browser drive. Ends with the
+  artifact named (test path, or screenshot, or the manual steps handed over).
+- **`## 7-Phase Pipeline` → `## 8-Phase Pipeline`**; update the Phase Selection table:
+  - `Feature, refactor, pre-PR` → All 8
+  - `Bug fix` → **Phase 8 mandatory when the bug had an observable symptom** — re-run the original
+    repro and show it gone. This is the exact gap that let the Win+Arrow snap fix ship twice without
+    working. Non-observable/internal bugs stay on build, diagnostics, tests, diff.
+  - `Skill/docs only` → exemption 1
+- **Phase 4 (Tests)** — replace the raw `dotnet test` block with the `test-fast.ps1` modes and link
+  `testing-workflow.md` as canonical. The skill currently never mentions `test-fast.ps1`,
+  `run-coverage.ps1`, or coverage thresholds at all.
+- **Final Report** — add a `Runtime` row. `Verdict: READY` is not allowed with `Runtime = SKIP`
+  unless a named exemption appears in the Evidence cell.
+
+## Task 3 — canonical pre-PR gate in `docs/development/testing-workflow.md`
+
+The five competing definitions collapse into one. `testing-workflow.md` owns it.
+
+- Add a `## Canonical pre-PR gate` section naming the one sequence, in order, with the commands it
+  already documents.
+- Point these four at it, deleting their local command lists:
+  - `AGENTS.md:200` — `Run dotnet build + dotnet test before creating a PR`
+  - `docs/development/coverage.md:3` — currently claims the title "Canonical local verification"
+  - `.github/PULL_REQUEST_TEMPLATE.md` — its own 4-item checklist
+  - `.agents/dck-verify/SKILL.md` — via the Task 2 Phase 4 edit
+
+## Task 4 — unbreak the browser-verification path
+
+The path Task 1 mandates is currently broken in two places.
+
+- **`docs/development/playwright-setup.md:34-39`** hardcodes `5601`/`5600` as *the* URLs. Agents work
+  in worktrees (mandatory for Git mutations, `AGENTS.md:203-207`) which use offset ports — following
+  this doc hits the main checkout or a dead port. Mark the table main-checkout-only and point to the
+  worktree's own `launchSettings.json`, matching `AGENTS.md:177-179`.
+- **`.agents/playwright-cli/SKILL.md`** is 328 lines of vendored generic Playwright CLI reference with
+  zero AHKFlowApp content and a generic trigger. Don't rewrite the vendored body — prepend a short
+  project-context block: worktree offset ports, the no-auth test provider (`Auth:UseTestProvider=true`,
+  always signed in as "Test User"), **prefer an E2E flow test over an ad-hoc drive**, and links to the
+  `AGENTS.md` section plus `testing-workflow.md`. Update `description` to fire on project UI
+  verification, not just "local web pages".
+- **`.claude/CLAUDE.md:12-13`** duplicates the browser-verification rule that `ae19f0d` moved to
+  `AGENTS.md` — the move left these behind. Collapse to one pointer at the new `AGENTS.md` section.
+  Keep the "don't claim a capability is unavailable without checking `.claude/skills/`" half; it is
+  a separate, still-useful guard.
+
+## Task 5 — reactivate `dck-testing` as the test-writing skill
+
+The plan mandates writing tests; the repo already has a 341-line templates skill that nothing loads
+because it is named `REFERENCE.md` instead of `SKILL.md`. Its frontmatter is already valid
+(`name: dck-testing`, description covering xUnit / WebApplicationFactory / Testcontainers / bUnit).
+
+- **Rename** `.agents/dck-testing/REFERENCE.md` → `SKILL.md`.
+- **Refresh the stale test-project list** (`REFERENCE.md:16-25`) — it predates `AHKFlowApp.E2E.Tests`,
+  `AHKFlowApp.CLI.Tests`, and `AHKFlowApp.TestUtilities`, all of which exist now.
+- **Add an E2E flow-test template** modeled on `tests/AHKFlowApp.E2E.Tests/HotkeysCrudFlowTests.cs`:
+  `[Collection(E2ETestCollection.Name)]`, `StackFixture` injection, `ResetDataAsync()` in
+  `InitializeAsync`, `data-test` selectors, and `.desktop-branch` scoping so a selector cannot match
+  both the desktop and mobile branch. This is the artifact the Task 1 routing table demands most
+  often, so the template carries the most weight.
+- **Cross-link** to `testing-workflow.md` for which slice to run, and to the `AGENTS.md` section for
+  when to write which kind of test.
+- **Trim overlap** with `AGENTS.md` Testing — the skill keeps code templates, `AGENTS.md` keeps the
+  principles. Don't restate the anti-patterns in both.
+
+## Task 6 — dedupe the user memory
+
+`feedback_branch_completion_pr_default.md:17` holds the strongest wording of this rule but says
+*offer* a smoke pass at recommendation level "recommended". Once `AGENTS.md` says *do it*, the memory
+contradicts the repo and only Claude Code can see it.
+
+Slim it to the push+PR fact it is named for, and replace the smoke-pass paragraph with a pointer to
+the `AGENTS.md` section. Keep the Debug-vs-Release gotcha — that one is a real trap and now also
+lives in `AGENTS.md` Testing from commit `4a846d1`, so make the memory defer rather than restate.
+
+## Not doing
+
+- **Stop hook gate.** You chose docs-only. The pre-push hook already runs build+tests, your insights
+  report flagged slow-hook friction, and a Stop hook cannot tell whether *UI* verification happened —
+  it would give false assurance.
+- **Consolidating the `AGENTS.md` Testing section into `testing-workflow.md`.** Tempting while
+  reshuffling testing docs, but `AGENTS.md` is read unconditionally by every agent and the principles
+  belong there. Only command detail moves out.
+
+## Commits
+
+Branch `docs/wt-verification-routing`, worktree `.claude/worktrees/verification-routing` — both
+already created. This plan is already committed there as `7345fa2`
+(`docs/superpowers/plans/2026-07-26-post-implementation-verification-plan.md`), so execution starts
+at commit 2 below.
+
+1. ~~plan doc~~ — landed, `7345fa2`
+2. `docs: route verification by surface after implementation` — Task 1
+3. `docs: add runtime phase to dck-verify` — Task 2
+4. `docs: one canonical pre-PR gate` — Task 3
+5. `docs: fix worktree ports + playwright-cli project context` — Task 4
+6. `docs: reactivate dck-testing with E2E template` — Task 5
+
+Task 6 (memory dedupe) is a user-config edit outside the repo, not a commit. Per the standing rule on
+`~/.claude` changes, flag it for the user to commit in their own config repo.
+
+Amend `7345fa2` if the answers below change the plan text, so the committed plan matches what ships.
+
+Separate and unrelated: the `docs/wt-insights-rules` worktree from earlier this session holds
+`4a846d1` (root-cause + smoke-test + laptop-key rules), still unpushed. `git worktree prune` also
+needs running — the dead `wt-hotkey-type-filter` registration errors on every worktree creation.
+
+## Verification
+
+This plan's own changes are docs + skills only, so **exemption 1 applies** — and the exemption still
+has to produce evidence:
+
+1. `pwsh ./scripts/agents/setup-cross-agent-skills.ps1` — required after any `.agents/` change;
+   expect a `[DONE]` line. Skips silently wrong without it.
+2. `pwsh -NoProfile -File tests/SkillParity.Tests.ps1` and
+   `pwsh -NoProfile -File tests/CodexSkillsHashParity.Tests.ps1` — prove the `dck-verify`,
+   `playwright-cli`, and newly-activated `dck-testing` edits propagated to `.claude/skills/` and
+   `.github/skills/`. `dck-testing` is the one that can actually fail here: it has never had a
+   `SKILL.md`, so it has no symlink in either mirror yet.
+3. `git diff --check` plus a read-through of each changed file.
+4. Grep that no orphan cross-references remain: search for `clearly easier or faster`,
+   `7-Phase`, and `Manual Testing Requests` — all three strings should be gone repo-wide.
+5. Confirm `AHKFlowApp.E2E.Tests` appears in `AGENTS.md` again.
+
+**Dogfood check:** after landing, the next UI change in this repo should produce a new or extended
+`*FlowTests.cs` without being asked. If it does not, the rule still is not firing and the wording
+needs another pass.
+
+## Decisions locked
+
+Nothing outstanding. Settled during planning:
+
+- Frontend default artifact is an E2E flow test; `playwright-cli` driving only for visual/exploratory
+  checks; manual steps only for real Azure AD, visual judgment, or an AHK runtime run.
+- Docs-only enforcement — no Stop hook.
+- Three exemptions, with the refactor one fenced by named covering tests plus fresh green output.
+- `testing-workflow.md` owns the single canonical pre-PR gate; four other definitions link to it.
+- `dck-testing` reactivated as the test-writing templates skill, refreshed with an E2E template.
+- Manual AHK checklist only for constructs the repo has not emitted before.
+- Phase 8 mandatory for bug fixes that had an observable symptom.
+
+One risk worth naming: this plan fixes wording, and wording already failed once here — the strong
+draft was deleted by a dedupe commit minutes after it landed. The dogfood check above is the only real
+proof. If the next UI change does not produce a flow test unprompted, the fix did not take.

--- a/docs/superpowers/plans/2026-07-26-post-implementation-verification-plan.md
+++ b/docs/superpowers/plans/2026-07-26-post-implementation-verification-plan.md
@@ -129,24 +129,25 @@ The path Task 1 mandates is currently broken in two places.
   Keep the "don't claim a capability is unavailable without checking `.claude/skills/`" half; it is
   a separate, still-useful guard.
 
-## Task 5 — reactivate `dck-testing` as the test-writing skill
+## Task 5 — dropped mid-execution: do not reactivate `dck-testing`
 
-The plan mandates writing tests; the repo already has a 341-line templates skill that nothing loads
-because it is named `REFERENCE.md` instead of `SKILL.md`. Its frontmatter is already valid
-(`name: dck-testing`, description covering xUnit / WebApplicationFactory / Testcontainers / bUnit).
+Originally this task reactivated `.agents/dck-testing/REFERENCE.md` as a `SKILL.md` to hold the E2E
+template. **Reversed during execution after checking history.** `45278aa` (2026-07-16) retired that
+skill and five siblings deliberately:
 
-- **Rename** `.agents/dck-testing/REFERENCE.md` → `SKILL.md`.
-- **Refresh the stale test-project list** (`REFERENCE.md:16-25`) — it predates `AHKFlowApp.E2E.Tests`,
-  `AHKFlowApp.CLI.Tests`, and `AHKFlowApp.TestUtilities`, all of which exist now.
-- **Add an E2E flow-test template** modeled on `tests/AHKFlowApp.E2E.Tests/HotkeysCrudFlowTests.cs`:
-  `[Collection(E2ETestCollection.Name)]`, `StackFixture` injection, `ResetDataAsync()` in
-  `InitializeAsync`, `data-test` selectors, and `.desktop-branch` scoping so a selector cannot match
-  both the desktop and mobile branch. This is the artifact the Task 1 routing table demands most
-  often, so the template carries the most weight.
-- **Cross-link** to `testing-workflow.md` for which slice to run, and to the `AGENTS.md` section for
-  when to write which kind of test.
-- **Trim overlap** with `AGENTS.md` Testing — the skill keeps code templates, `AGENTS.md` keeps the
-  principles. Don't restate the anti-patterns in both.
+> Ambient triggers ("use when writing C#") never fire — no discrete moment to load a reference.
+> Content already in always-loaded AGENTS.md, so each was a second source of truth that could drift.
+
+`.claude/skills/README.md:21-25` documents `REFERENCE.md` as the retirement convention, and unique
+rules were ported into `AGENTS.md` before retiring. One of the two reasons has expired — the routing
+table *is* the discrete trigger that was missing — but the drift risk has not.
+
+**Resolution:** the E2E flow-test template went into `docs/development/testing-workflow.md` (Task 3),
+which now owns testing routing anyway. `dck-testing` stays retired. Skill count unchanged.
+
+Worth recording as a process point: the original framing here ("deactivated by filename, nothing loads
+it") was asserted without reading git history, and a decision was taken on it. That is the same defect
+this plan exists to prevent.
 
 ## Task 6 — dedupe the user memory
 
@@ -169,22 +170,19 @@ lives in `AGENTS.md` Testing from commit `4a846d1`, so make the memory defer rat
 
 ## Commits
 
-Branch `docs/wt-verification-routing`, worktree `.claude/worktrees/verification-routing` — both
-already created. This plan is already committed there as `7345fa2`
-(`docs/superpowers/plans/2026-07-26-post-implementation-verification-plan.md`), so execution starts
-at commit 2 below.
+Branch `docs/wt-verification-routing`, worktree `.claude/worktrees/verification-routing`. As landed:
 
-1. ~~plan doc~~ — landed, `7345fa2`
-2. `docs: route verification by surface after implementation` — Task 1
-3. `docs: add runtime phase to dck-verify` — Task 2
-4. `docs: one canonical pre-PR gate` — Task 3
-5. `docs: fix worktree ports + playwright-cli project context` — Task 4
-6. `docs: reactivate dck-testing with E2E template` — Task 5
+| SHA | Commit | Task |
+|---|---|---|
+| `743264d` | `docs: plan post-implementation verification routing` | this plan |
+| `bf344c6` | `docs: route verification by surface after implementation` | 1 |
+| `d6acbf0` | `docs: add runtime phase to dck-verify` | 2 |
+| `86fa855` | `docs: one canonical pre-PR gate` | 3 + E2E template |
+| `7f2a187` | `docs: fix worktree ports + playwright-cli project context` | 4 |
+| `249f9a2` | `chore: refresh Codex plugin mirror for skill edits` | setup script output |
 
-Task 6 (memory dedupe) is a user-config edit outside the repo, not a commit. Per the standing rule on
-`~/.claude` changes, flag it for the user to commit in their own config repo.
-
-Amend `7345fa2` if the answers below change the plan text, so the committed plan matches what ships.
+Task 5 was dropped (see above). Task 6 (memory dedupe) is a user-config edit outside the repo, not a
+commit — per the standing rule on `~/.claude` changes, the user commits it in their own config repo.
 
 Separate and unrelated: the `docs/wt-insights-rules` worktree from earlier this session holds
 `4a846d1` (root-cause + smoke-test + laptop-key rules), still unpushed. `git worktree prune` also
@@ -198,10 +196,9 @@ has to produce evidence:
 1. `pwsh ./scripts/agents/setup-cross-agent-skills.ps1` — required after any `.agents/` change;
    expect a `[DONE]` line. Skips silently wrong without it.
 2. `pwsh -NoProfile -File tests/SkillParity.Tests.ps1` and
-   `pwsh -NoProfile -File tests/CodexSkillsHashParity.Tests.ps1` — prove the `dck-verify`,
-   `playwright-cli`, and newly-activated `dck-testing` edits propagated to `.claude/skills/` and
-   `.github/skills/`. `dck-testing` is the one that can actually fail here: it has never had a
-   `SKILL.md`, so it has no symlink in either mirror yet.
+   `pwsh -NoProfile -File tests/CodexSkillsHashParity.Tests.ps1` — prove the `dck-verify` and
+   `playwright-cli` edits propagated to `.claude/skills/` and `.github/skills/`. The Codex hash parity
+   script is Linux-only and skips on Windows; the setup script's own hard-link refresh covers it.
 3. `git diff --check` plus a read-through of each changed file.
 4. Grep that no orphan cross-references remain: search for `clearly easier or faster`,
    `7-Phase`, and `Manual Testing Requests` — all three strings should be gone repo-wide.
@@ -220,7 +217,7 @@ Nothing outstanding. Settled during planning:
 - Docs-only enforcement — no Stop hook.
 - Three exemptions, with the refactor one fenced by named covering tests plus fresh green output.
 - `testing-workflow.md` owns the single canonical pre-PR gate; four other definitions link to it.
-- `dck-testing` reactivated as the test-writing templates skill, refreshed with an E2E template.
+- `dck-testing` stays retired per `45278aa`; the E2E template lives in `testing-workflow.md` instead.
 - Manual AHK checklist only for constructs the repo has not emitted before.
 - Phase 8 mandatory for bug fixes that had an observable symptom.
 

--- a/docs/superpowers/plans/2026-07-26-post-implementation-verification-plan.md
+++ b/docs/superpowers/plans/2026-07-26-post-implementation-verification-plan.md
@@ -140,7 +140,13 @@ skill and five siblings deliberately:
 
 `.claude/skills/README.md:21-25` documents `REFERENCE.md` as the retirement convention, and unique
 rules were ported into `AGENTS.md` before retiring. One of the two reasons has expired — the routing
-table *is* the discrete trigger that was missing — but the drift risk has not.
+table *is* the discrete trigger that was missing — but the drift risk has not, and the drift already
+happened: `REFERENCE.md:121-134` builds a per-class `MsSqlContainer` and migrates it by hand, while the
+live API suite uses a shared `[Collection("WebApi")]` plus `ApiTestFixture`
+(`tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs:12-15`). Refreshing the project
+list alone would have shipped a misleading template. A correct reactivation means rewriting every
+template against the live suites — a bigger job than this plan, and not one worth doing to hold a
+single E2E snippet.
 
 **Resolution:** the E2E flow-test template went into `docs/development/testing-workflow.md` (Task 3),
 which now owns testing routing anyway. `dck-testing` stays retired. Skill count unchanged.
@@ -195,13 +201,23 @@ has to produce evidence:
 
 1. `pwsh ./scripts/agents/setup-cross-agent-skills.ps1` — required after any `.agents/` change;
    expect a `[DONE]` line. Skips silently wrong without it.
-2. `pwsh -NoProfile -File tests/SkillParity.Tests.ps1` and
-   `pwsh -NoProfile -File tests/CodexSkillsHashParity.Tests.ps1` — prove the `dck-verify` and
-   `playwright-cli` edits propagated to `.claude/skills/` and `.github/skills/`. The Codex hash parity
-   script is Linux-only and skips on Windows; the setup script's own hard-link refresh covers it.
+2. `pwsh -NoProfile -File tests/SkillParity.Tests.ps1` — proves the **Codex plugin mirror**
+   (`plugins/ahkflowapp/skills`) is byte-identical to `.agents`. That is all it checks: it never reads
+   `.claude/skills/` or `.github/skills/` (`SkillParity.Tests.ps1:10-11`).
+   `tests/CodexSkillsHashParity.Tests.ps1` skips on Windows — the bash script is Linux-only — so it
+   proves nothing here.
+   The symlink mirrors are proven instead by the setup script's own per-entry output
+   (`[OK] .claude/skills/<name> already points to .agents/<name>`, same for `.github/skills`). Read
+   those lines; don't infer them from the parity test.
 3. `git diff --check` plus a read-through of each changed file.
-4. Grep that no orphan cross-references remain: search for `clearly easier or faster`,
-   `7-Phase`, and `Manual Testing Requests` — all three strings should be gone repo-wide.
+4. Grep that no orphan cross-references remain in **active instruction surfaces** — search
+   `clearly easier or faster`, `7-Phase`, and `Manual Testing Requests` across `AGENTS.md`, `.agents/`,
+   `.claude/`, `.github/`, and `docs/development/`. Not repo-wide: this plan quotes all three strings
+   as historical context, so an unrestricted search can never come back empty.
+
+   ```bash
+   git grep -n -- "clearly easier or faster" -- AGENTS.md .agents .claude .github docs/development
+   ```
 5. Confirm `AHKFlowApp.E2E.Tests` appears in `AGENTS.md` again.
 
 **Dogfood check:** after landing, the next UI change in this repo should produce a new or extended

--- a/docs/superpowers/plans/2026-07-26-post-implementation-verification-plan.md
+++ b/docs/superpowers/plans/2026-07-26-post-implementation-verification-plan.md
@@ -23,7 +23,7 @@ Three concrete reasons, all found by audit:
 
 Compounding it: `AGENTS.md` stopped naming `AHKFlowApp.E2E.Tests` two days ago (`2e888e5`), so
 "Playwright" in agent instructions now means only ad-hoc `playwright-cli` driving — while the repo
-actually has 11 mature E2E flow classes. And five documents define five different pre-PR gates with
+actually has 10 mature E2E flow classes. And five documents define five different pre-PR gates with
 no cross-references.
 
 **Outcome wanted:** verification happens as part of implementing, routed by surface, with a durable
@@ -33,7 +33,7 @@ test as the default artifact — so regressions are caught by the suite, not by 
 
 | Asset | Path | Use |
 |---|---|---|
-| E2E flow suite | `tests/AHKFlowApp.E2E.Tests/*FlowTests.cs` (11 classes) | Template for new flow tests |
+| E2E flow suite | `tests/AHKFlowApp.E2E.Tests/*FlowTests.cs` (10 classes) | Template for new flow tests |
 | E2E stack fixture | `tests/AHKFlowApp.E2E.Tests/Fixtures/StackFixture.cs` | API+SPA+browser, `ResetDataAsync()` per test |
 | E2E test shape | `HotkeysCrudFlowTests.cs` | `[Collection(E2ETestCollection.Name)]`, `data-test` selectors, `.desktop-branch` scoping |
 | Test slice runner | `scripts/test-fast.ps1` (`-Mode Fast\|Integration\|E2E\|Coverage`) | Every command in the routing table |

--- a/plugins/ahkflowapp/.codex-plugin/plugin.json
+++ b/plugins/ahkflowapp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ahkflowapp",
-  "version": "0.1.0+codex.25c51d5d88d6",
+  "version": "0.1.0+codex.004384b32475",
   "description": "Repo-local Codex plugin exposing focused AHKFlowApp project skills.",
   "author": {
     "name": "AHKFlowApp maintainers",

--- a/plugins/ahkflowapp/skills/dck-verify/SKILL.md
+++ b/plugins/ahkflowapp/skills/dck-verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dck-verify
-description: Use when verifying AHKFlowApp build, tests, formatting, diagnostics, security, or readiness before commit, push, or PR.
+description: Use when verifying AHKFlowApp build, tests, formatting, diagnostics, security, runtime behavior, or readiness — after implementing a change, and before commit, push, or PR.
 ---
 
 # Verify
@@ -13,8 +13,8 @@ Verification is evidence, not confidence. Report PASS, WARN, FAIL, or SKIP for e
 
 | Change | Phases |
 |---|---|
-| Feature, refactor, pre-PR | All 7 |
-| Bug fix | Build, diagnostics, tests, diff |
+| Feature, refactor, pre-PR | All 8 |
+| Bug fix | Build, diagnostics, tests, diff — **plus runtime when the bug had an observable symptom** |
 | Dependency update | Build, tests, vulnerable packages, format |
 | EF migration | Build, migration SQL review, tests, format, diff |
 | Skill/docs only | Targeted text checks, setup script if skill surface changed, diff |
@@ -22,7 +22,7 @@ Verification is evidence, not confidence. Report PASS, WARN, FAIL, or SKIP for e
 
 When unsure, run the full pipeline.
 
-## 7-Phase Pipeline
+## 8-Phase Pipeline
 
 ### 1. Build
 
@@ -55,18 +55,18 @@ Look especially for sync-over-async, `DateTime.Now`/`UtcNow`, missing `Cancellat
 
 ### 4. Tests
 
-```bash
-dotnet test --configuration Release --no-build --verbosity normal
-```
-
-For narrow changes, run affected test projects first, then broaden if risk warrants:
+Pick the slice that covers what changed. `docs/development/testing-workflow.md` owns the mode
+definitions and the canonical pre-PR gate — follow it rather than restating commands here.
 
 ```bash
-dotnet test tests/AHKFlowApp.Application.Tests --configuration Release --verbosity normal
-dotnet test tests/AHKFlowApp.API.Tests --configuration Release --verbosity normal
+pwsh .\scripts\test-fast.ps1 -Mode Fast          # domain, validators, bUnit
+pwsh .\scripts\test-fast.ps1 -Mode Integration   # EF Core, API, CLI flows
+pwsh .\scripts\test-fast.ps1 -Mode E2E           # browser, PWA, mobile viewport
+pwsh .\scripts\test-fast.ps1 -Mode Coverage      # full gate before a PR
 ```
 
-Any failing test is FAIL.
+The script manages one disposable shared SQL container; plain `dotnet test` falls back to slower
+per-project Testcontainers. Any failing test is FAIL.
 
 ### 5. Security and Packages
 
@@ -101,6 +101,29 @@ git diff --check
 
 Inspect the diff for accidental files, debug leftovers, secrets, stale references, and changes outside the task.
 
+### 8. Runtime Verification
+
+The other seven phases prove the code compiles and the existing suite still passes. None of them
+exercise the change. This phase does.
+
+Route on what surface changed — the table in `AGENTS.md` under **Verification After Implementation**
+is authoritative. In short:
+
+| Changed | Evidence |
+|---|---|
+| Blazor UI flow | A new or extended `*FlowTests.cs` in `tests/AHKFlowApp.E2E.Tests`, green under `-Mode E2E` |
+| UI, visual only | A `playwright-cli` drive of the running app plus a screenshot |
+| API, use case, EF Core | An integration test covering the new behavior, green under `-Mode Integration` |
+| CLI | A `CLI.Tests` integration flow, green under `-Mode Integration` |
+| Emitted `.ahk` | An assertion on the generated text; manual AHK steps only for a construct never shipped before |
+| Bug fix with an observable symptom | The original repro re-run, showing the symptom gone |
+
+Prefer a durable test over a one-off drive — a test keeps proving the behavior after this session.
+
+Report the artifact by path, not as a claim. SKIP is allowed only for one of the three exemptions in
+`AGENTS.md`, and the exemption must be named. For the refactor exemption, name the covering tests and
+paste their fresh output.
+
 ## Skill Surface Verification
 
 When `.agents/*` skills change:
@@ -130,8 +153,12 @@ For renamed skills, confirm no stale `.agents/cck-*` directories remain and the 
 | Tests | PASS | Failed: 0 |
 | Format | PASS | verify-no-changes exit 0 |
 | Diff | WARN | docs-only changes plus plugin cache refresh |
+| Runtime | PASS | HotkeysCrudFlowTests.CreateRunHotkey_... green under -Mode E2E |
 
 Verdict: READY / NEEDS FIXES
 ```
 
 Do not claim ready until the evidence is fresh.
+
+`Runtime = SKIP` blocks `READY` unless the Evidence cell names one of the three `AGENTS.md`
+exemptions. Green build and green tests are not runtime evidence.

--- a/plugins/ahkflowapp/skills/playwright-cli/SKILL.md
+++ b/plugins/ahkflowapp/skills/playwright-cli/SKILL.md
@@ -1,10 +1,30 @@
 ---
 name: playwright-cli
-description: Use when testing local web pages, browser behavior, screenshots, or Playwright flows from the CLI.
+description: Use when driving the AHKFlowApp UI in a browser for a visual or exploratory check, or when testing local web pages, screenshots, or Playwright flows from the CLI.
 allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
 ---
 
 # Browser Automation with playwright-cli
+
+## In this project, first
+
+**Prefer an E2E flow test over an ad-hoc drive.** If the check can be asserted, add or extend a
+`*FlowTests.cs` in `tests/AHKFlowApp.E2E.Tests` and run `pwsh .\scripts\test-fast.ps1 -Mode E2E` — the
+test keeps proving the behavior after this session ends, a drive proves it once. Reach for this skill
+when the check is visual or exploratory, or when you need to see the page to work out what is wrong.
+See **Verification After Implementation** in `AGENTS.md` for the routing, and
+`docs/development/testing-workflow.md#writing-a-flow-test` for the test template.
+
+**Get the ports from `launchSettings.json`, not from memory.** The main checkout runs the frontend on
+5601 and the API on 5600, but every agent worktree gets its own offset pair (e.g. 5603 / 5602) so it can
+run alongside. Driving 5601 from a worktree silently hits the main checkout or a dead port, and it looks
+like a broken app rather than a wrong URL.
+
+**Worktrees are already signed in.** They run no-auth (`Auth:UseTestProvider=true`, user "Test User"),
+so full CRUD is reachable with no login step. The main checkout runs real MSAL unless started on its
+`http (No Auth)` profile.
+
+Setup and troubleshooting: `docs/development/playwright-setup.md`.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

Agents finished implementing and reported done without ever exercising the change, leaving bugs for a review agent or a human to find. The rule meant to prevent that existed but never fired, for three separable reasons:

1. **It cancelled itself.** The old `AGENTS.md` rule ended `…or when asking is clearly easier or faster.` Asking is always faster for an agent. Git history shows a stronger draft landed in `ae19f0d` and was deleted minutes later by dedupe commit `00216db`; the weak version survived.
2. **`dck-verify` never ran the app.** Its 7 phases were build, diagnostics, antipatterns, tests, security, format, diff — no runtime, no browser, no mention of `AHKFlowApp.E2E.Tests`. `Verdict: READY` was reachable with zero runtime evidence, and its trigger was strictly `before commit, push, or PR`.
3. **No routing rule existed.** Nothing branched on what surface changed to pick a verification mode. The strongest wording lived in an untracked user memory file that Codex and Copilot never see, and it said *offer* a smoke pass, not *perform* one.

## Changes

- `AGENTS.md` → `## Verification After Implementation`: fires before reporting done, routes by changed surface, escape hatch deleted. Three exemptions, with the refactor one fenced — claiming it requires naming the covering tests and pasting fresh green output.
- `dck-verify` gains **Phase 8 Runtime**, trigger widened to fire after implementing, test phase switched to `test-fast.ps1` modes. `Runtime = SKIP` blocks `READY` unless a named exemption appears.
- `docs/development/testing-workflow.md` becomes the single canonical pre-PR gate. Four competing definitions (`AGENTS.md`, `coverage.md`, the PR template, `dck-verify`) now link to it. Also carries an E2E flow-test template.
- Unbroke the browser path: `playwright-setup.md` hardcoded ports that are dead inside a worktree; `playwright-cli/SKILL.md` was vendored generic text with no project context or E2E-first preference.
- PR template asks how the change was exercised.

Default artifact is a **durable test**, not an ad-hoc drive — the repo has 10 mature E2E flow classes with a shared `StackFixture`, so writing one is cheap.

## Two reversals worth reviewing

**`dck-testing` stays retired.** An earlier draft reactivated it to hold the E2E template. Reversed after reading history: `45278aa` retired it deliberately, and the drift is real — its handler template still builds a per-class `MsSqlContainer` while the live API suite uses shared `ApiTestFixture` (`HotstringsEndpointsTests.cs:12-15`). Template went to `testing-workflow.md` instead. Recorded in the plan doc.

**"CI enforces on every PR" was false.** `ci.yml`'s `paths-filter` skips build, test, and coverage for PRs touching only markdown, docs, or `.claude`. Qualified as "non-docs" in all four places that claimed it.

## Verification

Docs and skills only, so exemption 1 — which still requires evidence:

- `setup-cross-agent-skills.ps1` → `[DONE]`, Codex plugin mirror refreshed
- `SkillParity.Tests.ps1` → passed. Note it compares `.agents` against the **Codex plugin mirror only**; the symlink mirrors are proven by the setup script's per-entry output instead. `CodexSkillsHashParity.Tests.ps1` skips on Windows.
- Scoped grep confirms `clearly easier or faster`, `7-Phase`, `Manual Testing Requests` are gone from active instruction surfaces. Deliberately scoped, not repo-wide — the plan doc quotes all three as historical context.
- `git diff --check main...HEAD` clean

**No build or test run** — `dotnet` was never invoked, and this PR is docs-only so CI will skip those jobs too.

## Ordering

Touches `AGENTS.md`, as does #216. Whichever merges second needs a rebase. #216 also carries the Release-build rule that a user-level memory note currently stands in for.

Plan: `docs/superpowers/plans/2026-07-26-post-implementation-verification-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)