### PR TITLE
fix: TimeProvider for download filename stamp

### DIFF
--- a/src/Backend/AHKFlowApp.API/Controllers/DownloadsController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/DownloadsController.cs
@@ -33,7 +33,7 @@ public sealed class DownloadsController(
     {
         Result<ProfileScript> result = await generateProfileScript.ExecuteAsync(new GenerateProfileScriptQuery(profileId), ct);
         if (!result.IsSuccess)
-            return result.ToProblemActionResult(this).Result!;
+            return result.ToProblemResult(this);
 
         byte[] bytes = Encoding.UTF8.GetBytes(result.Value.Content);
         return File(bytes, AhkContentType, fileDownloadName: result.Value.FileName);
@@ -59,7 +59,7 @@ public sealed class DownloadsController(
     {
         Result<ProfileScriptZip> result = await generateAllProfileScriptsZip.ExecuteAsync(new GenerateAllProfileScriptsZipQuery(), ct);
         if (!result.IsSuccess)
-            return result.ToProblemActionResult(this).Result!;
+            return result.ToProblemResult(this);
 
         return File(result.Value.Content, ZipContentType, fileDownloadName: result.Value.FileName);
     }

--- a/src/Backend/AHKFlowApp.API/Extensions/ProblemDetailsResultExtensions.cs
+++ b/src/Backend/AHKFlowApp.API/Extensions/ProblemDetailsResultExtensions.cs
@@ -29,6 +29,19 @@ internal static class ProblemDetailsResultExtensions
             ? new OkResult()
             : BuildProblem(result.Status, result.Errors, result.ValidationErrors, controller.HttpContext);
 
+    /// <summary>
+    /// The same problem response as <see cref="ToProblemActionResult{T}"/>, but as a bare
+    /// <see cref="IActionResult"/> — for actions whose success path returns a file rather than
+    /// <typeparamref name="T"/>, so the declared return type is <c>Task&lt;IActionResult&gt;</c>.
+    /// Both <c>ActionResult&lt;T&gt;</c> branches are built from an <see cref="ActionResult"/>,
+    /// so <c>Result</c> is always populated. Use this instead of reading
+    /// <c>ToProblemActionResult(...).Result</c> at the call site: that property is not
+    /// <see cref="Task{TResult}.Result"/>, but it reads exactly like it and invites a
+    /// sync-over-async misdiagnosis on every review.
+    /// </summary>
+    public static IActionResult ToProblemResult<T>(this Result<T> result, ControllerBase controller) =>
+        result.ToProblemActionResult(controller).Result!;
+
     private static ObjectResult BuildProblem(
         ResultStatus status,
         IEnumerable<string> errors,

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/DownloadFileNames.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/DownloadFileNames.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+
+namespace AHKFlowApp.UI.Blazor.Helpers;
+
+/// <summary>
+/// Sortable local-time stamps for generated download file names. Invariant culture keeps the
+/// stamp digits identical on every machine — a non-Gregorian calendar culture would otherwise
+/// change the year in the file name.
+/// </summary>
+public static class DownloadFileNames
+{
+    /// <summary>Stamps the clock's current local moment, e.g. <c>20260726_140509</c>.</summary>
+    public static string Timestamp(TimeProvider clock) => Timestamp(clock.GetLocalNow());
+
+    /// <summary>Stamps an explicit local moment, e.g. <c>20260726_140509</c>.</summary>
+    public static string Timestamp(DateTimeOffset localNow) =>
+        localNow.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Downloads.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Downloads.razor
@@ -64,6 +64,7 @@
     [Inject] private IDownloadsApiClient DownloadsApi { get; set; } = default!;
     [Inject] private IFileSaver FileSaver { get; set; } = default!;
     [Inject] private ISnackbar Snackbar { get; set; } = default!;
+    [Inject] private TimeProvider Clock { get; set; } = default!;
 
     private List<ProfileDto> _profiles = [];
     private bool _isAuthenticated;
@@ -155,7 +156,7 @@
         }
     }
 
-    private static string Timestamp() => DownloadFileNames.Timestamp(TimeProvider.System);
+    private string Timestamp() => DownloadFileNames.Timestamp(Clock);
 
     private static string SafeStem(string name)
     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Downloads.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Downloads.razor
@@ -1,5 +1,6 @@
 @page "/downloads"
 @using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Helpers
 @using AHKFlowApp.UI.Blazor.Services
 @using MudBlazor
 @using Microsoft.AspNetCore.Components.Authorization
@@ -154,7 +155,7 @@
         }
     }
 
-    private static string Timestamp() => DateTime.Now.ToString("yyyyMMdd_HHmmss");
+    private static string Timestamp() => DownloadFileNames.Timestamp(TimeProvider.System);
 
     private static string SafeStem(string name)
     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
@@ -47,6 +47,7 @@ if (!useTestAuth)
 builder.RootComponents.Add<AHKFlowApp.UI.Blazor.App>("#app");
 
 builder.Services.AddMudServices();
+builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddScoped<IFileSaver, JsFileSaver>();
 builder.Services.AddScoped<LocalStorageUserPreferencesService>();
 builder.Services.AddScoped<IUserPreferencesService, HybridUserPreferencesService>();

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/DownloadFileNamesTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/DownloadFileNamesTests.cs
@@ -1,0 +1,28 @@
+using AHKFlowApp.UI.Blazor.Helpers;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Helpers;
+
+public sealed class DownloadFileNamesTests
+{
+    [Fact]
+    public void Timestamp_formats_local_moment_as_sortable_stamp() =>
+        DownloadFileNames.Timestamp(new DateTimeOffset(2026, 7, 26, 14, 5, 9, TimeSpan.FromHours(2)))
+            .Should().Be("20260726_140509");
+
+    [Fact]
+    public void Timestamp_pads_single_digit_parts() =>
+        DownloadFileNames.Timestamp(new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero))
+            .Should().Be("20260102_030405");
+
+    [Fact]
+    public void Timestamp_reads_the_clock_in_local_time()
+    {
+        FakeTimeProvider clock = new(new DateTimeOffset(2026, 7, 26, 12, 0, 0, TimeSpan.Zero));
+        clock.SetLocalTimeZone(TimeZoneInfo.CreateCustomTimeZone("t", TimeSpan.FromHours(2), "t", "t"));
+
+        DownloadFileNames.Timestamp(clock).Should().Be("20260726_140000");
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/DownloadFileNamesTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/DownloadFileNamesTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using AHKFlowApp.UI.Blazor.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.Time.Testing;
@@ -24,5 +25,22 @@ public sealed class DownloadFileNamesTests
         clock.SetLocalTimeZone(TimeZoneInfo.CreateCustomTimeZone("t", TimeSpan.FromHours(2), "t", "t"));
 
         DownloadFileNames.Timestamp(clock).Should().Be("20260726_140000");
+    }
+
+    [Fact]
+    public void Timestamp_ignores_a_non_Gregorian_ambient_calendar()
+    {
+        CultureInfo original = CultureInfo.CurrentCulture;
+        // th-TH resolves to the Buddhist calendar, which would stamp year 2569 without InvariantCulture.
+        CultureInfo.CurrentCulture = new CultureInfo("th-TH");
+        try
+        {
+            DownloadFileNames.Timestamp(new DateTimeOffset(2026, 7, 26, 14, 5, 9, TimeSpan.Zero))
+                .Should().Be("20260726_140509");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
     }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/DownloadsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/DownloadsPageTests.cs
@@ -6,6 +6,7 @@ using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using MudBlazor;
 using MudBlazor.Services;
 using NSubstitute;
@@ -18,6 +19,7 @@ public sealed class DownloadsPageTests : BunitContext, IAsyncLifetime
     private readonly IProfilesApiClient _profiles = Substitute.For<IProfilesApiClient>();
     private readonly IDownloadsApiClient _downloads = Substitute.For<IDownloadsApiClient>();
     private readonly IFileSaver _saver = Substitute.For<IFileSaver>();
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 7, 26, 14, 5, 9, TimeSpan.Zero));
 
     private static readonly Task<AuthenticationState> AuthenticatedState =
         Task.FromResult(new AuthenticationState(
@@ -28,6 +30,7 @@ public sealed class DownloadsPageTests : BunitContext, IAsyncLifetime
         Services.AddSingleton(_profiles);
         Services.AddSingleton(_downloads);
         Services.AddSingleton(_saver);
+        Services.AddSingleton<TimeProvider>(_clock);
         Services.AddMudServices();
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
@@ -82,9 +85,9 @@ public sealed class DownloadsPageTests : BunitContext, IAsyncLifetime
         cut.WaitForAssertion(() => cut.Find("button.download-profile"));
         cut.Find("button.download-profile").Click();
 
-        // filename is {yyyyMMdd_HHmmss}_ahkflow_Work.ahk — assert suffix, not exact timestamp
+        // Exact name — the stamp comes from the injected clock, so it is deterministic.
         return _saver.Received(1).SaveAsync(
-            Arg.Is<string>(n => n.EndsWith("_ahkflow_Work.ahk")),
+            "20260726_140509_ahkflow_Work.ahk",
             "text/plain; charset=utf-8",
             Arg.Is<byte[]>(b => b.SequenceEqual(payload.Content)));
     }
@@ -101,9 +104,9 @@ public sealed class DownloadsPageTests : BunitContext, IAsyncLifetime
         cut.WaitForAssertion(() => cut.Find("button.download-all"));
         cut.Find("button.download-all").Click();
 
-        // filename is {yyyyMMdd_HHmmss}_ahkflow_scripts.zip — assert suffix
+        // Exact name — the stamp comes from the injected clock, so it is deterministic.
         return _saver.Received(1).SaveAsync(
-            Arg.Is<string>(n => n.EndsWith("_ahkflow_scripts.zip")),
+            "20260726_140509_ahkflow_scripts.zip",
             "application/zip",
             Arg.Is<byte[]>(b => b.SequenceEqual(zip.Content)));
     }


### PR DESCRIPTION
## What

The Downloads page stamped generated file names with `DateTime.Now`, violating the `TimeProvider` rule and leaving the filename format unreachable from a test.

- `DownloadFileNames.Timestamp` extracts the stamp behind a `TimeProvider` seam, formatting with `InvariantCulture` so a non-Gregorian calendar culture cannot change the year in the file name.
- `Downloads.razor` injects `TimeProvider` instead of reaching for `TimeProvider.System`, so the page's clock is substitutable in tests.
- `ToProblemResult` gives file-returning controller actions a named extension instead of a bare `ActionResult<T>.Result` at the call site.

## Why `ToProblemResult`

`ActionResult<T>.Result` is not `Task<T>.Result` — it does not block — but it reads exactly like it, and reviewers and syntactic analyzers keep flagging the call site as sync-over-async. The extension moves that read behind one documented name so the explanation lives in one place instead of being re-litigated per review.

## Tests

| Change | Coverage |
|---|---|
| Page uses the injected clock | `DownloadsPageTests` asserts the exact file name via `FakeTimeProvider` |
| Timestamp format and local-time read | `DownloadFileNamesTests` |
| `InvariantCulture` guarantee | `DownloadFileNamesTests` under a `th-TH` (Buddhist calendar) ambient culture |

Both new guarantees were mutation-checked: reverting the page to a hardcoded clock, and dropping `InvariantCulture`, each fail the corresponding test.

## Gate

Canonical pre-PR gate, all four steps:

- `dotnet build --configuration Release` — 17 projects, 0 warnings, 0 errors
- `dotnet format --verify-no-changes` — exit 0
- `test-fast.ps1 -Mode Coverage` — 3032 passed, 0 failed (19 E2E); all per-assembly thresholds met
- `git diff --check main...HEAD` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
