### PR TITLE
docs: convert template-heavy skills to pointer style

### DIFF
--- a/.agents/dck-blazor-mudblazor/SKILL.md
+++ b/.agents/dck-blazor-mudblazor/SKILL.md
@@ -18,242 +18,27 @@ description: Use when building AHKFlowApp Blazor WebAssembly UI with MudBlazor p
 
 ### Page Layout (List View)
 
-```razor
-@page "/hotstrings"
+This app uses two shapes depending on list complexity (documented in `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md`, "Conventions"):
+- **Simple list, ≤6 short fields, inline edit** — `MudTable` with inline row editing. See `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Categories.razor`.
+- **Larger list needing sort/filter/bulk-select** — `MudDataGrid` with `ServerData`, inline row editing, and a bulk-select toolbar. See `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor:70-78` (the `MudDataGrid` declaration) and `Pages/Hotkeys.razor` for a second example.
 
-<PageTitle>Hotstrings</PageTitle>
-
-<MudContainer MaxWidth="MaxWidth.Large" Class="mt-4">
-    <MudText Typo="Typo.h4" Class="mb-4">Hotstrings</MudText>
-
-    <MudButton Variant="Variant.Filled" Color="Color.Primary"
-               StartIcon="@Icons.Material.Filled.Add"
-               OnClick="OpenCreateDialog" Class="mb-4">
-        Add Hotstring
-    </MudButton>
-
-    <MudTable Items="_hotstrings" Hover Loading="_loading"
-              Breakpoint="Breakpoint.Sm" LoadingProgressColor="Color.Primary">
-        <HeaderContent>
-            <MudTh>Trigger</MudTh>
-            <MudTh>Replacement</MudTh>
-            <MudTh Style="width: 120px;">Actions</MudTh>
-        </HeaderContent>
-        <RowTemplate>
-            <MudTd DataLabel="Trigger">@context.Trigger</MudTd>
-            <MudTd DataLabel="Replacement">@context.Replacement</MudTd>
-            <MudTd>
-                <MudIconButton Icon="@Icons.Material.Filled.Edit"
-                               Size="Size.Small"
-                               OnClick="() => OpenEditDialog(context)" />
-                <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                               Size="Size.Small" Color="Color.Error"
-                               OnClick="() => ConfirmDelete(context)" />
-            </MudTd>
-        </RowTemplate>
-    </MudTable>
-</MudContainer>
-
-@code {
-    [Inject] private IAHKFlowApiHttpClient Api { get; set; } = default!;
-    [Inject] private IDialogService DialogService { get; set; } = default!;
-    [Inject] private ISnackbar Snackbar { get; set; } = default!;
-
-    private List<HotstringDto> _hotstrings = [];
-    private bool _loading = true;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await LoadDataAsync();
-    }
-
-    private async Task LoadDataAsync()
-    {
-        _loading = true;
-        _hotstrings = await Api.GetHotstringsAsync();
-        _loading = false;
-    }
-}
-```
+Pages needing mobile support render both a `.desktop-branch` and `.mobile-branch`, gated by scoped CSS at 959.95px — see `Components/Hotstrings/` and `Components/Hotkeys/` for the mobile-branch components.
 
 ### MudDialog for Create/Edit
 
-```razor
-<MudDialog>
-    <TitleContent>
-        <MudText Typo="Typo.h6">@(IsEdit ? "Edit Hotstring" : "Add Hotstring")</MudText>
-    </TitleContent>
-    <DialogContent>
-        <MudForm @ref="_form" Model="_model" Validation="_validator.ValidateValue">
-            <MudTextField @bind-Value="_model.Trigger"
-                          For="() => _model.Trigger"
-                          Label="Trigger" Variant="Variant.Outlined"
-                          Immediate />
-            <MudTextField @bind-Value="_model.Replacement"
-                          For="() => _model.Replacement"
-                          Label="Replacement" Variant="Variant.Outlined"
-                          Lines="3" Immediate />
-        </MudForm>
-    </DialogContent>
-    <DialogActions>
-        <MudButton OnClick="Cancel">Cancel</MudButton>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                   OnClick="Submit">Save</MudButton>
-    </DialogActions>
-</MudDialog>
+Full-screen `MudDialog` for create/edit is the **mobile-branch** pattern in this app, not the default — desktop list pages edit inline in the table/grid (previous section). See `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor` for the live shape: a `MudDialog` with a `TitleContent` back-button + save button, an `EditModel` (`Validation/HotstringEditModel.cs`) bound via `@bind-Value`, and per-field `Func<string,string?>` validators (see "Form Validation" below — no FluentValidation adapter is involved).
 
-@code {
-    [CascadingParameter] private MudDialogInstance MudDialog { get; set; } = default!;
-    [Parameter] public HotstringDto? Existing { get; set; }
+### Opening Dialogs / Delete Confirmation
 
-    private bool IsEdit => Existing is not null;
-    private MudForm _form = default!;
-    private CreateHotstringDto _model = new();
-    private CreateHotstringDtoValidator _validator = new();
+See `HotstringEditDialog.razor`'s caller in `Pages/Hotstrings.razor` for `IDialogService.ShowAsync<T>` and result handling, and any page's delete action for `IDialogService.ShowMessageBox(...)` — the shape (title, message, yesText/cancelText, `== true` check) matches the original template; no drift found here.
 
-    protected override void OnParametersSet()
-    {
-        if (Existing is not null)
-        {
-            _model = new() { Trigger = Existing.Trigger, Replacement = Existing.Replacement };
-        }
-    }
+### Form Validation (per-field delegates, not a FluentValidation adapter)
 
-    private async Task Submit()
-    {
-        await _form.Validate();
-        if (_form.IsValid)
-        {
-            MudDialog.Close(DialogResult.Ok(_model));
-        }
-    }
-
-    private void Cancel() => MudDialog.Cancel();
-}
-```
-
-### Opening Dialogs from Pages
-
-```csharp
-private async Task OpenCreateDialog()
-{
-    var dialog = await DialogService.ShowAsync<HotstringDialog>("Add Hotstring");
-    var result = await dialog.Result;
-
-    if (result is { Canceled: false, Data: CreateHotstringDto dto })
-    {
-        await Api.CreateHotstringAsync(dto);
-        Snackbar.Add("Hotstring created", Severity.Success);
-        await LoadDataAsync();
-    }
-}
-
-private async Task OpenEditDialog(HotstringDto hotstring)
-{
-    var parameters = new DialogParameters { ["Existing"] = hotstring };
-    var dialog = await DialogService.ShowAsync<HotstringDialog>("Edit Hotstring", parameters);
-    var result = await dialog.Result;
-
-    if (result is { Canceled: false, Data: CreateHotstringDto dto })
-    {
-        await Api.UpdateHotstringAsync(hotstring.Id, dto);
-        Snackbar.Add("Hotstring updated", Severity.Success);
-        await LoadDataAsync();
-    }
-}
-```
-
-### Delete Confirmation
-
-```csharp
-private async Task ConfirmDelete(HotstringDto hotstring)
-{
-    var confirmed = await DialogService.ShowMessageBox(
-        "Delete Hotstring",
-        $"Delete trigger '{hotstring.Trigger}'? This cannot be undone.",
-        yesText: "Delete", cancelText: "Cancel");
-
-    if (confirmed == true)
-    {
-        await Api.DeleteHotstringAsync(hotstring.Id);
-        Snackbar.Add("Hotstring deleted", Severity.Success);
-        await LoadDataAsync();
-    }
-}
-```
-
-### MudForm Validation with FluentValidation
-
-```csharp
-// Validator adapter for MudForm — wraps FluentValidation for @bind-Value + For
-public static class FluentValidationExtensions
-{
-    public static Func<object, string, Task<IEnumerable<string>>> ValidateValue<T>(
-        this IValidator<T> validator) where T : class
-    {
-        return async (model, propertyName) =>
-        {
-            var result = await validator.ValidateAsync(
-                ValidationContext<T>.CreateWithOptions(
-                    (T)model, x => x.IncludeProperties(propertyName)));
-
-            return result.IsValid
-                ? []
-                : result.Errors.Select(e => e.ErrorMessage);
-        };
-    }
-}
-```
+There is no `FluentValidationExtensions.ValidateValue` adapter in this codebase — real forms validate with a plain `Func<string, string?>` delegate per field, defined as a method on an `EditModel` class in `Validation/` (e.g. `Validation/HotstringEditModel.cs`), wired up as `Validation="@(new Func<string, string?>(Item.ValidateReplacement))"` (see `Components/Hotstrings/HotstringEditDialog.razor:90`). Don't introduce a FluentValidation-to-MudForm adapter — follow the `EditModel` pattern instead.
 
 ### Server-Side Table (Pagination/Search)
 
-```razor
-<MudTable ServerData="LoadServerData" @ref="_table" Hover
-          Loading="_loading" LoadingProgressColor="Color.Primary">
-    <ToolBarContent>
-        <MudTextField @bind-Value="_searchString" Placeholder="Search..."
-                      Adornment="Adornment.Start"
-                      AdornmentIcon="@Icons.Material.Filled.Search"
-                      Immediate DebounceInterval="300"
-                      OnDebounceIntervalElapsed="OnSearch" />
-    </ToolBarContent>
-    <HeaderContent>
-        <MudTh><MudTableSortLabel SortLabel="trigger" T="HotstringDto">Trigger</MudTableSortLabel></MudTh>
-        <MudTh><MudTableSortLabel SortLabel="replacement" T="HotstringDto">Replacement</MudTableSortLabel></MudTh>
-    </HeaderContent>
-    <RowTemplate>
-        <MudTd DataLabel="Trigger">@context.Trigger</MudTd>
-        <MudTd DataLabel="Replacement">@context.Replacement</MudTd>
-    </RowTemplate>
-    <PagerContent>
-        <MudTablePager />
-    </PagerContent>
-</MudTable>
-
-@code {
-    private MudTable<HotstringDto> _table = default!;
-    private string _searchString = string.Empty;
-    private bool _loading;
-
-    private async Task<TableData<HotstringDto>> LoadServerData(TableState state,
-        CancellationToken ct)
-    {
-        _loading = true;
-        var response = await Api.SearchHotstringsAsync(
-            _searchString, state.Page + 1, state.PageSize, state.SortLabel,
-            state.SortDirection == SortDirection.Descending, ct);
-        _loading = false;
-
-        return new TableData<HotstringDto>
-        {
-            Items = response.Items,
-            TotalItems = response.TotalCount
-        };
-    }
-
-    private void OnSearch() => _table.ReloadServerData();
-}
-```
+`Pages/Categories.razor` (`MudTable`) and `Pages/Hotstrings.razor` / `Pages/Hotkeys.razor` (`MudDataGrid`) all use `ServerData` — see "Page Layout" above for which shape applies to a new page.
 
 ## Anti-patterns
 
@@ -275,7 +60,7 @@ public static class FluentValidationExtensions
 @* BAD — validation messages won't display for this field *@
 <MudTextField @bind-Value="_model.Trigger" Label="Trigger" />
 
-@* GOOD — For links the field to FluentValidation *@
+@* GOOD — For links the field to the model's validation delegate *@
 <MudTextField @bind-Value="_model.Trigger" For="() => _model.Trigger" Label="Trigger" />
 ```
 
@@ -318,13 +103,14 @@ MudDialog.Close(DialogResult.Ok(result));
 
 | Scenario | Recommendation |
 |----------|---------------|
-| List of items | `MudTable` with `Items` (client) or `ServerData` (server) |
-| Create/Edit form | `MudDialog` + `MudForm` + FluentValidation |
+| List of items, simple (≤6 fields) | `MudTable` inline row editing (see `Categories.razor`) |
+| List of items, larger/sortable/bulk-select | `MudDataGrid` with `ServerData` (see `Hotstrings.razor`, `Hotkeys.razor`) |
+| Create/Edit form | Inline edit (`MudTable`/`MudDataGrid`) by default; `MudDialog` + `EditModel` only for the mobile branch |
 | Delete confirmation | `DialogService.ShowMessageBox()` |
 | Success/error feedback | `ISnackbar.Add()` with `Severity` |
 | Search with debounce | `MudTextField` with `DebounceInterval` + `OnDebounceIntervalElapsed` |
 | Sorting | `MudTableSortLabel` with `SortLabel` |
 | Pagination | `MudTablePager` (server-side) or built-in (client-side) |
-| Form validation | `MudForm` + `Validation` + `For` lambdas |
+| Form validation | `EditModel` with per-field `Func<string,string?>` delegates + `For` lambdas |
 | Loading indicator | `MudTable.Loading` or `MudProgressLinear` |
 | Navigation | `MudNavMenu` + `MudNavLink` |

--- a/.agents/dck-blazor-mudblazor/SKILL.md
+++ b/.agents/dck-blazor-mudblazor/SKILL.md
@@ -8,7 +8,7 @@ description: Use when building AHKFlowApp Blazor WebAssembly UI with MudBlazor p
 ## Core Principles
 
 1. **MudBlazor components first** — Always use MudBlazor components (`MudTable`, `MudForm`, `MudDialog`, `MudButton`) over raw HTML. Consistent styling, accessibility, and behavior out of the box.
-2. **Typed HttpClient for all API calls** — Use `IAHKFlowApiHttpClient` (registered via `AddHttpClient<T>`). Never create HttpClient manually.
+2. **Typed API client per entity** — Use the per-entity interface in `src/Frontend/AHKFlowApp.UI.Blazor/Services/` (`ICategoriesApiClient`, `IHotstringsApiClient`, `IHotkeysApiClient`, etc.), each extending `ApiClientBase` and exposing `ListAsync`/`GetAsync`/`CreateAsync`/`UpdateAsync`/`DeleteAsync` returning `ApiResult`/`ApiResult<T>`. `IAhkFlowAppApiHttpClient` only exposes `GetHealthAsync` — never route entity CRUD through it. Never create `HttpClient` manually.
 3. **Dialogs for create/edit, snackbars for feedback** — `IDialogService.ShowAsync<T>` for forms, `ISnackbar.Add()` for success/error notifications.
 4. **Loading states everywhere** — Set `_loading = true` before async calls, `false` after. Use `MudTable.Loading` and `MudProgressLinear` for visual feedback.
 5. **CancellationToken propagation** — Pass tokens through all async paths to support cancellation.
@@ -30,7 +30,7 @@ Full-screen `MudDialog` for create/edit is the **mobile-branch** pattern in this
 
 ### Opening Dialogs / Delete Confirmation
 
-See `HotstringEditDialog.razor`'s caller in `Pages/Hotstrings.razor` for `IDialogService.ShowAsync<T>` and result handling, and any page's delete action for `IDialogService.ShowMessageBox(...)` — the shape (title, message, yesText/cancelText, `== true` check) matches the original template; no drift found here.
+See `HotstringEditDialog.razor`'s caller in `Pages/Hotstrings.razor` for `IDialogService.ShowAsync<T>` and result handling. For delete confirmation, the real method is `IDialogService.ShowMessageBoxAsync(...)`, not `ShowMessageBox(...)` — see `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Categories.razor:222-225` (`bool? confirm = await DialogService.ShowMessageBoxAsync(title: ..., message: ..., yesText: "Delete", cancelText: "Cancel"); if (confirm != true) return;`).
 
 ### Form Validation (per-field delegates, not a FluentValidation adapter)
 
@@ -54,25 +54,30 @@ There is no `FluentValidationExtensions.ValidateValue` adapter in this codebase 
 <MudButton Variant="Variant.Filled" OnClick="Submit">Save</MudButton>
 ```
 
-### Don't Forget `For` Lambda on Form Fields
+### Don't Skip Field-Level Validation
+
+Real forms in this app don't use a `For` lambda at all — `Validation/HotstringEditModel.cs`'s fields validate through a `Func<string, string?>` delegate passed directly to `Validation`, with `Error`/`ErrorText` bound to the same check (see `Components/Hotstrings/HotstringEditDialog.razor:89-94`, no `For` present). `For` only matters if a field is linked into `MudForm`'s `EditContext`-based validation, which this codebase doesn't use.
 
 ```razor
-@* BAD — validation messages won't display for this field *@
+@* BAD — no validation wired up at all *@
 <MudTextField @bind-Value="_model.Trigger" Label="Trigger" />
 
-@* GOOD — For links the field to the model's validation delegate *@
-<MudTextField @bind-Value="_model.Trigger" For="() => _model.Trigger" Label="Trigger" />
+@* GOOD — Validation delegate + Error/ErrorText, matching HotstringEditDialog.razor *@
+<MudTextField @bind-Value="_model.Trigger" Label="Trigger"
+              Validation="@(new Func<string, string?>(ValidateTrigger))"
+              Error="@(ValidateTrigger(_model.Trigger) is not null)"
+              ErrorText="@ValidateTrigger(_model.Trigger)" />
 ```
 
 ### Don't Skip Loading States
 
 ```csharp
 // BAD — UI freezes with no feedback during API calls
-_hotstrings = await Api.GetHotstringsAsync();
+ApiResult<PagedList<HotstringDto>> result = await Api.ListAsync(request, ct);
 
-// GOOD — loading indicator visible during fetch
+// GOOD — loading indicator visible during fetch (Api is IHotstringsApiClient)
 _loading = true;
-_hotstrings = await Api.GetHotstringsAsync();
+ApiResult<PagedList<HotstringDto>> result = await Api.ListAsync(request, ct);
 _loading = false;
 ```
 
@@ -80,12 +85,12 @@ _loading = false;
 
 ```csharp
 // BAD — unnecessary, Blazor re-renders after event handlers
-await Api.CreateHotstringAsync(dto);
+await Api.CreateAsync(dto, ct);
 StateHasChanged(); // redundant
 
 // GOOD — only call StateHasChanged after non-UI-thread operations
 // Blazor auto-renders after event handlers and OnInitializedAsync
-await Api.CreateHotstringAsync(dto);
+await Api.CreateAsync(dto, ct);
 ```
 
 ### Don't Nest Dialogs
@@ -106,11 +111,11 @@ MudDialog.Close(DialogResult.Ok(result));
 | List of items, simple (≤6 fields) | `MudTable` inline row editing (see `Categories.razor`) |
 | List of items, larger/sortable/bulk-select | `MudDataGrid` with `ServerData` (see `Hotstrings.razor`, `Hotkeys.razor`) |
 | Create/Edit form | Inline edit (`MudTable`/`MudDataGrid`) by default; `MudDialog` + `EditModel` only for the mobile branch |
-| Delete confirmation | `DialogService.ShowMessageBox()` |
+| Delete confirmation | `DialogService.ShowMessageBoxAsync()` |
 | Success/error feedback | `ISnackbar.Add()` with `Severity` |
 | Search with debounce | `MudTextField` with `DebounceInterval` + `OnDebounceIntervalElapsed` |
 | Sorting | `MudTableSortLabel` with `SortLabel` |
 | Pagination | `MudTablePager` (server-side) or built-in (client-side) |
-| Form validation | `EditModel` with per-field `Func<string,string?>` delegates + `For` lambdas |
+| Form validation | `EditModel` with per-field `Func<string,string?>` delegates on `Validation`/`Error`/`ErrorText` (no `For`) |
 | Loading indicator | `MudTable.Loading` or `MudProgressLinear` |
 | Navigation | `MudNavMenu` + `MudNavLink` |

--- a/.agents/dck-ef-core/SKILL.md
+++ b/.agents/dck-ef-core/SKILL.md
@@ -8,7 +8,7 @@ description: Use when changing AHKFlowApp EF Core, SQL Server, DbContext, migrat
 ## Core Principles
 
 1. **EF Core is the default ORM** — Use it for all data access. No stored procedures, no raw ADO.NET except for diagnostics.
-2. **DbContext injected directly into handlers** — No repository pattern. No IAppDbContext interface. EF Core's DbSet already implements repository and unit-of-work. Adding another layer adds indirection without value.
+2. **`IAppDbContext` injected into handlers** — This project wraps `AppDbContext` behind `IAppDbContext` (`src/Backend/AHKFlowApp.Application/Abstractions/IAppDbContext.cs`) purely so handler unit tests can substitute it — the interface still exposes `DbSet<T>` properties directly, no per-entity CRUD methods, so it is not a repository. Never add a repository interface on top of it.
 3. **SQL Server only** — LocalDB for local dev, Docker Compose SQL Server for dev containers, Azure SQL for production. `EnableRetryOnFailure()` on all registrations.
 4. **Queries should be projections** — Use `.Select()` to project into DTOs. Avoids over-fetching and N+1 issues.
 5. **Migrations are code** — Review them, test them, never auto-apply in production.
@@ -17,79 +17,25 @@ description: Use when changing AHKFlowApp EF Core, SQL Server, DbContext, migrat
 
 ### DbContext Registration (SQL Server)
 
-```csharp
-// Program.cs or Infrastructure DI extension
-services.AddDbContext<AppDbContext>(options =>
-    options.UseSqlServer(
-        connectionString,
-        sql => sql.EnableRetryOnFailure(
-            maxRetryCount: 3,
-            maxRetryDelay: TimeSpan.FromSeconds(10),
-            errorNumbersToAdd: null)));
-```
+See `src/Backend/AHKFlowApp.Infrastructure/DependencyInjection.cs:16-21` for the live registration — `AddDbContext<AppDbContext>` with `EnableRetryOnFailure()`, plus a scoped `IAppDbContext` registration that resolves to the same `AppDbContext` instance.
 
 ### DbContext Configuration
 
-Use `IEntityTypeConfiguration<T>` to keep entity configs separate and discoverable. No data annotations on entities.
+`AppDbContext` lives at `src/Backend/AHKFlowApp.Infrastructure/Persistence/AppDbContext.cs`; entity configs live one level down in `Configurations/`, one file per entity, each implementing `IEntityTypeConfiguration<T>`. `Configurations/HotstringConfiguration.cs` is the fullest example — required/max-length properties, an enum-as-int conversion, and a filtered unique index (`HasIndex(...).HasFilter(null)`) for the "one global row per owner+trigger" rule. Follow its shape rather than a simplified one.
 
-```csharp
-// Infrastructure/Persistence/AppDbContext.cs
-public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
-{
-    public DbSet<Hotstring> Hotstrings => Set<Hotstring>();
+### Handler Injects IAppDbContext Directly
 
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
-    }
-}
-```
+`src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringQuery.cs` is the live shape: the handler class is named `{Query}Handler` off the full query name (`GetHotstringQueryHandler`, not `GetHotstringHandler`), it takes `IAppDbContext` (not `AppDbContext`) and `ICurrentUser` in its primary constructor, and it loads the entity with `AsNoTracking()` + `Include()` rather than a `.Select()` projection, then maps with an explicit `.ToDto()` extension (`Application/Mapping/`). Follow that shape, not a `.Select()` projection — see below.
 
-```csharp
-// Infrastructure/Persistence/Configurations/HotstringConfiguration.cs
-internal sealed class HotstringConfiguration : IEntityTypeConfiguration<Hotstring>
-{
-    public void Configure(EntityTypeBuilder<Hotstring> builder)
-    {
-        builder.HasKey(x => x.Id);
-        builder.Property(x => x.Trigger).HasMaxLength(50).IsRequired();
-        builder.Property(x => x.Replacement).HasMaxLength(500).IsRequired();
-        builder.HasIndex(x => x.Trigger).IsUnique();
-    }
-}
-```
+### Loading and Mapping (not `.Select()` projection)
 
-### Handler Injects DbContext Directly
-
-```csharp
-// Application/Queries/GetHotstringHandler.cs — DO inject DbContext directly
-internal sealed class GetHotstringHandler(AppDbContext db)
-    : IUseCaseHandler<GetHotstringQuery, Result<HotstringDto>>
-{
-    public async Task<Result<HotstringDto>> ExecuteAsync(
-        GetHotstringQuery request, CancellationToken ct)
-    {
-        var entity = await db.Hotstrings.FindAsync([request.Id], ct);
-        return entity is not null
-            ? Result.Success(new HotstringDto(entity.Id, entity.Trigger, entity.Replacement))
-            : Result.NotFound();
-    }
-}
-```
-
-### Query Projections (Avoid Over-Fetching)
-
-```csharp
-// GOOD — project to DTO, only loads needed columns
-var dto = await db.Hotstrings
-    .Where(h => h.Id == request.Id)
-    .Select(h => new HotstringDto(h.Id, h.Trigger, h.Replacement))
-    .FirstOrDefaultAsync(ct);
-```
+Core Principle #4 above ("Queries should be projections") describes the *intent* — avoid over-fetching — but the actual pattern in this codebase is `AsNoTracking()` + `Include()` on the entity, then an explicit `.ToDto()` extension method in `Application/Mapping/`, not an inline `.Select(x => new Dto(...))`. See `GetHotstringQuery.cs` above for the live shape. Reach for `.Select()` projection only if a query needs to avoid loading a large related collection that `.ToDto()` would otherwise touch.
 
 ### ExecuteUpdateAsync / ExecuteDeleteAsync
 
 Bulk operations that bypass change tracking for better performance.
+
+_No live example in this codebase yet — nothing here bulk-updates/deletes today. Framework API reference for when that need arises; convert to a pointer at that time instead of trusting this snippet to still be current._
 
 ```csharp
 // Update without loading entities
@@ -105,7 +51,7 @@ await db.Hotstrings
 
 ### Interceptors
 
-Use interceptors for cross-cutting concerns like audit trails.
+_No `SaveChangesInterceptor` exists in this codebase. This app's audit trail (`EntityHistory`) is written explicitly inside command handlers, not via an interceptor — see `src/Backend/AHKFlowApp.Application/Commands/Hotkeys/RestoreHotkeyCommand.cs` for the shape. Keep this section as a framework-API reference only; don't imply the project uses interceptors._
 
 ```csharp
 public sealed class AuditInterceptor(TimeProvider clock) : SaveChangesInterceptor
@@ -149,6 +95,8 @@ services.AddDbContext<AppDbContext>((sp, options) =>
 
 Use for hot-path queries that execute frequently with the same shape.
 
+_No live example in this codebase — no compiled query exists today. Framework API reference only._
+
 ```csharp
 public static class HotstringQueries
 {
@@ -167,17 +115,13 @@ var dto = await HotstringQueries.GetById(db, request.Id, ct);
 ### Value Converters
 
 ```csharp
-// Store enum as string
-builder.Property(h => h.Status)
-    .HasConversion<string>()
-    .HasMaxLength(50);
-
-// Strongly-typed IDs
-public readonly record struct HotstringId(int Value);
-
-builder.Property(h => h.Id)
-    .HasConversion(id => id.Value, value => new HotstringId(value));
+// Real example: enum stored as int — src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/HotstringConfiguration.cs:35-37
+builder.Property(x => x.Kind)
+    .IsRequired()
+    .HasConversion<int>();
 ```
+
+_Strongly-typed ID value converters (e.g. a `HotstringId` wrapper) are not used anywhere in this codebase — every ID is a plain `Guid`. Framework API reference only if that changes._
 
 ### Migrations Workflow
 
@@ -199,30 +143,15 @@ dotnet ef database update \
 dotnet ef migrations script --idempotent --output migrations.sql
 ```
 
-### Global Query Filters
+### Soft Delete / Recycle Bin (this app does NOT use a global query filter)
 
-```csharp
-// Soft delete filter
-builder.HasQueryFilter(h => !h.IsDeleted);
-
-// Bypass when needed
-var all = await db.Hotstrings.IgnoreQueryFilters().ToListAsync(ct);
-```
+This app has no `IsDeleted` flag and no `HasQueryFilter`. Delete/restore is modeled through an `EntityHistory` snapshot table plus explicit commands — see `src/Backend/AHKFlowApp.Application/Commands/Hotkeys/{RestoreHotkeyCommand,PurgeDeletedHotkeyCommand}.cs`. If a future entity needs true soft-delete via a boolean flag, `HasQueryFilter` is still the right EF Core mechanism — but don't describe it as what this app already does.
 
 ### Testcontainers (SQL Server)
 
 Always use SQL Server Testcontainers for integration tests — never in-memory provider.
 
-```csharp
-private readonly MsSqlContainer _mssql = new MsSqlBuilder()
-    .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
-    .Build();
-
-// In ConfigureWebHost
-services.RemoveAll<DbContextOptions<AppDbContext>>();
-services.AddDbContext<AppDbContext>(options =>
-    options.UseSqlServer(_mssql.GetConnectionString()));
-```
+The shared fixture lives in `tests/AHKFlowApp.TestUtilities/Fixtures/`: `SqlContainerFixture.cs` owns the `MsSqlContainer`, `ApiTestFixture.cs` wraps it with a `CustomWebApplicationFactory`. Tests share one container per collection via `[Collection("WebApi")]` — see `tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs:12-15` for the live shape. Never spin up a per-test-class `MsSqlContainer` — that is the exact pattern this project already retired once (see issue #220).
 
 ### Query Performance
 
@@ -258,6 +187,8 @@ Projecting into a DTO with `.Select()` (the default in this project) is already 
 #### Split Queries (avoid cartesian explosion)
 
 A single query with multiple or large `Include`s multiplies rows (cartesian product). Split it into one round-trip per collection.
+
+_No live example in this codebase — no query combines multiple/large `Include`s today. Framework API reference only._
 
 ```csharp
 var profiles = await db.Profiles
@@ -298,8 +229,8 @@ public interface IHotstringRepository
     Task SaveChangesAsync();
 }
 
-// GOOD — use AppDbContext directly in handlers
-internal sealed class GetHotstringHandler(AppDbContext db) { }
+// GOOD — use IAppDbContext directly in handlers (see GetHotstringQueryHandler)
+internal sealed class GetHotstringQueryHandler(IAppDbContext db, ICurrentUser currentUser) { }
 ```
 
 ### Don't Use Lazy Loading
@@ -350,15 +281,15 @@ options.UseSqlServer(connectionString, sql => sql.EnableRetryOnFailure(...));
 
 | Scenario | Recommendation |
 |---|---|
-| Standard CRUD | AppDbContext with projections in handler |
-| Bulk updates (100+ rows) | `ExecuteUpdateAsync` / `ExecuteDeleteAsync` |
-| Hot-path read query | Compiled query |
-| Read-only query | `AsNoTracking()`, or project to a DTO |
-| Multiple / large `Include`s | `AsSplitQuery()` |
+| Standard CRUD | `IAppDbContext` with `AsNoTracking()` + `Include()` + `.ToDto()` in handler |
+| Bulk updates (100+ rows) | `ExecuteUpdateAsync` / `ExecuteDeleteAsync` (no live example yet) |
+| Hot-path read query | Compiled query (no live example yet) |
+| Read-only query | `AsNoTracking()`, or map with `.ToDto()` |
+| Multiple / large `Include`s | `AsSplitQuery()` (no live example yet) |
 | Existence check | `AnyAsync`, never `CountAsync > 0` |
 | Diagnosing a slow query | Log `Microsoft.EntityFrameworkCore.Database.Command` |
-| Audit trails | `SaveChangesInterceptor` |
-| Soft deletes | Global query filter + interceptor |
-| Strongly-typed IDs | Value converter |
+| Audit trails | Explicit `EntityHistory` writes in the handler (no interceptor) |
+| Delete / restore | `EntityHistory` snapshot + explicit commands (no global query filter) |
+| Strongly-typed IDs | Not used — every ID is a `Guid` |
 | Production migration | Idempotent SQL script, never auto-migrate |
 | Integration tests | Testcontainers `MsSqlContainer` |

--- a/.agents/dck-ef-core/SKILL.md
+++ b/.agents/dck-ef-core/SKILL.md
@@ -10,7 +10,7 @@ description: Use when changing AHKFlowApp EF Core, SQL Server, DbContext, migrat
 1. **EF Core is the default ORM** — Use it for all data access. No stored procedures, no raw ADO.NET except for diagnostics.
 2. **`IAppDbContext` injected into handlers** — This project wraps `AppDbContext` behind `IAppDbContext` (`src/Backend/AHKFlowApp.Application/Abstractions/IAppDbContext.cs`) purely so handler unit tests can substitute it — the interface still exposes `DbSet<T>` properties directly, no per-entity CRUD methods, so it is not a repository. Never add a repository interface on top of it.
 3. **SQL Server only** — LocalDB for local dev, Docker Compose SQL Server for dev containers, Azure SQL for production. `EnableRetryOnFailure()` on all registrations.
-4. **Queries should be projections** — Use `.Select()` to project into DTOs. Avoids over-fetching and N+1 issues.
+4. **List queries project, detail queries load-and-map** — List/paginated queries use `.Select()` to build the DTO directly in the query (see `ListCategoriesQuery.cs:52`, `ListHotstringsQuery.cs:179`); single-entity "get by id" queries load the tracked-off entity with `Include()` and map with an explicit `.ToDto()` extension instead (see `GetHotstringQuery.cs`, below). Both avoid over-fetching; pick the shape that matches the query, not one universal rule.
 5. **Migrations are code** — Review them, test them, never auto-apply in production.
 
 ## Patterns
@@ -25,28 +25,30 @@ See `src/Backend/AHKFlowApp.Infrastructure/DependencyInjection.cs:16-21` for the
 
 ### Handler Injects IAppDbContext Directly
 
-`src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringQuery.cs` is the live shape: the handler class is named `{Query}Handler` off the full query name (`GetHotstringQueryHandler`, not `GetHotstringHandler`), it takes `IAppDbContext` (not `AppDbContext`) and `ICurrentUser` in its primary constructor, and it loads the entity with `AsNoTracking()` + `Include()` rather than a `.Select()` projection, then maps with an explicit `.ToDto()` extension (`Application/Mapping/`). Follow that shape, not a `.Select()` projection — see below.
+`src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringQuery.cs` is the live shape for a detail query: the handler class is named `{Query}Handler` off the full query name (`GetHotstringQueryHandler`, not `GetHotstringHandler`), it takes `IAppDbContext` (not `AppDbContext`) and `ICurrentUser` in its primary constructor, and it loads the entity with `AsNoTracking()` + `Include()`, then maps with an explicit `.ToDto()` extension (`Application/Mapping/`). List queries use a different shape — see below.
 
-### Loading and Mapping (not `.Select()` projection)
+### Loading and Mapping — detail queries vs list queries
 
-Core Principle #4 above ("Queries should be projections") describes the *intent* — avoid over-fetching — but the actual pattern in this codebase is `AsNoTracking()` + `Include()` on the entity, then an explicit `.ToDto()` extension method in `Application/Mapping/`, not an inline `.Select(x => new Dto(...))`. See `GetHotstringQuery.cs` above for the live shape. Reach for `.Select()` projection only if a query needs to avoid loading a large related collection that `.ToDto()` would otherwise touch.
+Two live shapes, not one:
+- **Detail query (single entity by id)** — `AsNoTracking()` + `Include()` on the entity, then an explicit `.ToDto()` extension method in `Application/Mapping/`. See `GetHotstringQuery.cs` above.
+- **List/paginated query** — `.Select(x => new Dto(...))` projecting straight from the queryable, no `.ToDto()` call. See `ListCategoriesQuery.cs:52` (`.Select(c => new CategoryDto(c.Id, c.Name, c.CreatedAt, c.UpdatedAt))`) and `ListHotstringsQuery.cs:179`.
+
+Follow whichever shape matches the query you're writing — don't force a list query into `.ToDto()` or a detail query into `.Select()`.
 
 ### ExecuteUpdateAsync / ExecuteDeleteAsync
 
 Bulk operations that bypass change tracking for better performance.
 
-_No live example in this codebase yet — nothing here bulk-updates/deletes today. Framework API reference for when that need arises; convert to a pointer at that time instead of trusting this snippet to still be current._
+_No live example in this codebase yet — nothing here bulk-updates/deletes today, and no `Hotstring.ProfileId`/`Hotstring.IsActive` properties exist (see `Hotstring.cs`) to bulk-update. The example below is the official EF Core 10 docs sample (generic `Employees`/`Tags` entities), not this app's data — convert to a pointer once a real usage exists._
 
 ```csharp
+// From https://learn.microsoft.com/ef/core/saving/execute-insert-update-delete (EF Core 10)
 // Update without loading entities
-await db.Hotstrings
-    .Where(h => h.ProfileId == request.ProfileId)
-    .ExecuteUpdateAsync(s => s.SetProperty(h => h.IsActive, false), ct);
+await context.Employees.ExecuteUpdateAsync(
+    s => s.SetProperty(e => e.Salary, e => e.Salary + 1000), ct);
 
-// Delete without loading entities
-await db.Hotstrings
-    .Where(h => h.ProfileId == request.ProfileId)
-    .ExecuteDeleteAsync(ct);
+// Delete without loading entities, with a filter
+await context.Tags.Where(t => t.Text.Contains(".NET")).ExecuteDeleteAsync(ct);
 ```
 
 ### Interceptors
@@ -95,21 +97,16 @@ services.AddDbContext<AppDbContext>((sp, options) =>
 
 Use for hot-path queries that execute frequently with the same shape.
 
-_No live example in this codebase — no compiled query exists today. Framework API reference only._
+_No live example in this codebase — no compiled query exists today. The example below is the official EF Core 10 docs sample (`EF.CompileAsyncQuery` API definition), not this app's data — every ID in this app is a `Guid`, not the `int` shown here._
 
 ```csharp
-public static class HotstringQueries
-{
-    public static readonly Func<AppDbContext, int, CancellationToken, Task<HotstringDto?>> GetById =
-        EF.CompileAsyncQuery((AppDbContext db, int id, CancellationToken ct) =>
-            db.Hotstrings
-                .Where(h => h.Id == id)
-                .Select(h => new HotstringDto(h.Id, h.Trigger, h.Replacement))
-                .FirstOrDefault());
-}
+// From https://learn.microsoft.com/dotnet/api/microsoft.entityframeworkcore.ef.compileasyncquery (EF Core 10)
+private static readonly Func<BloggingContext, int, IAsyncEnumerable<Blog>> _compiledQuery
+    = EF.CompileAsyncQuery(
+        (BloggingContext context, int length) => context.Blogs.Where(b => b.Url.StartsWith("http://") && b.Url.Length == length));
 
-// Usage
-var dto = await HotstringQueries.GetById(db, request.Id, ct);
+// Usage — the delegate is thread-safe and can run concurrently on different context instances
+await foreach (Blog blog in _compiledQuery(context, 8)) { /* ... */ }
 ```
 
 ### Value Converters

--- a/.agents/dck-ef-core/SKILL.md
+++ b/.agents/dck-ef-core/SKILL.md
@@ -182,7 +182,7 @@ var hotstrings = await db.Hotstrings
     .ToListAsync(ct);
 ```
 
-Projecting into a DTO with `.Select()` (the default in this project) is already effectively no-tracking. Reach for `AsNoTrackingWithIdentityResolution()` only when a query can return the same row more than once (e.g. a join that repeats a `Profile`) and you want one shared instance instead of duplicates.
+`AsNoTracking()` (the default read pattern in this project — see "Loading and Mapping" above) is enough for a single-row read. Reach for `AsNoTrackingWithIdentityResolution()` only when a query can return the same row more than once (e.g. a join that repeats a `Profile`) and you want one shared instance instead of duplicates.
 
 #### Split Queries (avoid cartesian explosion)
 
@@ -292,4 +292,4 @@ options.UseSqlServer(connectionString, sql => sql.EnableRetryOnFailure(...));
 | Delete / restore | `EntityHistory` snapshot + explicit commands (no global query filter) |
 | Strongly-typed IDs | Not used — every ID is a `Guid` |
 | Production migration | Idempotent SQL script, never auto-migrate |
-| Integration tests | Testcontainers `MsSqlContainer` |
+| Integration tests | Shared `ApiTestFixture` / `SqlContainerFixture`, `[Collection("WebApi")]` — never a per-class `MsSqlContainer` |

--- a/.agents/dck-openapi/SKILL.md
+++ b/.agents/dck-openapi/SKILL.md
@@ -16,140 +16,31 @@ description: Use when changing AHKFlowApp OpenAPI, Swagger, API docs, response a
 
 ### Basic Setup (Program.cs)
 
-```csharp
-// Program.cs
-builder.Services.AddSwaggerGen(options =>
-{
-    options.SwaggerDoc("v1", new OpenApiInfo
-    {
-        Title = "AHKFlowApp API",
-        Version = "v1",
-        Description = "API for managing AutoHotkey hotstrings and hotkeys."
-    });
-
-    // Include XML comments from the API project
-    var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
-    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
-    options.IncludeXmlComments(xmlPath);
-});
-
-// ...
-
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI(options =>
-    {
-        options.SwaggerEndpoint("/swagger/v1/swagger.json", "AHKFlowApp API v1");
-        options.RoutePrefix = "swagger";  // available at /swagger
-    });
-}
-```
+Swagger setup is behind two extension methods, not inlined in `Program.cs`: `AddSwaggerDocs()` and `UseSwaggerDocs()` in `src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs:50-101`, called conditionally in Development from `src/Backend/AHKFlowApp.API/Program.cs:102,196`. Read the extension methods rather than copying an inline shape — they also register `AddSwaggerExamplesFromAssemblies` and read XML comments from both `AHKFlowApp.API` and `AHKFlowApp.Application` assemblies.
 
 ### ProducesResponseType on Controller Actions
 
-Every action must declare all possible response types.
-
-```csharp
-[ApiController]
-[Route("api/v1/[controller]")]
-public sealed class HotstringsController(
-    IUseCase<CreateHotstringCommand, Result<HotstringDto>> createHotstring,
-    IUseCase<GetHotstringQuery, Result<HotstringDto>> getHotstring,
-    IUseCase<ListHotstringsQuery, Result<IReadOnlyList<HotstringDto>>> listHotstrings)
-    : ControllerBase
-{
-    /// <summary>Creates a new hotstring.</summary>
-    /// <param name="dto">Trigger and replacement text.</param>
-    /// <response code="201">Hotstring created successfully.</response>
-    /// <response code="400">Validation failed.</response>
-    /// <response code="409">A hotstring with this trigger already exists.</response>
-    [HttpPost]
-    [ProducesResponseType<HotstringDto>(StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> Create(CreateHotstringDto dto, CancellationToken ct)
-    {
-        var result = await createHotstring.ExecuteAsync(new CreateHotstringCommand(dto.Trigger, dto.Replacement), ct);
-        return result.ToActionResult(this);
-    }
-
-    /// <summary>Gets a hotstring by ID.</summary>
-    /// <param name="id">The hotstring ID.</param>
-    /// <response code="200">Returns the hotstring.</response>
-    /// <response code="404">Hotstring not found.</response>
-    [HttpGet("{id:int}")]
-    [ProducesResponseType<HotstringDto>(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetById(int id, CancellationToken ct)
-    {
-        var result = await getHotstring.ExecuteAsync(new GetHotstringQuery(id), ct);
-        return result.ToActionResult(this);
-    }
-
-    /// <summary>Lists all hotstrings.</summary>
-    /// <response code="200">Returns the list of hotstrings.</response>
-    [HttpGet]
-    [ProducesResponseType<IReadOnlyList<HotstringDto>>(StatusCodes.Status200OK)]
-    public async Task<IActionResult> List(CancellationToken ct)
-    {
-        var result = await listHotstrings.ExecuteAsync(new ListHotstringsQuery(), ct);
-        return result.ToActionResult(this);
-    }
-}
-```
+Every action must declare all possible response types. `src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs` is the live, much larger example — 15 actions, each with XML `<summary>`/`<response>` comments and `[ProducesResponseType]` per possible status. It also carries class-level `[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]` / `...Status403Forbidden` that a per-action-only approach would miss — those apply to every action via `[Authorize]` + `[RequiredScope]` and don't need repeating per action.
 
 ### Enable XML Documentation
 
-In `AHKFlowApp.API.csproj`:
-
-```xml
-<PropertyGroup>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);1591</NoWarn>  <!-- suppress missing XML comment warnings -->
-</PropertyGroup>
+```csharp
+<!-- src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj:4-5 (also set in AHKFlowApp.Application.csproj:3) -->
+<GenerateDocumentationFile>true</GenerateDocumentationFile>
+<NoWarn>$(NoWarn);CS1591</NoWarn>
 ```
 
 ### Bearer Token Security Scheme
 
-For Azure AD (MSAL) authentication in Swagger UI:
-
-```csharp
-builder.Services.AddSwaggerGen(options =>
-{
-    options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
-    {
-        Name = "Authorization",
-        Type = SecuritySchemeType.Http,
-        Scheme = "bearer",
-        BearerFormat = "JWT",
-        In = ParameterLocation.Header,
-        Description = "Enter JWT token"
-    });
-
-    options.AddSecurityRequirement(new OpenApiSecurityRequirement
-    {
-        {
-            new OpenApiSecurityScheme
-            {
-                Reference = new OpenApiReference
-                {
-                    Type = ReferenceType.SecurityScheme,
-                    Id = "Bearer"
-                }
-            },
-            []
-        }
-    });
-});
-```
+The real registration is in `AddSwaggerDocs()` (`ApiExtensions.cs:61-74`) and uses the newer `Microsoft.OpenApi` shape — `OpenApiSecuritySchemeReference("Bearer", doc)` inside `AddSecurityRequirement(doc => ...)`, not the older `OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" }` shape. Copy the live extension method rather than an older-API block; the two are not interchangeable across `Microsoft.OpenApi` versions.
 
 ### ProblemDetails Schema
 
-Register `AddProblemDetails()` to ensure ProblemDetails appears correctly in the OpenAPI schema:
-
 ```csharp
-builder.Services.AddProblemDetails();
+// src/Backend/AHKFlowApp.API/Program.cs:75-77 — also stamps a traceId extension on every problem response
+builder.Services.AddProblemDetails(options =>
+    options.CustomizeProblemDetails = ctx =>
+        ctx.ProblemDetails.Extensions["traceId"] = ctx.HttpContext.TraceIdentifier);
 ```
 
 ## Anti-patterns

--- a/.agents/dck-openapi/SKILL.md
+++ b/.agents/dck-openapi/SKILL.md
@@ -49,14 +49,14 @@ builder.Services.AddProblemDetails(options =>
 
 ```csharp
 // BAD — no response type annotations, schema won't include response types
-[HttpGet("{id:int}")]
-public async Task<IActionResult> GetById(int id, CancellationToken ct) { ... }
+[HttpGet("{id:guid}")]
+public async Task<ActionResult<HotstringDto>> Get(Guid id, CancellationToken ct) { ... }
 
-// GOOD — explicit annotations
-[HttpGet("{id:int}")]
-[ProducesResponseType<HotstringDto>(StatusCodes.Status200OK)]
-[ProducesResponseType(StatusCodes.Status404NotFound)]
-public async Task<IActionResult> GetById(int id, CancellationToken ct) { ... }
+// GOOD — explicit annotations (real IDs in this app are Guid, routed with :guid)
+[HttpGet("{id:guid}")]
+[ProducesResponseType(typeof(HotstringDto), StatusCodes.Status200OK)]
+[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+public async Task<ActionResult<HotstringDto>> Get(Guid id, CancellationToken ct) { ... }
 ```
 
 ### Minimal API OpenAPI Patterns in Controllers

--- a/.agents/dck-openapi/SKILL.md
+++ b/.agents/dck-openapi/SKILL.md
@@ -24,7 +24,7 @@ Every action must declare all possible response types. `src/Backend/AHKFlowApp.A
 
 ### Enable XML Documentation
 
-```csharp
+```xml
 <!-- src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj:4-5 (also set in AHKFlowApp.Application.csproj:3) -->
 <GenerateDocumentationFile>true</GenerateDocumentationFile>
 <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/.agents/dck-scaffolding/SKILL.md
+++ b/.agents/dck-scaffolding/SKILL.md
@@ -51,7 +51,7 @@ src/Backend/AHKFlowApp.Infrastructure/
 
 ## Validator
 
-Validators are usually a nested class in the same file as the command they validate (see `CreateHotkeyCommandValidator` in `CreateHotkeyCommand.cs` above) — not a separate file, despite the Layer Structure diagram above implying otherwise for large validators. Follow the co-located shape unless a validator grows large enough to warrant its own file.
+Validators are usually a top-level class co-located in the same file as the command they validate — not nested inside the handler, and not a separate file (see `CreateHotkeyCommandValidator` in `CreateHotkeyCommand.cs:15` above), despite the Layer Structure diagram above implying a separate file for large validators. Follow the co-located shape unless a validator grows large enough to warrant its own file.
 
 ## Query and Handler
 

--- a/.agents/dck-scaffolding/SKILL.md
+++ b/.agents/dck-scaffolding/SKILL.md
@@ -47,167 +47,27 @@ src/Backend/AHKFlowApp.Infrastructure/
 
 ## Command and Handler
 
-```csharp
-namespace AHKFlowApp.Application.Commands;
-
-public sealed record CreateHotstringCommand(CreateHotstringDto Input);
-```
-
-```csharp
-namespace AHKFlowApp.Application.Commands;
-
-internal sealed class CreateHotstringHandler(AppDbContext db, TimeProvider timeProvider)
-    : IUseCaseHandler<CreateHotstringCommand, Result<HotstringDto>>
-{
-    public async Task<Result<HotstringDto>> ExecuteAsync(
-        CreateHotstringCommand request,
-        CancellationToken cancellationToken)
-    {
-        var hotstring = Hotstring.Create(
-            ownerOid,
-            request.Input.Trigger,
-            request.Input.Replacement,
-            timeProvider.GetUtcNow());
-
-        db.Hotstrings.Add(hotstring);
-        await db.SaveChangesAsync(cancellationToken);
-
-        return Result.Success(new HotstringDto(hotstring.Id, hotstring.Trigger, hotstring.Replacement));
-    }
-}
-```
-
-Register the use case in Application DI:
-
-```csharp
-services.AddUseCase<CreateHotstringCommand, Result<HotstringDto>, CreateHotstringHandler>();
-```
+`src/Backend/AHKFlowApp.Application/Commands/Hotkeys/CreateHotkeyCommand.cs` is a live example: command record + validator + handler share one file, the handler class is `{CommandName}Handler` (e.g. `CreateHotkeyCommandHandler`, not `CreateHotkeyHandler`), it injects `IAppDbContext` (not `AppDbContext`) plus `ICurrentUser` and `TimeProvider`, and DI registration is a chained `.AddUseCase<TCommand, TResult, THandler>()` call in `src/Backend/AHKFlowApp.Application/DependencyInjection.cs` (see lines 33-40 for the chain shape).
 
 ## Validator
 
-```csharp
-namespace AHKFlowApp.Application.Commands;
-
-public sealed class CreateHotstringValidator : AbstractValidator<CreateHotstringCommand>
-{
-    public CreateHotstringValidator()
-    {
-        RuleFor(x => x.Input.Trigger).NotEmpty().MaximumLength(50);
-        RuleFor(x => x.Input.Replacement).NotEmpty().MaximumLength(500);
-    }
-}
-```
+Validators are usually a nested class in the same file as the command they validate (see `CreateHotkeyCommandValidator` in `CreateHotkeyCommand.cs` above) — not a separate file, despite the Layer Structure diagram above implying otherwise for large validators. Follow the co-located shape unless a validator grows large enough to warrant its own file.
 
 ## Query and Handler
 
-```csharp
-namespace AHKFlowApp.Application.Queries;
-
-public sealed record GetHotstringQuery(Guid Id);
-```
-
-```csharp
-namespace AHKFlowApp.Application.Queries;
-
-internal sealed class GetHotstringHandler(AppDbContext db)
-    : IUseCaseHandler<GetHotstringQuery, Result<HotstringDto>>
-{
-    public async Task<Result<HotstringDto>> ExecuteAsync(
-        GetHotstringQuery request,
-        CancellationToken cancellationToken)
-    {
-        var entity = await db.Hotstrings.FindAsync([request.Id], cancellationToken);
-        return entity is null
-            ? Result.NotFound()
-            : Result.Success(new HotstringDto(entity.Id, entity.Trigger, entity.Replacement));
-    }
-}
-```
+`src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringQuery.cs` is the live shape — handler class `GetHotstringQueryHandler` (not `GetHotstringHandler`), `IAppDbContext` + `ICurrentUser` injected, `AsNoTracking()` + `Include()` + `.ToDto()` rather than a `.Select()` projection. See `.agents/dck-ef-core/SKILL.md` for the EF Core side of this pattern.
 
 ## Controller
 
-```csharp
-namespace AHKFlowApp.API.Controllers;
-
-[ApiController]
-[Route("api/v1/[controller]")]
-[Authorize]
-public sealed class HotstringsController(
-    IUseCase<CreateHotstringCommand, Result<HotstringDto>> createHotstring,
-    IUseCase<GetHotstringQuery, Result<HotstringDto>> getHotstring)
-    : ControllerBase
-{
-    [HttpPost]
-    [ProducesResponseType<HotstringDto>(StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
-    public async Task<IActionResult> Create(CreateHotstringDto dto, CancellationToken cancellationToken)
-    {
-        var result = await createHotstring.ExecuteAsync(new CreateHotstringCommand(dto), cancellationToken);
-        return result.ToActionResult(this);
-    }
-
-    [HttpGet("{id:guid}")]
-    [ProducesResponseType<HotstringDto>(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken)
-    {
-        var result = await getHotstring.ExecuteAsync(new GetHotstringQuery(id), cancellationToken);
-        return result.ToActionResult(this);
-    }
-}
-```
+`src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs` is the live shape. Note three things the simplified template above misses: results map via `result.ToProblemActionResult(this)` (an in-repo RFC 9457 extension, `src/Backend/AHKFlowApp.API/Extensions/ProblemDetailsResultExtensions.cs`), not the bare `Ardalis.Result.AspNetCore.ToActionResult`; class-level attributes add `[RequiredScope("access_as_user")]` and `[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]` / `...Status403Forbidden`; and action methods return `ActionResult<T>`, not `IActionResult`.
 
 ## Entity and EF Configuration
 
-Entities use private setters, constructor/factory methods, and domain methods:
-
-```csharp
-namespace AHKFlowApp.Domain.Entities;
-
-public sealed class Hotstring
-{
-    private Hotstring()
-    {
-        Trigger = string.Empty;
-        Replacement = string.Empty;
-    }
-
-    public Guid Id { get; private set; }
-    public Guid OwnerOid { get; private set; }
-    public string Trigger { get; private set; }
-    public string Replacement { get; private set; }
-    public DateTimeOffset CreatedAt { get; private set; }
-    public DateTimeOffset UpdatedAt { get; private set; }
-
-    public static Hotstring Create(Guid ownerOid, string trigger, string replacement, DateTimeOffset now) =>
-        new()
-        {
-            Id = Guid.NewGuid(),
-            OwnerOid = ownerOid,
-            Trigger = trigger,
-            Replacement = replacement,
-            CreatedAt = now,
-            UpdatedAt = now
-        };
-}
-```
-
-```csharp
-internal sealed class HotstringConfiguration : IEntityTypeConfiguration<Hotstring>
-{
-    public void Configure(EntityTypeBuilder<Hotstring> builder)
-    {
-        builder.HasKey(x => x.Id);
-        builder.Property(x => x.Trigger).HasMaxLength(50).IsRequired();
-        builder.Property(x => x.Replacement).HasMaxLength(500).IsRequired();
-        builder.HasIndex(x => new { x.OwnerOid, x.Trigger }).IsUnique();
-    }
-}
-```
+`src/Backend/AHKFlowApp.Domain/Entities/Hotstring.cs` (entity: private setters, `Create` factory) and `src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/HotstringConfiguration.cs` (EF config: required/max-length properties, enum-as-int conversions, a filtered unique index) are the live, much richer versions of the toy example above — read them before scaffolding a new entity, don't copy the simplified shape here.
 
 ## Integration Test Shape
 
-Use `WebApplicationFactory` and SQL Server Testcontainers. Replace `DbContextOptions<AppDbContext>` with `services.RemoveAll<DbContextOptions<AppDbContext>>()`, run migrations, and assert behavior through HTTP or handler results.
+Use the shared `ApiTestFixture` (`tests/AHKFlowApp.TestUtilities/Fixtures/ApiTestFixture.cs`) via `[Collection("WebApi")]` — see `tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs:12-15`. Don't stand up a new `WebApplicationFactory`/`MsSqlContainer` per test class.
 
 ## Anti-Patterns
 

--- a/.agents/dck-security-scan/SKILL.md
+++ b/.agents/dck-security-scan/SKILL.md
@@ -146,6 +146,8 @@ CHECKLIST:
    - API key validation in middleware, not in each controller
 ```
 
+This app doesn't hand-build `TokenValidationParameters` — it delegates JWT validation to `Microsoft.Identity.Web`'s `AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"))` (`src/Backend/AHKFlowApp.API/Program.cs:130-135`), which reads issuer/audience/signing-key config from the `AzureAd` section and validates all four checklist items above automatically. A test-only bypass exists for local dev (`TestAuthenticationHandler`, gated to `Development` + `Auth:UseTestProvider=true`, `Program.cs:114-129`) — flag it as a finding only if it can be reached outside Development. Scanning this project's auth means checking the `AzureAd` config is populated and that `useTestAuth` can't go true outside Development, not reviewing hand-rolled `TokenValidationParameters` (the BAD/GOOD block below is a reference for other .NET apps that do configure JWT bearer manually — this app doesn't).
+
 ```csharp
 // BAD — JWT configuration with weak validation
 builder.Services.AddAuthentication().AddJwtBearer(options =>
@@ -200,7 +202,11 @@ policy.AllowAnyOrigin()             // Any website can read API responses
       .AllowAnyHeader()
       .AllowAnyMethod();
 // Acceptable ONLY for truly public APIs (e.g., public data feeds)
+```
 
+This app's real CORS policy (`src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs:10-24`) doesn't use a static `WithOrigins(...)` array like the block below — it uses `SetIsOriginAllowed` reading `Cors:AllowedOrigins` from live configuration on every request, so an edited `appsettings.Development.json` takes effect without an API restart. Check for that dynamic-origin pattern here specifically; the static-array block below is the general-case illustration.
+
+```csharp
 // GOOD — explicit origins
 builder.Services.AddCors(options =>
 {

--- a/docs/superpowers/plans/2026-07-27-skill-template-drift-plan.md
+++ b/docs/superpowers/plans/2026-07-27-skill-template-drift-plan.md
@@ -6,7 +6,7 @@
 
 **Architecture:** No app code changes. Each task edits one `SKILL.md` file. A "pointer" is one or two sentences naming the exact file (and line range where useful) that demonstrates the pattern, replacing an inlined code block that copied it. Where research below found **no live example** of a taught pattern anywhere in the repo, the block is kept but re-labeled so a reader knows it is a framework-API reference, not a description of this app's behavior — inventing a citation for something that does not exist would be exactly the kind of fabrication the issue is about.
 
-**Tech Stack:** Markdown only. No build, no tests to run — this falls under AGENTS.md's "Docs, skills, or plan files only" verification exemption. Verification per task is: (1) grep the cited `file:line` after editing to confirm it still contains what's claimed, (2) read the rewritten section back for accuracy.
+**Tech Stack:** Markdown only, no application build. This still has one real test gate: `tests/SkillParity.Tests.ps1` byte-compares every canonical `.agents/<skill>/SKILL.md` against its mirrored copy under `plugins/ahkflowapp/skills/<skill>/`, so editing a canonical skill file without re-running `scripts/agents/setup-cross-agent-skills.ps1` fails that test. Verification per task is: (1) grep the cited `file:line` after editing to confirm it still contains what's claimed, (2) read the rewritten section back for accuracy; after all five skills are edited, run the setup script once and confirm `tests/SkillParity.Tests.ps1` passes (Task 6).
 
 ## Global Constraints
 
@@ -410,7 +410,23 @@ Confirm no leftover contradiction (e.g. a "Decision Guide" row that still says `
 
 Run: `wc -l .agents/dck-security-scan/SKILL.md .agents/dck-ef-core/SKILL.md .agents/dck-blazor-mudblazor/SKILL.md .agents/dck-scaffolding/SKILL.md .agents/dck-openapi/SKILL.md`
 
-- [ ] **Step 3: Push and open the PR referencing #220**
+- [ ] **Step 3: Sync the Codex plugin mirror and re-run parity**
+
+Editing files under `.agents/` only touches the canonical copy — `tests/SkillParity.Tests.ps1` byte-compares each one against its mirror under `plugins/ahkflowapp/skills/` and fails until the mirror catches up.
+
+```powershell
+pwsh scripts/agents/setup-cross-agent-skills.ps1
+pwsh tests/SkillParity.Tests.ps1
+```
+
+Commit the mirrored files plus the resulting `plugins/ahkflowapp/.codex-plugin/plugin.json` version bump.
+
+```bash
+git add plugins/ahkflowapp
+git commit -m "chore: sync Codex plugin mirror after skill edits"
+```
+
+- [ ] **Step 4: Push and open the PR referencing #220**
 
 ```bash
 git push -u origin fix/wt-skill-template-drift

--- a/docs/superpowers/plans/2026-07-27-skill-template-drift-plan.md
+++ b/docs/superpowers/plans/2026-07-27-skill-template-drift-plan.md
@@ -1,0 +1,418 @@
+# Skill Template Drift (Issue #220) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the five template-heavy skill files under `.agents/` (`dck-security-scan`, `dck-ef-core`, `dck-blazor-mudblazor`, `dck-scaffolding`, `dck-openapi`) so every code block that copies a project-specific pattern is replaced by a pointer to the real, compiled/tested file that already shows that pattern — per issue [#220](https://github.com/s205109/AHKFlowApp/issues/220).
+
+**Architecture:** No app code changes. Each task edits one `SKILL.md` file. A "pointer" is one or two sentences naming the exact file (and line range where useful) that demonstrates the pattern, replacing an inlined code block that copied it. Where research below found **no live example** of a taught pattern anywhere in the repo, the block is kept but re-labeled so a reader knows it is a framework-API reference, not a description of this app's behavior — inventing a citation for something that does not exist would be exactly the kind of fabrication the issue is about.
+
+**Tech Stack:** Markdown only. No build, no tests to run — this falls under AGENTS.md's "Docs, skills, or plan files only" verification exemption. Verification per task is: (1) grep the cited `file:line` after editing to confirm it still contains what's claimed, (2) read the rewritten section back for accuracy.
+
+## Global Constraints
+
+- Every citation in the rewritten skills must be a real `file:line` that was read during this plan's research (listed per task) — no invented paths.
+- Where research found a pattern the skill teaches has **no live implementation**, keep the block but mark it clearly (see the standard note text in each task) — do not point it at a file that doesn't demonstrate it.
+- Don't touch the other seven active skills (`dck-build-fix`, `dck-de-sloppify`, `dck-ef-core` migration workflow companion `dck-migration-workflow`, `dck-openapi` companion docs, `dck-verify`, `dck-workflow-mastery`, `dck-scaffolding`'s sibling `dck-security-scan`... i.e. anything not in the five named above) — the issue explicitly scopes risk to these five.
+- Don't fix unrelated staleness discovered during research (e.g. `AGENTS.md`'s own `result.ToActionResult(this)` reference, which the real code has replaced with `ToProblemActionResult`) — out of scope for this issue; flag it to the user instead of expanding scope.
+- Preserve each skill's frontmatter (`name`, `description`) and overall section order unless a task says otherwise.
+
+---
+
+## Research Findings (evidence backing every task below)
+
+Read during this plan's research, with what was found:
+
+| Claim | Proof |
+|---|---|
+| `IAppDbContext` interface exists and is injected into handlers (contradicts dck-ef-core's stated "No `IAppDbContext` interface" principle) | `src/Backend/AHKFlowApp.Application/Abstractions/IAppDbContext.cs:7-27`; injected in `src/Backend/AHKFlowApp.Application/Commands/Hotkeys/CreateHotkeyCommand.cs:28-31` and `src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringQuery.cs:12-14` |
+| DbContext registration differs from template (adds `IAppDbContext` scoped registration) | `src/Backend/AHKFlowApp.Infrastructure/DependencyInjection.cs:16-21` |
+| Real query handlers use `AsNoTracking()` + `Include()` + an explicit `.ToDto()` mapping extension, not `.Select()` DTO projection as the skill's "Query Projections" section teaches | `src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringQuery.cs:22-29` |
+| `HotstringConfiguration` is far richer than the skill's toy version (unique index with `HasFilter(null)`, enum-as-int conversions, `nvarchar(max)` column) | `src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/HotstringConfiguration.cs:1-74` |
+| `ExecuteUpdateAsync`/`ExecuteDeleteAsync`, `SaveChangesInterceptor`, `EF.CompileAsyncQuery`, strongly-typed-ID value converters, `HasQueryFilter`, and `AsSplitQuery` are **not used anywhere** in the codebase | `grep -rl` for each across `src/Backend` returned no matches (session transcript) |
+| Soft-delete/recycle-bin is implemented via an `EntityHistory` snapshot table plus explicit Restore/Purge commands, not an `IsDeleted` flag + global query filter | no `IsDeleted`/`DeletedAt` property anywhere in `src/Backend/AHKFlowApp.Domain`; `src/Backend/AHKFlowApp.Application/Commands/Hotkeys/{RestoreHotkeyCommand,PurgeDeletedHotkeyCommand}.cs`, `.../Hotstrings/PurgeDeletedHotstringCommand.cs` reference `EntityHistories` directly |
+| Testcontainers usage is a shared fixture, not a per-class `MsSqlContainer` | `tests/AHKFlowApp.TestUtilities/Fixtures/SqlContainerFixture.cs`, `tests/AHKFlowApp.TestUtilities/Fixtures/ApiTestFixture.cs:1-28`; consumed via `[Collection("WebApi")]` per issue #220's own body, citing `tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs:12-15` |
+| Handler naming in dck-scaffolding/dck-ef-core templates (`CreateHotstringHandler`, `GetHotstringHandler`) doesn't match the real `{Command/Query}Handler` convention (`CreateHotstringCommandHandler`, `GetHotstringQueryHandler`) | `src/Backend/AHKFlowApp.Application/DependencyInjection.cs:39` (`CreateHotstringCommandHandler`); `GetHotstringQueryHandler` class name in `src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringQuery.cs:12` |
+| Controllers map `Result` via a custom `ToProblemActionResult` extension, not the bare `Ardalis.Result.AspNetCore.ToActionResult` the scaffolding/openapi templates show | `src/Backend/AHKFlowApp.API/Extensions/ProblemDetailsResultExtensions.cs:6-10` (doc comment explicitly says it replaces `ToActionResult`), method defined at lines 22-30; usage at `src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs:71,78,91` |
+| Real controllers also carry `[RequiredScope("access_as_user")]` and class-level `[ProducesResponseType]` for 401/403, absent from every scaffolding/openapi template | `src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs:16-19` |
+| Swagger setup lives behind `AddSwaggerDocs()`/`UseSwaggerDocs()` extensions, not the inline `AddSwaggerGen` block the openapi skill teaches; uses the newer `OpenApiSecuritySchemeReference` API, not `OpenApiReference` | `src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs:50-101`; called from `src/Backend/AHKFlowApp.API/Program.cs:102,196` |
+| XML doc generation is on for both API and Application projects | `src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj:4-5`, `src/Backend/AHKFlowApp.Application/AHKFlowApp.Application.csproj:3` |
+| Real CORS policy uses `SetIsOriginAllowed` reading live config (not the static `WithOrigins(...)` the security-scan "GOOD" example shows) | `src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs:10-24` |
+| Real auth setup delegates JWT validation to `AddMicrosoftIdentityWebApi` (Microsoft.Identity.Web) rather than hand-building `TokenValidationParameters` as the security-scan "BAD/GOOD JWT configuration" example assumes | `src/Backend/AHKFlowApp.API/Program.cs:130-135` |
+| Blazor's own `CLAUDE.md` already documents the real, more nuanced pattern set (MudDataGrid inline edit for complex lists, MudTable inline edit for simple ones, full-screen MudDialog only on the mobile branch) that the skill's single MudTable+MudDialog template doesn't reflect | `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md` ("Conventions" section); confirmed in code at `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor:70-78` (`MudDataGrid` inline edit), `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Categories.razor:32` (`MudTable` inline edit), `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor:10` (`MudDialog`, mobile-only per the CLAUDE.md) |
+| No `FluentValidationExtensions.ValidateValue` adapter exists anywhere — real Blazor forms validate with plain `Func<string,string?>` delegates on `EditModel` classes | `grep -rl ValidateValue src/Frontend` returned nothing; real pattern in `src/Frontend/AHKFlowApp.UI.Blazor/Validation/HotstringEditModel.cs` and used at `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor:90` (`Validation="@(new Func<string, string?>(Item.ValidateReplacement))"`) |
+
+---
+
+## Task 1: `dck-ef-core/SKILL.md`
+
+**Files:**
+- Modify: `.agents/dck-ef-core/SKILL.md` (364 lines)
+
+- [ ] **Step 1: Fix Core Principle #2 (stale "no IAppDbContext" claim)**
+
+Replace (current lines 11):
+```
+2. **DbContext injected directly into handlers** — No repository pattern. No IAppDbContext interface. EF Core's DbSet already implements repository and unit-of-work. Adding another layer adds indirection without value.
+```
+with:
+```
+2. **`IAppDbContext` injected into handlers** — This project wraps `AppDbContext` behind `IAppDbContext` (`src/Backend/AHKFlowApp.Application/Abstractions/IAppDbContext.cs`) purely so handler unit tests can substitute it — the interface still exposes `DbSet<T>` properties directly, no per-entity CRUD methods, so it is not a repository. Never add a repository interface on top of it.
+```
+
+- [ ] **Step 2: Replace "DbContext Registration (SQL Server)" with a pointer**
+
+Replace the code block under that heading (lines 20-29) with:
+```
+See `src/Backend/AHKFlowApp.Infrastructure/DependencyInjection.cs:16-21` for the live registration — `AddDbContext<AppDbContext>` with `EnableRetryOnFailure()`, plus a scoped `IAppDbContext` registration that resolves to the same `AppDbContext` instance.
+```
+
+- [ ] **Step 3: Replace "DbContext Configuration" with a pointer**
+
+Replace both code blocks under that heading (lines 33-60) with:
+```
+`AppDbContext` lives at `src/Backend/AHKFlowApp.Infrastructure/Persistence/AppDbContext.cs`; entity configs live one level down in `Configurations/`, one file per entity, each implementing `IEntityTypeConfiguration<T>`. `Configurations/HotstringConfiguration.cs` is the fullest example — required/max-length properties, an enum-as-int conversion, and a filtered unique index (`HasIndex(...).HasFilter(null)`) for the "one global row per owner+trigger" rule. Follow its shape rather than a simplified one.
+```
+
+- [ ] **Step 4: Fix "Handler Injects DbContext Directly" — wrong type, wrong naming, wrong projection style**
+
+Replace the heading and code block (lines 62-78) with:
+```
+### Handler Injects IAppDbContext Directly
+
+`src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringQuery.cs` is the live shape: the handler class is named `{Query}Handler` off the full query name (`GetHotstringQueryHandler`, not `GetHotstringHandler`), it takes `IAppDbContext` (not `AppDbContext`) and `ICurrentUser` in its primary constructor, and it loads the entity with `AsNoTracking()` + `Include()` rather than a `.Select()` projection, then maps with an explicit `.ToDto()` extension (`Application/Mapping/`). Follow that shape, not a `.Select()` projection — see Step 5.
+```
+
+- [ ] **Step 5: Fix "Query Projections (Avoid Over-Fetching)" — contradicts real handlers**
+
+Replace the heading, prose, and code block (lines 80-88) with:
+```
+### Loading and Mapping (not `.Select()` projection)
+
+Core Principle #4 above ("Queries should be projections") describes the *intent* — avoid over-fetching — but the actual pattern in this codebase is `AsNoTracking()` + `Include()` on the entity, then an explicit `.ToDto()` extension method in `Application/Mapping/`, not an inline `.Select(x => new Dto(...))`. See `GetHotstringQuery.cs` (Step 4) for the live shape. Reach for `.Select()` projection only if a query needs to avoid loading a large related collection that `.ToDto()` would otherwise touch.
+```
+
+- [ ] **Step 6: Mark "ExecuteUpdateAsync / ExecuteDeleteAsync" as framework reference, not live pattern**
+
+Insert this line immediately under the heading (before its existing code block, which stays as-is):
+```
+_No live example in this codebase yet — nothing here bulk-updates/deletes today. Framework API reference for when that need arises; convert to a pointer at that time instead of trusting this snippet to still be current._
+```
+
+- [ ] **Step 7: Mark "Interceptors" the same way, and correct the audit-trail claim**
+
+Replace the prose line under the heading ("Use interceptors for cross-cutting concerns like audit trails.") with:
+```
+_No `SaveChangesInterceptor` exists in this codebase. This app's audit trail (`EntityHistory`) is written explicitly inside command handlers, not via an interceptor — see `src/Backend/AHKFlowApp.Application/Commands/Hotkeys/RestoreHotkeyCommand.cs` for the shape. Keep this section as a framework-API reference only; don't imply the project uses interceptors._
+```
+Keep the existing code block below it — it is illustrative, not a claim about this app.
+
+- [ ] **Step 8: Mark "Compiled Queries" as framework reference**
+
+Insert under the heading, before the existing code block:
+```
+_No live example in this codebase — no compiled query exists today. Framework API reference only._
+```
+
+- [ ] **Step 9: Fix "Value Converters" — cite the real enum conversion, mark strongly-typed IDs as unused**
+
+Replace the code block (lines 169-180) with:
+```csharp
+// Real example: enum stored as int — src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/HotstringConfiguration.cs:35-37
+builder.Property(x => x.Kind)
+    .IsRequired()
+    .HasConversion<int>();
+```
+followed by:
+```
+_Strongly-typed ID value converters (e.g. a `HotstringId` wrapper) are not used anywhere in this codebase — every ID is a plain `Guid`. Framework API reference only if that changes._
+```
+
+- [ ] **Step 10: Fix "Global Query Filters" — this app doesn't soft-delete this way**
+
+Replace the heading, prose, and code block (lines 202-210) with:
+```
+### Soft Delete / Recycle Bin (this app does NOT use a global query filter)
+
+This app has no `IsDeleted` flag and no `HasQueryFilter`. Delete/restore is modeled through an `EntityHistory` snapshot table plus explicit commands — see `src/Backend/AHKFlowApp.Application/Commands/Hotkeys/{RestoreHotkeyCommand,PurgeDeletedHotkeyCommand}.cs`. If a future entity needs true soft-delete via a boolean flag, `HasQueryFilter` is still the right EF Core mechanism — but don't describe it as what this app already does.
+```
+
+- [ ] **Step 11: Fix "Testcontainers (SQL Server)" — per-class container is the exact pattern issue #220 already retired once**
+
+Replace the code block (lines 217-225) with:
+```
+The shared fixture lives in `tests/AHKFlowApp.TestUtilities/Fixtures/`: `SqlContainerFixture.cs` owns the `MsSqlContainer`, `ApiTestFixture.cs` wraps it with a `CustomWebApplicationFactory`. Tests share one container per collection via `[Collection("WebApi")]` — see `tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs:12-15` for the live shape. Never spin up a per-test-class `MsSqlContainer` — that is the exact pattern this project already retired once (see issue #220).
+```
+
+- [ ] **Step 12: Mark "Split Queries (avoid cartesian explosion)" as framework reference**
+
+Insert under the heading, before its existing code block:
+```
+_No live example in this codebase — no query combines multiple/large `Include`s today. Framework API reference only._
+```
+
+- [ ] **Step 13: Fix the "Don't Wrap DbContext in a Repository" anti-pattern GOOD example**
+
+Replace the GOOD line (line 302):
+```csharp
+// GOOD — use AppDbContext directly in handlers
+internal sealed class GetHotstringHandler(AppDbContext db) { }
+```
+with:
+```csharp
+// GOOD — use IAppDbContext directly in handlers (see GetHotstringQueryHandler)
+internal sealed class GetHotstringQueryHandler(IAppDbContext db, ICurrentUser currentUser) { }
+```
+
+- [ ] **Step 14: Re-check word count and commit**
+
+Run: `wc -l .agents/dck-ef-core/SKILL.md` — expect a drop from 364 lines (large code blocks became one-paragraph pointers).
+
+```bash
+git add .agents/dck-ef-core/SKILL.md
+git commit -m "docs: point dck-ef-core at live code instead of stale templates"
+```
+
+---
+
+## Task 2: `dck-blazor-mudblazor/SKILL.md`
+
+**Files:**
+- Modify: `.agents/dck-blazor-mudblazor/SKILL.md` (330 lines)
+
+- [ ] **Step 1: Replace "Page Layout (List View)" with pointers to the two real shapes**
+
+Replace the code block (lines 21-77) with:
+```
+This app uses two shapes depending on list complexity (documented in `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md`, "Conventions"):
+- **Simple list, ≤6 short fields, inline edit** — `MudTable` with inline row editing. See `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Categories.razor`.
+- **Larger list needing sort/filter/bulk-select** — `MudDataGrid` with `ServerData`, inline row editing, and a bulk-select toolbar. See `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor:70-78` (the `MudDataGrid` declaration) and `Pages/Hotkeys.razor` for a second example.
+
+Pages needing mobile support render both a `.desktop-branch` and `.mobile-branch`, gated by scoped CSS at 959.95px — see `Components/Hotstrings/` and `Components/Hotkeys/` for the mobile-branch components.
+```
+
+- [ ] **Step 2: Replace "MudDialog for Create/Edit" with a pointer, correcting when dialogs are actually used**
+
+Replace the code block (lines 81-133) with:
+```
+Full-screen `MudDialog` for create/edit is the **mobile-branch** pattern in this app, not the default — desktop list pages edit inline in the table/grid (Step 1). See `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor` for the live shape: a `MudDialog` with a `TitleContent` back-button + save button, an `EditModel` (`Validation/HotstringEditModel.cs`) bound via `@bind-Value`, and per-field `Func<string,string?>` validators (see Task's Step 4 below — no FluentValidation adapter is involved).
+```
+
+- [ ] **Step 3: Replace "Opening Dialogs from Pages" and "Delete Confirmation" with pointers**
+
+Replace both code blocks (lines 137-183) with:
+```
+### Opening Dialogs / Delete Confirmation
+
+See `HotstringEditDialog.razor`'s caller in `Pages/Hotstrings.razor` for `IDialogService.ShowAsync<T>` and result handling, and any page's delete action for `IDialogService.ShowMessageBox(...)` — the shape (title, message, yesText/cancelText, `== true` check) matches the original template; no drift found here.
+```
+
+- [ ] **Step 4: Fix "MudForm Validation with FluentValidation" — this adapter does not exist**
+
+Replace the heading, prose, and code block (lines 185-206) with:
+```
+### Form Validation (per-field delegates, not a FluentValidation adapter)
+
+There is no `FluentValidationExtensions.ValidateValue` adapter in this codebase — real forms validate with a plain `Func<string, string?>` delegate per field, defined as a method on an `EditModel` class in `Validation/` (e.g. `Validation/HotstringEditModel.cs`), wired up as `Validation="@(new Func<string, string?>(Item.ValidateReplacement))"` (see `Components/Hotstrings/HotstringEditDialog.razor:90`). Don't introduce a FluentValidation-to-MudForm adapter — follow the `EditModel` pattern instead.
+```
+
+- [ ] **Step 5: Replace "Server-Side Table (Pagination/Search)" with a pointer**
+
+Replace the code block (lines 210-256) with:
+```
+`Pages/Categories.razor` (`MudTable`) and `Pages/Hotstrings.razor` / `Pages/Hotkeys.razor` (`MudDataGrid`) all use `ServerData` — see Step 1 for which shape applies to a new page.
+```
+
+- [ ] **Step 6: Leave the "Anti-patterns" and "Decision Guide" sections as-is**
+
+These are short generic MudBlazor do/don't rules (raw HTML, missing `For`, skipping loading states, `StateHasChanged()` misuse, nested dialogs) that don't copy a specific project template and were not found to contradict live code — no change needed. Update the Decision Guide's "Create/Edit form" row only, from `MudDialog + MudForm + FluentValidation` to `Inline edit (MudTable/MudDataGrid) by default; MudDialog + EditModel only for the mobile branch`.
+
+- [ ] **Step 7: Re-check word count and commit**
+
+Run: `wc -l .agents/dck-blazor-mudblazor/SKILL.md`
+
+```bash
+git add .agents/dck-blazor-mudblazor/SKILL.md
+git commit -m "docs: point dck-blazor-mudblazor at live pages instead of stale templates"
+```
+
+---
+
+## Task 3: `dck-scaffolding/SKILL.md`
+
+**Files:**
+- Modify: `.agents/dck-scaffolding/SKILL.md` (231 lines)
+
+- [ ] **Step 1: Replace "Command and Handler" with a pointer, fixing the naming and `IAppDbContext` gaps**
+
+Replace both code blocks (lines 50-78) plus the "Register the use case" block (lines 80-84) with:
+```
+`src/Backend/AHKFlowApp.Application/Commands/Hotkeys/CreateHotkeyCommand.cs` is a live example: command record + validator + handler share one file, the handler class is `{CommandName}Handler` (e.g. `CreateHotkeyCommandHandler`, not `CreateHotkeyHandler`), it injects `IAppDbContext` (not `AppDbContext`) plus `ICurrentUser` and `TimeProvider`, and DI registration is a chained `.AddUseCase<TCommand, TResult, THandler>()` call in `src/Backend/AHKFlowApp.Application/DependencyInjection.cs` (see lines 33-40 for the chain shape).
+```
+
+- [ ] **Step 2: Replace "Validator" with a pointer**
+
+Replace the code block (lines 88-98) with:
+```
+Validators are usually a nested class in the same file as the command they validate (see `CreateHotkeyCommandValidator` in `CreateHotkeyCommand.cs`, Step 1) — not a separate file, despite the Layer Structure diagram above implying otherwise for large validators. Follow the co-located shape unless a validator grows large enough to warrant its own file.
+```
+
+- [ ] **Step 3: Replace "Query and Handler" with a pointer, fixing naming**
+
+Replace both code blocks (lines 103-125) with:
+```
+`src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringQuery.cs` is the live shape — handler class `GetHotstringQueryHandler` (not `GetHotstringHandler`), `IAppDbContext` + `ICurrentUser` injected, `AsNoTracking()` + `Include()` + `.ToDto()` rather than a `.Select()` projection. See `.agents/dck-ef-core/SKILL.md` for the EF Core side of this pattern.
+```
+
+- [ ] **Step 4: Replace "Controller" with a pointer, fixing `ToActionResult`**
+
+Replace the code block (lines 129-158) with:
+```
+`src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs` is the live shape. Note three things the simplified template above misses: results map via `result.ToProblemActionResult(this)` (an in-repo RFC 9457 extension, `src/Backend/AHKFlowApp.API/Extensions/ProblemDetailsResultExtensions.cs`), not the bare `Ardalis.Result.AspNetCore.ToActionResult`; class-level attributes add `[RequiredScope("access_as_user")]` and `[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]` / `...Status403Forbidden`; and action methods return `ActionResult<T>`, not `IActionResult`.
+```
+
+- [ ] **Step 5: Replace "Entity and EF Configuration" with a pointer**
+
+Replace both code blocks (lines 164-206) with:
+```
+`src/Backend/AHKFlowApp.Domain/Entities/Hotstring.cs` (entity: private setters, `Create` factory) and `src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/HotstringConfiguration.cs` (EF config: required/max-length properties, enum-as-int conversions, a filtered unique index) are the live, much richer versions of the toy example above — read them before scaffolding a new entity, don't copy the simplified shape here.
+```
+
+- [ ] **Step 6: Leave "Integration Test Shape" — already a pointer-style paragraph, just fix the fixture name**
+
+Replace (line 210):
+```
+Use `WebApplicationFactory` and SQL Server Testcontainers. Replace `DbContextOptions<AppDbContext>` with `services.RemoveAll<DbContextOptions<AppDbContext>>()`, run migrations, and assert behavior through HTTP or handler results.
+```
+with:
+```
+Use the shared `ApiTestFixture` (`tests/AHKFlowApp.TestUtilities/Fixtures/ApiTestFixture.cs`) via `[Collection("WebApi")]` — see `tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs:12-15`. Don't stand up a new `WebApplicationFactory`/`MsSqlContainer` per test class.
+```
+
+- [ ] **Step 7: Leave "Mandatory Checklist", "Layer Structure", "Anti-Patterns", "Decision Guide" as-is**
+
+These are short bullet/table content, not inlined code templates — no drift found; no change needed.
+
+- [ ] **Step 8: Re-check word count and commit**
+
+Run: `wc -l .agents/dck-scaffolding/SKILL.md`
+
+```bash
+git add .agents/dck-scaffolding/SKILL.md
+git commit -m "docs: point dck-scaffolding at live code instead of stale templates"
+```
+
+---
+
+## Task 4: `dck-openapi/SKILL.md`
+
+**Files:**
+- Modify: `.agents/dck-openapi/SKILL.md` (212 lines)
+
+- [ ] **Step 1: Replace "Basic Setup (Program.cs)" with a pointer**
+
+Replace the code block (lines 19-47) with:
+```
+Swagger setup is behind two extension methods, not inlined in `Program.cs`: `AddSwaggerDocs()` and `UseSwaggerDocs()` in `src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs:50-101`, called conditionally in Development from `src/Backend/AHKFlowApp.API/Program.cs:102,196`. Read the extension methods rather than copying the inline shape above — they also register `AddSwaggerExamplesFromAssemblies` and read XML comments from both `AHKFlowApp.API` and `AHKFlowApp.Application` assemblies.
+```
+
+- [ ] **Step 2: Replace "ProducesResponseType on Controller Actions" with a pointer**
+
+Replace the code block (lines 53-100) with:
+```
+`src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs` is the live, much larger example — 15 actions, each with XML `<summary>`/`<response>` comments and `[ProducesResponseType]` per possible status. It also carries class-level `[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]` / `...Status403Forbidden` that this simplified template omits — those apply to every action via `[Authorize]` + `[RequiredScope]` and don't need repeating per action.
+```
+
+- [ ] **Step 3: Leave "Enable XML Documentation" but cite the real csproj lines**
+
+Replace the code block (lines 106-111) with:
+```csharp
+<!-- src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj:4-5 (also set in AHKFlowApp.Application.csproj:3) -->
+<GenerateDocumentationFile>true</GenerateDocumentationFile>
+<NoWarn>$(NoWarn);CS1591</NoWarn>
+```
+
+- [ ] **Step 4: Fix "Bearer Token Security Scheme" — API shape has moved on**
+
+Replace the code block (lines 117-145) with:
+```
+The real registration is in `AddSwaggerDocs()` (`ApiExtensions.cs:61-74`) and uses the newer `Microsoft.OpenApi` shape — `OpenApiSecuritySchemeReference("Bearer", doc)` inside `AddSecurityRequirement(doc => ...)`, not the older `OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" }` this template shows. Copy the live extension method rather than this block; the two are not interchangeable across `Microsoft.OpenApi` versions.
+```
+
+- [ ] **Step 5: Leave "ProblemDetails Schema" but note the real registration also adds a trace ID**
+
+Replace the code block (line 152) with:
+```csharp
+// src/Backend/AHKFlowApp.API/Program.cs:75-77 — also stamps a traceId extension on every problem response
+builder.Services.AddProblemDetails(options =>
+    options.CustomizeProblemDetails = ctx =>
+        ctx.ProblemDetails.Extensions["traceId"] = ctx.HttpContext.TraceIdentifier);
+```
+
+- [ ] **Step 6: Leave "Anti-patterns" and "Decision Guide" as-is**
+
+Generic dos/don'ts (missing `ProducesResponseType`, Minimal API metadata on controllers, exposing Swagger in prod) — no drift found; no change needed.
+
+- [ ] **Step 7: Re-check word count and commit**
+
+Run: `wc -l .agents/dck-openapi/SKILL.md`
+
+```bash
+git add .agents/dck-openapi/SKILL.md
+git commit -m "docs: point dck-openapi at live code instead of stale templates"
+```
+
+---
+
+## Task 5: `dck-security-scan/SKILL.md`
+
+**Files:**
+- Modify: `.agents/dck-security-scan/SKILL.md` (374 lines)
+
+**Note on scope for this file specifically:** unlike the other four, most of this skill's BAD/GOOD examples (Layers 1, 2, 3, 6) are generic OWASP teaching content using placeholder names (`OrderController`, `SearchOrders`) — they were never copied from this project's real code, so there's no live file to point them at and no drift to fix. Only Layers 4 and 5 assume a configuration shape this app doesn't use. Leave everything else as-is.
+
+- [ ] **Step 1: Fix Layer 4 (Auth Configuration) — this app doesn't hand-configure JWT validation**
+
+Replace the "BAD/GOOD JWT configuration" code block (lines 149-179) with:
+```
+This app doesn't hand-build `TokenValidationParameters` — it delegates JWT validation to `Microsoft.Identity.Web`'s `AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"))` (`src/Backend/AHKFlowApp.API/Program.cs:130-135`), which reads issuer/audience/signing-key config from the `AzureAd` section and validates all four checklist items above automatically. A test-only bypass exists for local dev (`TestAuthenticationHandler`, gated to `Development` + `Auth:UseTestProvider=true`, `Program.cs:114-129`) — flag it as a finding only if it can be reached outside Development. Scanning this project's auth means checking the `AzureAd` config is populated and that `useTestAuth` can't go true outside Development, not reviewing hand-rolled `TokenValidationParameters` (keep the BAD/GOOD block below only as a reference for other .NET apps that do configure JWT bearer manually).
+```
+Keep the existing BAD/GOOD code block below this new paragraph — don't delete it, since other projects using this skill may hand-roll JWT bearer.
+
+- [ ] **Step 2: Fix Layer 5 (CORS Configuration) — point the GOOD example at the real policy**
+
+Insert this paragraph immediately before the existing "GOOD — explicit origins" code block (before line 204):
+```
+This app's real CORS policy (`src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs:10-24`) doesn't use a static `WithOrigins(...)` array like the block below — it uses `SetIsOriginAllowed` reading `Cors:AllowedOrigins` from live configuration on every request, so an edited `appsettings.Development.json` takes effect without an API restart. Check for that dynamic-origin pattern here specifically; the static-array block below is the general-case illustration.
+```
+
+- [ ] **Step 3: Leave Layers 1, 2, 3, 6, "Full Scan Report", "Anti-patterns", and "Decision Guide" as-is**
+
+No drift found — these don't copy project-specific code.
+
+- [ ] **Step 4: Re-check word count and commit**
+
+Run: `wc -l .agents/dck-security-scan/SKILL.md`
+
+```bash
+git add .agents/dck-security-scan/SKILL.md
+git commit -m "docs: point dck-security-scan auth/CORS layers at live code"
+```
+
+---
+
+## Task 6: Close the loop
+
+- [ ] **Step 1: Re-read all five rewritten files end to end**
+
+Confirm no leftover contradiction (e.g. a "Decision Guide" row that still says `AppDbContext` where the body now says `IAppDbContext`).
+
+- [ ] **Step 2: Report total line-count change**
+
+Run: `wc -l .agents/dck-security-scan/SKILL.md .agents/dck-ef-core/SKILL.md .agents/dck-blazor-mudblazor/SKILL.md .agents/dck-scaffolding/SKILL.md .agents/dck-openapi/SKILL.md`
+
+- [ ] **Step 3: Push and open the PR referencing #220**
+
+```bash
+git push -u origin fix/wt-skill-template-drift
+gh pr create --title "docs: convert template-heavy skills to pointer style" --body "Closes #220"
+```

--- a/plugins/ahkflowapp/.codex-plugin/plugin.json
+++ b/plugins/ahkflowapp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ahkflowapp",
-  "version": "0.1.0+codex.ba1fb4238e7a",
+  "version": "0.1.0+codex.b27f31c5820c",
   "description": "Repo-local Codex plugin exposing focused AHKFlowApp project skills.",
   "author": {
     "name": "AHKFlowApp maintainers",

--- a/plugins/ahkflowapp/skills/dck-blazor-mudblazor/SKILL.md
+++ b/plugins/ahkflowapp/skills/dck-blazor-mudblazor/SKILL.md
@@ -8,7 +8,7 @@ description: Use when building AHKFlowApp Blazor WebAssembly UI with MudBlazor p
 ## Core Principles
 
 1. **MudBlazor components first** — Always use MudBlazor components (`MudTable`, `MudForm`, `MudDialog`, `MudButton`) over raw HTML. Consistent styling, accessibility, and behavior out of the box.
-2. **Typed HttpClient for all API calls** — Use `IAHKFlowApiHttpClient` (registered via `AddHttpClient<T>`). Never create HttpClient manually.
+2. **Typed API client per entity** — Use the per-entity interface in `src/Frontend/AHKFlowApp.UI.Blazor/Services/` (`ICategoriesApiClient`, `IHotstringsApiClient`, `IHotkeysApiClient`, etc.), each extending `ApiClientBase` and exposing `ListAsync`/`GetAsync`/`CreateAsync`/`UpdateAsync`/`DeleteAsync` returning `ApiResult`/`ApiResult<T>`. `IAhkFlowAppApiHttpClient` only exposes `GetHealthAsync` — never route entity CRUD through it. Never create `HttpClient` manually.
 3. **Dialogs for create/edit, snackbars for feedback** — `IDialogService.ShowAsync<T>` for forms, `ISnackbar.Add()` for success/error notifications.
 4. **Loading states everywhere** — Set `_loading = true` before async calls, `false` after. Use `MudTable.Loading` and `MudProgressLinear` for visual feedback.
 5. **CancellationToken propagation** — Pass tokens through all async paths to support cancellation.
@@ -18,242 +18,27 @@ description: Use when building AHKFlowApp Blazor WebAssembly UI with MudBlazor p
 
 ### Page Layout (List View)
 
-```razor
-@page "/hotstrings"
+This app uses two shapes depending on list complexity (documented in `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md`, "Conventions"):
+- **Simple list, ≤6 short fields, inline edit** — `MudTable` with inline row editing. See `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Categories.razor`.
+- **Larger list needing sort/filter/bulk-select** — `MudDataGrid` with `ServerData`, inline row editing, and a bulk-select toolbar. See `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor:70-78` (the `MudDataGrid` declaration) and `Pages/Hotkeys.razor` for a second example.
 
-<PageTitle>Hotstrings</PageTitle>
-
-<MudContainer MaxWidth="MaxWidth.Large" Class="mt-4">
-    <MudText Typo="Typo.h4" Class="mb-4">Hotstrings</MudText>
-
-    <MudButton Variant="Variant.Filled" Color="Color.Primary"
-               StartIcon="@Icons.Material.Filled.Add"
-               OnClick="OpenCreateDialog" Class="mb-4">
-        Add Hotstring
-    </MudButton>
-
-    <MudTable Items="_hotstrings" Hover Loading="_loading"
-              Breakpoint="Breakpoint.Sm" LoadingProgressColor="Color.Primary">
-        <HeaderContent>
-            <MudTh>Trigger</MudTh>
-            <MudTh>Replacement</MudTh>
-            <MudTh Style="width: 120px;">Actions</MudTh>
-        </HeaderContent>
-        <RowTemplate>
-            <MudTd DataLabel="Trigger">@context.Trigger</MudTd>
-            <MudTd DataLabel="Replacement">@context.Replacement</MudTd>
-            <MudTd>
-                <MudIconButton Icon="@Icons.Material.Filled.Edit"
-                               Size="Size.Small"
-                               OnClick="() => OpenEditDialog(context)" />
-                <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                               Size="Size.Small" Color="Color.Error"
-                               OnClick="() => ConfirmDelete(context)" />
-            </MudTd>
-        </RowTemplate>
-    </MudTable>
-</MudContainer>
-
-@code {
-    [Inject] private IAHKFlowApiHttpClient Api { get; set; } = default!;
-    [Inject] private IDialogService DialogService { get; set; } = default!;
-    [Inject] private ISnackbar Snackbar { get; set; } = default!;
-
-    private List<HotstringDto> _hotstrings = [];
-    private bool _loading = true;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await LoadDataAsync();
-    }
-
-    private async Task LoadDataAsync()
-    {
-        _loading = true;
-        _hotstrings = await Api.GetHotstringsAsync();
-        _loading = false;
-    }
-}
-```
+Pages needing mobile support render both a `.desktop-branch` and `.mobile-branch`, gated by scoped CSS at 959.95px — see `Components/Hotstrings/` and `Components/Hotkeys/` for the mobile-branch components.
 
 ### MudDialog for Create/Edit
 
-```razor
-<MudDialog>
-    <TitleContent>
-        <MudText Typo="Typo.h6">@(IsEdit ? "Edit Hotstring" : "Add Hotstring")</MudText>
-    </TitleContent>
-    <DialogContent>
-        <MudForm @ref="_form" Model="_model" Validation="_validator.ValidateValue">
-            <MudTextField @bind-Value="_model.Trigger"
-                          For="() => _model.Trigger"
-                          Label="Trigger" Variant="Variant.Outlined"
-                          Immediate />
-            <MudTextField @bind-Value="_model.Replacement"
-                          For="() => _model.Replacement"
-                          Label="Replacement" Variant="Variant.Outlined"
-                          Lines="3" Immediate />
-        </MudForm>
-    </DialogContent>
-    <DialogActions>
-        <MudButton OnClick="Cancel">Cancel</MudButton>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                   OnClick="Submit">Save</MudButton>
-    </DialogActions>
-</MudDialog>
+Full-screen `MudDialog` for create/edit is the **mobile-branch** pattern in this app, not the default — desktop list pages edit inline in the table/grid (previous section). See `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor` for the live shape: a `MudDialog` with a `TitleContent` back-button + save button, an `EditModel` (`Validation/HotstringEditModel.cs`) bound via `@bind-Value`, and per-field `Func<string,string?>` validators (see "Form Validation" below — no FluentValidation adapter is involved).
 
-@code {
-    [CascadingParameter] private MudDialogInstance MudDialog { get; set; } = default!;
-    [Parameter] public HotstringDto? Existing { get; set; }
+### Opening Dialogs / Delete Confirmation
 
-    private bool IsEdit => Existing is not null;
-    private MudForm _form = default!;
-    private CreateHotstringDto _model = new();
-    private CreateHotstringDtoValidator _validator = new();
+See `HotstringEditDialog.razor`'s caller in `Pages/Hotstrings.razor` for `IDialogService.ShowAsync<T>` and result handling. For delete confirmation, the real method is `IDialogService.ShowMessageBoxAsync(...)`, not `ShowMessageBox(...)` — see `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Categories.razor:222-225` (`bool? confirm = await DialogService.ShowMessageBoxAsync(title: ..., message: ..., yesText: "Delete", cancelText: "Cancel"); if (confirm != true) return;`).
 
-    protected override void OnParametersSet()
-    {
-        if (Existing is not null)
-        {
-            _model = new() { Trigger = Existing.Trigger, Replacement = Existing.Replacement };
-        }
-    }
+### Form Validation (per-field delegates, not a FluentValidation adapter)
 
-    private async Task Submit()
-    {
-        await _form.Validate();
-        if (_form.IsValid)
-        {
-            MudDialog.Close(DialogResult.Ok(_model));
-        }
-    }
-
-    private void Cancel() => MudDialog.Cancel();
-}
-```
-
-### Opening Dialogs from Pages
-
-```csharp
-private async Task OpenCreateDialog()
-{
-    var dialog = await DialogService.ShowAsync<HotstringDialog>("Add Hotstring");
-    var result = await dialog.Result;
-
-    if (result is { Canceled: false, Data: CreateHotstringDto dto })
-    {
-        await Api.CreateHotstringAsync(dto);
-        Snackbar.Add("Hotstring created", Severity.Success);
-        await LoadDataAsync();
-    }
-}
-
-private async Task OpenEditDialog(HotstringDto hotstring)
-{
-    var parameters = new DialogParameters { ["Existing"] = hotstring };
-    var dialog = await DialogService.ShowAsync<HotstringDialog>("Edit Hotstring", parameters);
-    var result = await dialog.Result;
-
-    if (result is { Canceled: false, Data: CreateHotstringDto dto })
-    {
-        await Api.UpdateHotstringAsync(hotstring.Id, dto);
-        Snackbar.Add("Hotstring updated", Severity.Success);
-        await LoadDataAsync();
-    }
-}
-```
-
-### Delete Confirmation
-
-```csharp
-private async Task ConfirmDelete(HotstringDto hotstring)
-{
-    var confirmed = await DialogService.ShowMessageBox(
-        "Delete Hotstring",
-        $"Delete trigger '{hotstring.Trigger}'? This cannot be undone.",
-        yesText: "Delete", cancelText: "Cancel");
-
-    if (confirmed == true)
-    {
-        await Api.DeleteHotstringAsync(hotstring.Id);
-        Snackbar.Add("Hotstring deleted", Severity.Success);
-        await LoadDataAsync();
-    }
-}
-```
-
-### MudForm Validation with FluentValidation
-
-```csharp
-// Validator adapter for MudForm — wraps FluentValidation for @bind-Value + For
-public static class FluentValidationExtensions
-{
-    public static Func<object, string, Task<IEnumerable<string>>> ValidateValue<T>(
-        this IValidator<T> validator) where T : class
-    {
-        return async (model, propertyName) =>
-        {
-            var result = await validator.ValidateAsync(
-                ValidationContext<T>.CreateWithOptions(
-                    (T)model, x => x.IncludeProperties(propertyName)));
-
-            return result.IsValid
-                ? []
-                : result.Errors.Select(e => e.ErrorMessage);
-        };
-    }
-}
-```
+There is no `FluentValidationExtensions.ValidateValue` adapter in this codebase — real forms validate with a plain `Func<string, string?>` delegate per field, defined as a method on an `EditModel` class in `Validation/` (e.g. `Validation/HotstringEditModel.cs`), wired up as `Validation="@(new Func<string, string?>(Item.ValidateReplacement))"` (see `Components/Hotstrings/HotstringEditDialog.razor:90`). Don't introduce a FluentValidation-to-MudForm adapter — follow the `EditModel` pattern instead.
 
 ### Server-Side Table (Pagination/Search)
 
-```razor
-<MudTable ServerData="LoadServerData" @ref="_table" Hover
-          Loading="_loading" LoadingProgressColor="Color.Primary">
-    <ToolBarContent>
-        <MudTextField @bind-Value="_searchString" Placeholder="Search..."
-                      Adornment="Adornment.Start"
-                      AdornmentIcon="@Icons.Material.Filled.Search"
-                      Immediate DebounceInterval="300"
-                      OnDebounceIntervalElapsed="OnSearch" />
-    </ToolBarContent>
-    <HeaderContent>
-        <MudTh><MudTableSortLabel SortLabel="trigger" T="HotstringDto">Trigger</MudTableSortLabel></MudTh>
-        <MudTh><MudTableSortLabel SortLabel="replacement" T="HotstringDto">Replacement</MudTableSortLabel></MudTh>
-    </HeaderContent>
-    <RowTemplate>
-        <MudTd DataLabel="Trigger">@context.Trigger</MudTd>
-        <MudTd DataLabel="Replacement">@context.Replacement</MudTd>
-    </RowTemplate>
-    <PagerContent>
-        <MudTablePager />
-    </PagerContent>
-</MudTable>
-
-@code {
-    private MudTable<HotstringDto> _table = default!;
-    private string _searchString = string.Empty;
-    private bool _loading;
-
-    private async Task<TableData<HotstringDto>> LoadServerData(TableState state,
-        CancellationToken ct)
-    {
-        _loading = true;
-        var response = await Api.SearchHotstringsAsync(
-            _searchString, state.Page + 1, state.PageSize, state.SortLabel,
-            state.SortDirection == SortDirection.Descending, ct);
-        _loading = false;
-
-        return new TableData<HotstringDto>
-        {
-            Items = response.Items,
-            TotalItems = response.TotalCount
-        };
-    }
-
-    private void OnSearch() => _table.ReloadServerData();
-}
-```
+`Pages/Categories.razor` (`MudTable`) and `Pages/Hotstrings.razor` / `Pages/Hotkeys.razor` (`MudDataGrid`) all use `ServerData` — see "Page Layout" above for which shape applies to a new page.
 
 ## Anti-patterns
 
@@ -269,25 +54,30 @@ public static class FluentValidationExtensions
 <MudButton Variant="Variant.Filled" OnClick="Submit">Save</MudButton>
 ```
 
-### Don't Forget `For` Lambda on Form Fields
+### Don't Skip Field-Level Validation
+
+Real forms in this app don't use a `For` lambda at all — `Validation/HotstringEditModel.cs`'s fields validate through a `Func<string, string?>` delegate passed directly to `Validation`, with `Error`/`ErrorText` bound to the same check (see `Components/Hotstrings/HotstringEditDialog.razor:89-94`, no `For` present). `For` only matters if a field is linked into `MudForm`'s `EditContext`-based validation, which this codebase doesn't use.
 
 ```razor
-@* BAD — validation messages won't display for this field *@
+@* BAD — no validation wired up at all *@
 <MudTextField @bind-Value="_model.Trigger" Label="Trigger" />
 
-@* GOOD — For links the field to FluentValidation *@
-<MudTextField @bind-Value="_model.Trigger" For="() => _model.Trigger" Label="Trigger" />
+@* GOOD — Validation delegate + Error/ErrorText, matching HotstringEditDialog.razor *@
+<MudTextField @bind-Value="_model.Trigger" Label="Trigger"
+              Validation="@(new Func<string, string?>(ValidateTrigger))"
+              Error="@(ValidateTrigger(_model.Trigger) is not null)"
+              ErrorText="@ValidateTrigger(_model.Trigger)" />
 ```
 
 ### Don't Skip Loading States
 
 ```csharp
 // BAD — UI freezes with no feedback during API calls
-_hotstrings = await Api.GetHotstringsAsync();
+ApiResult<PagedList<HotstringDto>> result = await Api.ListAsync(request, ct);
 
-// GOOD — loading indicator visible during fetch
+// GOOD — loading indicator visible during fetch (Api is IHotstringsApiClient)
 _loading = true;
-_hotstrings = await Api.GetHotstringsAsync();
+ApiResult<PagedList<HotstringDto>> result = await Api.ListAsync(request, ct);
 _loading = false;
 ```
 
@@ -295,12 +85,12 @@ _loading = false;
 
 ```csharp
 // BAD — unnecessary, Blazor re-renders after event handlers
-await Api.CreateHotstringAsync(dto);
+await Api.CreateAsync(dto, ct);
 StateHasChanged(); // redundant
 
 // GOOD — only call StateHasChanged after non-UI-thread operations
 // Blazor auto-renders after event handlers and OnInitializedAsync
-await Api.CreateHotstringAsync(dto);
+await Api.CreateAsync(dto, ct);
 ```
 
 ### Don't Nest Dialogs
@@ -318,13 +108,14 @@ MudDialog.Close(DialogResult.Ok(result));
 
 | Scenario | Recommendation |
 |----------|---------------|
-| List of items | `MudTable` with `Items` (client) or `ServerData` (server) |
-| Create/Edit form | `MudDialog` + `MudForm` + FluentValidation |
-| Delete confirmation | `DialogService.ShowMessageBox()` |
+| List of items, simple (≤6 fields) | `MudTable` inline row editing (see `Categories.razor`) |
+| List of items, larger/sortable/bulk-select | `MudDataGrid` with `ServerData` (see `Hotstrings.razor`, `Hotkeys.razor`) |
+| Create/Edit form | Inline edit (`MudTable`/`MudDataGrid`) by default; `MudDialog` + `EditModel` only for the mobile branch |
+| Delete confirmation | `DialogService.ShowMessageBoxAsync()` |
 | Success/error feedback | `ISnackbar.Add()` with `Severity` |
 | Search with debounce | `MudTextField` with `DebounceInterval` + `OnDebounceIntervalElapsed` |
 | Sorting | `MudTableSortLabel` with `SortLabel` |
 | Pagination | `MudTablePager` (server-side) or built-in (client-side) |
-| Form validation | `MudForm` + `Validation` + `For` lambdas |
+| Form validation | `EditModel` with per-field `Func<string,string?>` delegates on `Validation`/`Error`/`ErrorText` (no `For`) |
 | Loading indicator | `MudTable.Loading` or `MudProgressLinear` |
 | Navigation | `MudNavMenu` + `MudNavLink` |

--- a/plugins/ahkflowapp/skills/dck-ef-core/SKILL.md
+++ b/plugins/ahkflowapp/skills/dck-ef-core/SKILL.md
@@ -8,104 +8,52 @@ description: Use when changing AHKFlowApp EF Core, SQL Server, DbContext, migrat
 ## Core Principles
 
 1. **EF Core is the default ORM** — Use it for all data access. No stored procedures, no raw ADO.NET except for diagnostics.
-2. **DbContext injected directly into handlers** — No repository pattern. No IAppDbContext interface. EF Core's DbSet already implements repository and unit-of-work. Adding another layer adds indirection without value.
+2. **`IAppDbContext` injected into handlers** — This project wraps `AppDbContext` behind `IAppDbContext` (`src/Backend/AHKFlowApp.Application/Abstractions/IAppDbContext.cs`) purely so handler unit tests can substitute it — the interface still exposes `DbSet<T>` properties directly, no per-entity CRUD methods, so it is not a repository. Never add a repository interface on top of it.
 3. **SQL Server only** — LocalDB for local dev, Docker Compose SQL Server for dev containers, Azure SQL for production. `EnableRetryOnFailure()` on all registrations.
-4. **Queries should be projections** — Use `.Select()` to project into DTOs. Avoids over-fetching and N+1 issues.
+4. **List queries project, detail queries load-and-map** — List/paginated queries use `.Select()` to build the DTO directly in the query (see `ListCategoriesQuery.cs:52`, `ListHotstringsQuery.cs:179`); single-entity "get by id" queries load the tracked-off entity with `Include()` and map with an explicit `.ToDto()` extension instead (see `GetHotstringQuery.cs`, below). Both avoid over-fetching; pick the shape that matches the query, not one universal rule.
 5. **Migrations are code** — Review them, test them, never auto-apply in production.
 
 ## Patterns
 
 ### DbContext Registration (SQL Server)
 
-```csharp
-// Program.cs or Infrastructure DI extension
-services.AddDbContext<AppDbContext>(options =>
-    options.UseSqlServer(
-        connectionString,
-        sql => sql.EnableRetryOnFailure(
-            maxRetryCount: 3,
-            maxRetryDelay: TimeSpan.FromSeconds(10),
-            errorNumbersToAdd: null)));
-```
+See `src/Backend/AHKFlowApp.Infrastructure/DependencyInjection.cs:16-21` for the live registration — `AddDbContext<AppDbContext>` with `EnableRetryOnFailure()`, plus a scoped `IAppDbContext` registration that resolves to the same `AppDbContext` instance.
 
 ### DbContext Configuration
 
-Use `IEntityTypeConfiguration<T>` to keep entity configs separate and discoverable. No data annotations on entities.
+`AppDbContext` lives at `src/Backend/AHKFlowApp.Infrastructure/Persistence/AppDbContext.cs`; entity configs live one level down in `Configurations/`, one file per entity, each implementing `IEntityTypeConfiguration<T>`. `Configurations/HotstringConfiguration.cs` is the fullest example — required/max-length properties, an enum-as-int conversion, and a filtered unique index (`HasIndex(...).HasFilter(null)`) for the "one global row per owner+trigger" rule. Follow its shape rather than a simplified one.
 
-```csharp
-// Infrastructure/Persistence/AppDbContext.cs
-public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
-{
-    public DbSet<Hotstring> Hotstrings => Set<Hotstring>();
+### Handler Injects IAppDbContext Directly
 
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
-    }
-}
-```
+`src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringQuery.cs` is the live shape for a detail query: the handler class is named `{Query}Handler` off the full query name (`GetHotstringQueryHandler`, not `GetHotstringHandler`), it takes `IAppDbContext` (not `AppDbContext`) and `ICurrentUser` in its primary constructor, and it loads the entity with `AsNoTracking()` + `Include()`, then maps with an explicit `.ToDto()` extension (`Application/Mapping/`). List queries use a different shape — see below.
 
-```csharp
-// Infrastructure/Persistence/Configurations/HotstringConfiguration.cs
-internal sealed class HotstringConfiguration : IEntityTypeConfiguration<Hotstring>
-{
-    public void Configure(EntityTypeBuilder<Hotstring> builder)
-    {
-        builder.HasKey(x => x.Id);
-        builder.Property(x => x.Trigger).HasMaxLength(50).IsRequired();
-        builder.Property(x => x.Replacement).HasMaxLength(500).IsRequired();
-        builder.HasIndex(x => x.Trigger).IsUnique();
-    }
-}
-```
+### Loading and Mapping — detail queries vs list queries
 
-### Handler Injects DbContext Directly
+Two live shapes, not one:
+- **Detail query (single entity by id)** — `AsNoTracking()` + `Include()` on the entity, then an explicit `.ToDto()` extension method in `Application/Mapping/`. See `GetHotstringQuery.cs` above.
+- **List/paginated query** — `.Select(x => new Dto(...))` projecting straight from the queryable, no `.ToDto()` call. See `ListCategoriesQuery.cs:52` (`.Select(c => new CategoryDto(c.Id, c.Name, c.CreatedAt, c.UpdatedAt))`) and `ListHotstringsQuery.cs:179`.
 
-```csharp
-// Application/Queries/GetHotstringHandler.cs — DO inject DbContext directly
-internal sealed class GetHotstringHandler(AppDbContext db)
-    : IUseCaseHandler<GetHotstringQuery, Result<HotstringDto>>
-{
-    public async Task<Result<HotstringDto>> ExecuteAsync(
-        GetHotstringQuery request, CancellationToken ct)
-    {
-        var entity = await db.Hotstrings.FindAsync([request.Id], ct);
-        return entity is not null
-            ? Result.Success(new HotstringDto(entity.Id, entity.Trigger, entity.Replacement))
-            : Result.NotFound();
-    }
-}
-```
-
-### Query Projections (Avoid Over-Fetching)
-
-```csharp
-// GOOD — project to DTO, only loads needed columns
-var dto = await db.Hotstrings
-    .Where(h => h.Id == request.Id)
-    .Select(h => new HotstringDto(h.Id, h.Trigger, h.Replacement))
-    .FirstOrDefaultAsync(ct);
-```
+Follow whichever shape matches the query you're writing — don't force a list query into `.ToDto()` or a detail query into `.Select()`.
 
 ### ExecuteUpdateAsync / ExecuteDeleteAsync
 
 Bulk operations that bypass change tracking for better performance.
 
-```csharp
-// Update without loading entities
-await db.Hotstrings
-    .Where(h => h.ProfileId == request.ProfileId)
-    .ExecuteUpdateAsync(s => s.SetProperty(h => h.IsActive, false), ct);
+_No live example in this codebase yet — nothing here bulk-updates/deletes today, and no `Hotstring.ProfileId`/`Hotstring.IsActive` properties exist (see `Hotstring.cs`) to bulk-update. The example below is the official EF Core 10 docs sample (generic `Employees`/`Tags` entities), not this app's data — convert to a pointer once a real usage exists._
 
-// Delete without loading entities
-await db.Hotstrings
-    .Where(h => h.ProfileId == request.ProfileId)
-    .ExecuteDeleteAsync(ct);
+```csharp
+// From https://learn.microsoft.com/ef/core/saving/execute-insert-update-delete (EF Core 10)
+// Update without loading entities
+await context.Employees.ExecuteUpdateAsync(
+    s => s.SetProperty(e => e.Salary, e => e.Salary + 1000), ct);
+
+// Delete without loading entities, with a filter
+await context.Tags.Where(t => t.Text.Contains(".NET")).ExecuteDeleteAsync(ct);
 ```
 
 ### Interceptors
 
-Use interceptors for cross-cutting concerns like audit trails.
+_No `SaveChangesInterceptor` exists in this codebase. This app's audit trail (`EntityHistory`) is written explicitly inside command handlers, not via an interceptor — see `src/Backend/AHKFlowApp.Application/Commands/Hotkeys/RestoreHotkeyCommand.cs` for the shape. Keep this section as a framework-API reference only; don't imply the project uses interceptors._
 
 ```csharp
 public sealed class AuditInterceptor(TimeProvider clock) : SaveChangesInterceptor
@@ -149,35 +97,28 @@ services.AddDbContext<AppDbContext>((sp, options) =>
 
 Use for hot-path queries that execute frequently with the same shape.
 
-```csharp
-public static class HotstringQueries
-{
-    public static readonly Func<AppDbContext, int, CancellationToken, Task<HotstringDto?>> GetById =
-        EF.CompileAsyncQuery((AppDbContext db, int id, CancellationToken ct) =>
-            db.Hotstrings
-                .Where(h => h.Id == id)
-                .Select(h => new HotstringDto(h.Id, h.Trigger, h.Replacement))
-                .FirstOrDefault());
-}
+_No live example in this codebase — no compiled query exists today. The example below is the official EF Core 10 docs sample (`EF.CompileAsyncQuery` API definition), not this app's data — every ID in this app is a `Guid`, not the `int` shown here._
 
-// Usage
-var dto = await HotstringQueries.GetById(db, request.Id, ct);
+```csharp
+// From https://learn.microsoft.com/dotnet/api/microsoft.entityframeworkcore.ef.compileasyncquery (EF Core 10)
+private static readonly Func<BloggingContext, int, IAsyncEnumerable<Blog>> _compiledQuery
+    = EF.CompileAsyncQuery(
+        (BloggingContext context, int length) => context.Blogs.Where(b => b.Url.StartsWith("http://") && b.Url.Length == length));
+
+// Usage — the delegate is thread-safe and can run concurrently on different context instances
+await foreach (Blog blog in _compiledQuery(context, 8)) { /* ... */ }
 ```
 
 ### Value Converters
 
 ```csharp
-// Store enum as string
-builder.Property(h => h.Status)
-    .HasConversion<string>()
-    .HasMaxLength(50);
-
-// Strongly-typed IDs
-public readonly record struct HotstringId(int Value);
-
-builder.Property(h => h.Id)
-    .HasConversion(id => id.Value, value => new HotstringId(value));
+// Real example: enum stored as int — src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/HotstringConfiguration.cs:35-37
+builder.Property(x => x.Kind)
+    .IsRequired()
+    .HasConversion<int>();
 ```
+
+_Strongly-typed ID value converters (e.g. a `HotstringId` wrapper) are not used anywhere in this codebase — every ID is a plain `Guid`. Framework API reference only if that changes._
 
 ### Migrations Workflow
 
@@ -199,30 +140,15 @@ dotnet ef database update \
 dotnet ef migrations script --idempotent --output migrations.sql
 ```
 
-### Global Query Filters
+### Soft Delete / Recycle Bin (this app does NOT use a global query filter)
 
-```csharp
-// Soft delete filter
-builder.HasQueryFilter(h => !h.IsDeleted);
-
-// Bypass when needed
-var all = await db.Hotstrings.IgnoreQueryFilters().ToListAsync(ct);
-```
+This app has no `IsDeleted` flag and no `HasQueryFilter`. Delete/restore is modeled through an `EntityHistory` snapshot table plus explicit commands — see `src/Backend/AHKFlowApp.Application/Commands/Hotkeys/{RestoreHotkeyCommand,PurgeDeletedHotkeyCommand}.cs`. If a future entity needs true soft-delete via a boolean flag, `HasQueryFilter` is still the right EF Core mechanism — but don't describe it as what this app already does.
 
 ### Testcontainers (SQL Server)
 
 Always use SQL Server Testcontainers for integration tests — never in-memory provider.
 
-```csharp
-private readonly MsSqlContainer _mssql = new MsSqlBuilder()
-    .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
-    .Build();
-
-// In ConfigureWebHost
-services.RemoveAll<DbContextOptions<AppDbContext>>();
-services.AddDbContext<AppDbContext>(options =>
-    options.UseSqlServer(_mssql.GetConnectionString()));
-```
+The shared fixture lives in `tests/AHKFlowApp.TestUtilities/Fixtures/`: `SqlContainerFixture.cs` owns the `MsSqlContainer`, `ApiTestFixture.cs` wraps it with a `CustomWebApplicationFactory`. Tests share one container per collection via `[Collection("WebApi")]` — see `tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs:12-15` for the live shape. Never spin up a per-test-class `MsSqlContainer` — that is the exact pattern this project already retired once (see issue #220).
 
 ### Query Performance
 
@@ -253,11 +179,13 @@ var hotstrings = await db.Hotstrings
     .ToListAsync(ct);
 ```
 
-Projecting into a DTO with `.Select()` (the default in this project) is already effectively no-tracking. Reach for `AsNoTrackingWithIdentityResolution()` only when a query can return the same row more than once (e.g. a join that repeats a `Profile`) and you want one shared instance instead of duplicates.
+`AsNoTracking()` (the default read pattern in this project — see "Loading and Mapping" above) is enough for a single-row read. Reach for `AsNoTrackingWithIdentityResolution()` only when a query can return the same row more than once (e.g. a join that repeats a `Profile`) and you want one shared instance instead of duplicates.
 
 #### Split Queries (avoid cartesian explosion)
 
 A single query with multiple or large `Include`s multiplies rows (cartesian product). Split it into one round-trip per collection.
+
+_No live example in this codebase — no query combines multiple/large `Include`s today. Framework API reference only._
 
 ```csharp
 var profiles = await db.Profiles
@@ -298,8 +226,8 @@ public interface IHotstringRepository
     Task SaveChangesAsync();
 }
 
-// GOOD — use AppDbContext directly in handlers
-internal sealed class GetHotstringHandler(AppDbContext db) { }
+// GOOD — use IAppDbContext directly in handlers (see GetHotstringQueryHandler)
+internal sealed class GetHotstringQueryHandler(IAppDbContext db, ICurrentUser currentUser) { }
 ```
 
 ### Don't Use Lazy Loading
@@ -350,15 +278,15 @@ options.UseSqlServer(connectionString, sql => sql.EnableRetryOnFailure(...));
 
 | Scenario | Recommendation |
 |---|---|
-| Standard CRUD | AppDbContext with projections in handler |
-| Bulk updates (100+ rows) | `ExecuteUpdateAsync` / `ExecuteDeleteAsync` |
-| Hot-path read query | Compiled query |
-| Read-only query | `AsNoTracking()`, or project to a DTO |
-| Multiple / large `Include`s | `AsSplitQuery()` |
+| Standard CRUD | `IAppDbContext` with `AsNoTracking()` + `Include()` + `.ToDto()` in handler |
+| Bulk updates (100+ rows) | `ExecuteUpdateAsync` / `ExecuteDeleteAsync` (no live example yet) |
+| Hot-path read query | Compiled query (no live example yet) |
+| Read-only query | `AsNoTracking()`, or map with `.ToDto()` |
+| Multiple / large `Include`s | `AsSplitQuery()` (no live example yet) |
 | Existence check | `AnyAsync`, never `CountAsync > 0` |
 | Diagnosing a slow query | Log `Microsoft.EntityFrameworkCore.Database.Command` |
-| Audit trails | `SaveChangesInterceptor` |
-| Soft deletes | Global query filter + interceptor |
-| Strongly-typed IDs | Value converter |
+| Audit trails | Explicit `EntityHistory` writes in the handler (no interceptor) |
+| Delete / restore | `EntityHistory` snapshot + explicit commands (no global query filter) |
+| Strongly-typed IDs | Not used — every ID is a `Guid` |
 | Production migration | Idempotent SQL script, never auto-migrate |
-| Integration tests | Testcontainers `MsSqlContainer` |
+| Integration tests | Shared `ApiTestFixture` / `SqlContainerFixture`, `[Collection("WebApi")]` — never a per-class `MsSqlContainer` |

--- a/plugins/ahkflowapp/skills/dck-openapi/SKILL.md
+++ b/plugins/ahkflowapp/skills/dck-openapi/SKILL.md
@@ -16,140 +16,31 @@ description: Use when changing AHKFlowApp OpenAPI, Swagger, API docs, response a
 
 ### Basic Setup (Program.cs)
 
-```csharp
-// Program.cs
-builder.Services.AddSwaggerGen(options =>
-{
-    options.SwaggerDoc("v1", new OpenApiInfo
-    {
-        Title = "AHKFlowApp API",
-        Version = "v1",
-        Description = "API for managing AutoHotkey hotstrings and hotkeys."
-    });
-
-    // Include XML comments from the API project
-    var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
-    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
-    options.IncludeXmlComments(xmlPath);
-});
-
-// ...
-
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI(options =>
-    {
-        options.SwaggerEndpoint("/swagger/v1/swagger.json", "AHKFlowApp API v1");
-        options.RoutePrefix = "swagger";  // available at /swagger
-    });
-}
-```
+Swagger setup is behind two extension methods, not inlined in `Program.cs`: `AddSwaggerDocs()` and `UseSwaggerDocs()` in `src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs:50-101`, called conditionally in Development from `src/Backend/AHKFlowApp.API/Program.cs:102,196`. Read the extension methods rather than copying an inline shape — they also register `AddSwaggerExamplesFromAssemblies` and read XML comments from both `AHKFlowApp.API` and `AHKFlowApp.Application` assemblies.
 
 ### ProducesResponseType on Controller Actions
 
-Every action must declare all possible response types.
-
-```csharp
-[ApiController]
-[Route("api/v1/[controller]")]
-public sealed class HotstringsController(
-    IUseCase<CreateHotstringCommand, Result<HotstringDto>> createHotstring,
-    IUseCase<GetHotstringQuery, Result<HotstringDto>> getHotstring,
-    IUseCase<ListHotstringsQuery, Result<IReadOnlyList<HotstringDto>>> listHotstrings)
-    : ControllerBase
-{
-    /// <summary>Creates a new hotstring.</summary>
-    /// <param name="dto">Trigger and replacement text.</param>
-    /// <response code="201">Hotstring created successfully.</response>
-    /// <response code="400">Validation failed.</response>
-    /// <response code="409">A hotstring with this trigger already exists.</response>
-    [HttpPost]
-    [ProducesResponseType<HotstringDto>(StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> Create(CreateHotstringDto dto, CancellationToken ct)
-    {
-        var result = await createHotstring.ExecuteAsync(new CreateHotstringCommand(dto.Trigger, dto.Replacement), ct);
-        return result.ToActionResult(this);
-    }
-
-    /// <summary>Gets a hotstring by ID.</summary>
-    /// <param name="id">The hotstring ID.</param>
-    /// <response code="200">Returns the hotstring.</response>
-    /// <response code="404">Hotstring not found.</response>
-    [HttpGet("{id:int}")]
-    [ProducesResponseType<HotstringDto>(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetById(int id, CancellationToken ct)
-    {
-        var result = await getHotstring.ExecuteAsync(new GetHotstringQuery(id), ct);
-        return result.ToActionResult(this);
-    }
-
-    /// <summary>Lists all hotstrings.</summary>
-    /// <response code="200">Returns the list of hotstrings.</response>
-    [HttpGet]
-    [ProducesResponseType<IReadOnlyList<HotstringDto>>(StatusCodes.Status200OK)]
-    public async Task<IActionResult> List(CancellationToken ct)
-    {
-        var result = await listHotstrings.ExecuteAsync(new ListHotstringsQuery(), ct);
-        return result.ToActionResult(this);
-    }
-}
-```
+Every action must declare all possible response types. `src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs` is the live, much larger example — 15 actions, each with XML `<summary>`/`<response>` comments and `[ProducesResponseType]` per possible status. It also carries class-level `[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]` / `...Status403Forbidden` that a per-action-only approach would miss — those apply to every action via `[Authorize]` + `[RequiredScope]` and don't need repeating per action.
 
 ### Enable XML Documentation
 
-In `AHKFlowApp.API.csproj`:
-
 ```xml
-<PropertyGroup>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);1591</NoWarn>  <!-- suppress missing XML comment warnings -->
-</PropertyGroup>
+<!-- src/Backend/AHKFlowApp.API/AHKFlowApp.API.csproj:4-5 (also set in AHKFlowApp.Application.csproj:3) -->
+<GenerateDocumentationFile>true</GenerateDocumentationFile>
+<NoWarn>$(NoWarn);CS1591</NoWarn>
 ```
 
 ### Bearer Token Security Scheme
 
-For Azure AD (MSAL) authentication in Swagger UI:
-
-```csharp
-builder.Services.AddSwaggerGen(options =>
-{
-    options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
-    {
-        Name = "Authorization",
-        Type = SecuritySchemeType.Http,
-        Scheme = "bearer",
-        BearerFormat = "JWT",
-        In = ParameterLocation.Header,
-        Description = "Enter JWT token"
-    });
-
-    options.AddSecurityRequirement(new OpenApiSecurityRequirement
-    {
-        {
-            new OpenApiSecurityScheme
-            {
-                Reference = new OpenApiReference
-                {
-                    Type = ReferenceType.SecurityScheme,
-                    Id = "Bearer"
-                }
-            },
-            []
-        }
-    });
-});
-```
+The real registration is in `AddSwaggerDocs()` (`ApiExtensions.cs:61-74`) and uses the newer `Microsoft.OpenApi` shape — `OpenApiSecuritySchemeReference("Bearer", doc)` inside `AddSecurityRequirement(doc => ...)`, not the older `OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" }` shape. Copy the live extension method rather than an older-API block; the two are not interchangeable across `Microsoft.OpenApi` versions.
 
 ### ProblemDetails Schema
 
-Register `AddProblemDetails()` to ensure ProblemDetails appears correctly in the OpenAPI schema:
-
 ```csharp
-builder.Services.AddProblemDetails();
+// src/Backend/AHKFlowApp.API/Program.cs:75-77 — also stamps a traceId extension on every problem response
+builder.Services.AddProblemDetails(options =>
+    options.CustomizeProblemDetails = ctx =>
+        ctx.ProblemDetails.Extensions["traceId"] = ctx.HttpContext.TraceIdentifier);
 ```
 
 ## Anti-patterns
@@ -158,14 +49,14 @@ builder.Services.AddProblemDetails();
 
 ```csharp
 // BAD — no response type annotations, schema won't include response types
-[HttpGet("{id:int}")]
-public async Task<IActionResult> GetById(int id, CancellationToken ct) { ... }
+[HttpGet("{id:guid}")]
+public async Task<ActionResult<HotstringDto>> Get(Guid id, CancellationToken ct) { ... }
 
-// GOOD — explicit annotations
-[HttpGet("{id:int}")]
-[ProducesResponseType<HotstringDto>(StatusCodes.Status200OK)]
-[ProducesResponseType(StatusCodes.Status404NotFound)]
-public async Task<IActionResult> GetById(int id, CancellationToken ct) { ... }
+// GOOD — explicit annotations (real IDs in this app are Guid, routed with :guid)
+[HttpGet("{id:guid}")]
+[ProducesResponseType(typeof(HotstringDto), StatusCodes.Status200OK)]
+[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+public async Task<ActionResult<HotstringDto>> Get(Guid id, CancellationToken ct) { ... }
 ```
 
 ### Minimal API OpenAPI Patterns in Controllers

--- a/plugins/ahkflowapp/skills/dck-scaffolding/SKILL.md
+++ b/plugins/ahkflowapp/skills/dck-scaffolding/SKILL.md
@@ -47,167 +47,27 @@ src/Backend/AHKFlowApp.Infrastructure/
 
 ## Command and Handler
 
-```csharp
-namespace AHKFlowApp.Application.Commands;
-
-public sealed record CreateHotstringCommand(CreateHotstringDto Input);
-```
-
-```csharp
-namespace AHKFlowApp.Application.Commands;
-
-internal sealed class CreateHotstringHandler(AppDbContext db, TimeProvider timeProvider)
-    : IUseCaseHandler<CreateHotstringCommand, Result<HotstringDto>>
-{
-    public async Task<Result<HotstringDto>> ExecuteAsync(
-        CreateHotstringCommand request,
-        CancellationToken cancellationToken)
-    {
-        var hotstring = Hotstring.Create(
-            ownerOid,
-            request.Input.Trigger,
-            request.Input.Replacement,
-            timeProvider.GetUtcNow());
-
-        db.Hotstrings.Add(hotstring);
-        await db.SaveChangesAsync(cancellationToken);
-
-        return Result.Success(new HotstringDto(hotstring.Id, hotstring.Trigger, hotstring.Replacement));
-    }
-}
-```
-
-Register the use case in Application DI:
-
-```csharp
-services.AddUseCase<CreateHotstringCommand, Result<HotstringDto>, CreateHotstringHandler>();
-```
+`src/Backend/AHKFlowApp.Application/Commands/Hotkeys/CreateHotkeyCommand.cs` is a live example: command record + validator + handler share one file, the handler class is `{CommandName}Handler` (e.g. `CreateHotkeyCommandHandler`, not `CreateHotkeyHandler`), it injects `IAppDbContext` (not `AppDbContext`) plus `ICurrentUser` and `TimeProvider`, and DI registration is a chained `.AddUseCase<TCommand, TResult, THandler>()` call in `src/Backend/AHKFlowApp.Application/DependencyInjection.cs` (see lines 33-40 for the chain shape).
 
 ## Validator
 
-```csharp
-namespace AHKFlowApp.Application.Commands;
-
-public sealed class CreateHotstringValidator : AbstractValidator<CreateHotstringCommand>
-{
-    public CreateHotstringValidator()
-    {
-        RuleFor(x => x.Input.Trigger).NotEmpty().MaximumLength(50);
-        RuleFor(x => x.Input.Replacement).NotEmpty().MaximumLength(500);
-    }
-}
-```
+Validators are usually a top-level class co-located in the same file as the command they validate — not nested inside the handler, and not a separate file (see `CreateHotkeyCommandValidator` in `CreateHotkeyCommand.cs:15` above), despite the Layer Structure diagram above implying a separate file for large validators. Follow the co-located shape unless a validator grows large enough to warrant its own file.
 
 ## Query and Handler
 
-```csharp
-namespace AHKFlowApp.Application.Queries;
-
-public sealed record GetHotstringQuery(Guid Id);
-```
-
-```csharp
-namespace AHKFlowApp.Application.Queries;
-
-internal sealed class GetHotstringHandler(AppDbContext db)
-    : IUseCaseHandler<GetHotstringQuery, Result<HotstringDto>>
-{
-    public async Task<Result<HotstringDto>> ExecuteAsync(
-        GetHotstringQuery request,
-        CancellationToken cancellationToken)
-    {
-        var entity = await db.Hotstrings.FindAsync([request.Id], cancellationToken);
-        return entity is null
-            ? Result.NotFound()
-            : Result.Success(new HotstringDto(entity.Id, entity.Trigger, entity.Replacement));
-    }
-}
-```
+`src/Backend/AHKFlowApp.Application/Queries/Hotstrings/GetHotstringQuery.cs` is the live shape — handler class `GetHotstringQueryHandler` (not `GetHotstringHandler`), `IAppDbContext` + `ICurrentUser` injected, `AsNoTracking()` + `Include()` + `.ToDto()` rather than a `.Select()` projection. See `.agents/dck-ef-core/SKILL.md` for the EF Core side of this pattern.
 
 ## Controller
 
-```csharp
-namespace AHKFlowApp.API.Controllers;
-
-[ApiController]
-[Route("api/v1/[controller]")]
-[Authorize]
-public sealed class HotstringsController(
-    IUseCase<CreateHotstringCommand, Result<HotstringDto>> createHotstring,
-    IUseCase<GetHotstringQuery, Result<HotstringDto>> getHotstring)
-    : ControllerBase
-{
-    [HttpPost]
-    [ProducesResponseType<HotstringDto>(StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
-    public async Task<IActionResult> Create(CreateHotstringDto dto, CancellationToken cancellationToken)
-    {
-        var result = await createHotstring.ExecuteAsync(new CreateHotstringCommand(dto), cancellationToken);
-        return result.ToActionResult(this);
-    }
-
-    [HttpGet("{id:guid}")]
-    [ProducesResponseType<HotstringDto>(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken)
-    {
-        var result = await getHotstring.ExecuteAsync(new GetHotstringQuery(id), cancellationToken);
-        return result.ToActionResult(this);
-    }
-}
-```
+`src/Backend/AHKFlowApp.API/Controllers/HotstringsController.cs` is the live shape. Note three things the simplified template above misses: results map via `result.ToProblemActionResult(this)` (an in-repo RFC 9457 extension, `src/Backend/AHKFlowApp.API/Extensions/ProblemDetailsResultExtensions.cs`), not the bare `Ardalis.Result.AspNetCore.ToActionResult`; class-level attributes add `[RequiredScope("access_as_user")]` and `[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]` / `...Status403Forbidden`; and action methods return `ActionResult<T>`, not `IActionResult`.
 
 ## Entity and EF Configuration
 
-Entities use private setters, constructor/factory methods, and domain methods:
-
-```csharp
-namespace AHKFlowApp.Domain.Entities;
-
-public sealed class Hotstring
-{
-    private Hotstring()
-    {
-        Trigger = string.Empty;
-        Replacement = string.Empty;
-    }
-
-    public Guid Id { get; private set; }
-    public Guid OwnerOid { get; private set; }
-    public string Trigger { get; private set; }
-    public string Replacement { get; private set; }
-    public DateTimeOffset CreatedAt { get; private set; }
-    public DateTimeOffset UpdatedAt { get; private set; }
-
-    public static Hotstring Create(Guid ownerOid, string trigger, string replacement, DateTimeOffset now) =>
-        new()
-        {
-            Id = Guid.NewGuid(),
-            OwnerOid = ownerOid,
-            Trigger = trigger,
-            Replacement = replacement,
-            CreatedAt = now,
-            UpdatedAt = now
-        };
-}
-```
-
-```csharp
-internal sealed class HotstringConfiguration : IEntityTypeConfiguration<Hotstring>
-{
-    public void Configure(EntityTypeBuilder<Hotstring> builder)
-    {
-        builder.HasKey(x => x.Id);
-        builder.Property(x => x.Trigger).HasMaxLength(50).IsRequired();
-        builder.Property(x => x.Replacement).HasMaxLength(500).IsRequired();
-        builder.HasIndex(x => new { x.OwnerOid, x.Trigger }).IsUnique();
-    }
-}
-```
+`src/Backend/AHKFlowApp.Domain/Entities/Hotstring.cs` (entity: private setters, `Create` factory) and `src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/HotstringConfiguration.cs` (EF config: required/max-length properties, enum-as-int conversions, a filtered unique index) are the live, much richer versions of the toy example above — read them before scaffolding a new entity, don't copy the simplified shape here.
 
 ## Integration Test Shape
 
-Use `WebApplicationFactory` and SQL Server Testcontainers. Replace `DbContextOptions<AppDbContext>` with `services.RemoveAll<DbContextOptions<AppDbContext>>()`, run migrations, and assert behavior through HTTP or handler results.
+Use the shared `ApiTestFixture` (`tests/AHKFlowApp.TestUtilities/Fixtures/ApiTestFixture.cs`) via `[Collection("WebApi")]` — see `tests/AHKFlowApp.API.Tests/Hotstrings/HotstringsEndpointsTests.cs:12-15`. Don't stand up a new `WebApplicationFactory`/`MsSqlContainer` per test class.
 
 ## Anti-Patterns
 

--- a/plugins/ahkflowapp/skills/dck-security-scan/SKILL.md
+++ b/plugins/ahkflowapp/skills/dck-security-scan/SKILL.md
@@ -146,6 +146,8 @@ CHECKLIST:
    - API key validation in middleware, not in each controller
 ```
 
+This app doesn't hand-build `TokenValidationParameters` — it delegates JWT validation to `Microsoft.Identity.Web`'s `AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"))` (`src/Backend/AHKFlowApp.API/Program.cs:130-135`), which reads issuer/audience/signing-key config from the `AzureAd` section and validates all four checklist items above automatically. A test-only bypass exists for local dev (`TestAuthenticationHandler`, gated to `Development` + `Auth:UseTestProvider=true`, `Program.cs:114-129`) — flag it as a finding only if it can be reached outside Development. Scanning this project's auth means checking the `AzureAd` config is populated and that `useTestAuth` can't go true outside Development, not reviewing hand-rolled `TokenValidationParameters` (the BAD/GOOD block below is a reference for other .NET apps that do configure JWT bearer manually — this app doesn't).
+
 ```csharp
 // BAD — JWT configuration with weak validation
 builder.Services.AddAuthentication().AddJwtBearer(options =>
@@ -200,7 +202,11 @@ policy.AllowAnyOrigin()             // Any website can read API responses
       .AllowAnyHeader()
       .AllowAnyMethod();
 // Acceptable ONLY for truly public APIs (e.g., public data feeds)
+```
 
+This app's real CORS policy (`src/Backend/AHKFlowApp.API/Extensions/ApiExtensions.cs:10-24`) doesn't use a static `WithOrigins(...)` array like the block below — it uses `SetIsOriginAllowed` reading `Cors:AllowedOrigins` from live configuration on every request, so an edited `appsettings.Development.json` takes effect without an API restart. Check for that dynamic-origin pattern here specifically; the static-array block below is the general-case illustration.
+
+```csharp
 // GOOD — explicit origins
 builder.Services.AddCors(options =>
 {


### PR DESCRIPTION
## Summary
- Convert dck-security-scan, dck-ef-core, dck-blazor-mudblazor, dck-scaffolding, dck-openapi from inlined project-shaped code templates to pointers at real, compiled/tested files
- Fixed several places where the templates had already drifted or invented identifiers that don't exist (IAppDbContext vs AppDbContext, ToProblemActionResult vs ToActionResult, per-entity API clients vs a single HTTP client, ShowMessageBoxAsync vs ShowMessageBox, list-query .Select() vs detail-query Include()+.ToDto(), etc.)
- Synced the Codex plugin mirror (plugins/ahkflowapp/) and bumped its version hash so SkillParity.Tests.ps1 passes

Closes #220

## Test plan
- [x] `tests/SkillLayout.Tests.ps1` passes
- [x] `tests/SkillParity.Tests.ps1` passes
- [x] Pre-push gate (build + fast test slice) passed
- [x] Every citation in the plan (docs/superpowers/plans/2026-07-27-skill-template-drift-plan.md) backed by a real file:line read during research

🤖 Generated with [Claude Code](https://claude.com/claude-code)