### PR TITLE
fix: link private plans repo into worktrees, follow it in @ picker

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -32,15 +32,20 @@ Create the worktree first. Do not start writing a plan in the main checkout and 
 afterwards. Use `scripts/new-worktree.ps1`, or the native `EnterWorktree` tool — that tool fires the
 `WorktreeCreate` hook, which runs the same script for you.
 
-You cannot write the planning documents inside the worktree. The file system forbids it. Worktrees
-have **no `docs/superpowers/` folder** — it is a separate private repo (`AHKFlowApp-plans`), the
-public repo ignores the path, and `git worktree add` does not create it. So follow this order:
+Write and commit the planning documents from the **main checkout**, not from the worktree.
+`docs/superpowers/` is a separate private repo (`AHKFlowApp-plans`). The public repo ignores the
+path, so `git worktree add` never checks it out. `scripts/new-worktree.ps1` links the folder into
+each worktree instead, so a worktree can **read** its spec and plan at the same relative path.
+Treat that link as read-only: keep every plan write and plan commit in the main checkout, so the
+plans repo has one place work happens. Follow this order:
 
 1. Create the worktree, but stay in the main checkout for now.
 2. Write and commit the spec and the plan there, under `docs/superpowers/specs/` and
    `docs/superpowers/plans/`. Commit from inside `docs/superpowers/`, never from the repo root.
 3. Switch fully into the worktree. Everything else — code, tests, docs, config — happens there and
-   commits from there.
+   commits from there. The spec and plan stay readable at `docs/superpowers/` through the link.
+4. If a review round changes the plan, go back to the main checkout to edit and commit it. The
+   worktree sees the update straight away, because the link points at one shared working copy.
 
 Step 2 does not apply to every plan. **Plans** in AGENTS.md lists the kinds that stay out of the
 private repo: agent optimization, personal workflow tuning, agent housekeeping, and one-off

--- a/.claude/file-suggestion.sh
+++ b/.claude/file-suggestion.sh
@@ -37,8 +37,13 @@ fi
 
 # --no-ignore-vcs drops .gitignore but keeps .ignore.
 # The .git glob covers the nested repository under docs/superpowers/ too.
+# --follow is what makes docs/superpowers show up in an agent worktree: there it is a
+# directory symlink back to the main checkout (see scripts/new-worktree.ps1), and rg does
+# not descend into symlinked directories without this flag. .ignore denies the pre-existing
+# skill-mirror symlinks (.claude/skills/, .github/skills/, .github/AGENTS.md) so --follow
+# does not also duplicate every skill file and AGENTS.md in the suggestion list.
 list_files() {
-  rg --files --hidden --no-ignore-vcs --glob '!**/.git/**' 2>/dev/null | tr '\\' '/'
+  rg --files --hidden --no-ignore-vcs --follow --glob '!**/.git/**' 2>/dev/null | tr '\\' '/'
 }
 
 if [ -z "$query" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
           ./tests/WorktreeBranchName.Tests.ps1
           ./tests/WorktreeBaseRef.Tests.ps1
           ./tests/WorktreeMergedCleanup.Tests.ps1
+          ./tests/WorktreePlansSymlink.Tests.ps1
           ./tests/WorktreeRemoveHook.Tests.ps1
           ./tests/WorktreeLocalDevSetup.Tests.ps1
           ./tests/SkillParity.Tests.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -466,4 +466,4 @@ CoverageReport/
 
 # Planning docs live in a separate PRIVATE repo (AHKFlowApp-plans), cloned into
 # docs/superpowers/. The public repo must not track them.
-docs/superpowers/
+docs/superpowers

--- a/.ignore
+++ b/.ignore
@@ -32,3 +32,10 @@ target/
 
 # Note: do not add `dist/` here. Bootstrap ships tracked files under
 # src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/lib/bootstrap/dist/.
+
+# Symlink mirrors of .agents/<skill>/ and root AGENTS.md. The suggestion script now passes
+# --follow (for the docs/superpowers worktree link above), which would otherwise list every
+# skill file and AGENTS.md two or three times.
+.claude/skills/
+.github/skills/
+.github/AGENTS.md

--- a/scripts/new-worktree.ps1
+++ b/scripts/new-worktree.ps1
@@ -142,6 +142,66 @@ function Copy-WorktreeIncludeEntries {
     }
 }
 
+# Links the worktree's docs\superpowers to the main checkout's copy instead of duplicating it.
+# docs\superpowers holds a second, private git repo (AHKFlowApp-plans); the public repo's
+# .gitignore excludes it, so `git worktree add` never checks it out. A one-time copy would go
+# stale the moment the plan is revised in the main checkout, and a second clone would let the
+# worktree accumulate commits that never reach the canonical repo -- every commit to that repo
+# must happen from the main checkout. A symlink keeps both paths pointing at the same working
+# copy, so there is nothing to keep in sync. Best-effort and non-fatal: a missing or broken
+# plans checkout must never block worktree creation.
+function Add-PlansSymlink {
+    param(
+        [string] $RepoRoot,
+        [string] $WorktreePath
+    )
+
+    $sourcePath = Join-Path $RepoRoot 'docs\superpowers'
+    if (-not (Test-Path -LiteralPath $sourcePath)) {
+        return
+    }
+
+    $linkPath = Join-Path $WorktreePath 'docs\superpowers'
+    $resolvedSource = (Resolve-Path -LiteralPath $sourcePath).Path
+
+    if (Test-Path -LiteralPath $linkPath) {
+        $existing = Get-Item -LiteralPath $linkPath -Force
+        if ($existing.LinkType -eq 'SymbolicLink') {
+            $target = $existing.Target
+            if ($target -is [array]) { $target = $target[0] }
+            $resolvedTarget = if ($target) {
+                (Resolve-Path -LiteralPath $target -ErrorAction SilentlyContinue).Path
+            } else {
+                $null
+            }
+
+            if ($resolvedTarget -and $resolvedTarget.TrimEnd('\') -ieq $resolvedSource.TrimEnd('\')) {
+                return
+            }
+
+            Remove-Item -LiteralPath $linkPath -Force
+        } else {
+            Write-Stderr "docs\superpowers already exists in the worktree and is not a symlink; leaving it alone: $linkPath"
+            return
+        }
+    }
+
+    New-Item -ItemType Directory -Path (Split-Path -Parent $linkPath) -Force | Out-Null
+
+    Push-Location (Split-Path -Parent $linkPath)
+    try {
+        cmd /c mklink /D 'superpowers' $resolvedSource > $null 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Stderr 'Failed to link docs\superpowers into the worktree; continuing without it.'
+            return
+        }
+    } finally {
+        Pop-Location
+    }
+
+    Write-Stderr "Linked docs\superpowers -> $resolvedSource"
+}
+
 # Sweep orphaned per-worktree Docker compose projects (worktrees removed by plain git,
 # Codex, or Copilot never fire the WorktreeRemove hook). Best-effort and non-fatal: a
 # missing docker CLI or a prune error must never block worktree creation. Output is
@@ -272,6 +332,12 @@ if (-not $worktreeExists) {
 }
 
 Copy-WorktreeIncludeEntries $repoRoot $worktreePath
+
+try {
+    Add-PlansSymlink -RepoRoot $repoRoot -WorktreePath $worktreePath
+} catch {
+    Write-Stderr "Plans symlink skipped: $($_.Exception.Message)"
+}
 
 $setupScript = Join-Path $worktreePath 'scripts\setup-worktree-local-dev.ps1'
 if (-not (Test-Path -LiteralPath $setupScript)) {

--- a/scripts/new-worktree.ps1
+++ b/scripts/new-worktree.ps1
@@ -31,6 +31,7 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'worktree-git.common.ps1')
 . (Join-Path $PSScriptRoot 'worktree-powershell.common.ps1')
+. (Join-Path $PSScriptRoot 'worktree-plans.common.ps1')
 
 function Get-HookInput {
     if (-not [Console]::IsInputRedirected) {
@@ -140,66 +141,6 @@ function Copy-WorktreeIncludeEntries {
 
         Write-Stderr "Copied $relativePath into worktree."
     }
-}
-
-# Links the worktree's docs\superpowers to the main checkout's copy instead of duplicating it.
-# docs\superpowers holds a second, private git repo (AHKFlowApp-plans); the public repo's
-# .gitignore excludes it, so `git worktree add` never checks it out. A one-time copy would go
-# stale the moment the plan is revised in the main checkout, and a second clone would let the
-# worktree accumulate commits that never reach the canonical repo -- every commit to that repo
-# must happen from the main checkout. A symlink keeps both paths pointing at the same working
-# copy, so there is nothing to keep in sync. Best-effort and non-fatal: a missing or broken
-# plans checkout must never block worktree creation.
-function Add-PlansSymlink {
-    param(
-        [string] $RepoRoot,
-        [string] $WorktreePath
-    )
-
-    $sourcePath = Join-Path $RepoRoot 'docs\superpowers'
-    if (-not (Test-Path -LiteralPath $sourcePath)) {
-        return
-    }
-
-    $linkPath = Join-Path $WorktreePath 'docs\superpowers'
-    $resolvedSource = (Resolve-Path -LiteralPath $sourcePath).Path
-
-    if (Test-Path -LiteralPath $linkPath) {
-        $existing = Get-Item -LiteralPath $linkPath -Force
-        if ($existing.LinkType -eq 'SymbolicLink') {
-            $target = $existing.Target
-            if ($target -is [array]) { $target = $target[0] }
-            $resolvedTarget = if ($target) {
-                (Resolve-Path -LiteralPath $target -ErrorAction SilentlyContinue).Path
-            } else {
-                $null
-            }
-
-            if ($resolvedTarget -and $resolvedTarget.TrimEnd('\') -ieq $resolvedSource.TrimEnd('\')) {
-                return
-            }
-
-            Remove-Item -LiteralPath $linkPath -Force
-        } else {
-            Write-Stderr "docs\superpowers already exists in the worktree and is not a symlink; leaving it alone: $linkPath"
-            return
-        }
-    }
-
-    New-Item -ItemType Directory -Path (Split-Path -Parent $linkPath) -Force | Out-Null
-
-    Push-Location (Split-Path -Parent $linkPath)
-    try {
-        cmd /c mklink /D 'superpowers' $resolvedSource > $null 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            Write-Stderr 'Failed to link docs\superpowers into the worktree; continuing without it.'
-            return
-        }
-    } finally {
-        Pop-Location
-    }
-
-    Write-Stderr "Linked docs\superpowers -> $resolvedSource"
 }
 
 # Sweep orphaned per-worktree Docker compose projects (worktrees removed by plain git,

--- a/scripts/worktree-plans.common.ps1
+++ b/scripts/worktree-plans.common.ps1
@@ -1,0 +1,69 @@
+#Requires -Version 5.1
+# Links a worktree's docs\superpowers at the main checkout's copy instead of duplicating it.
+#
+# docs\superpowers holds a second, private git repo (AHKFlowApp-plans). The public repo's
+# .gitignore excludes it, so `git worktree add` never checks it out and a new worktree cannot
+# see the spec or plan it is meant to implement.
+#
+# A copy is the wrong tool: it goes stale the moment a plan is revised, and a second clone would
+# let a worktree accumulate commits that never reach the canonical repo. A symlink keeps both
+# paths pointing at one working copy, so there is nothing to keep in sync.
+#
+# The link exists so a worktree can READ its plans. Writing and committing plans still happens
+# from the main checkout path -- see the planning workflow in .claude/CLAUDE.md.
+#
+# Requires Write-Stderr from worktree-powershell.common.ps1; dot-source that first.
+
+function Add-PlansSymlink {
+    param(
+        [string] $RepoRoot,
+        [string] $WorktreePath
+    )
+
+    $sourcePath = Join-Path $RepoRoot 'docs\superpowers'
+    if (-not (Test-Path -LiteralPath $sourcePath)) {
+        return
+    }
+
+    $linkPath = Join-Path $WorktreePath 'docs\superpowers'
+    $resolvedSource = (Resolve-Path -LiteralPath $sourcePath).Path
+
+    if (Test-Path -LiteralPath $linkPath) {
+        $existing = Get-Item -LiteralPath $linkPath -Force
+        if ($existing.LinkType -eq 'SymbolicLink') {
+            $target = $existing.Target
+            if ($target -is [array]) { $target = $target[0] }
+            $resolvedTarget = if ($target) {
+                (Resolve-Path -LiteralPath $target -ErrorAction SilentlyContinue).Path
+            } else {
+                $null
+            }
+
+            if ($resolvedTarget -and $resolvedTarget.TrimEnd('\') -ieq $resolvedSource.TrimEnd('\')) {
+                return
+            }
+
+            Remove-Item -LiteralPath $linkPath -Force
+        } else {
+            # A real directory here is unexpected -- the path is gitignored, so git never creates
+            # one. It may hold work someone put there by hand, so warn instead of deleting.
+            Write-Stderr "docs\superpowers already exists in the worktree and is not a symlink; leaving it alone: $linkPath"
+            return
+        }
+    }
+
+    New-Item -ItemType Directory -Path (Split-Path -Parent $linkPath) -Force | Out-Null
+
+    Push-Location (Split-Path -Parent $linkPath)
+    try {
+        cmd /c mklink /D 'superpowers' $resolvedSource > $null 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Stderr 'Failed to link docs\superpowers into the worktree; continuing without it.'
+            return
+        }
+    } finally {
+        Pop-Location
+    }
+
+    Write-Stderr "Linked docs\superpowers -> $resolvedSource"
+}

--- a/tests/WorktreePlansSymlink.Tests.ps1
+++ b/tests/WorktreePlansSymlink.Tests.ps1
@@ -1,0 +1,227 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+# Mirrors the production wiring: new-worktree.ps1 dot-sources the PowerShell common file (for
+# Write-Stderr) before the plans common file that depends on it.
+. (Join-Path $repoRoot 'scripts\worktree-powershell.common.ps1')
+. (Join-Path $repoRoot 'scripts\worktree-plans.common.ps1')
+
+function New-PlansFixture {
+    param([string] $Slug = 'plans')
+
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ("wtplans-$Slug-" + [guid]::NewGuid().ToString('N').Substring(0, 8))
+    New-Item -ItemType Directory -Path (Join-Path $root 'main\docs\superpowers') -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $root 'main\docs\superpowers\marker.md') -Value 'seed' -Encoding utf8
+    return $root
+}
+
+function Remove-Fixture {
+    param([string] $Path)
+
+    for ($attempt = 1; $attempt -le 3; $attempt++) {
+        try {
+            Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction Stop
+            return
+        } catch {
+            if ($attempt -eq 3) { return }
+            Start-Sleep -Milliseconds 200
+        }
+    }
+}
+
+function Get-LinkTarget {
+    param([string] $Path)
+
+    $item = Get-Item -LiteralPath $Path -Force
+    $target = $item.Target
+    if ($target -is [array]) { $target = $target[0] }
+    return $target
+}
+
+# --- Case 1: a fresh worktree gets a symlink, and reads the main checkout's content ---------
+$fixture = New-PlansFixture 'fresh'
+try {
+    $main = Join-Path $fixture 'main'
+    $wt = Join-Path $fixture 'wt'
+    New-Item -ItemType Directory -Path $wt -Force | Out-Null
+
+    Add-PlansSymlink -RepoRoot $main -WorktreePath $wt
+
+    $link = Join-Path $wt 'docs\superpowers'
+    Assert-True (Test-Path -LiteralPath $link) 'A fresh worktree must receive docs\superpowers.'
+    Assert-True ((Get-Item -LiteralPath $link -Force).LinkType -eq 'SymbolicLink') 'docs\superpowers must be a symlink, not a copied directory.'
+    Assert-True ((Get-Content -LiteralPath (Join-Path $link 'marker.md')) -ceq 'seed') "The worktree must read the main checkout's plan content through the link."
+
+    # Case 3 (live sync): the link is not a snapshot. A plan revised in the main checkout after
+    # the worktree exists must be visible immediately -- this is the whole reason it is not a copy.
+    Set-Content -LiteralPath (Join-Path $main 'docs\superpowers\later-plan.md') -Value 'revised' -Encoding utf8
+    Assert-True ((Get-Content -LiteralPath (Join-Path $link 'later-plan.md')) -ceq 'revised') 'A plan written after linking must be visible through the worktree path.'
+
+    # Case 2 (idempotent): re-running against an existing, correct link is a no-op. new-worktree.ps1
+    # calls this on every run, including when reusing a worktree.
+    Add-PlansSymlink -RepoRoot $main -WorktreePath $wt
+    Assert-True ((Get-Item -LiteralPath $link -Force).LinkType -eq 'SymbolicLink') 'Re-running must leave the symlink in place.'
+    Assert-True ((Get-Content -LiteralPath (Join-Path $link 'marker.md')) -ceq 'seed') 'Re-running must not disturb linked content.'
+} finally {
+    Remove-Fixture $fixture
+}
+
+# --- Case 4: no plans repo cloned -> skip silently, create nothing --------------------------
+# A contributor who never cloned the private repo must still get a working worktree.
+$fixture = New-PlansFixture 'missing'
+try {
+    $wt = Join-Path $fixture 'wt'
+    New-Item -ItemType Directory -Path $wt -Force | Out-Null
+
+    Add-PlansSymlink -RepoRoot (Join-Path $fixture 'no-such-repo') -WorktreePath $wt
+
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $wt 'docs\superpowers'))) 'With no plans repo to link, nothing may be created.'
+} finally {
+    Remove-Fixture $fixture
+}
+
+# --- Case 5: a real directory already present -> leave it alone ------------------------------
+# Never delete data. The path is gitignored, so anything real there was put there by a human.
+$fixture = New-PlansFixture 'realdir'
+try {
+    $main = Join-Path $fixture 'main'
+    $wt = Join-Path $fixture 'wt'
+    New-Item -ItemType Directory -Path (Join-Path $wt 'docs\superpowers') -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $wt 'docs\superpowers\handwritten.txt') -Value 'do not delete' -Encoding utf8
+
+    Add-PlansSymlink -RepoRoot $main -WorktreePath $wt
+
+    $existing = Get-Item -LiteralPath (Join-Path $wt 'docs\superpowers') -Force
+    Assert-True ($existing.LinkType -ne 'SymbolicLink') 'A real directory must not be replaced by a symlink.'
+    Assert-True (Test-Path -LiteralPath (Join-Path $wt 'docs\superpowers\handwritten.txt')) 'Content in a real directory must survive untouched.'
+} finally {
+    Remove-Fixture $fixture
+}
+
+# --- Case 6: a symlink aimed at the wrong target is repointed --------------------------------
+# Happens when the main checkout moves. A stale link silently serves the wrong repo's plans.
+$fixture = New-PlansFixture 'wrongtarget'
+try {
+    $main = Join-Path $fixture 'main'
+    $wt = Join-Path $fixture 'wt'
+    New-Item -ItemType Directory -Path (Join-Path $fixture 'elsewhere\docs\superpowers') -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $fixture 'elsewhere\docs\superpowers\other.md') -Value 'wrong repo' -Encoding utf8
+    New-Item -ItemType Directory -Path (Join-Path $wt 'docs') -Force | Out-Null
+
+    Push-Location (Join-Path $wt 'docs')
+    try {
+        cmd /c mklink /D 'superpowers' (Join-Path $fixture 'elsewhere\docs\superpowers') > $null 2>&1
+    } finally {
+        Pop-Location
+    }
+
+    Add-PlansSymlink -RepoRoot $main -WorktreePath $wt
+
+    $link = Join-Path $wt 'docs\superpowers'
+    $target = Get-LinkTarget $link
+    $expected = (Resolve-Path -LiteralPath (Join-Path $main 'docs\superpowers')).Path
+    Assert-True ((Resolve-Path -LiteralPath $target).Path.TrimEnd('\') -ieq $expected.TrimEnd('\')) "A wrong-target symlink must be repointed at the main checkout (target was '$target')."
+    Assert-True (Test-Path -LiteralPath (Join-Path $link 'marker.md')) 'After repointing, the main checkout content must be reachable.'
+} finally {
+    Remove-Fixture $fixture
+}
+
+# --- Case 7: removing the worktree must not touch the main checkout's plans ------------------
+# remove-worktree-local-dev.ps1 tears worktrees down with Remove-Item -Recurse -Force. If that
+# followed the link, a worktree cleanup would delete the real plans repo.
+$fixture = New-PlansFixture 'removal'
+try {
+    $main = Join-Path $fixture 'main'
+    $wt = Join-Path $fixture 'wt'
+    New-Item -ItemType Directory -Path $wt -Force | Out-Null
+
+    Add-PlansSymlink -RepoRoot $main -WorktreePath $wt
+    Remove-Item -LiteralPath $wt -Recurse -Force
+
+    Assert-True (Test-Path -LiteralPath (Join-Path $main 'docs\superpowers\marker.md')) 'Removing a worktree must never delete the main checkout plans.'
+} finally {
+    Remove-Fixture $fixture
+}
+
+# --- Case 8: paths containing spaces ---------------------------------------------------------
+# mklink is invoked through cmd, so an unquoted space would silently produce a broken link.
+$fixture = New-PlansFixture 'spaces'
+try {
+    $main = Join-Path $fixture 'main repo'
+    $wt = Join-Path $fixture 'work tree'
+    New-Item -ItemType Directory -Path (Join-Path $main 'docs\superpowers') -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $main 'docs\superpowers\marker.md') -Value 'spaced' -Encoding utf8
+    New-Item -ItemType Directory -Path $wt -Force | Out-Null
+
+    Add-PlansSymlink -RepoRoot $main -WorktreePath $wt
+
+    $link = Join-Path $wt 'docs\superpowers'
+    Assert-True (Test-Path -LiteralPath $link) 'A path containing spaces must still produce a link.'
+    Assert-True ((Get-Content -LiteralPath (Join-Path $link 'marker.md')) -ceq 'spaced') 'Content must be readable through a link whose path contains spaces.'
+} finally {
+    Remove-Fixture $fixture
+}
+
+# --- The .gitignore pattern must hide the symlink, not just a real directory -----------------
+# A pattern ending in '/' matches directories only. Every worktree's docs\superpowers is now a
+# symlink, so a trailing slash would leave it showing as untracked in git status.
+$gitignorePath = Join-Path $repoRoot '.gitignore'
+$plansRules = @(Get-Content -LiteralPath $gitignorePath | Where-Object { $_.Trim() -eq 'docs/superpowers' -or $_.Trim() -eq 'docs/superpowers/' })
+Assert-True ($plansRules.Count -ge 1) '.gitignore must carry a docs/superpowers rule.'
+Assert-True (-not ($plansRules -contains 'docs/superpowers/')) '.gitignore must use "docs/superpowers" without a trailing slash, or the worktree symlink is not ignored.'
+
+# --- The @-picker script must follow symlinks and suppress the mirror duplicates -------------
+# Without --follow, rg does not descend into the docs\superpowers link and the picker shows no
+# plans at all inside a worktree -- the bug this change exists to fix.
+$suggestionPath = Join-Path $repoRoot '.claude\file-suggestion.sh'
+$suggestion = Get-Content -LiteralPath $suggestionPath -Raw
+Assert-True ($suggestion -match '(?m)^\s*rg --files[^\r\n]*--follow') '.claude/file-suggestion.sh must pass --follow, or worktree plans stay invisible to the @ picker.'
+
+# --follow also walks the pre-existing skill-mirror symlinks, so .ignore must deny them or every
+# skill file and AGENTS.md is listed two or three times.
+$ignoreLines = @(Get-Content -LiteralPath (Join-Path $repoRoot '.ignore') | ForEach-Object { $_.Trim() })
+foreach ($rule in @('.claude/skills/', '.github/skills/', '.github/AGENTS.md')) {
+    Assert-True ($ignoreLines -contains $rule) ".ignore must deny '$rule' so --follow does not duplicate it in the @ picker."
+}
+
+# End-to-end picker behavior, when the tools it needs are present. rg is required by the script
+# itself; bash and rg are not guaranteed on every runner, so assert only when both exist.
+$hasBash = [bool] (Get-Command bash -ErrorAction SilentlyContinue)
+$hasRg = [bool] (Get-Command rg -ErrorAction SilentlyContinue)
+if ($hasBash -and $hasRg) {
+    $suggestionUnixPath = './.claude/file-suggestion.sh'
+    Push-Location $repoRoot
+    try {
+        $env:CLAUDE_PROJECT_DIR = $repoRoot
+        $picked = '{"query":"AGENTS.md"}' | & bash $suggestionUnixPath 2>$null
+        $agentsHits = @($picked | Where-Object { $_.Trim() -eq 'AGENTS.md' -or $_.Trim() -eq '.github/AGENTS.md' })
+        Assert-True (-not ($agentsHits -contains '.github/AGENTS.md')) 'The @ picker must not list the .github/AGENTS.md symlink mirror.'
+        Assert-True ($agentsHits -contains 'AGENTS.md') 'The @ picker must still list the real root AGENTS.md.'
+
+        $skillPicked = '{"query":"dck-build-fix"}' | & bash $suggestionUnixPath 2>$null
+        $mirrorHits = @($skillPicked | Where-Object { $_ -like '.claude/skills/*' -or $_ -like '.github/skills/*' })
+        Assert-True ($mirrorHits.Count -eq 0) "The @ picker must not list .claude/skills or .github/skills mirrors (got: $($mirrorHits -join ', '))."
+    } finally {
+        Remove-Item Env:\CLAUDE_PROJECT_DIR -ErrorAction SilentlyContinue
+        Pop-Location
+    }
+} else {
+    Write-Host 'Skipped the live @-picker checks: bash and/or rg not available on this host.'
+}
+
+Write-Host 'Worktree plans symlink tests passed.'


### PR DESCRIPTION
## Problem

`docs/superpowers/` is a second, private git repo (`AHKFlowApp-plans`) cloned into the main
checkout. The public repo gitignores that path, so `git worktree add` never checks it out —
worktrees only get committed files, and this path has none. An agent that switches into a
worktree to implement a plan cannot read the spec or plan it just wrote.

A separate `@`-mention file picker was added recently (`.claude/file-suggestion.sh`), but it did
not surface these plans from a worktree either.

## Fix

1. **`scripts/worktree-plans.common.ps1`** (new) — `Add-PlansSymlink` links a worktree's
   `docs\superpowers` at the main checkout's copy. A symlink, not a copy: a copy goes stale the
   moment a plan is revised, and a second clone would let a worktree accumulate commits that never
   reach the canonical repo. Best-effort and non-fatal, idempotent, and it refuses to delete a
   real directory it finds there.
2. **`.claude/file-suggestion.sh`** — add `--follow`. `rg` does not descend into symlinked
   directories without it, so the link alone still showed no plans.
3. **`.ignore`** — deny `.claude/skills/`, `.github/skills/`, `.github/AGENTS.md`. These are
   pre-existing symlink mirrors; `--follow` would otherwise list every skill file and `AGENTS.md`
   two or three times.
4. **`.gitignore`** — `docs/superpowers/` → `docs/superpowers`. A trailing-slash pattern matches
   real directories only, not the new symlink, so `git status` listed it as untracked in every
   worktree.
5. **`.claude/CLAUDE.md`** — it said worktrees have *no* `docs/superpowers/` folder. This change
   makes that false. Reworded: the link is for **reading** plans; plan writes and plan commits
   stay in the main checkout.

## Tests

`tests/WorktreePlansSymlink.Tests.ps1`, wired into the existing `worktree-powershell-tests` CI
job. Covers 11 behaviors: fresh link, idempotent re-run, live sync, missing plans repo, real
directory left alone, wrong-target repoint, worktree teardown not deleting the real plans repo,
spaced paths, and the `.gitignore` / `--follow` / `.ignore` config guards.

`Add-PlansSymlink` lives in a `*.common.ps1` file specifically so a test can dot-source it, the
same way `tests/WorktreeBaseRef.Tests.ps1:44` reaches `scripts/worktree-git.common.ps1`.

The two config guards were mutation-tested — removing `--follow` and restoring the trailing slash
each failed the suite with its intended message.

**Not covered:** the full `new-worktree.ps1` creation flow. It must run from the main checkout,
so testing it would mean creating real worktrees on a CI runner. Same trade-off
`WorktreeBaseRef.Tests.ps1` makes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
