### PR TITLE
docs: prove plan claims before approval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,22 @@ Frameworks: xUnit, FluentAssertions (over raw `Assert`), NSubstitute, Testcontai
 
 At the end of each plan, give me a list of unresolved questions to answer, if any. Make the questions extremely concise. Sacrifice grammar for the sake of concision.
 
+### Verify the draft before you present it
+
+Run this on your own draft, right before you present a plan or spec for approval. It is not optional, and it is not something I have to ask for.
+
+Every plan names things it claims already exist. Each one is either proven or made up. Prove them:
+
+- **Code identifiers** — a type, method, property, or option a plan says to call or extend. Paste the `file:line` that defines it.
+- **Component parameters** — any MudBlazor or other component parameter you pass. Prove it from the component API, not from memory. Guessed parameter names have reached plans before.
+- **Selectors and test hooks** — every CSS selector and `data-test` value a test step depends on. Paste the `file:line` in the `.razor` file that renders it.
+- **Emitted AHK syntax** — every option flag or construct the plan says to emit. Cite [`docs/development/ahk-v2-syntax.md`](docs/development/ahk-v2-syntax.md) or the official AHK v2 docs.
+- **Branch and file state** — every claim about what is merged, what a sibling branch contains, or which files exist. Prove each with a `git` or filesystem command and keep the output.
+
+Anything you cannot prove is marked **FABRICATED** in the draft. Do not quietly delete it and do not soften it into a vague sentence. List the fabricated items, then revise, then present.
+
+Skill and reference file paths are already checked by `tests/SkillLayout.Tests.ps1` in CI. You do not need to re-check those by hand.
+
 When finalizing a plan or spec (right before presenting the final plan for approval), save it in the repo as `docs/superpowers/plans/YYYY-MM-DD-<topic>-plan.md` or `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` — never only in a local plans folder outside the repo.
 
 Only commit plans/specs to `docs/superpowers/` when they relate to project improvements — code, features, infra, deployment, tests, repo tooling that affects contributors. Skip writing (or keep out-of-repo) plans for agent optimization, personal workflow tuning, agent housekeeping, or one-off context/config cleanups.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,15 +138,14 @@ Run this on your own draft, right before you present a plan or spec for approval
 
 Every plan names things it claims already exist. Each one is either proven or made up. Prove them:
 
-- **Code identifiers** — a type, method, property, or option a plan says to call or extend. Paste the `file:line` that defines it.
-- **Component parameters** — any MudBlazor or other component parameter you pass. Prove it from the component API, not from memory. Guessed parameter names have reached plans before.
+- **Identifiers defined in this repository** — a type, method, property, or option the plan says to call or extend. Paste the `file:line` that defines it.
+- **Identifiers from .NET or a NuGet package** — `TimeProvider`, `HttpClient`, an `Ardalis.Result` member, an EF Core method. These have no `file:line` here, so that form of proof does not apply. Cite the official documentation instead, for the version this repository uses. Read that version from `Directory.Packages.props`. Never cite an external API from memory.
+- **Component parameters** — any MudBlazor or other component parameter you pass. Prove it against the component API for the version in `Directory.Packages.props`. Guessed parameter names have reached plans before.
 - **Selectors and test hooks** — every CSS selector and `data-test` value a test step depends on. Paste the `file:line` in the `.razor` file that renders it.
 - **Emitted AHK syntax** — every option flag or construct the plan says to emit. Cite [`docs/development/ahk-v2-syntax.md`](docs/development/ahk-v2-syntax.md) or the official AHK v2 docs.
 - **Branch and file state** — every claim about what is merged, what a sibling branch contains, or which files exist. Prove each with a `git` or filesystem command and keep the output.
 
 Anything you cannot prove is marked **FABRICATED** in the draft. Do not quietly delete it and do not soften it into a vague sentence. List the fabricated items, then revise, then present.
-
-Skill and reference file paths are already checked by `tests/SkillLayout.Tests.ps1` in CI. You do not need to re-check those by hand.
 
 When finalizing a plan or spec (right before presenting the final plan for approval), save it in the repo as `docs/superpowers/plans/YYYY-MM-DD-<topic>-plan.md` or `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` — never only in a local plans folder outside the repo.
 


### PR DESCRIPTION
## Why

Plans kept naming things that did not exist — component parameters, `data-test` selectors, and claims about what a sibling branch already contained. Those defects surfaced later as review findings, after code was written.

`Verification After Implementation` (added in #217) fires only once implementation is done. `## Plans` had no gate at all. This adds one.

## What

New `### Verify the draft before you present it` under `## Plans` in AGENTS.md. Six proof categories:

- repository identifiers — `file:line`
- .NET / NuGet identifiers — official docs for the version in `Directory.Packages.props`
- component parameters — the component API for that same version
- selectors and `data-test` hooks — `file:line` in the `.razor` file
- emitted AHK syntax — `docs/development/ahk-v2-syntax.md` or official AHK v2 docs
- branch and file state — a `git` or filesystem command

Unprovable items get marked **FABRICATED** and listed, not quietly dropped.

## Verification

Docs-only, nothing compiled — exemption 1 in AGENTS.md. Ran `tests/SkillLayout.Tests.ps1` anyway: passed, 25 active skills. Pre-push fast slice passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)