### PR TITLE
chore: make private plans reachable from the @-file picker

### DIFF
--- a/.claude/file-suggestion.sh
+++ b/.claude/file-suggestion.sh
@@ -3,8 +3,16 @@
 #
 # Why this exists: the built-in file picker does not list files under
 # docs/superpowers/. That folder holds a second, private git repository
-# (AHKFlowApp-plans), and the built-in picker skips nested repositories.
-# Setting "respectGitignore": false was not enough on its own.
+# (AHKFlowApp-plans), and the built-in picker appears to skip nested
+# repositories. Setting "respectGitignore": false was not enough on its own.
+#
+# Tools:
+#   rg  - required. Without ripgrep this script can produce no list at all.
+#   jq  - optional. Reads the query out of the JSON on stdin. Without it the
+#         query is read with sed instead.
+#   fzf - optional. Ranks results by fuzzy match. Without it the script falls
+#         back to a case-insensitive substring match. Less clever, but it
+#         never hands back an empty picker.
 #
 # Contract (see .claude/settings.json -> fileSuggestion):
 #   stdin  - JSON, for example {"query": "2026-07-2"}
@@ -19,7 +27,13 @@ set -uo pipefail
 root="${CLAUDE_PROJECT_DIR:-$PWD}"
 cd "$root" 2>/dev/null || exit 0
 
-query=$(jq -r '.query // ""' 2>/dev/null)
+payload=$(cat)
+
+if command -v jq >/dev/null 2>&1; then
+  query=$(printf '%s' "$payload" | jq -r '.query // ""' 2>/dev/null)
+else
+  query=$(printf '%s' "$payload" | sed -n 's/.*"query"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+fi
 
 # --no-ignore-vcs drops .gitignore but keeps .ignore.
 # The .git glob covers the nested repository under docs/superpowers/ too.
@@ -29,6 +43,8 @@ list_files() {
 
 if [ -z "$query" ]; then
   list_files | head -30
-else
+elif command -v fzf >/dev/null 2>&1; then
   list_files | fzf --filter="$query" 2>/dev/null | head -30
+else
+  list_files | grep -i -F -- "$query" | head -30
 fi

--- a/.claude/file-suggestion.sh
+++ b/.claude/file-suggestion.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Supplies the file list for @-mentions in Claude Code.
+#
+# Why this exists: the built-in file picker does not list files under
+# docs/superpowers/. That folder holds a second, private git repository
+# (AHKFlowApp-plans), and the built-in picker skips nested repositories.
+# Setting "respectGitignore": false was not enough on its own.
+#
+# Contract (see .claude/settings.json -> fileSuggestion):
+#   stdin  - JSON, for example {"query": "2026-07-2"}
+#   stdout - one file path per line, relative to the project root
+#   env    - CLAUDE_PROJECT_DIR, same variables that hooks receive
+#
+# Ignore rules come from .ignore, never from .gitignore. That is deliberate.
+# It is why .ignore repeats the build-output folders such as bin/ and obj/.
+
+set -uo pipefail
+
+root="${CLAUDE_PROJECT_DIR:-$PWD}"
+cd "$root" 2>/dev/null || exit 0
+
+query=$(jq -r '.query // ""' 2>/dev/null)
+
+# --no-ignore-vcs drops .gitignore but keeps .ignore.
+# The .git glob covers the nested repository under docs/superpowers/ too.
+list_files() {
+  rg --files --hidden --no-ignore-vcs --glob '!**/.git/**' 2>/dev/null | tr '\\' '/'
+}
+
+if [ -z "$query" ]; then
+  list_files | head -30
+else
+  list_files | fzf --filter="$query" 2>/dev/null | head -30
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,10 @@
     "MAX_MCP_OUTPUT_TOKENS": "50000"
   },
   "respectGitignore": false,
+  "fileSuggestion": {
+    "type": "command",
+    "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/file-suggestion.sh\""
+  },
   "enabledMcpjsonServers": ["cwm-roslyn-navigator"],
   "permissions": {
     "allow": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "env": {
     "MAX_MCP_OUTPUT_TOKENS": "50000"
   },
+  "respectGitignore": false,
   "enabledMcpjsonServers": ["cwm-roslyn-navigator"],
   "permissions": {
     "allow": [

--- a/.ignore
+++ b/.ignore
@@ -20,5 +20,12 @@ target/
 .vs/
 .worktrees/
 
+# Hidden folders that hold whole checkouts or tool caches. The suggestion
+# script passes --hidden, so these need naming or they flood the picker.
+.claude/worktrees/
+.vscode/
+.playwright-cli/
+.tmp/
+
 # Note: do not add `dist/` here. Bootstrap ships tracked files under
 # src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/lib/bootstrap/dist/.

--- a/.ignore
+++ b/.ignore
@@ -1,7 +1,10 @@
-# Search and @-file-picker rules. Read by ripgrep and by Codex.
-# Claude Code reads this file too, and `.claude/settings.json` sets
-# "respectGitignore": false. That turns off .gitignore filtering for the
-# @-file picker, so every rule the picker needs must live here.
+# Search and @-file-picker rules. Three tools read this file: ripgrep, Codex,
+# and .claude/file-suggestion.sh, which supplies the @-mention list in
+# Claude Code. That script runs ripgrep with --no-ignore-vcs, so .gitignore is
+# switched off and this file is not. Every rule the @ picker needs lives here.
+#
+# Keep this file in step with .gitignore. A new build folder added there stays
+# visible to the @ picker until it is named here too.
 
 # Keep private plans searchable in Codex and ripgrep.
 !docs/
@@ -9,8 +12,8 @@
 !docs/superpowers/**
 
 # Build output and caches. .gitignore already hides these from git, but the
-# @-file picker no longer reads .gitignore, so repeat them here. Without these
-# the picker lists about 17,600 files instead of about 1,700.
+# suggestion script does not read .gitignore, so repeat them here. Without
+# these the picker offers about 17,600 files instead of about 1,500.
 bin/
 obj/
 node_modules/

--- a/.ignore
+++ b/.ignore
@@ -1,4 +1,24 @@
+# Search and @-file-picker rules. Read by ripgrep and by Codex.
+# Claude Code reads this file too, and `.claude/settings.json` sets
+# "respectGitignore": false. That turns off .gitignore filtering for the
+# @-file picker, so every rule the picker needs must live here.
+
 # Keep private plans searchable in Codex and ripgrep.
 !docs/
 !docs/superpowers/
 !docs/superpowers/**
+
+# Build output and caches. .gitignore already hides these from git, but the
+# @-file picker no longer reads .gitignore, so repeat them here. Without these
+# the picker lists about 17,600 files instead of about 1,700.
+bin/
+obj/
+node_modules/
+CoverageReport/
+TestResults/
+target/
+.vs/
+.worktrees/
+
+# Note: do not add `dist/` here. Bootstrap ships tracked files under
+# src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/lib/bootstrap/dist/.


### PR DESCRIPTION
## Problem

Plans and specs under `docs/superpowers/` never appeared in the `@` file picker,
even though Codex and ripgrep could find them. That folder is a second, private
git repository, and `.gitignore` hides it from the public repo.

## What was tried

`respectGitignore: false` in `.claude/settings.json`. It works — the picker
started offering gitignored files — but still skipped `docs/superpowers/`.
That folder holds a nested `.git`, and the built-in picker appears to skip
nested repositories. This is the best explanation for the evidence, not a
verified cause, and no setting changes it.

## Fix

A custom `fileSuggestion` command supplies the `@` list instead. It runs
ripgrep with `--no-ignore-vcs`, so `.ignore` applies and `.gitignore` does not.

- `.claude/file-suggestion.sh` — the suggestion script
- `.claude/settings.json` — `fileSuggestion` plus `respectGitignore: false`
- `.ignore` — build output and cache folders, so the picker stays small

Only ripgrep is required. `jq` and `fzf` are used when present and have
fallbacks: without `jq` the query is read with sed, without `fzf` results are
matched by case-insensitive substring instead of fuzzy rank.

## Result

- Query `2026-07-2` now returns plan and spec files first
- Candidate pool 17,600 -> 1,482 files
- Normal source files still resolve, for example `HotstringsController`
- No `.git` internals leak into suggestions

Tested with each optional tool removed from PATH, ripgrep still present:

| Scenario | Before | After |
|---|---|---|
| all tools present | 30 ranked hits | 30 ranked hits |
| `fzf` absent | 0 results | all 17 matches |
| `jq` absent | query ignored, first 30 files | correct matches |
| malformed stdin | first 30 files | first 30 files |

## Note for reviewers

`.ignore` and `.gitignore` must stay in step. A new build folder added to
`.gitignore` stays visible to the `@` picker until it is named in `.ignore`
as well. The header comment in `.ignore` says so.

`respectGitignore: false` is kept even though `fileSuggestion` overrides it.
It costs one line and leaves a better fallback if the script ever fails to run.
