### PR TITLE
docs: add Plain English writing standard

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-Be concise in all interactions. Optimize for readability when writing documentation. In commit messages, be extremely concise — sacrifice grammar for brevity.
+Be concise in all interactions. For documentation and app-facing text, follow **Plain English** in AGENTS.md — when short and easy-to-read fight, easy-to-read wins. In commit messages, be extremely concise — sacrifice grammar for brevity.
 
 @../AGENTS.md
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-Be concise in all interactions. For documentation and app-facing text, follow **Plain English** in AGENTS.md — when short and easy-to-read fight, easy-to-read wins. In commit messages, be extremely concise — sacrifice grammar for brevity.
+Be concise in all interactions. For documentation and app-facing text, follow **Plain English** in AGENTS.md — when short and easy-to-read conflict, choose easy-to-read. In commit messages, be extremely concise — sacrifice grammar for brevity.
 
 @../AGENTS.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,12 +95,13 @@ Applies to repo documentation (`docs/`, `AGENTS.md`, `CLAUDE.md`, specs, plans, 
 
 The reader may not be a native English speaker. Write so they never have to re-read a sentence.
 
-- Easy to read beats short. When the two fight, use more words.
+- Easy to read matters more than short. When the two conflict, use more words.
 - One idea per sentence. Keep sentences under about 20 words.
 - Use common words. "use" not "leverage". "cannot be undone" not "irreversible". "start" not "initiate". "text" not "prose".
 - No idioms, no metaphors, no culture references. Cut "blow past it", "moving the needle", "escape hatch".
 - Active voice. "The handler saves the record", not "the record is saved by the handler".
-- Keep technical terms exact. Never simplify `IUseCaseHandler`, `Result.NotFound()`, or an error string. Explain the term once instead.
+- Keep identifiers exact. Never simplify `IUseCaseHandler` or `Result.NotFound()`. Explain the term once instead.
+- When you quote an existing error string, keep it exact. When you write a new error message, apply the rules above.
 - Do not stack clauses. Split a long sentence into two.
 
 Commit messages and PR titles are the exception — those stay extremely short, grammar optional.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ dotnet format
 - `sealed` on classes not designed for inheritance; `internal` by default, `public` only when needed
 - Domain state: private setters plus factory/domain methods — never public setters on domain entities
 - Style (file-scoped namespaces, Allman braces, `var`, collection expressions, pattern matching) — enforced by `.editorconfig`; run `dotnet format`
-- English for all code comments and documentation
+- English for all code comments and documentation — follow **Plain English** below
 - PowerShell for script files, bash for manual scripts in .md files
 
 ### Patterns We DON'T Use (Never Suggest)
@@ -88,6 +88,22 @@ dotnet format
 - **Exceptions for flow control** — use Ardalis.Result
 - **Stored procedures** — EF Core only
 - **.NET Foundation license header** — this project is not part of the .NET Foundation
+
+## Plain English
+
+Applies to repo documentation (`docs/`, `AGENTS.md`, `CLAUDE.md`, specs, plans, skill files, README) and to app-facing text (Blazor UI labels, error messages, validation messages, CLI help and output).
+
+The reader may not be a native English speaker. Write so they never have to re-read a sentence.
+
+- Easy to read beats short. When the two fight, use more words.
+- One idea per sentence. Keep sentences under about 20 words.
+- Use common words. "use" not "leverage". "cannot be undone" not "irreversible". "start" not "initiate". "text" not "prose".
+- No idioms, no metaphors, no culture references. Cut "blow past it", "moving the needle", "escape hatch".
+- Active voice. "The handler saves the record", not "the record is saved by the handler".
+- Keep technical terms exact. Never simplify `IUseCaseHandler`, `Result.NotFound()`, or an error string. Explain the term once instead.
+- Do not stack clauses. Split a long sentence into two.
+
+Commit messages and PR titles are the exception — those stay extremely short, grammar optional.
 
 ## Testing
 


### PR DESCRIPTION
## Why

Repo instructions said both "be concise" and "optimize for readability" but ranked neither. Dense, idiom-heavy English kept winning. The reader may not be a native English speaker.

## What

New `## Plain English` section in `AGENTS.md`:

- Ranks easy-to-read above short when the two conflict.
- 7 testable rules: one idea per sentence, common words, no idioms, active voice, no stacked clauses.
- Technical terms and error strings are protected — never simplified.
- Scope: repo docs plus app-facing text (Blazor UI labels, error messages, validation messages, CLI help).
- Commit messages and PR titles stay terse, as before.

Also:
- `Code Conventions` bullet now points at the new section.
- `.claude/CLAUDE.md` line 1 rewritten to state which rule wins.

## Verification

Docs only, nothing compiled — exemption 1 in **Verification After Implementation**. Diff reviewed; no code, schema, or emitted `.ahk` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)