### PR TITLE
docs: add Known shortcut, Used by, Shortcut warning glossary terms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -87,6 +87,18 @@ _Avoid_: terminator, delimiter, end char
 A user's note on a hotstring or hotkey, carried into its Profile script as a comment above the definition. For a Raw Hotstring it is lifted from the leading comments of the pasted definition.
 _Avoid_: comment, note, label
 
+**Known shortcut**:
+A key and modifiers that something outside AHKFlow uses. It is a record of a use, not a problem — a problem only exists once a Hotkey matches one. Not the same as two AHKFlow hotkeys sharing a combination, which the app refuses outright.
+_Avoid_: conflict, clash, collision, duplicate, reserved, blacklist
+
+**Used by**:
+What uses a Known shortcut — Windows, a named application, or a label the Owner types. An Owner who records a Visual Studio shortcut has not become the user of it; Visual Studio is still what uses it.
+_Avoid_: source, provider, origin, owner
+
+**Shortcut warning**:
+The notice shown when a Hotkey matches a Known shortcut. It describes what else uses those keys. It never blocks saving, and it never promises what will happen when the keys are pressed.
+_Avoid_: error, conflict, alert
+
 ### Organizing
 
 **Profile**:


### PR DESCRIPTION
## What

Adds three glossary terms to CONTEXT.md: **Known shortcut**, **Used by**, **Shortcut warning**.

## Why

The hotkey shortcut warnings feature needs settled vocabulary before any code is written. A wrong shared assumption about a word is cheap to fix now and expensive to undo after the API, UI, and tests all use it.

The key distinction the terms draw:

- A **Known shortcut** is something outside AHKFlow using a key combination. It is a record of a use, not a problem.
- Two AHKFlow hotkeys sharing a combination is a different thing. The app refuses that outright.

Each term carries an `_Avoid_` list so `conflict`, `clash`, `collision`, `reserved`, and `blacklist` stay out of new names and new user-facing text.

## Verification

Docs only, nothing compiled. Exemption 1 in AGENTS.md ("Verification After Implementation"). Diff reviewed; wording follows Plain English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
