### PR TITLE
docs: require plan + worktree before non-trivial work

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,6 +8,38 @@ Be concise in all interactions. For documentation and app-facing text, follow **
 
 ## Workflow Preferences
 
+### Plan before you edit
+
+Before any **non-trivial** task, run `superpowers:brainstorming`, write a plan, and use `mp-grilling`
+to settle open questions. Do this before touching code, not after.
+
+Only these are exempt. Everything else plans first:
+
+- A change confined to a single file
+- Typo, comment, or formatting fixes
+- Answering a question, or reading and reporting
+- Running a command that changes nothing
+
+Picking up a `.claude/backlog/` item is never trivial. Neither is any change to user-facing wording,
+labels, or names — a wrong shared assumption about a word is cheap to catch up front and expensive
+to undo later.
+
+### Create the worktree before you write the plan
+
+Create the worktree first, then switch fully into it, and only then write the plan. Use
+`scripts/new-worktree.ps1` or the `WorktreeCreate` tool. Do not start writing a plan in the main
+checkout and move the work afterwards.
+
+One exception, because the file system forces it. Worktrees have **no `docs/superpowers/` folder** —
+it is a separate private repo (`AHKFlowApp-plans`), the public repo ignores the path, and
+`git worktree add` does not create it. So:
+
+- **The plan file** is written and committed in `docs/superpowers/plans/` in the **main checkout**.
+  Commit from inside `docs/superpowers/`, never from the repo root.
+- **Everything else** — code, tests, docs, config — happens in the worktree and commits from there.
+
+### Other
+
 - When asked to store instructions or rules, put them in CLAUDE.md (not memory files) unless explicitly told otherwise.
 - Verifying finished work is governed by **Verification After Implementation** in AGENTS.md. Invoke the `playwright-cli` skill via the Skill tool when that routing calls for a browser drive.
 - Before claiming a tool or capability is unavailable, check `.claude/skills/` and available skills. Never assume browser automation is missing — `playwright-cli` is installed.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -15,28 +15,36 @@ to settle open questions. Do this before touching code, not after.
 
 Only these are exempt. Everything else plans first:
 
-- A change confined to a single file
+- A one-file change that changes no behavior, no user-facing wording or name, and no interface
+  that other code depends on
 - Typo, comment, or formatting fixes
 - Answering a question, or reading and reporting
 - Running a command that changes nothing
 
 Picking up a `.claude/backlog/` item is never trivial. Neither is any change to user-facing wording,
 labels, or names — a wrong shared assumption about a word is cheap to catch up front and expensive
-to undo later.
+to undo later. Staying inside one file does not make such a change trivial. When a change matches
+both the exemption list and this paragraph, this paragraph wins: plan first.
 
 ### Create the worktree before you write the plan
 
-Create the worktree first, then switch fully into it, and only then write the plan. Use
-`scripts/new-worktree.ps1` or the `WorktreeCreate` tool. Do not start writing a plan in the main
-checkout and move the work afterwards.
+Create the worktree first. Do not start writing a plan in the main checkout and then move the work
+afterwards. Use `scripts/new-worktree.ps1`, or the native `EnterWorktree` tool — that tool fires the
+`WorktreeCreate` hook, which runs the same script for you.
 
-One exception, because the file system forces it. Worktrees have **no `docs/superpowers/` folder** —
-it is a separate private repo (`AHKFlowApp-plans`), the public repo ignores the path, and
-`git worktree add` does not create it. So:
+You cannot write the planning documents inside the worktree. The file system forbids it. Worktrees
+have **no `docs/superpowers/` folder** — it is a separate private repo (`AHKFlowApp-plans`), the
+public repo ignores the path, and `git worktree add` does not create it. So follow this order:
 
-- **The plan file** is written and committed in `docs/superpowers/plans/` in the **main checkout**.
-  Commit from inside `docs/superpowers/`, never from the repo root.
-- **Everything else** — code, tests, docs, config — happens in the worktree and commits from there.
+1. Create the worktree, but stay in the main checkout for now.
+2. Write and commit the spec and the plan there, under `docs/superpowers/specs/` and
+   `docs/superpowers/plans/`. Commit from inside `docs/superpowers/`, never from the repo root.
+3. Switch fully into the worktree. Everything else — code, tests, docs, config — happens there and
+   commits from there.
+
+Step 2 does not apply to every plan. **Plans** in AGENTS.md lists the kinds that stay out of the
+private repo: agent optimization, personal workflow tuning, agent housekeeping, and one-off
+context or config cleanups. Those still get a plan. The plan just is not committed there.
 
 ### Other
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,7 +273,8 @@ worktree creation cannot pass a base ref, so stacked work must call the script d
 
 The AHKFlowApp main checkout is human-owned for Git mutations. Agents may inspect, edit, build,
 test, and format there, but must branch, add, commit, merge, rebase, and push for this repository
-only from a managed linked worktree. Use `scripts/new-worktree.ps1` or the `WorktreeCreate` tool.
+only from a managed linked worktree. Use `scripts/new-worktree.ps1`, or the native `EnterWorktree`
+tool — that tool fires the `WorktreeCreate` hook, which runs the same script.
 `AHKFLOW_ALLOW_MAIN=1` is an explicit location override; destructive-command protections still
 apply. See `docs/agents/cross-agent-git-guardrails.md`.
 

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -14,7 +14,8 @@ A Git mutation is allowed only from a **managed linked worktree**, which is all 
    once, the three ports numeric, the API/UI URLs carrying the manifest ports, DB/compose values
    non-empty, and `AHKFLOW_ROOT` resolving back to the worktree root.
 
-The supported way to create one is `scripts/new-worktree.ps1` or the agent `WorktreeCreate` tool.
+The supported way to create one is `scripts/new-worktree.ps1`, or the agent's native `EnterWorktree`
+tool — that tool fires the `WorktreeCreate` hook, which runs the same script.
 A raw `git worktree add` run by an agent is itself a guarded mutation — denied from main — and it
 skips the manifest and no-auth setup, so the result would fail the managed check anyway. Use the
 tool, whose child Git calls the payload never exposes to the guard.


### PR DESCRIPTION
## What

Adds a **Plan before you edit** rule and a **Create the worktree before you write the plan** rule to `.claude/CLAUDE.md`.

## Why

Non-trivial work kept starting in the main checkout, with the plan written after the fact or not at all. These rules make the order explicit.

## Review fixes included

A review of the first commit found five contradictions. All five are fixed here:

1. The single-file exemption cancelled the wording rule. A one-file label change matched both. The exemption now excludes behavior, user-facing wording, names, and shared interfaces, and the wording rule wins on a tie.
2. The worktree sequence could not be followed. It said to enter the worktree first, then to write the plan in the main checkout — but worktrees have no `docs/superpowers/`. Now a numbered order: create worktree, stay in main and commit the planning docs, then enter the worktree.
3. Specs were missing. `superpowers:brainstorming` writes and commits `docs/superpowers/specs/` before plans. Step 2 now names both.
4. Mandatory committed plans conflicted with `AGENTS.md` **Plans**, which skips the private repo for agent optimization, workflow tuning, housekeeping, and one-off config cleanups. That carve-out is now referenced.
5. `WorktreeCreate` is the hook, not the tool. `EnterWorktree` is the tool that fires it. Corrected in `.claude/CLAUDE.md`, plus the same pre-existing error in `AGENTS.md` and `docs/agents/cross-agent-git-guardrails.md`.

## Verification

Docs only, nothing compiled — exemption 1 in **Verification After Implementation**. Text checks plus diff review. Pre-push gate passed: 2428 tests across the fast slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)