### PR TITLE
chore: align UI labels with CONTEXT.md vocabulary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,6 +4,21 @@ Where a user defines the text expansions and keyboard shortcuts they want on Win
 
 ## Language
 
+### Short forms
+
+Some places in the UI are too narrow for a full term. A chip or a dense grid cell is an example.
+
+In those places you may shorten a canonical term, but only by removing words from it. Never swap in
+a different word. "All profiles" is allowed, because it is "Apply to all profiles" with two words
+removed. "Any" is not allowed, because it is a different word — that is why it appears under
+_Avoid_.
+
+Use the full term everywhere there is room, such as a dialog or a form label.
+
+| Canonical term | Short form |
+|---|---|
+| Apply to all profiles | All profiles |
+
 ### Definitions
 
 **Hotstring**:
@@ -13,6 +28,11 @@ _Avoid_: abbreviation, snippet, expansion, shortcut
 **Hotkey**:
 A key plus any of Ctrl/Alt/Shift/Win that runs one Action.
 _Avoid_: shortcut, binding, keybinding, accelerator
+
+**Item**:
+A Hotstring or a Hotkey, when it does not matter which of the two it is. Use it where both are
+meant, such as the Recycle Bin or an entry's history.
+_Avoid_: type, entity, record, object
 
 **Trigger**:
 The characters a user types to fire a Hotstring. Hotkeys have no trigger — they have a key and modifiers.
@@ -75,6 +95,7 @@ _Avoid_: group, set, collection, workspace
 
 **Apply to all profiles**:
 Said of a hotstring or hotkey that belongs to every Profile, including profiles created later, instead of being listed in particular ones.
+Short form in narrow places: "All profiles". See **Short forms** above.
 _Avoid_: Any, global, shared, all-profiles
 
 **Category**:

--- a/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
@@ -15,7 +15,7 @@ Blazor WebAssembly PWA frontend for AHKFlowApp.
 - `IDialogService.ShowMessageBox(...)` for delete confirmations
 - No `StateHasChanged()` after standard event handlers — Blazor re-renders automatically
 - For list pages that need mobile support: render both branches as plain `.desktop-branch` and `.mobile-branch` containers, then gate visibility in the page's scoped `.razor.css` at `959.95px`. Desktop uses `MudDataGrid`; mobile uses a compact list component, full-screen `MudDialog`, and `MudFab`. See `Components/Hotstrings/` and `Components/Hotkeys/` for examples.
-- Reuse shared selection/chip components in `Components/Common/` — `EntityMultiSelect` (multi-select over an `EntityOption` list), `EntityChips` (read-only id→name chips, with `Any` for "all profiles"), `CategoryFilterChips` (category filter chipset). Don't hand-roll `MudSelect`/`MudChip` blocks for profiles/categories.
+- Reuse shared selection/chip components in `Components/Common/` — `EntityMultiSelect` (multi-select over an `EntityOption` list), `EntityChips` (read-only id→name chips; its `Any` parameter renders a single "All profiles" chip), `CategoryFilterChips` (category filter chipset). Don't hand-roll `MudSelect`/`MudChip` blocks for profiles/categories.
 
 ## MudBlazor API Verification
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Common/EntityChips.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Common/EntityChips.razor
@@ -2,7 +2,7 @@
 
 @if (Any)
 {
-    <MudChip T="string" Size="Size.Small" Color="MudBlazor.Color.Info" Variant="Variant">Any</MudChip>
+    <MudChip T="string" Size="Size.Small" Color="MudBlazor.Color.Info" Variant="Variant">All profiles</MudChip>
 }
 else
 {
@@ -16,12 +16,12 @@ else
     [Parameter, EditorRequired] public IReadOnlyCollection<Guid> Ids { get; set; } = [];
     [Parameter, EditorRequired] public IReadOnlyList<EntityOption> Options { get; set; } = [];
 
-    /// <summary>When true, renders a single "Any" chip instead of the id list (profiles case).</summary>
+    /// <summary>When true, renders a single "All profiles" chip instead of the id list (profiles case).</summary>
     [Parameter] public bool Any { get; set; }
 
     [Parameter] public Variant Variant { get; set; } = Variant.Filled;
 
-    /// <summary>Color for the id chips. Null keeps MudBlazor's default (grey). Does not affect the "Any" chip.</summary>
+    /// <summary>Color for the id chips. Null keeps MudBlazor's default (grey). Does not affect the "All profiles" chip.</summary>
     [Parameter] public MudBlazor.Color? Color { get; set; }
 
     private string NameFor(Guid id) =>

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -73,7 +73,7 @@
                 <MudSelect T="HotstringDelivery" @bind-Value="Item.Delivery" Label="Delivery"
                            UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "delivery-select" })">
                     <MudSelectItem T="HotstringDelivery" Value="HotstringDelivery.Auto">Auto</MudSelectItem>
-                    <MudSelectItem T="HotstringDelivery" Value="HotstringDelivery.Type">Hotstring</MudSelectItem>
+                    <MudSelectItem T="HotstringDelivery" Value="HotstringDelivery.Type">Typed</MudSelectItem>
                     <MudSelectItem T="HotstringDelivery" Value="HotstringDelivery.ClipboardPaste">Clipboard</MudSelectItem>
                 </MudSelect>
                 <MudText Typo="Typo.caption" Color="Color.Secondary">

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringEditDialog.razor
@@ -72,9 +72,9 @@
             {
                 <MudSelect T="HotstringDelivery" @bind-Value="Item.Delivery" Label="Delivery"
                            UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "delivery-select" })">
-                    <MudSelectItem T="HotstringDelivery" Value="HotstringDelivery.Auto">Auto</MudSelectItem>
-                    <MudSelectItem T="HotstringDelivery" Value="HotstringDelivery.Type">Typed</MudSelectItem>
-                    <MudSelectItem T="HotstringDelivery" Value="HotstringDelivery.ClipboardPaste">Clipboard</MudSelectItem>
+                    <MudSelectItem T="HotstringDelivery" Value="HotstringDelivery.Auto">@DeliveryDisplay.OptionLabel(HotstringDelivery.Auto)</MudSelectItem>
+                    <MudSelectItem T="HotstringDelivery" Value="HotstringDelivery.Type">@DeliveryDisplay.OptionLabel(HotstringDelivery.Type)</MudSelectItem>
+                    <MudSelectItem T="HotstringDelivery" Value="HotstringDelivery.ClipboardPaste">@DeliveryDisplay.OptionLabel(HotstringDelivery.ClipboardPaste)</MudSelectItem>
                 </MudSelect>
                 <MudText Typo="Typo.caption" Color="Color.Secondary">
                     Auto types short replacements and pastes 200+ characters via the clipboard. Pasted text is not case-conforming (typed replacements adapt to how you capitalized the trigger; pasted ones don't).

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringKindChip.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringKindChip.razor
@@ -2,7 +2,7 @@
 @using AHKFlowApp.UI.Blazor.Helpers
 @using MudBlazor
 
-@* Every row shows its own kind, so a column titled "Type" actually reports the type. Delivery is
+@* Every row shows its own kind, so the column titled "Kind" actually reports the kind. Delivery is
    surfaced only for the clipboard exception — clipboard delivery has a real side effect (it
    overwrites the user's clipboard), whereas keystroke delivery is the unremarkable default and
    labelling it on every row was noise. Lives in its own component so the desktop grid and the

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotstrings/HotstringMobileList.razor
@@ -53,7 +53,7 @@
                                        @onchange="e => OnRowCheckboxChanged(item, IsChecked(e))" />
                             </td>
                         }
-                        @* Same chip as the desktop grid's Type column — kind for every row, tinted per
+                        @* Same chip as the desktop grid's Kind column — kind for every row, tinted per
                            kind, with Raw's warning icon riding on the chip. It sits under the trigger
                            rather than beside the replacement: at 390px a word-width chip in the
                            replacement cell left that column only wide enough for an ellipsis. *@

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/DeliveryDisplay.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/DeliveryDisplay.cs
@@ -13,5 +13,15 @@ internal static class DeliveryDisplay
     /// <summary>Only reached from the Kind tooltip now — the chip itself reports the kind, and
     /// keystroke delivery is the unremarkable default, so only clipboard gets a visual marker.</summary>
     public static string Label(HotstringDelivery effectiveDelivery) =>
-        IsClipboard(effectiveDelivery) ? "Clipboard" : "Typed";
+        IsClipboard(effectiveDelivery) ? "Clipboard" : OptionLabel(HotstringDelivery.Type);
+
+    /// <summary>The label for one choice in the delivery picker. Single-sourced so the picker and
+    /// <see cref="Label"/> cannot drift apart — CONTEXT.md lists "Hotstring" under Avoid here.</summary>
+    public static string OptionLabel(HotstringDelivery delivery) => delivery switch
+    {
+        HotstringDelivery.Auto => "Auto",
+        HotstringDelivery.Type => "Typed",
+        HotstringDelivery.ClipboardPaste => "Clipboard",
+        _ => throw new ArgumentOutOfRangeException(nameof(delivery), delivery, null),
+    };
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/DeliveryDisplay.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/DeliveryDisplay.cs
@@ -10,8 +10,8 @@ internal static class DeliveryDisplay
     public static bool IsClipboard(HotstringDelivery effectiveDelivery) =>
         effectiveDelivery == HotstringDelivery.ClipboardPaste;
 
-    /// <summary>Only reached from the Type tooltip now — the chip itself reports the kind, and
+    /// <summary>Only reached from the Kind tooltip now — the chip itself reports the kind, and
     /// keystroke delivery is the unremarkable default, so only clipboard gets a visual marker.</summary>
     public static string Label(HotstringDelivery effectiveDelivery) =>
-        IsClipboard(effectiveDelivery) ? "Clipboard" : "Hotstring";
+        IsClipboard(effectiveDelivery) ? "Clipboard" : "Typed";
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
@@ -765,7 +765,9 @@
     private RenderFragment RenderProfiles(bool appliesToAllProfiles, IReadOnlyCollection<Guid> profileIds) =>
         @<EntityChips Ids="profileIds" Options="_profileOptions" Any="appliesToAllProfiles" />;
 
-    private RenderFragment RenderProfileEditor(HotkeyEditModel edit) => @<MudStack AlignItems="AlignItems.Start" Spacing="1">
+    @* No Row and no AlignItems: MudStack defaults to a column, and leaving alignment unset lets the
+       multi-select stretch to the cell width. AlignItems.Start shrank it to about 50px. *@
+    private RenderFragment RenderProfileEditor(HotkeyEditModel edit) => @<MudStack Spacing="1">
         <MudCheckBox T="bool" Value="edit.AppliesToAllProfiles"
                      ValueChanged="value => SetAppliesToAllProfiles(edit, value)"
                      Label="All profiles"

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
@@ -109,7 +109,7 @@
             @* The chip renders in both modes: the kind is not inline-changeable, so it is
                context for the payload beside it, not a control. *@
             @* The toolbar Action dropdown owns this filter value; a column funnel here would be a
-               second control writing the same request field. Same reason Hotstrings' Type column sets it. *@
+               second control writing the same request field. Same reason Hotstrings' Kind column sets it. *@
             <PropertyColumn Property="x => x.ActionKind" Title="Action" Filterable="false">
                 <CellTemplate>
                     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
@@ -765,10 +765,10 @@
     private RenderFragment RenderProfiles(bool appliesToAllProfiles, IReadOnlyCollection<Guid> profileIds) =>
         @<EntityChips Ids="profileIds" Options="_profileOptions" Any="appliesToAllProfiles" />;
 
-    private RenderFragment RenderProfileEditor(HotkeyEditModel edit) => @<MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+    private RenderFragment RenderProfileEditor(HotkeyEditModel edit) => @<MudStack AlignItems="AlignItems.Start" Spacing="1">
         <MudCheckBox T="bool" Value="edit.AppliesToAllProfiles"
                      ValueChanged="value => SetAppliesToAllProfiles(edit, value)"
-                     Label="Any"
+                     Label="All profiles"
                      UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "applies-to-all-checkbox" })" />
         @if (!edit.AppliesToAllProfiles)
         {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor.css
@@ -82,6 +82,14 @@
     padding-right: 4px;
 }
 
+/* The cell rule above sets white-space: nowrap, so the edit-mode checkbox label could not wrap and
+   clipped its last letter instead: 32px control plus an 82px label needs 114px, and the content box
+   is 101px. Let this one label wrap onto a second line. That holds at any zoom, where adding a few
+   pixels of column width would not. */
+::deep .hotkeys-grid td:nth-child(5) .mud-checkbox {
+    white-space: normal;
+}
+
 ::deep .hotkeys-grid th:nth-child(7),
 ::deep .hotkeys-grid td:nth-child(7) {
     width: 160px;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor.css
@@ -74,6 +74,14 @@
     width: 12%;
 }
 
+/* Profiles renders one "All profiles" chip. The default 16px/24px cell padding ate 40px of a
+   ~109px cell at 1280px, clipping the chip. Trim the padding rather than widen the column. */
+::deep .hotkeys-grid th:nth-child(5),
+::deep .hotkeys-grid td:nth-child(5) {
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
 ::deep .hotkeys-grid th:nth-child(7),
 ::deep .hotkeys-grid td:nth-child(7) {
     width: 160px;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -964,7 +964,9 @@
     private RenderFragment RenderProfiles(bool appliesToAllProfiles, IReadOnlyCollection<Guid> profileIds) =>
         @<EntityChips Ids="profileIds" Options="_profileOptions" Any="appliesToAllProfiles" />;
 
-    private RenderFragment RenderProfileEditor(HotstringEditModel edit) => @<MudStack AlignItems="AlignItems.Start" Spacing="1">
+    @* No Row and no AlignItems: MudStack defaults to a column, and leaving alignment unset lets the
+       multi-select stretch to the cell width. AlignItems.Start shrank it to about 50px. *@
+    private RenderFragment RenderProfileEditor(HotstringEditModel edit) => @<MudStack Spacing="1">
         <MudCheckBox T="bool" Value="edit.AppliesToAllProfiles"
                      ValueChanged="value => SetAppliesToAllProfiles(edit, value)"
                      Label="All profiles"
@@ -1045,7 +1047,7 @@
                            Color="Color.Default" OnClick="CancelEditAsync" />
             <MudIconButton Class="promote-edit" Icon="@Icons.Material.Filled.Tune"
                            OnClick="() => PromoteInlineRowAsync(item)"
-                           UserAttributes="@(new Dictionary<string, object?> { ["title"] = "More options / change type", ["aria-label"] = "More options / change type" })" />
+                           UserAttributes="@(new Dictionary<string, object?> { ["title"] = "More options / change kind", ["aria-label"] = "More options / change kind" })" />
         }
         else
         {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor
@@ -39,7 +39,7 @@
             }
             <MudSpacer />
             <MudSelect T="HotstringKind?" @bind-Value="_selectedKind" @bind-Value:after="OnKindFilterChangedAsync"
-                       Label="Type" Placeholder="All" Clearable="true"
+                       Label="Kind" Placeholder="All" Clearable="true"
                        Class="kind-filter" Style="max-width: 200px;"
                        UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "kind-filter" })">
                 <MudSelectItem T="HotstringKind?" Value="HotstringKind.Text">Text</MudSelectItem>
@@ -158,18 +158,18 @@
                     <TemplateColumn Sortable="true" SortBy="x => x.Kind" Filterable="false">
                         <HeaderTemplate>
                             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="0">
-                                <MudText>Type</MudText>
+                                <MudText>Kind</MudText>
                                 <MudTooltip Text="* = expands immediately · ? = triggers inside words · C = case sensitive · O = omits ending character · window icon = only in a specific app · clipboard icon = pasted via clipboard">
                                     <MudIconButton Icon="@Icons.Material.Filled.HelpOutline" Size="Size.Small"
-                                                   Class="type-legend-help"
+                                                   Class="kind-legend-help"
                                                    UserAttributes="@(new Dictionary<string, object?> { ["aria-label"] = "Glyph legend: * expands immediately, ? triggers inside words, C case sensitive, O omits ending character, window icon only in a specific app, clipboard icon pasted via clipboard" })" />
                                 </MudTooltip>
                             </MudStack>
                         </HeaderTemplate>
                         <CellTemplate>
                             <MudTooltip Text="@OptionsTooltip(context.Item)">
-                                <span class="type-badge">
-                                    @RenderTypeChip(context.Item)
+                                <span class="kind-badge">
+                                    @RenderKindChip(context.Item)
                                     <span class="option-glyphs">@OptionGlyphs(context.Item)</span>
                                     @if (context.Item.ContextMatchType is not null)
                                     {
@@ -233,7 +233,7 @@
                           FullWidth="true" Clearable="true" Immediate="true" />
 
             <MudSelect T="HotstringKind?" @bind-Value="_selectedKind" @bind-Value:after="OnKindFilterChangedAsync"
-                       Label="Type" Placeholder="All" Clearable="true"
+                       Label="Kind" Placeholder="All" Clearable="true"
                        Class="kind-filter-mobile mb-2" FullWidth="true"
                        UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "kind-filter-mobile" })">
                 <MudSelectItem T="HotstringKind?" Value="HotstringKind.Text">Text</MudSelectItem>
@@ -435,7 +435,7 @@
             "trigger" or nameof(HotstringEditModel.Trigger) => "trigger",
             "replacement" or nameof(HotstringEditModel.Replacement) => "replacement",
             "description" or nameof(HotstringEditModel.Description) => "description",
-            // The Type column is a TemplateColumn: MudBlazor 9.3.0 auto-generates its PropertyName
+            // The Kind column is a TemplateColumn: MudBlazor 9.3.0 auto-generates its PropertyName
             // as a random GUID (TemplateColumn<T>.PropertyName has no settable parameter), so it
             // can't be matched by literal string. It's the only other sortable column in this grid
             // (SortMode.Single), so any value that isn't one of the known property names is
@@ -964,10 +964,10 @@
     private RenderFragment RenderProfiles(bool appliesToAllProfiles, IReadOnlyCollection<Guid> profileIds) =>
         @<EntityChips Ids="profileIds" Options="_profileOptions" Any="appliesToAllProfiles" />;
 
-    private RenderFragment RenderProfileEditor(HotstringEditModel edit) => @<MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+    private RenderFragment RenderProfileEditor(HotstringEditModel edit) => @<MudStack AlignItems="AlignItems.Start" Spacing="1">
         <MudCheckBox T="bool" Value="edit.AppliesToAllProfiles"
                      ValueChanged="value => SetAppliesToAllProfiles(edit, value)"
-                     Label="Any"
+                     Label="All profiles"
                      UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "applies-to-all-checkbox" })" />
         @if (!edit.AppliesToAllProfiles)
         {
@@ -998,7 +998,7 @@
     private RenderFragment RenderCategories(IReadOnlyCollection<Guid> categoryIds) =>
         @<EntityChips Ids="categoryIds" Options="_categoryOptions" Variant="Variant.Outlined" Color="Color.Primary" />;
 
-    private RenderFragment RenderTypeChip(HotstringEditModel item) =>
+    private RenderFragment RenderKindChip(HotstringEditModel item) =>
         @<HotstringKindChip Kind="item.Kind" EffectiveDelivery="item.EffectiveDelivery" />;
 
     private static string OptionGlyphs(HotstringEditModel item)

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
@@ -91,6 +91,13 @@
     padding-right: 4px;
 }
 
+/* The cell rule above sets white-space: nowrap, so the edit-mode checkbox label cannot wrap and
+   would clip its last letter once the column tightens. Let this one label wrap onto a second line.
+   That holds at any zoom, where adding a few pixels of column width would not. */
+::deep .hotstrings-grid td:nth-child(5) .mud-checkbox {
+    white-space: normal;
+}
+
 ::deep .hotstrings-grid th:nth-child(6),
 ::deep .hotstrings-grid td:nth-child(6) {
     width: 130px;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
@@ -58,7 +58,7 @@
 
 ::deep .hotstrings-grid th:nth-child(3),
 ::deep .hotstrings-grid td:nth-child(3) {
-    width: 19%;
+    width: 15%;
 }
 
 /* Replacement column: multi-line imports (continuation sections, converted Send
@@ -73,12 +73,13 @@
     width: 13%;
 }
 
-/* Profiles renders one short chip ("Any" for most rows), so it can give a little width to
-   Categories — but not much: at high zoom the fixed layout squeezes percentage columns hard,
-   and below ~9% the "Any" chip clips. */
+/* Profiles renders one chip reading "All profiles" for most rows. That is four times longer than
+   the old "Any" label, which already clipped below ~9%, so this column needs the extra width. The
+   4% came from Replacement, which ellipsizes anyway. At high zoom the fixed layout squeezes
+   percentage columns hard, so do not take this back below 13%. */
 ::deep .hotstrings-grid th:nth-child(5),
 ::deep .hotstrings-grid td:nth-child(5) {
-    width: 9%;
+    width: 13%;
 }
 
 ::deep .hotstrings-grid th:nth-child(6),

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor.css
@@ -82,6 +82,15 @@
     width: 13%;
 }
 
+/* The default cell padding is 16px left and 24px right. That is 40px of a ~114px cell at 1280px,
+   which left only 74px for a chip needing 98px, so the chip clipped even at 13%. Trim the padding
+   instead of taking more width from Replacement. */
+::deep .hotstrings-grid th:nth-child(5),
+::deep .hotstrings-grid td:nth-child(5) {
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
 ::deep .hotstrings-grid th:nth-child(6),
 ::deep .hotstrings-grid td:nth-child(6) {
     width: 130px;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/RecycleBin.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/RecycleBin.razor
@@ -39,7 +39,7 @@
     {
         <MudTable Items="_rows" T="RecycleBinRow" Dense="true" Hover="true">
             <HeaderContent>
-                <MudTh>Type</MudTh>
+                <MudTh>Item</MudTh>
                 <MudTh>Name</MudTh>
                 <MudTh>Details</MudTh>
                 <MudTh Style="width:160px">Deleted</MudTh>

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Common/EntityChipsTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Common/EntityChipsTests.cs
@@ -44,7 +44,10 @@ public sealed class EntityChipsTests : BunitContext, IAsyncLifetime
             .Add(p => p.Options, options)
             .Add(p => p.Any, true));
 
-        cut.Markup.Should().Contain("Any");
+        // "All profiles" is the glossary short form of "Apply to all profiles" (CONTEXT.md).
+        // The old "Any" label was an avoided synonym, so assert it is gone for good.
+        cut.Markup.Should().Contain("All profiles");
+        cut.Markup.Should().NotContain(">Any<");
         cut.Markup.Should().NotContain("Work");
     }
 

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -1474,6 +1474,30 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public async Task DeliverySelector_OpenMenu_RendersGlossaryOptions()
+    {
+        HotstringEditModel item = new() { Trigger = "btw", Replacement = "by the way" };
+        IRenderedComponent<MudDialogProvider> provider = await RenderDialogAsync(item);
+        provider.WaitForAssertion(() => provider.Find("[data-test=\"delivery-select\"]"));
+
+        // The theory above covers the helper. This covers the dialog markup actually calling it —
+        // swapping the literals back to "Hotstring" must fail here.
+        IRenderedComponent<MudSelect<HotstringDelivery>> select =
+            provider.FindComponent<MudSelect<HotstringDelivery>>();
+        await provider.InvokeAsync(select.Instance.OpenMenu);
+
+        IRenderedComponent<MudPopoverProvider> popover = _popoverProvider!;
+        popover.WaitForAssertion(() =>
+        {
+            string menu = popover.Markup;
+            menu.Should().Contain("Typed");
+            menu.Should().Contain("Auto");
+            menu.Should().Contain("Clipboard");
+            menu.Should().NotContain("Hotstring");
+        });
+    }
+
+    [Fact]
     public async Task PreviewPanel_ShowsEffectiveTypedDeliveryAsTyped()
     {
         _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
@@ -1526,9 +1550,13 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
     private static void DisablePreviewDebounce(IRenderedComponent<MudDialogProvider> provider) =>
         provider.FindComponent<HotstringEditDialog>().Instance.PreviewDebounce = TimeSpan.Zero;
 
+    /// <summary>Set by <see cref="RenderDialogAsync"/>. MudSelect renders its open menu into the
+    /// popover provider's tree, not the dialog's, so a test that inspects menu items needs this.</summary>
+    private IRenderedComponent<MudPopoverProvider>? _popoverProvider;
+
     private async Task<IRenderedComponent<MudDialogProvider>> RenderDialogAsync(HotstringEditModel? item = null)
     {
-        Render<MudPopoverProvider>();
+        _popoverProvider = Render<MudPopoverProvider>();
         IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
 
         await provider.InvokeAsync(async () =>

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -1475,7 +1475,9 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
 
         provider.WaitForAssertion(() =>
         {
-            provider.Find("[data-test=\"preview-delivery\"]").TextContent.Should().Contain("Hotstring");
+            // "Typed" replaced "Hotstring" here — CONTEXT.md lists the old label under Avoid,
+            // because it overloaded the name of the whole entity.
+            provider.Find("[data-test=\"preview-delivery\"]").TextContent.Should().Contain("Typed");
         });
     }
 

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotstrings/HotstringEditDialogTests.cs
@@ -1,5 +1,6 @@
 using AHKFlowApp.UI.Blazor.Components.Hotstrings;
 using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Helpers;
 using AHKFlowApp.UI.Blazor.Services;
 using AHKFlowApp.UI.Blazor.Validation;
 using Bunit;
@@ -1461,8 +1462,19 @@ public sealed class HotstringEditDialogTests : BunitContext, IAsyncLifetime
         });
     }
 
+    [Theory]
+    [InlineData(HotstringDelivery.Auto, "Auto")]
+    [InlineData(HotstringDelivery.Type, "Typed")]
+    [InlineData(HotstringDelivery.ClipboardPaste, "Clipboard")]
+    public void DeliveryOptionLabel_UsesGlossaryWording(HotstringDelivery delivery, string expected)
+    {
+        // The delivery picker renders these three labels (HotstringEditDialog.razor). CONTEXT.md
+        // lists "Hotstring" under Avoid for Delivery — it overloaded the name of the whole entity.
+        DeliveryDisplay.OptionLabel(delivery).Should().Be(expected);
+    }
+
     [Fact]
-    public async Task PreviewPanel_ShowsEffectiveTypedDeliveryAsHotstring()
+    public async Task PreviewPanel_ShowsEffectiveTypedDeliveryAsTyped()
     {
         _api.PreviewAsync(Arg.Any<HotstringPreviewRequestDto>(), Arg.Any<CancellationToken>())
             .Returns(ApiResult<HotstringPreviewDto>.Ok(

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
@@ -675,7 +675,7 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
     {
         // The toolbar dropdown owns ActionKind. A live column funnel on the same field would be a
         // second control writing the same request value - keep it off (Hotstrings does the same
-        // for its Type column).
+        // for its Kind column).
         StubList(Page());
 
         IRenderedComponent<Hotkeys> cut = RenderPage();

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -614,10 +614,10 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
 
         cut.WaitForAssertion(() =>
         {
-            // The Type column reports the kind. Keystroke delivery is the unremarkable default and
+            // The Kind column reports the kind. Keystroke delivery is the unremarkable default and
             // is deliberately left unmarked — only clipboard delivery, which overwrites the user's
             // clipboard, earns an icon.
-            cut.Find(".desktop-branch .type-badge").TextContent.Should().Contain("Text");
+            cut.Find(".desktop-branch .kind-badge").TextContent.Should().Contain("Text");
             cut.FindAll(".desktop-branch [data-test=\"clipboard-delivery\"]").Should().BeEmpty();
             cut.Find(".option-glyphs").TextContent.Should().Be("*?C");
         });
@@ -637,7 +637,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         cut.WaitForAssertion(() =>
         {
             // Kind chip plus a clipboard icon beside it; the icon carries the marker, not text.
-            cut.Find(".desktop-branch .type-badge .mud-chip").TextContent.Should().Contain("Text");
+            cut.Find(".desktop-branch .kind-badge .mud-chip").TextContent.Should().Contain("Text");
             cut.FindAll(".desktop-branch [data-test=\"clipboard-delivery\"]").Should().HaveCount(1);
         });
         return Task.CompletedTask;
@@ -814,6 +814,29 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public Task Page_KindFilter_IsLabelledKindNotType()
+    {
+        StubList(Page());
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+
+        cut.WaitForAssertion(() =>
+        {
+            // CONTEXT.md lists "type" under Avoid for Kind. Lock the label so it cannot drift back.
+            IRenderedComponent<MudSelect<HotstringKind?>> desktop = cut
+                .FindComponents<MudSelect<HotstringKind?>>()
+                .Single(c => c.Markup.Contains("data-test=\"kind-filter\""));
+            desktop.Instance.Label.Should().Be("Kind");
+
+            IRenderedComponent<MudSelect<HotstringKind?>> mobile = cut
+                .FindComponents<MudSelect<HotstringKind?>>()
+                .Single(c => c.Markup.Contains("data-test=\"kind-filter-mobile\""));
+            mobile.Instance.Label.Should().Be("Kind");
+        });
+        return Task.CompletedTask;
+    }
+
+    [Fact]
     public Task Page_RawRow_ShowsFirstLineMonospaceEllipsis()
     {
         var dto = new HotstringDto(Guid.NewGuid(), [], true, "~ver", ":*:~ver::\n{\nMsgBox A_AhkVersion\n}",
@@ -842,7 +865,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
 
         cut.WaitForAssertion(() =>
         {
-            AngleSharp.Dom.IElement badge = cut.Find(".type-badge .mud-chip");
+            AngleSharp.Dom.IElement badge = cut.Find(".kind-badge .mud-chip");
             badge.TextContent.Should().Contain("Raw");
             badge.ClassList.Should().Contain("kind-chip--raw");
             // Warning must be conveyed semantically, not just via color — screen readers read the
@@ -865,7 +888,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
 
         cut.WaitForAssertion(() =>
         {
-            AngleSharp.Dom.IElement badge = cut.Find(".type-badge .mud-chip");
+            AngleSharp.Dom.IElement badge = cut.Find(".kind-badge .mud-chip");
             badge.TextContent.Should().Contain("Date");
             badge.ClassList.Should().Contain("kind-chip--datetime");
         });
@@ -883,7 +906,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
 
         cut.WaitForAssertion(() =>
         {
-            AngleSharp.Dom.IElement badge = cut.Find(".type-badge .mud-chip");
+            AngleSharp.Dom.IElement badge = cut.Find(".kind-badge .mud-chip");
             badge.TextContent.Should().Contain("Macro");
             badge.ClassList.Should().Contain("kind-chip--macro");
         });
@@ -922,7 +945,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
 
         IRenderedComponent<Hotstrings> cut = RenderPage();
 
-        cut.WaitForAssertion(() => cut.Find(".type-legend-help").Should().NotBeNull());
+        cut.WaitForAssertion(() => cut.Find(".kind-legend-help").Should().NotBeNull());
     }
 
     [Fact]
@@ -954,7 +977,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
         cut.WaitForAssertion(() =>
         {
             cut.Find(".hotstrings-grid .option-glyphs").TextContent.Should().BeEmpty();
-            cut.Find(".hotstrings-grid .type-badge").TextContent.Should().Contain("Raw");
+            cut.Find(".hotstrings-grid .kind-badge").TextContent.Should().Contain("Raw");
         });
         return Task.CompletedTask;
     }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotstringsPageTests.cs
@@ -602,7 +602,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public Task Page_RendersTypeBadgeWithOptionGlyphs()
+    public Task Page_RendersKindBadgeWithOptionGlyphs()
     {
         var dto = new HotstringDto(Guid.NewGuid(), [], true, "btw", "by the way", null,
             false, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null,
@@ -814,6 +814,29 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public Task Page_PromoteButton_SaysChangeKindNotChangeType()
+    {
+        var dto = new HotstringDto(Guid.NewGuid(), [], true, "btw", "by the way", null, true, true,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        StubList(Page(dto));
+
+        IRenderedComponent<Hotstrings> cut = RenderPage();
+
+        cut.WaitForAssertion(() => cut.Find("button.edit"));
+        cut.Find("button.edit").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            // Both the visible tooltip and the accessible name. CONTEXT.md lists "type" under
+            // Avoid for Kind, so a screen reader must not hear the retired word either.
+            AngleSharp.Dom.IElement promote = cut.Find("button.promote-edit");
+            promote.GetAttribute("title").Should().Be("More options / change kind");
+            promote.GetAttribute("aria-label").Should().Be("More options / change kind");
+        });
+        return Task.CompletedTask;
+    }
+
+    [Fact]
     public Task Page_KindFilter_IsLabelledKindNotType()
     {
         StubList(Page());
@@ -931,7 +954,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
             categoryChips.Should().NotBeEmpty();
             categoryChips.Should().OnlyContain(chip => chip.ClassList.Contains("mud-chip-outlined"));
             // Categories carry the brand accent, not MudBlazor's default grey. Outlined + accent is
-            // a deliberately separate channel from the tinted, filled kind chips in the Type column.
+            // a deliberately separate channel from the tinted, filled kind chips in the Kind column.
             categoryChips.Should().OnlyContain(chip =>
                 chip.ClassList.Any(c => c.Contains("primary", StringComparison.OrdinalIgnoreCase)));
         });
@@ -939,7 +962,7 @@ public sealed class HotstringsPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public void Page_TypeColumnHeader_ShowsGlyphLegendHelpIcon()
+    public void Page_KindColumnHeader_ShowsGlyphLegendHelpIcon()
     {
         StubList(Page());
 

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/RecycleBinPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/RecycleBinPageTests.cs
@@ -62,6 +62,10 @@ public sealed class RecycleBinPageTests : BunitContext, IAsyncLifetime
         cut.Markup.Should().Contain("Open Notepad");
         cut.Markup.Should().Contain("Hotstring");
         cut.Markup.Should().Contain("Hotkey");
+
+        // First column says whether the row is a Hotstring or a Hotkey. CONTEXT.md calls that
+        // an Item; "Type" is on its Avoid list and clashed with a Hotstring's Kind.
+        cut.Find("th").TextContent.Trim().Should().Be("Item");
     }
 
     [Fact]


### PR DESCRIPTION
Backlog 034. `CONTEXT.md` declared canonical terms, but several avoided synonyms were still live UI labels. This makes the UI follow the glossary.

## What changed

| Where | From | To |
|---|---|---|
| Kind filter + column header | `Type` | `Kind` |
| Profiles chip + inline checkbox | `Any` | `All profiles` |
| Delivery option | `Hotstring` | `Typed` |
| Recycle Bin column | `Type` | `Item` |
| Inline editor tooltip + aria-label | `change type` | `change kind` |

## Glossary additions

Two gaps surfaced while doing this, so `CONTEXT.md` gained:

- **Short forms** — a canonical term may be shortened only by *dropping words*, never by swapping in a synonym. That is why `All profiles` is allowed and `Any` is not. Without this rule the next tight space invents a new word again.
- **Item** — the collective term for a hotstring or hotkey. The glossary already used the word six times without defining it, and Recycle Bin's `Type` column is this third axis — not `Kind`, not `Action` — so a blanket rename would have made it wrong.

## Layout

The `All profiles` chip is four times longer than `Any` and clipped on both grids. The cause was **padding, not width**: 40px of a ~114px cell (16px left, 24px right) left 74px for content needing 98px. Profiles cell padding is now 4px on both grids. Hotstrings also moved 9% → 13%, taking 4% from Replacement, which ellipsizes anyway.

The inline edit cell now stacks the checkbox above the multi-select instead of sitting in a row. `AlignItems` is deliberately unset — `MudStack` already defaults to a column, and setting `AlignItems.Start` stopped the multi-select stretching (50px at 1280px).

Delivery picker labels now come from `DeliveryDisplay.OptionLabel`, so the picker and the preview label cannot drift apart.

## Deliberately unchanged

- Ending-character labels. `Omit ending character` already matches the glossary exactly, and `Expand` beats `fire` under Plain English for a non-native reader.
- `HotstringDelivery.Type` and other enum members — out of scope per the backlog item.
- `EntityChips.Any` parameter name. Noted as a follow-up rather than an unrequested API rename.

## Verification

Canonical pre-PR gate ([`testing-workflow.md`](docs/development/testing-workflow.md#canonical-pre-pr-gate)):

```
dotnet build AHKFlowApp.slnx --configuration Release   17 projects, 0 errors, 0 warnings
dotnet format AHKFlowApp.slnx --verify-no-changes      exit 0
pwsh .\scripts\test-fast.ps1 -Mode Coverage            3037 passed, 0 failed
git diff --check main...HEAD                           clean
```

Browser-measured at 1280px and 1440px, since no unit test can see a clipped chip:

| Grid | Before | After |
|---|---|---|
| Hotstrings cell | 114 / 138 overflow | 114 / 114 clean |
| Hotkeys cell | 109 / 133 overflow | 109 / 109 clean |
| Edit-mode multi-select | 50px | 106px (full cell width) |

New assertions lock the wording: kind filter reads `Kind`, chip reads `All profiles`, Recycle Bin header reads `Item`, promote button says `change kind`, and the three delivery labels are covered by a theory.

## Known cosmetic limits

- The profile select placeholder still shows `Select pr...` at 1280px. The control is full-width and not overflowing; `MudSelect` reserves ~24px for its dropdown adornment.
- `Descriptior` clipping in the Description header at 1280px is pre-existing — that column was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
