### PR TITLE
chore: make private plans searchable

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,4 @@
+# Keep private plans searchable in Codex and ripgrep.
+!docs/
+!docs/superpowers/
+!docs/superpowers/**


### PR DESCRIPTION
## Summary
- Add a root `.ignore` file.
- Include `docs/superpowers/**` in Codex and ripgrep searches.
- Keep the private plans repository excluded from public Git tracking.

## Why
Codex `@` file search uses ripgrep-style ignore processing. The existing `.gitignore` rule hid the private plans repository from file search.
Git does not read `.ignore`. The new rules make local plans searchable without changing the public repository's Git protection.

## Impact
Contributors with the private plans repository can reference its files through Codex `@`.
Root-level ripgrep searches will also include those files. Contributors without the private repository are unaffected.

## Verification
- Ran the canonical pre-PR build, format, coverage, and diff checks.
- Confirmed `git check-ignore` still resolves private plan files to `.gitignore:469`.
- Confirmed `rg --files` includes files under `docs/superpowers/`.