### PR TITLE
feat: hotkey shortcut warnings (Stage 1 - static catalog)

### DIFF
--- a/.claude/backlog/038-known-shortcut-indicator-on-hotkeys-list.md
+++ b/.claude/backlog/038-known-shortcut-indicator-on-hotkeys-list.md
@@ -1,0 +1,31 @@
+# 038 - Flag known-shortcut matches on the hotkeys list
+
+## Metadata
+
+- **Epic**: Hotkeys
+- **Type**: Feature
+- **Interfaces**: UI
+
+## Summary
+
+The shortcut warning shows only inside the hotkey edit dialog. A hotkey that already matches a known shortcut stays invisible until its owner happens to open it. Someone with many existing hotkeys may never see the warning at all.
+
+## User story
+
+As an owner, I want my hotkeys list to show which hotkeys match a known shortcut, so that I do not have to open each one to find out.
+
+## Acceptance criteria
+
+- [ ] A row whose combination matches a known shortcut carries a visible marker
+- [ ] The marker names what uses the combination, on hover or on tap
+- [ ] The desktop `MudDataGrid` branch and the mobile list branch both show it
+- [ ] The list reads the catalog through `IKnownShortcutCatalog`, so it costs no extra fetch
+
+## Out of scope
+
+- Blocking or bulk-fixing. The marker is advice, exactly like the dialog warning
+
+## Notes / dependencies
+
+- Needs Stage 1 of the hotkey shortcut warnings plan (2026-07-29) merged
+- Both list branches live in `src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/`

--- a/src/Backend/AHKFlowApp.API/Controllers/HotkeysController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/HotkeysController.cs
@@ -31,6 +31,7 @@ public sealed class HotkeysController(
     IUseCase<RestoreHotkeyCommand, Result<HotkeyDto>> restoreHotkey,
     IUseCase<PurgeDeletedHotkeyCommand, Result> purgeDeletedHotkey,
     IUseCase<ListHotkeyKeysQuery, Result<HotkeyKeyCatalogDto>> listHotkeyKeys,
+    IUseCase<ListKnownShortcutsQuery, Result<KnownShortcutCatalogDto>> listKnownShortcuts,
     IUseCase<GetHotkeyPreviewQuery, Result<HotkeyPreviewDto>> previewHotkey) : ControllerBase
 {
     /// <summary>Get the canonical key registry backing the hotkey key picker.</summary>
@@ -39,6 +40,16 @@ public sealed class HotkeysController(
     [ProducesResponseType(typeof(HotkeyKeyCatalogDto), StatusCodes.Status200OK)]
     public async Task<ActionResult<HotkeyKeyCatalogDto>> Keys(CancellationToken ct) =>
         (await listHotkeyKeys.ExecuteAsync(new ListHotkeyKeysQuery(), ct)).ToProblemActionResult(this);
+
+    /// <summary>Get the curated list of shortcuts Windows already uses.</summary>
+    /// <remarks>
+    /// Advisory only — nothing here blocks a save. Static reference data in this release;
+    /// authorized because the controller is, not because it is user-scoped.
+    /// </remarks>
+    [HttpGet("known-shortcuts")]
+    [ProducesResponseType(typeof(KnownShortcutCatalogDto), StatusCodes.Status200OK)]
+    public async Task<ActionResult<KnownShortcutCatalogDto>> KnownShortcuts(CancellationToken ct) =>
+        (await listKnownShortcuts.ExecuteAsync(new ListKnownShortcutsQuery(), ct)).ToProblemActionResult(this);
 
     /// <summary>List hotkeys for the current user, optionally filtered by profile. Paginated.</summary>
     [HttpGet]

--- a/src/Backend/AHKFlowApp.Application/Constants/KnownShortcutCatalog.cs
+++ b/src/Backend/AHKFlowApp.Application/Constants/KnownShortcutCatalog.cs
@@ -1,0 +1,176 @@
+using AHKFlowApp.Domain.Enums;
+
+namespace AHKFlowApp.Application.Constants;
+
+/// <param name="UsedBy">What uses the combination — "Windows", "Chrome", or an owner's own label.</param>
+/// <param name="Protection">How hard the keys are to take over.</param>
+/// <param name="Scope">Whether the use fires anywhere, or only in front.</param>
+/// <param name="Does">Lowercase verb phrase completing "&lt;UsedBy&gt; uses &lt;combo&gt; to …".</param>
+/// <param name="EvidenceUrl">Pinned page proving this use. One per use; a use without one does not ship.</param>
+/// <param name="EvidenceCheckedOn">Date the pinned page was last read.</param>
+internal sealed record ShortcutUse(
+    string UsedBy,
+    ShortcutProtection Protection,
+    ShortcutScope Scope,
+    string Does,
+    string EvidenceUrl,
+    DateOnly EvidenceCheckedOn);
+
+/// <param name="Id">Stable, never reused. Format "windows.file-explorer".</param>
+/// <param name="Key">Canonical key from <see cref="HotkeyKeys"/>.</param>
+/// <param name="Ctrl">True when the combination needs Ctrl.</param>
+/// <param name="Alt">True when the combination needs Alt.</param>
+/// <param name="Shift">True when the combination needs Shift.</param>
+/// <param name="Win">True when the combination needs the Windows key.</param>
+/// <param name="Uses">Everything that uses this combination. At least one.</param>
+/// <param name="WarningText">
+/// Optional override. Warning text is normally composed from the uses; this is only for rows
+/// where the composed sentence reads badly. Null for every row shipped in this release.
+/// </param>
+internal sealed record KnownShortcut(
+    string Id,
+    string Key,
+    bool Ctrl,
+    bool Alt,
+    bool Shift,
+    bool Win,
+    IReadOnlyList<ShortcutUse> Uses,
+    string? WarningText = null);
+
+/// <summary>
+/// The curated list of shortcuts something outside AHKFlow already uses. Curation is the whole
+/// product here: no user-mode API lists another process's hotkeys, so nothing is detected at
+/// runtime (design §1). Every row is pinned to a public page and dated, so the list can be
+/// re-checked by diffing that page.
+/// </summary>
+/// <remarks>
+/// No value promises a runtime outcome. AutoHotkey documents overriding Windows hotkeys as a
+/// feature, and a low-level keyboard hook installed earlier can swallow a keystroke outright,
+/// so the warning says what else uses the keys — never what will happen.
+/// </remarks>
+internal static class KnownShortcutCatalog
+{
+    private const string WindowsUrl =
+        "https://support.microsoft.com/en-us/windows/keyboard-shortcuts-in-windows-dcc61a57-8ff0-cffe-9796-cb9706c75eec";
+
+    private const string WinlogonUrl =
+        "https://learn.microsoft.com/en-us/windows/win32/secauthn/responsibilities-of-winlogon";
+
+    private const string WinLockUrl =
+        "https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-desktop/win-key-remains-held-after-pressing-ctrl-win-l-in-remote-session";
+
+    private static readonly DateOnly s_checkedOn = new(2026, 7, 29);
+
+    /// <summary>One row per combination, in design §3 order. Windows only in this release.</summary>
+    /// <remarks>
+    /// Letter keys are stored lowercase because that is what <see cref="HotkeyKeys"/> canonicalizes
+    /// them to. Matching ignores case, so the stored spelling is a storage rule, not a display one.
+    /// </remarks>
+    public static IReadOnlyList<KnownShortcut> All { get; } =
+    [
+        // ---- Windows. Every row is Global and UsedBy "Windows". ----
+        // The two Protected rows come first: they are the only rows with a Microsoft source
+        // stating Windows itself handles the keys.
+        Windows("windows.secure-attention", "Delete", "show the security screen",
+            ctrl: true, alt: true, win: false,
+            protection: ShortcutProtection.Protected, evidenceUrl: WinlogonUrl),
+        Windows("windows.lock", "l", "lock the computer",
+            protection: ShortcutProtection.Protected, evidenceUrl: WinLockUrl),
+
+        // Win + letter.
+        Windows("windows.action-center", "a", "open the action center"),
+        Windows("windows.copilot", "c", "open Copilot"),
+        Windows("windows.show-desktop", "d", "show and hide the desktop"),
+        Windows("windows.file-explorer", "e", "open File Explorer"),
+        Windows("windows.feedback-hub", "f", "open Feedback Hub"),
+        Windows("windows.game-bar", "g", "open Game Bar"),
+        Windows("windows.voice-dictation", "h", "open voice dictation"),
+        Windows("windows.settings", "i", "open Settings"),
+        Windows("windows.recall", "j", "open Recall"),
+        Windows("windows.cast", "k", "open Cast"),
+        Windows("windows.minimize-all", "m", "minimize all windows"),
+        Windows("windows.notification-center", "n", "open notification center and calendar"),
+        Windows("windows.lock-orientation", "o", "lock device orientation"),
+        Windows("windows.project", "p", "open presentation display modes"),
+        Windows("windows.search-q", "q", "open search"),
+        Windows("windows.run", "r", "open the Run dialog"),
+        Windows("windows.search-s", "s", "open search"),
+        Windows("windows.accessibility", "u", "open Accessibility settings"),
+        Windows("windows.clipboard-history", "v", "open clipboard history"),
+        Windows("windows.widgets", "w", "open Widgets"),
+        Windows("windows.quick-link", "x", "open the Quick Link menu"),
+        Windows("windows.mixed-reality", "y", "switch to Windows Mixed Reality"),
+        Windows("windows.snap-layouts", "z", "open snap layouts"),
+
+        // Win + named key.
+        Windows("windows.task-view", "Tab", "open Task View"),
+        Windows("windows.close-magnifier", "Escape", "close Magnifier"),
+        Windows("windows.about", "Pause", "open Settings to System > About"),
+        Windows("windows.screenshot-file", "PrintScreen", "save a full-screen screenshot to a file"),
+        Windows("windows.minimize-others", "Home", "minimize or restore all but the active window"),
+        Windows("windows.maximize", "Up", "maximize the active window"),
+        Windows("windows.minimize", "Down", "minimize the active window"),
+        Windows("windows.snap-left", "Left", "snap the window left"),
+        Windows("windows.snap-right", "Right", "snap the window right"),
+        Windows("windows.input-next", "Space", "switch to the next input language or layout"),
+
+        // Win + Shift.
+        Windows("windows.screenshot-region", "s", "capture a screen region to the clipboard", shift: true),
+        Windows("windows.restore-minimized", "m", "restore minimized windows", shift: true),
+        Windows("windows.record-region", "r", "record a screen region", shift: true),
+        Windows("windows.cycle-notifications", "v", "cycle through notifications", shift: true),
+        Windows("windows.monitor-left", "Left", "move the window to the monitor on the left", shift: true),
+        Windows("windows.monitor-right", "Right", "move the window to the monitor on the right", shift: true),
+        Windows("windows.stretch-vertical", "Up", "stretch the window top to bottom", shift: true),
+        Windows("windows.restore-snapped", "Down", "restore a snapped or maximized window", shift: true),
+        Windows("windows.uwp-fullscreen", "Enter", "make a UWP app full screen", shift: true),
+        Windows("windows.tip-focus", "a", "focus a Windows tip", shift: true),
+        Windows("windows.input-previous", "Space", "switch to the previous input language or layout", shift: true),
+
+        // Win + Ctrl. windows.wake-display carries Shift as well, so it lives here.
+        Windows("windows.color-filters", "c", "toggle color filters", ctrl: true),
+        Windows("windows.narrator", "Enter", "open Narrator", ctrl: true),
+        Windows("windows.find-devices", "f", "search for devices on a network", ctrl: true),
+        Windows("windows.quick-assist", "q", "open Quick Assist", ctrl: true),
+        Windows("windows.sound-output", "v", "open the sound output page", ctrl: true),
+        Windows("windows.wake-display", "b", "wake the device when the screen is blank", ctrl: true, shift: true),
+        Windows("windows.input-recent", "Space", "switch to the previous input option", ctrl: true),
+
+        // Win + Alt.
+        Windows("windows.hdr", "b", "toggle high dynamic range", alt: true),
+        Windows("windows.desktop-clock", "d", "show and hide date and time on the desktop", alt: true),
+        Windows("windows.voice-keyboard-focus", "h", "focus the keyboard during voice typing", alt: true),
+        Windows("windows.mute-mic", "k", "mute or unmute the microphone", alt: true),
+        Windows("windows.snap-top", "Up", "snap the window to the top half", alt: true),
+        Windows("windows.snap-bottom", "Down", "snap the window to the bottom half", alt: true),
+
+        // No-Win Windows rows.
+        Windows("windows.task-manager", "Escape", "open Task Manager", ctrl: true, shift: true, win: false),
+        Windows("windows.start-menu", "Escape", "open the Start menu", ctrl: true, win: false),
+        Windows("windows.switch-windows", "Tab", "switch between open windows", alt: true, win: false),
+        Windows("windows.app-thumbnails", "Tab", "view thumbnails of all open apps", ctrl: true, alt: true, win: false),
+        Windows("windows.cycle-windows", "Escape", "cycle windows in the order opened", alt: true, win: false),
+        Windows("windows.close-window", "F4", "close the active window", alt: true, win: false),
+        Windows("windows.window-menu", "Space", "open the active window's context menu", alt: true, win: false),
+        Windows("windows.show-password", "F8", "show the password on the sign-in screen", alt: true, win: false),
+
+        // Browser rows (design §3) are Stage 2 — see the Stage 2 plan. They need the ignore
+        // mechanism before they are tolerable, because they cover 15 of 26 Ctrl+letter keys.
+    ];
+
+    // Win is the default modifier because most Windows rows use it; the no-Win rows pass win: false.
+    private static KnownShortcut Windows(
+        string id,
+        string key,
+        string does,
+        bool ctrl = false,
+        bool alt = false,
+        bool shift = false,
+        bool win = true,
+        ShortcutProtection protection = ShortcutProtection.Normal,
+        string evidenceUrl = WindowsUrl) =>
+        new(id, key, ctrl, alt, shift, win,
+        [
+            new ShortcutUse("Windows", protection, ShortcutScope.Global, does, evidenceUrl, s_checkedOn),
+        ]);
+}

--- a/src/Backend/AHKFlowApp.Application/DTOs/KnownShortcutDtos.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/KnownShortcutDtos.cs
@@ -1,0 +1,41 @@
+using AHKFlowApp.Domain.Enums;
+
+namespace AHKFlowApp.Application.DTOs;
+
+/// <summary>One thing that uses a known shortcut, as the dialog needs it.</summary>
+/// <param name="UsedBy">Windows, a named application, or a label the owner typed.</param>
+/// <param name="Protection">How hard the keys are to take over.</param>
+/// <param name="Scope">Whether the use fires anywhere, or only while its application is in front.</param>
+/// <param name="Does">Lowercase verb phrase the warning composer completes a sentence with.</param>
+public sealed record ShortcutUseDto(
+    string UsedBy,
+    ShortcutProtection Protection,
+    ShortcutScope Scope,
+    string Does);
+
+/// <summary>
+/// One key-and-modifier combination something outside AHKFlow uses, with every use of it.
+/// EvidenceUrl and EvidenceCheckedOn stay server-side: they justify curation, and the dialog
+/// never shows them.
+/// </summary>
+/// <param name="Id">Stable identifier for the row, such as "windows.file-explorer".</param>
+/// <param name="Key">Canonical key spelling. Letter keys are lowercase.</param>
+/// <param name="Ctrl">True when the combination needs Ctrl.</param>
+/// <param name="Alt">True when the combination needs Alt.</param>
+/// <param name="Shift">True when the combination needs Shift.</param>
+/// <param name="Win">True when the combination needs the Windows key.</param>
+/// <param name="Uses">Everything that uses this combination. At least one.</param>
+/// <param name="WarningText">Hand-written warning text for this row, or null to compose it.</param>
+public sealed record KnownShortcutDto(
+    string Id,
+    string Key,
+    bool Ctrl,
+    bool Alt,
+    bool Shift,
+    bool Win,
+    IReadOnlyList<ShortcutUseDto> Uses,
+    string? WarningText);
+
+/// <summary>The whole known-shortcut list the dialog matches against.</summary>
+/// <param name="Shortcuts">Every curated combination, one record each.</param>
+public sealed record KnownShortcutCatalogDto(IReadOnlyList<KnownShortcutDto> Shortcuts);

--- a/src/Backend/AHKFlowApp.Application/DependencyInjection.cs
+++ b/src/Backend/AHKFlowApp.Application/DependencyInjection.cs
@@ -53,6 +53,7 @@ public static class DependencyInjection
             .AddUseCase<ImportHotstringsCommand, Result<HotstringImportResultDto>, ImportHotstringsCommandHandler>()
             .AddUseCase<GetHotstringPreviewQuery, Result<HotstringPreviewDto>, GetHotstringPreviewQueryHandler>()
             .AddUseCase<ListHotkeyKeysQuery, Result<HotkeyKeyCatalogDto>, ListHotkeyKeysQueryHandler>()
+            .AddUseCase<ListKnownShortcutsQuery, Result<KnownShortcutCatalogDto>, ListKnownShortcutsQueryHandler>()
             .AddUseCase<CreateHotkeyCommand, Result<HotkeyDto>, CreateHotkeyCommandHandler>()
             .AddUseCase<UpdateHotkeyCommand, Result<HotkeyDto>, UpdateHotkeyCommandHandler>()
             .AddUseCase<DeleteHotkeyCommand, Result, DeleteHotkeyCommandHandler>()

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListKnownShortcutsQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListKnownShortcutsQuery.cs
@@ -1,0 +1,28 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.Constants;
+using AHKFlowApp.Application.DTOs;
+using Ardalis.Result;
+
+namespace AHKFlowApp.Application.Queries.Hotkeys;
+
+/// <summary>Returns the curated known-shortcut list the hotkey dialog warns from. Static reference data.</summary>
+public sealed record ListKnownShortcutsQuery();
+
+internal sealed class ListKnownShortcutsQueryHandler
+    : IUseCaseHandler<ListKnownShortcutsQuery, Result<KnownShortcutCatalogDto>>
+{
+    // Projected once: the manifest is immutable for the process lifetime.
+    private static readonly KnownShortcutCatalogDto s_catalog = Project();
+
+    public Task<Result<KnownShortcutCatalogDto>> ExecuteAsync(
+        ListKnownShortcutsQuery request, CancellationToken ct) =>
+        Task.FromResult(Result<KnownShortcutCatalogDto>.Success(s_catalog));
+
+    private static KnownShortcutCatalogDto Project() => new(
+    [
+        .. KnownShortcutCatalog.All.Select(s => new KnownShortcutDto(
+            s.Id, s.Key, s.Ctrl, s.Alt, s.Shift, s.Win,
+            [.. s.Uses.Select(u => new ShortcutUseDto(u.UsedBy, u.Protection, u.Scope, u.Does))],
+            s.WarningText))
+    ]);
+}

--- a/src/Backend/AHKFlowApp.Domain/Enums/ShortcutProtection.cs
+++ b/src/Backend/AHKFlowApp.Domain/Enums/ShortcutProtection.cs
@@ -7,7 +7,11 @@ namespace AHKFlowApp.Domain.Enums;
 /// </summary>
 public enum ShortcutProtection
 {
-    /// <summary>Windows handles the keys before any hook can see them. Needs a pinned Microsoft source.</summary>
+    /// <summary>
+    /// Windows handles the keys itself. Needs a pinned Microsoft source saying so. It makes no
+    /// claim about what other software sees: no Microsoft source rules a keyboard hook out, and
+    /// PowerToys documents remapping keys at the low level.
+    /// </summary>
     Protected = 0,
 
     /// <summary>Something uses it, and a script may or may not take it over.</summary>

--- a/src/Backend/AHKFlowApp.Domain/Enums/ShortcutProtection.cs
+++ b/src/Backend/AHKFlowApp.Domain/Enums/ShortcutProtection.cs
@@ -1,0 +1,18 @@
+namespace AHKFlowApp.Domain.Enums;
+
+/// <summary>
+/// How hard it is for a script to take a key combination over. One axis only — which product
+/// uses the keys is carried by the use's UsedBy label, not by this enum. Not named Category or
+/// Kind: CONTEXT.md already gives both of those words other meanings.
+/// </summary>
+public enum ShortcutProtection
+{
+    /// <summary>Windows handles the keys before any hook can see them. Needs a pinned Microsoft source.</summary>
+    Protected = 0,
+
+    /// <summary>Something uses it, and a script may or may not take it over.</summary>
+    Normal = 1,
+
+    /// <summary>Recorded by an owner with no claim about how hard the keys are to take.</summary>
+    Unknown = 2,
+}

--- a/src/Backend/AHKFlowApp.Domain/Enums/ShortcutScope.cs
+++ b/src/Backend/AHKFlowApp.Domain/Enums/ShortcutScope.cs
@@ -1,0 +1,11 @@
+namespace AHKFlowApp.Domain.Enums;
+
+/// <summary>Whether a shortcut use fires anywhere, or only while its application is in front.</summary>
+public enum ShortcutScope
+{
+    /// <summary>Fires anywhere, whatever window has focus.</summary>
+    Global = 0,
+
+    /// <summary>Fires only while the application that owns it is in front.</summary>
+    Foreground = 1,
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
@@ -43,6 +43,15 @@
                              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "win-checkbox" })" />
             </MudStack>
 
+            @* ---- Known-shortcut notice. Advisory only — it never gates Save. ---- *@
+            @if (_shortcutWarning is not null)
+            {
+                <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-2"
+                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "shortcut-warning" })">
+                    @_shortcutWarning
+                </MudAlert>
+            }
+
             @* ---- Action selector. Generated from the enum so the set cannot drift.
                  The wrapper div carries the CSS-isolation scope for the wrapping rule. ---- *@
             <div class="action-kind-wrap">
@@ -271,6 +280,7 @@
     [Inject] private IJSRuntime JS { get; set; } = default!;
     [Inject] private ISnackbar Snackbar { get; set; } = default!;
     [Inject] private ILogger<HotkeyEditDialog> Logger { get; set; } = default!;
+    [Inject] private IKnownShortcutCatalog KnownShortcuts { get; set; } = default!;
 
     [Parameter] public HotkeyEditModel Item { get; set; } = new();
     [Parameter] public IReadOnlyList<ProfileDto> Profiles { get; set; } = [];
@@ -294,11 +304,11 @@
     private readonly Dictionary<string, string> _saveFieldErrors = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _previewFieldErrors = new(StringComparer.OrdinalIgnoreCase);
 
-    // The duplicate key+modifier conflict (409). Shown on the Key input but kept apart from a
+    // The duplicate key+modifier message (409). Shown on the Key input but kept apart from a
     // genuine key-validation error, because its verdict is on the whole combination: it must clear
     // when the key OR any modifier changes, whereas a "not a known key" error clears on key edit
     // only. Folding it into _saveFieldErrors["Key"] would tie the two together.
-    private string? _combinationConflict;
+    private string? _duplicateCombination;
 
     private string? _error;
     private bool _saving;
@@ -328,6 +338,13 @@
     private int _previewGeneration;
     private bool _disposed;
 
+    // The known-shortcut notice for the current combination, or null. Advisory only: it never
+    // gates Save. The list behind it is session-cached by IKnownShortcutCatalog, the same way
+    // IHotkeyKeyCatalog caches the key registry.
+    private string? _shortcutWarning;
+    private CancellationTokenSource? _shortcutCts;
+    private int _shortcutGeneration;
+
     protected override void OnParametersSet()
     {
         _profileOptions = [.. Profiles.Select(p => new EntityOption(p.Id, p.Name))];
@@ -338,6 +355,9 @@
             _lastItem = Item;
             if (Item.ActionKind == HotkeyActionKind.SendKeys)
                 DecomposeSendKeys();
+
+            _shortcutWarning = null;
+            _ = RefreshShortcutWarningAsync();
         }
     }
 
@@ -347,6 +367,74 @@
         _cts.Cancel();
         _cts.Dispose();
         CancelPendingPreview();
+        _shortcutCts?.Cancel();
+        _shortcutCts?.Dispose();
+        _shortcutCts = null;
+    }
+
+    /// <summary>
+    /// Refreshes the known-shortcut notice for the current combination. Fire-and-forget from the
+    /// change handlers: the notice is advisory, so nothing waits on it.
+    /// </summary>
+    /// <remarks>
+    /// Follows the preview's generation-counter pattern. A response for an older combination is
+    /// dropped rather than rendered, so holding a modifier key down cannot leave a stale notice
+    /// on screen. A failed fetch clears the notice and says nothing — a list that will not load
+    /// must never confuse saving.
+    /// </remarks>
+    private async Task RefreshShortcutWarningAsync()
+    {
+        _shortcutCts?.Cancel();
+        _shortcutCts?.Dispose();
+        CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+        _shortcutCts = cts;
+        int generation = ++_shortcutGeneration;
+
+        try
+        {
+            string canonical = await Catalog.CanonicalizeAsync(Item.Key, cts.Token);
+
+            // Session-cached: only the first call in a session reaches the network. The
+            // generation check below still earns its place, because that first call can be slow
+            // enough for the user to change the combination while it is in flight.
+            KnownShortcutCatalogDto? catalog = await KnownShortcuts.GetAsync(cts.Token);
+
+            if (generation != _shortcutGeneration || _disposed)
+                return;
+
+            if (catalog is null)
+            {
+                // The fetch failed. Say nothing to the user — the feature is advisory — but leave
+                // a trace in the browser console. The cache does not memoize the failure, so the
+                // next open retries.
+                Logger.LogWarning("Known-shortcut list could not be read; showing no warning.");
+                _shortcutWarning = null;
+                StateHasChanged();
+                return;
+            }
+
+            KnownShortcutDto? match = KnownShortcutWarning.Match(
+                catalog, canonical, Item.Ctrl, Item.Alt, Item.Shift, Item.Win);
+
+            _shortcutWarning = match is null
+                ? null
+                : KnownShortcutWarning.TextFor(match, HotkeyActionDisplay.ComboLabel(Item));
+
+            StateHasChanged();
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer combination, or the dialog closed. Nothing to show.
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Known-shortcut list could not be read; showing no warning.");
+            if (generation == _shortcutGeneration && !_disposed)
+            {
+                _shortcutWarning = null;
+                StateHasChanged();
+            }
+        }
     }
 
     /// <summary>
@@ -355,7 +443,7 @@
     /// verdict, and it is the reason the dialog is still open.
     /// </summary>
     private string? FieldError(string field) =>
-        (field == nameof(HotkeyEditModel.Key) ? _combinationConflict : null)
+        (field == nameof(HotkeyEditModel.Key) ? _duplicateCombination : null)
         ?? _saveFieldErrors.GetValueOrDefault(field)
         ?? _previewFieldErrors.GetValueOrDefault(field);
 
@@ -393,7 +481,7 @@
         _saving = true;
         _error = null;
         _saveFieldErrors.Clear();
-        _combinationConflict = null;
+        _duplicateCombination = null;
         try
         {
             await _form.ValidateAsync();
@@ -407,7 +495,7 @@
             if (!result.IsSuccess)
             {
                 if (result.Status == ApiResultStatus.Conflict)
-                    _combinationConflict = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+                    _duplicateCombination = ApiErrorMessageFactory.Build(result.Status, result.Problem);
                 else if (result.Status == ApiResultStatus.Validation && result.Problem?.Errors is { Count: > 0 } errors)
                     _error = ApplyFieldErrors(errors, _saveFieldErrors);
                 else
@@ -478,21 +566,23 @@
     {
         Item.Key = key ?? "";
         ClearSaveError(nameof(HotkeyEditModel.Key));
-        _combinationConflict = null;
+        _duplicateCombination = null;
         // The key is half the emitted line, so a stale preview here is worse than a stale
         // payload preview — it shows the wrong binding entirely.
         RefreshPreview();
+        _ = RefreshShortcutWarningAsync();
     }
 
     /// <summary>
     /// A modifier toggle changes which key+modifier combination is being saved, so a duplicate-
-    /// combination conflict from the last save no longer applies — drop it. A genuine key-validation
+    /// combination message from the last save no longer applies — drop it. A genuine key-validation
     /// error is left alone: it depends on the key, not the modifiers.
     /// </summary>
     private void OnModifierChanged()
     {
-        _combinationConflict = null;
+        _duplicateCombination = null;
         RefreshPreview();
+        _ = RefreshShortcutWarningAsync();
     }
 
     private void OnRunTargetKindChanged(RunTargetKind? kind)

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/KnownShortcutDtos.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/KnownShortcutDtos.cs
@@ -1,0 +1,22 @@
+namespace AHKFlowApp.UI.Blazor.DTOs;
+
+/// <summary>One thing that uses a known shortcut. Client copy of the API DTO.</summary>
+public sealed record ShortcutUseDto(
+    string UsedBy,
+    ShortcutProtection Protection,
+    ShortcutScope Scope,
+    string Does);
+
+/// <summary>One key-and-modifier combination something outside AHKFlow uses.</summary>
+public sealed record KnownShortcutDto(
+    string Id,
+    string Key,
+    bool Ctrl,
+    bool Alt,
+    bool Shift,
+    bool Win,
+    IReadOnlyList<ShortcutUseDto> Uses,
+    string? WarningText);
+
+/// <summary>The whole known-shortcut list the dialog matches against.</summary>
+public sealed record KnownShortcutCatalogDto(IReadOnlyList<KnownShortcutDto> Shortcuts);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/ShortcutProtection.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/ShortcutProtection.cs
@@ -1,0 +1,9 @@
+namespace AHKFlowApp.UI.Blazor.DTOs;
+
+/// <summary>Client copy of the API enum. See AHKFlowApp.Domain.Enums.ShortcutProtection.</summary>
+public enum ShortcutProtection
+{
+    Protected = 0,
+    Normal = 1,
+    Unknown = 2,
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/ShortcutScope.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/ShortcutScope.cs
@@ -1,0 +1,8 @@
+namespace AHKFlowApp.UI.Blazor.DTOs;
+
+/// <summary>Client copy of the API enum. See AHKFlowApp.Domain.Enums.ShortcutScope.</summary>
+public enum ShortcutScope
+{
+    Global = 0,
+    Foreground = 1,
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/KnownShortcutWarning.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/KnownShortcutWarning.cs
@@ -1,0 +1,96 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+
+namespace AHKFlowApp.UI.Blazor.Helpers;
+
+/// <summary>
+/// Finds the known shortcut a combination matches, and writes the notice shown for it.
+/// </summary>
+/// <remarks>
+/// Text is composed from the uses, never switched on one value. There is no two-way answer to
+/// "what happens when the user presses this": AutoHotkey may register the hotkey or install its
+/// own hook, and a low-level keyboard hook installed earlier can swallow the keystroke. So the
+/// notice says what else uses the keys, and stops short of promising a result.
+/// </remarks>
+internal static class KnownShortcutWarning
+{
+    // States what Windows does, rather than predicting what the hotkey will do. Says nothing
+    // about what other apps can or cannot see — no Microsoft source backs that, and PowerToys
+    // remaps keys at the low level. Avoids "reserves": CONTEXT.md rules that word out.
+    private const string ProtectedClosing =
+        "Windows handles these keys itself.";
+
+    // One short clause. This closing appears on almost every warning, so length is the cost.
+    // "may" hedges on purpose — the warning never promises an outcome.
+    private const string NormalClosing =
+        "Your hotkey may override this shortcut.";
+
+    // Only owner records carry Unknown, and those are Stage 2, so nothing shipped reaches this
+    // yet. Kept because the enum member is persisted in Stage 2 and the composer must not need
+    // reworking to accept it.
+    private const string UnknownClosing =
+        "What happens when you press these keys depends on what else is installed.";
+
+    private const string ForegroundTail = ", but only while that application is in front.";
+
+    /// <summary>
+    /// The known shortcut this combination matches, or null. The key must already be canonical —
+    /// call <c>IHotkeyKeyCatalog.CanonicalizeAsync</c> first, or "Esc" misses the "Escape" row.
+    /// </summary>
+    public static KnownShortcutDto? Match(
+        KnownShortcutCatalogDto? catalog,
+        string? canonicalKey,
+        bool ctrl,
+        bool alt,
+        bool shift,
+        bool win)
+    {
+        if (catalog is null || string.IsNullOrWhiteSpace(canonicalKey))
+            return null;
+
+        return catalog.Shortcuts.FirstOrDefault(s =>
+            s.Ctrl == ctrl && s.Alt == alt && s.Shift == shift && s.Win == win
+            && string.Equals(s.Key, canonicalKey, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>The notice for a matched shortcut. Plain text — MudAlert renders it verbatim.</summary>
+    public static string TextFor(KnownShortcutDto shortcut, string comboLabel)
+    {
+        if (shortcut.WarningText is { Length: > 0 } overrideText)
+            return overrideText;
+
+        List<string> sentences = [];
+
+        // Group by what the keys do, so two products doing the same thing share one sentence.
+        foreach (IGrouping<(string Does, ShortcutScope Scope), ShortcutUseDto> group in
+                 shortcut.Uses.GroupBy(u => (u.Does, u.Scope)))
+        {
+            string[] labels = [.. group.Select(u => u.UsedBy)];
+            string subject = JoinLabels(labels);
+            string verb = labels.Length == 1 ? "uses" : "use";
+            string tail = group.Key.Scope == ShortcutScope.Foreground ? ForegroundTail : ".";
+
+            sentences.Add($"{subject} {verb} {comboLabel} to {group.Key.Does}{tail}");
+        }
+
+        sentences.Add(Closing(shortcut));
+
+        return string.Join(" ", sentences);
+    }
+
+    private static string Closing(KnownShortcutDto shortcut)
+    {
+        if (shortcut.Uses.Any(u => u.Protection == ShortcutProtection.Protected))
+            return ProtectedClosing;
+
+        return shortcut.Uses.Any(u => u.Protection == ShortcutProtection.Normal)
+            ? NormalClosing
+            : UnknownClosing;
+    }
+
+    private static string JoinLabels(string[] labels) => labels.Length switch
+    {
+        0 => "Something",
+        1 => labels[0],
+        _ => $"{string.Join(", ", labels[..^1])} and {labels[^1]}",
+    };
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
@@ -125,6 +125,8 @@ if (useTestAuth)
         baseAddress, TimeSpan.FromSeconds(10), useAuth: false);
     AddApiClient<ICategoriesApiClient, CategoriesApiClient>(
         baseAddress, TimeSpan.FromSeconds(30), useAuth: false);
+    AddApiClient<IKnownShortcutsApiClient, KnownShortcutsApiClient>(
+        baseAddress, TimeSpan.FromSeconds(15), useAuth: false);
 }
 else
 {
@@ -159,8 +161,11 @@ else
         baseAddress, TimeSpan.FromSeconds(10), useAuth: true);
     AddApiClient<ICategoriesApiClient, CategoriesApiClient>(
         baseAddress, TimeSpan.FromSeconds(30), useAuth: true);
+    AddApiClient<IKnownShortcutsApiClient, KnownShortcutsApiClient>(
+        baseAddress, TimeSpan.FromSeconds(15), useAuth: true);
 }
 
 builder.Services.AddScoped<IHotkeyKeyCatalog, HotkeyKeyCatalog>();
+builder.Services.AddScoped<IKnownShortcutCatalog, KnownShortcutCatalog>();
 
 await builder.Build().RunAsync();

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/HotkeyKeyCatalog.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/HotkeyKeyCatalog.cs
@@ -69,6 +69,47 @@ public sealed partial class HotkeyKeyCatalog(IHotkeysApiClient api) : IHotkeyKey
         }
     }
 
+    public async ValueTask<string> CanonicalizeAsync(string? key, CancellationToken ct = default)
+    {
+        // No Trim. The server rejects surrounding whitespace rather than stripping it, so " Esc "
+        // is not "Esc" on either side. Returning it unchanged keeps the two in step.
+        if (string.IsNullOrWhiteSpace(key))
+            return "";
+
+        // Reuses the same load-once path the pickers use; a failed fetch leaves the maps empty
+        // and the input is returned unchanged, which is the safe answer.
+        await ForRoleAsync("HotkeyKey", ct);
+
+        // Alias map first, then registry names — HotkeyKeys.TryCanonicalize checks them in that
+        // order. Both maps are OrdinalIgnoreCase already.
+        if (_aliases.TryGetValue(key, out string? aliased))
+            return aliased;
+
+        if (_byName.TryGetValue(key, out HotkeyKeyDto? entry))
+            return entry.Canonical;
+
+        // vk/sc codes: pad to the server's widths and lowercase the digits, so vk1, VK01 and vk01
+        // all become vk01. An all-zero code names no key and the server rejects it, so it is
+        // handed back untouched rather than turned into a code that looks real.
+        if (VirtualKey().IsMatch(key))
+            return PadCode(key, "vk", width: 2);
+
+        if (ScanCode().IsMatch(key))
+            return PadCode(key, "sc", width: 3);
+
+        return key;
+    }
+
+    // Mirrors HotkeyKeys.TryCanonicalizeCode, minus its bool: an unusable code comes back as the
+    // caller wrote it, which is what every caller here wants for an unrecognised key.
+    private static string PadCode(string key, string prefix, int width)
+    {
+        string digits = key[2..];
+        return digits.All(c => c == '0')
+            ? key
+            : prefix + digits.ToLowerInvariant().PadLeft(width, '0');
+    }
+
     public bool IsValidKey(string? key)
     {
         // Optimistic before load: see the interface remark.

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/IHotkeyKeyCatalog.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/IHotkeyKeyCatalog.cs
@@ -23,6 +23,13 @@ public interface IHotkeyKeyCatalog
     /// </summary>
     bool IsValidKey(string? key);
 
+    /// <summary>
+    /// The canonical spelling of a key, fetching the registry on first call. Returns the input
+    /// unchanged for a name the registry does not know. Needed before comparing a typed key
+    /// against curated data, or "Esc" and "Escape" read as two different keys.
+    /// </summary>
+    ValueTask<string> CanonicalizeAsync(string? key, CancellationToken ct = default);
+
     /// <summary>Picker group for a canonical registry name, or null for a vk/sc code or unknown name.</summary>
     string? GroupOf(string? canonical);
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/IKnownShortcutCatalog.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/IKnownShortcutCatalog.cs
@@ -1,0 +1,16 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+
+namespace AHKFlowApp.UI.Blazor.Services;
+
+/// <summary>
+/// Session cache over the server's known-shortcut catalog. Mirrors <see cref="IHotkeyKeyCatalog"/>,
+/// which caches the key registry the same way for the same reason.
+/// </summary>
+public interface IKnownShortcutCatalog
+{
+    /// <summary>
+    /// The catalog, fetching it on first call and reusing it afterwards. Null when the fetch
+    /// failed — the caller shows no warning, and the next call tries again.
+    /// </summary>
+    ValueTask<KnownShortcutCatalogDto?> GetAsync(CancellationToken ct = default);
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/IKnownShortcutsApiClient.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/IKnownShortcutsApiClient.cs
@@ -1,0 +1,10 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+
+namespace AHKFlowApp.UI.Blazor.Services;
+
+/// <summary>Reads the curated list of shortcuts something outside AHKFlow already uses.</summary>
+public interface IKnownShortcutsApiClient
+{
+    /// <summary>Every known shortcut the dialog may warn about.</summary>
+    Task<ApiResult<KnownShortcutCatalogDto>> ListAsync(CancellationToken ct = default);
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/KnownShortcutCatalog.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/KnownShortcutCatalog.cs
@@ -1,0 +1,41 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+
+namespace AHKFlowApp.UI.Blazor.Services;
+
+/// <inheritdoc cref="IKnownShortcutCatalog"/>
+public sealed class KnownShortcutCatalog(IKnownShortcutsApiClient api) : IKnownShortcutCatalog
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private KnownShortcutCatalogDto? _catalog;
+
+    public async ValueTask<KnownShortcutCatalogDto?> GetAsync(CancellationToken ct = default)
+    {
+        // Fast path, no gate: _catalog is written once and never mutated, and WASM's single
+        // thread cannot tear the read.
+        if (_catalog is not null)
+            return _catalog;
+
+        await _gate.WaitAsync(ct);
+        try
+        {
+            // Re-check under the gate: another awaiter may have loaded it while we waited.
+            if (_catalog is not null)
+                return _catalog;
+
+            ApiResult<KnownShortcutCatalogDto> result = await api.ListAsync(ct);
+
+            // Assign only on success. Caching a failure would silence every warning for the rest
+            // of the session, even after the server recovers — the trap HotkeyKeyCatalog
+            // documents on EnsureCatalogAsync. Leaving _catalog null makes the next dialog open
+            // retry.
+            if (result.IsSuccess)
+                _catalog = result.Value;
+
+            return _catalog;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/KnownShortcutsApiClient.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/KnownShortcutsApiClient.cs
@@ -1,0 +1,14 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+
+namespace AHKFlowApp.UI.Blazor.Services;
+
+/// <inheritdoc cref="IKnownShortcutsApiClient"/>
+public sealed class KnownShortcutsApiClient(HttpClient httpClient)
+    : ApiClientBase(httpClient), IKnownShortcutsApiClient
+{
+    // Stage 1 serves the list from the hotkeys controller, beside the key registry.
+    private const string ListPath = "api/v1/hotkeys/known-shortcuts";
+
+    public Task<ApiResult<KnownShortcutCatalogDto>> ListAsync(CancellationToken ct = default) =>
+        SendAsync<KnownShortcutCatalogDto>(HttpMethod.Get, ListPath, content: null, ct);
+}

--- a/tests/AHKFlowApp.API.Tests/Hotkeys/KnownShortcutsEndpointTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Hotkeys/KnownShortcutsEndpointTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Net.Http.Json;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Enums;
+using AHKFlowApp.TestUtilities.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.API.Tests.Hotkeys;
+
+[Collection("WebApi")]
+public sealed class KnownShortcutsEndpointTests(ApiTestFixture fixture)
+{
+    private readonly CustomWebApplicationFactory _factory = fixture.Factory;
+
+    [Fact]
+    public async Task GetKnownShortcuts_ReturnsTheCatalog()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/hotkeys/known-shortcuts");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        KnownShortcutCatalogDto? catalog =
+            await response.Content.ReadFromJsonAsync<KnownShortcutCatalogDto>();
+        catalog.Should().NotBeNull();
+        // No count here. KnownShortcutCatalog is internal to AHKFlowApp.Application, and that
+        // project's InternalsVisibleTo names only Application.Tests and TestUtilities — reading
+        // All.Count from this project would not compile. The exact count is asserted once, in
+        // Application.Tests' All_HasExpectedRecordCount. This suite owns the HTTP contract instead.
+        catalog!.Shortcuts.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetKnownShortcuts_WindowsRowCarriesGlobalScopeAndDoesPhrase()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+
+        KnownShortcutCatalogDto? catalog =
+            await client.GetFromJsonAsync<KnownShortcutCatalogDto>("/api/v1/hotkeys/known-shortcuts");
+
+        KnownShortcutDto explorer = catalog!.Shortcuts.Single(s => s.Id == "windows.file-explorer");
+        // Lowercase because that is the canonical spelling HotkeyKeys gives letter keys.
+        explorer.Key.Should().Be("e");
+        explorer.Win.Should().BeTrue();
+        explorer.Ctrl.Should().BeFalse();
+
+        ShortcutUseDto use = explorer.Uses.Single();
+        use.UsedBy.Should().Be("Windows");
+        use.Scope.Should().Be(ShortcutScope.Global);
+        use.Protection.Should().Be(ShortcutProtection.Normal);
+        use.Does.Should().Be("open File Explorer");
+    }
+
+    [Fact]
+    public async Task GetKnownShortcuts_ProtectedRowIsMarkedProtected()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+
+        KnownShortcutCatalogDto? catalog =
+            await client.GetFromJsonAsync<KnownShortcutCatalogDto>("/api/v1/hotkeys/known-shortcuts");
+
+        catalog!.Shortcuts.Single(s => s.Id == "windows.lock")
+            .Uses.Single().Protection.Should().Be(ShortcutProtection.Protected);
+    }
+
+    [Fact]
+    public async Task GetKnownShortcuts_DoesNotLeakCurationMetadata()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+
+        string json = await client.GetStringAsync("/api/v1/hotkeys/known-shortcuts");
+
+        json.Should().NotContain("evidence", "curation metadata stays server-side");
+    }
+
+    [Fact]
+    public async Task GetKnownShortcuts_WithoutAuth_IsRefused()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/hotkeys/known-shortcuts");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Constants/KnownShortcutCatalogTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Constants/KnownShortcutCatalogTests.cs
@@ -129,4 +129,20 @@ public sealed class KnownShortcutCatalogTests
         KnownShortcutCatalog.All.SelectMany(s => s.Uses)
             .Should().NotContain(u => u.UsedBy == "Firefox");
     }
+
+    [Fact]
+    public void Manifest_TextMakesNoAbsoluteClaim()
+    {
+        string[] banned = ["never", "will not", "cannot", "won't", "can't"];
+
+        foreach (KnownShortcut shortcut in KnownShortcutCatalog.All)
+        {
+            foreach (string term in banned)
+            {
+                shortcut.WarningText?.ToLowerInvariant().Should().NotContain(term);
+                foreach (ShortcutUse use in shortcut.Uses)
+                    use.Does.ToLowerInvariant().Should().NotContain(term, $"{shortcut.Id} / {use.UsedBy}");
+            }
+        }
+    }
 }

--- a/tests/AHKFlowApp.Application.Tests/Constants/KnownShortcutCatalogTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Constants/KnownShortcutCatalogTests.cs
@@ -1,0 +1,132 @@
+using AHKFlowApp.Application.Constants;
+using AHKFlowApp.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Constants;
+
+public sealed class KnownShortcutCatalogTests
+{
+    [Fact]
+    public void All_HasExpectedRecordCount()
+    {
+        // 67 Windows rows, per design §3. The 36 browser rows are Stage 2 — when they land,
+        // this becomes 103. Recount from the manifest then; do not guess a new number.
+        KnownShortcutCatalog.All.Should().HaveCount(67);
+    }
+
+    [Fact]
+    public void All_ContainsOnlyWindowsRows()
+    {
+        // Guards the stage boundary. A browser row appearing here means Stage 2 work leaked in
+        // without the ignore mechanism that makes it tolerable.
+        KnownShortcutCatalog.All.Should()
+            .OnlyContain(s => s.Id.StartsWith("windows.", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void All_IdsAreUnique()
+    {
+        KnownShortcutCatalog.All.Select(s => s.Id)
+            .Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void All_CombinationsAreUnique()
+    {
+        // Grouping rule: one record per combination, with Uses carrying every label.
+        KnownShortcutCatalog.All
+            .Select(s => (s.Key.ToUpperInvariant(), s.Ctrl, s.Alt, s.Shift, s.Win))
+            .Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void All_KeysAreExpressibleHotkeyKeys()
+    {
+        foreach (KnownShortcut shortcut in KnownShortcutCatalog.All)
+            HotkeyKeys.IsValidHotkeyKey(shortcut.Key)
+                .Should().BeTrue($"{shortcut.Id} uses key '{shortcut.Key}'");
+    }
+
+    [Fact]
+    public void All_KeysAreStoredCanonically()
+    {
+        foreach (KnownShortcut shortcut in KnownShortcutCatalog.All)
+        {
+            HotkeyKeys.TryCanonicalize(shortcut.Key, out string canonical);
+            shortcut.Key.Should().Be(canonical, $"{shortcut.Id} must store the canonical spelling");
+        }
+    }
+
+    [Fact]
+    public void All_EveryShortcutHasAtLeastOneUse()
+    {
+        KnownShortcutCatalog.All.Should().OnlyContain(s => s.Uses.Count > 0);
+    }
+
+    [Fact]
+    public void All_EveryUseHasPinnedEvidence()
+    {
+        foreach (KnownShortcut shortcut in KnownShortcutCatalog.All)
+            foreach (ShortcutUse use in shortcut.Uses)
+            {
+                use.EvidenceUrl.Should().StartWith("https://", $"{shortcut.Id} / {use.UsedBy}");
+                use.EvidenceCheckedOn.Should().BeOnOrAfter(new DateOnly(2026, 7, 29));
+            }
+    }
+
+    [Fact]
+    public void All_EveryUseHasADoesPhrase()
+    {
+        foreach (KnownShortcut shortcut in KnownShortcutCatalog.All)
+            foreach (ShortcutUse use in shortcut.Uses)
+            {
+                use.Does.Should().NotBeNullOrWhiteSpace($"{shortcut.Id} / {use.UsedBy}");
+                char.IsLower(use.Does[0]).Should()
+                    .BeTrue($"{shortcut.Id} / {use.UsedBy} must read as a lowercase verb phrase");
+            }
+    }
+
+    [Fact]
+    public void Protected_IsClaimedByExactlyTheTwoDocumentedRows()
+    {
+        KnownShortcutCatalog.All
+            .Where(s => s.Uses.Any(u => u.Protection == ShortcutProtection.Protected))
+            .Select(s => s.Id)
+            .Should().BeEquivalentTo(["windows.secure-attention", "windows.lock"]);
+    }
+
+    [Fact]
+    public void Protected_RowsCiteMicrosoft()
+    {
+        foreach (ShortcutUse use in KnownShortcutCatalog.All
+                     .SelectMany(s => s.Uses)
+                     .Where(u => u.Protection == ShortcutProtection.Protected))
+            use.EvidenceUrl.Should().Contain("microsoft.com");
+    }
+
+    [Fact]
+    public void Windows_RowsAreAllGlobal()
+    {
+        KnownShortcutCatalog.All
+            .Where(s => s.Id.StartsWith("windows.", StringComparison.Ordinal))
+            .SelectMany(s => s.Uses)
+            .Should().OnlyContain(u => u.Scope == ShortcutScope.Global);
+    }
+
+    [Fact]
+    public void All_RowsCarryExactlyOneUse()
+    {
+        // True only while the manifest is Windows-only. Stage 2's browser rows carry two uses
+        // each, so that plan replaces this test rather than adding rows around it.
+        KnownShortcutCatalog.All.Should().OnlyContain(s => s.Uses.Count == 1);
+    }
+
+    [Fact]
+    public void FirefoxIsNotYetClaimed()
+    {
+        // Design §3: Mozilla's page was not enumerated, so no row may name Firefox.
+        KnownShortcutCatalog.All.SelectMany(s => s.Uses)
+            .Should().NotContain(u => u.UsedBy == "Firefox");
+    }
+}

--- a/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
@@ -1,0 +1,75 @@
+using AHKFlowApp.E2E.Tests.Fixtures;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace AHKFlowApp.E2E.Tests;
+
+[Collection(E2ETestCollection.Name)]
+public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifetime
+{
+    public Task InitializeAsync() => fixture.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task WinE_ShowsTheWarningAndStillSaves()
+    {
+        await using IBrowserContext context = await fixture.Browser.NewContextAsync();
+        IPage page = await context.NewPageAsync();
+
+        await OpenCreateDialogAsync(page);
+
+        await CommitKeyAsync(page, "e");
+        await page.CheckAsync(".hotkey-edit-dialog input[data-test=\"win-checkbox\"]");
+
+        // The notice names what uses the keys, and never promises what will happen.
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog [data-test=\"shortcut-warning\"]");
+        string warning = await page.InnerTextAsync(".hotkey-edit-dialog [data-test=\"shortcut-warning\"]");
+        Assert.Contains("Windows uses Win+E to open File Explorer.", warning, StringComparison.Ordinal);
+        Assert.DoesNotContain("never", warning, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("will not", warning, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("cannot", warning, StringComparison.OrdinalIgnoreCase);
+
+        // Nothing is blocked. The dialog opens on SendText, which needs its text before Save can
+        // succeed — that is ordinary field validation, not the warning.
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"description-input\"]", "E2E open my notes");
+        await page.FillAsync(".hotkey-edit-dialog [data-test=\"text-input\"]", "my notes");
+        await page.ClickAsync(".hotkey-edit-dialog button.commit-edit");
+        await page.WaitForSelectorAsync("text=Hotkey created.");
+    }
+
+    [Fact]
+    public async Task ClearingTheModifier_RemovesTheWarning()
+    {
+        await using IBrowserContext context = await fixture.Browser.NewContextAsync();
+        IPage page = await context.NewPageAsync();
+
+        await OpenCreateDialogAsync(page);
+
+        await CommitKeyAsync(page, "e");
+        await page.CheckAsync(".hotkey-edit-dialog input[data-test=\"win-checkbox\"]");
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog [data-test=\"shortcut-warning\"]");
+
+        await page.UncheckAsync(".hotkey-edit-dialog input[data-test=\"win-checkbox\"]");
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog [data-test=\"shortcut-warning\"]",
+            new PageWaitForSelectorOptions { State = WaitForSelectorState.Detached });
+    }
+
+    private async Task OpenCreateDialogAsync(IPage page)
+    {
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotkeys");
+        await page.WaitForSelectorAsync("button.add-hotkey");
+        await page.ClickAsync("button.add-hotkey");
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog");
+    }
+
+    // Fills the MudAutocomplete key picker and commits the typed value by blurring (CoerceValue),
+    // the same way HotkeysCrudFlowTests does.
+    private static async Task CommitKeyAsync(IPage page, string key)
+    {
+        ILocator input = page.Locator(".hotkey-edit-dialog input[data-test=\"key-picker\"]");
+        await input.ClickAsync();
+        await input.FillAsync(key);
+        await input.PressAsync("Tab");
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
@@ -30,6 +30,14 @@ public sealed class HotkeyEditDialogTests : BunitContext, IAsyncLifetime
 
     private readonly IHotkeysApiClient _api = Substitute.For<IHotkeysApiClient>();
     private readonly IHotkeyKeyCatalog _catalog = Substitute.For<IHotkeyKeyCatalog>();
+    private readonly IKnownShortcutCatalog _knownShortcuts = Substitute.For<IKnownShortcutCatalog>();
+
+    private static KnownShortcutCatalogDto WinECatalog() =>
+        new([
+            new KnownShortcutDto("windows.file-explorer", "e", false, false, false, true,
+                [new ShortcutUseDto("Windows", ShortcutProtection.Normal, ShortcutScope.Global, "open File Explorer")],
+                null),
+        ]);
 
     public HotkeyEditDialogTests()
     {
@@ -45,7 +53,15 @@ public sealed class HotkeyEditDialogTests : BunitContext, IAsyncLifetime
             .Returns(call => CatalogKeys.FirstOrDefault(k => k.Canonical == call.Arg<string>())?.Group);
         _catalog.RequiresBracesInSend(Arg.Any<string>())
             .Returns(call => CatalogKeys.FirstOrDefault(k => k.Canonical == call.Arg<string>())?.RequiresBracesInSend ?? false);
+        // Canonicalization is a real code path now: without this the substitute returns null and
+        // every combination misses its catalog row.
+        _catalog.CanonicalizeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(call => ValueTask.FromResult(call.Arg<string>() ?? ""));
         Services.AddSingleton(_catalog);
+
+        _knownShortcuts.GetAsync(Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<KnownShortcutCatalogDto?>(WinECatalog()));
+        Services.AddSingleton(_knownShortcuts);
 
         Services.AddMudServices();
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -84,6 +100,14 @@ public sealed class HotkeyEditDialogTests : BunitContext, IAsyncLifetime
     // selection from the dropdown does, without depending on popover/JS behaviour.
     private static bool IsChecked(IRenderedComponent<MudDialogProvider> provider, string dataTest) =>
         ((IHtmlInputElement)provider.Find($"input[data-test=\"{dataTest}\"]")).IsChecked;
+
+    // Same idea for the modifier boxes: drive ValueChanged rather than the rendered input, so the
+    // test does not depend on MudCheckBox's internal markup.
+    private static Task SetModifierAsync(IRenderedComponent<MudDialogProvider> provider, string dataTest, bool value) =>
+        provider.InvokeAsync(() => provider
+            .FindComponents<MudCheckBox<bool>>()
+            .Single(c => c.Instance.UserAttributes.TryGetValue("data-test", out object? v) && (string?)v == dataTest)
+            .Instance.ValueChanged.InvokeAsync(value));
 
     private static Task SetKeyAsync(IRenderedComponent<MudDialogProvider> provider, string dataTest, string? key) =>
         provider.InvokeAsync(() => provider
@@ -736,5 +760,90 @@ public sealed class HotkeyEditDialogTests : BunitContext, IAsyncLifetime
                 "an unexpected fault must not leave the spinner stuck forever");
             provider.Find("[data-test=\"preview-error\"]").TextContent.Should().NotBeNullOrWhiteSpace();
         });
+    }
+
+    [Fact]
+    public async Task Open_ExistingHotkeyMatchingAKnownShortcut_ShowsWarning()
+    {
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(
+            new HotkeyEditModel { Id = Guid.NewGuid(), Key = "e", Win = true, Description = "Open notes" });
+
+        provider.WaitForAssertion(() =>
+            provider.Find("[data-test=\"shortcut-warning\"]").TextContent
+                .Should().Contain("Windows uses Win+E to open File Explorer."));
+    }
+
+    [Fact]
+    public async Task Open_CombinationWithNoKnownShortcut_ShowsNoWarning()
+    {
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(
+            new HotkeyEditModel { Key = "F1", Ctrl = true });
+
+        provider.FindAll("[data-test=\"shortcut-warning\"]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ChangingModifier_IntoAKnownShortcut_ShowsWarning()
+    {
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(
+            new HotkeyEditModel { Key = "e" });
+
+        provider.FindAll("[data-test=\"shortcut-warning\"]").Should().BeEmpty();
+
+        await SetModifierAsync(provider, "win-checkbox", true);
+
+        provider.WaitForAssertion(() =>
+            provider.Find("[data-test=\"shortcut-warning\"]").Should().NotBeNull());
+    }
+
+    [Fact]
+    public async Task ChangingModifier_OutOfAKnownShortcut_ClearsWarning()
+    {
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(
+            new HotkeyEditModel { Key = "e", Win = true });
+
+        provider.WaitForAssertion(() =>
+            provider.Find("[data-test=\"shortcut-warning\"]").Should().NotBeNull());
+
+        await SetModifierAsync(provider, "win-checkbox", false);
+
+        provider.WaitForAssertion(() =>
+            provider.FindAll("[data-test=\"shortcut-warning\"]").Should().BeEmpty());
+    }
+
+    [Fact]
+    public async Task CatalogLoadFailure_ShowsNoWarningAndNoError()
+    {
+        // The catalog service turns a failed fetch into null, so that is what the dialog sees.
+        _knownShortcuts.GetAsync(Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<KnownShortcutCatalogDto?>(null));
+
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(
+            new HotkeyEditModel { Key = "e", Win = true });
+
+        provider.FindAll("[data-test=\"shortcut-warning\"]").Should().BeEmpty();
+        provider.FindAll(".mud-alert-filled-error").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Save_IsNeverBlockedByAWarning()
+    {
+        HotkeyDto created = new(Guid.NewGuid(), [], true, "Open notes", "e", false, false, false, true,
+            HotkeyActionKind.SendKeys, null, null, null, null, null, null, null,
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        _api.CreateAsync(Arg.Any<CreateHotkeyDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HotkeyDto>.Ok(created));
+
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(
+            new HotkeyEditModel { Key = "e", Win = true, Description = "Open notes" });
+
+        provider.WaitForAssertion(() =>
+            provider.Find("[data-test=\"shortcut-warning\"]").Should().NotBeNull());
+
+        provider.Find("button.commit-edit").HasAttribute("disabled").Should().BeFalse();
+        provider.Find("button.commit-edit").Click();
+
+        provider.WaitForAssertion(() => _api.Received(1).CreateAsync(
+            Arg.Any<CreateHotkeyDto>(), Arg.Any<CancellationToken>()));
     }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
@@ -846,4 +846,35 @@ public sealed class HotkeyEditDialogTests : BunitContext, IAsyncLifetime
         provider.WaitForAssertion(() => _api.Received(1).CreateAsync(
             Arg.Any<CreateHotkeyDto>(), Arg.Any<CancellationToken>()));
     }
+
+    [Fact]
+    public async Task SlowResponseForAnOldCombination_CannotOverwriteTheNewerVerdict()
+    {
+        // Regression test for the generation counter. The first fetch is held open while the user
+        // changes the key, so its response lands last and carries the old canonical key. The stub
+        // ignores the cancellation token on purpose: that models a response already past the point
+        // where cancelling helps, which leaves the generation check as the only thing guarding the
+        // notice. Drop that check and the stale "Win+E opens File Explorer" line appears here.
+        TaskCompletionSource<KnownShortcutCatalogDto?> gate = new();
+        _knownShortcuts.GetAsync(Arg.Any<CancellationToken>()).Returns(
+            _ => new ValueTask<KnownShortcutCatalogDto?>(gate.Task),
+            _ => ValueTask.FromResult<KnownShortcutCatalogDto?>(WinECatalog()));
+
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(
+            new HotkeyEditModel { Key = "e", Win = true });
+
+        // The first evaluation is still waiting on the gate, so nothing is shown yet.
+        provider.FindAll("[data-test=\"shortcut-warning\"]").Should().BeEmpty();
+
+        // A newer combination. Its own fetch answers at once and matches nothing.
+        await SetKeyAsync(provider, "key-picker", "F1");
+        provider.FindAll("[data-test=\"shortcut-warning\"]").Should().BeEmpty();
+
+        // Release the old fetch from inside the renderer, then flush: the continuation is queued
+        // on the same dispatcher, so the second InvokeAsync runs after it.
+        await provider.InvokeAsync(() => gate.SetResult(WinECatalog()));
+        await provider.InvokeAsync(() => { });
+
+        provider.FindAll("[data-test=\"shortcut-warning\"]").Should().BeEmpty();
+    }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/KnownShortcutWarningTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/KnownShortcutWarningTests.cs
@@ -110,6 +110,31 @@ public sealed class KnownShortcutWarningTests
     }
 
     [Fact]
+    public void TextFor_ProtectedBeatsNormal_ForTheClosingSentence()
+    {
+        // The pairing Stage 2's merged uses produce most often: a curated Windows row plus an
+        // owner-recorded Normal use on the same combination. Without this, Normal taking
+        // precedence over Protected would go unnoticed.
+        KnownShortcutDto shortcut = Shortcut("windows.lock", "l", false, false, false, true,
+            Use("Windows", ShortcutProtection.Protected, ShortcutScope.Global, "lock the computer"),
+            Use("My tool", ShortcutProtection.Normal, ShortcutScope.Global, "log the time"));
+
+        KnownShortcutWarning.TextFor(shortcut, "Win+L")
+            .Should().EndWith("Windows handles these keys itself.");
+    }
+
+    [Fact]
+    public void TextFor_NormalBeatsUnknown_ForTheClosingSentence()
+    {
+        KnownShortcutDto shortcut = Shortcut("windows.file-explorer", "e", false, false, false, true,
+            Use("Windows", ShortcutProtection.Normal, ShortcutScope.Global, "open File Explorer"),
+            Use("My tool", ShortcutProtection.Unknown, ShortcutScope.Global, "log the time"));
+
+        KnownShortcutWarning.TextFor(shortcut, "Win+E")
+            .Should().EndWith("Your hotkey may override this shortcut.");
+    }
+
+    [Fact]
     public void TextFor_UnknownOnly_UsesTheNeutralClosingSentence()
     {
         KnownShortcutDto shortcut = Shortcut("owner.thing", "q", true, true, false, false,

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/KnownShortcutWarningTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/KnownShortcutWarningTests.cs
@@ -1,0 +1,148 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Helpers;
+
+public sealed class KnownShortcutWarningTests
+{
+    private static readonly string[] BannedTerms = ["never", "will not", "cannot", "won't", "can't"];
+
+    private static KnownShortcutDto Shortcut(string id, string key, bool ctrl, bool alt, bool shift, bool win,
+        params ShortcutUseDto[] uses) =>
+        new(id, key, ctrl, alt, shift, win, uses, null);
+
+    private static ShortcutUseDto Use(string usedBy, ShortcutProtection protection, ShortcutScope scope, string does) =>
+        new(usedBy, protection, scope, does);
+
+    [Fact]
+    public void Match_FindsCombinationIgnoringKeyCase()
+    {
+        KnownShortcutCatalogDto catalog = new([
+            Shortcut("windows.file-explorer", "e", false, false, false, true,
+                Use("Windows", ShortcutProtection.Normal, ShortcutScope.Global, "open File Explorer")),
+        ]);
+
+        KnownShortcutWarning.Match(catalog, "E", ctrl: false, alt: false, shift: false, win: true)
+            .Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Match_RequiresEveryModifierToAgree()
+    {
+        KnownShortcutCatalogDto catalog = new([
+            Shortcut("windows.file-explorer", "e", false, false, false, true,
+                Use("Windows", ShortcutProtection.Normal, ShortcutScope.Global, "open File Explorer")),
+        ]);
+
+        KnownShortcutWarning.Match(catalog, "e", ctrl: true, alt: false, shift: false, win: true)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Match_OnNullCatalog_ReturnsNull()
+    {
+        KnownShortcutWarning.Match(null, "e", false, false, false, true).Should().BeNull();
+    }
+
+    [Fact]
+    public void TextFor_SingleGlobalUse_NamesUserAndAction()
+    {
+        KnownShortcutDto shortcut = Shortcut("windows.file-explorer", "e", false, false, false, true,
+            Use("Windows", ShortcutProtection.Normal, ShortcutScope.Global, "open File Explorer"));
+
+        KnownShortcutWarning.TextFor(shortcut, "Win+E").Should().Be(
+            "Windows uses Win+E to open File Explorer. " +
+            "Your hotkey may override this shortcut.");
+    }
+
+    // The next three build their DTOs by hand and never read the manifest. That is deliberate:
+    // no shipped row is Foreground or carries two uses until Stage 2, so this is the only thing
+    // holding the grouping and the Foreground tail correct in the meantime. The browser.* ids are
+    // just labels here — nothing looks them up.
+    [Fact]
+    public void TextFor_TwoLabelsSharingOneAction_JoinsThemAndUsesPluralVerb()
+    {
+        KnownShortcutDto shortcut = Shortcut("browser.new-tab", "t", true, false, false, false,
+            Use("Chrome", ShortcutProtection.Normal, ShortcutScope.Foreground, "open a new tab"),
+            Use("Edge", ShortcutProtection.Normal, ShortcutScope.Foreground, "open a new tab"));
+
+        KnownShortcutWarning.TextFor(shortcut, "Ctrl+T").Should().StartWith(
+            "Chrome and Edge use Ctrl+T to open a new tab, but only while that application is in front.");
+    }
+
+    [Fact]
+    public void TextFor_ThreeLabels_UsesCommaThenAnd()
+    {
+        KnownShortcutDto shortcut = Shortcut("browser.find", "f", true, false, false, false,
+            Use("Chrome", ShortcutProtection.Normal, ShortcutScope.Foreground, "find text on the page"),
+            Use("Edge", ShortcutProtection.Normal, ShortcutScope.Foreground, "find text on the page"),
+            Use("Firefox", ShortcutProtection.Normal, ShortcutScope.Foreground, "find text on the page"));
+
+        KnownShortcutWarning.TextFor(shortcut, "Ctrl+F")
+            .Should().StartWith("Chrome, Edge and Firefox use Ctrl+F to find text on the page,");
+    }
+
+    [Fact]
+    public void TextFor_DifferentActions_ProduceOneSentenceEach()
+    {
+        KnownShortcutDto shortcut = Shortcut("windows.file-explorer", "e", false, false, false, true,
+            Use("Windows", ShortcutProtection.Normal, ShortcutScope.Global, "open File Explorer"),
+            Use("Visual Studio", ShortcutProtection.Unknown, ShortcutScope.Foreground, "open the error list"));
+
+        string text = KnownShortcutWarning.TextFor(shortcut, "Win+E");
+
+        text.Should().Contain("Windows uses Win+E to open File Explorer.");
+        text.Should().Contain(
+            "Visual Studio uses Win+E to open the error list, but only while that application is in front.");
+    }
+
+    [Fact]
+    public void TextFor_StrongestProtectionWinsTheClosingSentence()
+    {
+        KnownShortcutDto shortcut = Shortcut("windows.lock", "l", false, false, false, true,
+            Use("Windows", ShortcutProtection.Protected, ShortcutScope.Global, "lock the computer"),
+            Use("My tool", ShortcutProtection.Unknown, ShortcutScope.Global, "log the time"));
+
+        KnownShortcutWarning.TextFor(shortcut, "Win+L")
+            .Should().EndWith("Windows handles these keys itself.");
+    }
+
+    [Fact]
+    public void TextFor_UnknownOnly_UsesTheNeutralClosingSentence()
+    {
+        KnownShortcutDto shortcut = Shortcut("owner.thing", "q", true, true, false, false,
+            Use("My tool", ShortcutProtection.Unknown, ShortcutScope.Global, "do something"));
+
+        KnownShortcutWarning.TextFor(shortcut, "Ctrl+Alt+Q")
+            .Should().EndWith("What happens when you press these keys depends on what else is installed.");
+    }
+
+    [Fact]
+    public void TextFor_OverrideText_IsReturnedVerbatim()
+    {
+        KnownShortcutDto shortcut = new("windows.odd", "q", false, false, false, true,
+            [Use("Windows", ShortcutProtection.Normal, ShortcutScope.Global, "do something odd")],
+            "Hand-written text for this row.");
+
+        KnownShortcutWarning.TextFor(shortcut, "Win+Q").Should().Be("Hand-written text for this row.");
+    }
+
+    [Theory]
+    [InlineData(ShortcutProtection.Protected, ShortcutScope.Global)]
+    [InlineData(ShortcutProtection.Normal, ShortcutScope.Global)]
+    [InlineData(ShortcutProtection.Normal, ShortcutScope.Foreground)]
+    [InlineData(ShortcutProtection.Unknown, ShortcutScope.Global)]
+    [InlineData(ShortcutProtection.Unknown, ShortcutScope.Foreground)]
+    public void TextFor_MakesNoAbsoluteClaim(ShortcutProtection protection, ShortcutScope scope)
+    {
+        KnownShortcutDto shortcut = Shortcut("any.row", "e", false, false, false, true,
+            Use("Windows", protection, scope, "do something"));
+
+        string text = KnownShortcutWarning.TextFor(shortcut, "Win+E");
+
+        foreach (string banned in BannedTerms)
+            text.Should().NotContainEquivalentOf(banned, $"'{banned}' promises an outcome we cannot know");
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
@@ -52,6 +52,13 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
         StubKeyCatalog(keysValid: true);
         Services.AddSingleton(_catalog);
 
+        // The edit dialog injects this. An empty catalog means no shortcut warning, which is what
+        // these page tests want — they are about the grid and the dialog opening, not the notice.
+        IKnownShortcutCatalog knownShortcuts = Substitute.For<IKnownShortcutCatalog>();
+        knownShortcuts.GetAsync(Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<KnownShortcutCatalogDto?>(new KnownShortcutCatalogDto([])));
+        Services.AddSingleton(knownShortcuts);
+
         Services.AddMudServices();
         JSInterop.Mode = JSRuntimeMode.Loose;
     }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Services/HotkeyKeyCatalogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Services/HotkeyKeyCatalogTests.cs
@@ -181,4 +181,29 @@ public sealed class HotkeyKeyCatalogTests
         (await catalog.ForRoleAsync("HotkeyKey", CancellationToken.None)).Should().NotBeEmpty();
         await api.Received(2).GetKeysAsync(Arg.Any<CancellationToken>());
     }
+
+    // Its own catalog, not the shared Sample: other tests count what Sample projects, so adding
+    // a key there would fail them.
+    private static readonly HotkeyKeyCatalogDto CanonicalSample = new(
+        [
+            new HotkeyKeyDto("Escape", "Navigation", ["HotkeyKey"], true),
+        ],
+        new Dictionary<string, string> { ["Esc"] = "Escape" });
+
+    [Theory]
+    [InlineData("Esc", "Escape")]       // alias
+    [InlineData("esc", "Escape")]       // alias, wrong case
+    [InlineData("Escape", "Escape")]    // already canonical
+    [InlineData("vk1B", "vk1b")]        // digits lowercased
+    [InlineData("vk1", "vk01")]         // padded to the server's width
+    [InlineData("SC1", "sc001")]        // prefix and digits both normalised
+    [InlineData("vk0", "vk0")]          // names no key, so unchanged
+    [InlineData(" Esc ", " Esc ")]      // whitespace rejected, never trimmed
+    [InlineData("", "")]
+    public async Task CanonicalizeAsync_MatchesTheServersCanonicalForm(string input, string expected)
+    {
+        var catalog = new HotkeyKeyCatalog(ApiReturning(CanonicalSample));
+
+        (await catalog.CanonicalizeAsync(input)).Should().Be(expected);
+    }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Services/KnownShortcutCatalogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Services/KnownShortcutCatalogTests.cs
@@ -1,0 +1,68 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Services;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Services;
+
+public sealed class KnownShortcutCatalogTests
+{
+    private static readonly KnownShortcutCatalogDto Sample = new(
+        [
+            new KnownShortcutDto("windows.file-explorer", "e", false, false, false, true,
+                [new ShortcutUseDto("Windows", ShortcutProtection.Normal, ShortcutScope.Global, "open File Explorer")],
+                null),
+        ]);
+
+    // NSubstitute over an interface this project owns, matching HotkeyKeyCatalogTests. Counting
+    // calls is the only way to observe caching at all, so a hand-written fake would restate the
+    // same helpers with no gain.
+    private static IKnownShortcutsApiClient ApiReturning(KnownShortcutCatalogDto catalog)
+    {
+        IKnownShortcutsApiClient api = Substitute.For<IKnownShortcutsApiClient>();
+        api.ListAsync(Arg.Any<CancellationToken>()).Returns(ApiResult<KnownShortcutCatalogDto>.Ok(catalog));
+        return api;
+    }
+
+    [Fact]
+    public async Task GetAsync_CalledTwice_FetchesOnce()
+    {
+        IKnownShortcutsApiClient api = ApiReturning(Sample);
+        var catalog = new KnownShortcutCatalog(api);
+
+        await catalog.GetAsync();
+        await catalog.GetAsync();
+
+        await api.Received(1).ListAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetAsync_OnFailure_ReturnsNull()
+    {
+        IKnownShortcutsApiClient api = Substitute.For<IKnownShortcutsApiClient>();
+        api.ListAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult<KnownShortcutCatalogDto>.Failure(ApiResultStatus.ServerError, null));
+
+        (await new KnownShortcutCatalog(api).GetAsync()).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAsync_AfterFailure_RetriesOnNextCall()
+    {
+        // The regression test for the caching trap: a memoized failure would silence every warning
+        // for the rest of the session, even after the server recovers.
+        IKnownShortcutsApiClient api = Substitute.For<IKnownShortcutsApiClient>();
+        api.ListAsync(Arg.Any<CancellationToken>()).Returns(
+            ApiResult<KnownShortcutCatalogDto>.Failure(ApiResultStatus.ServerError, null),
+            ApiResult<KnownShortcutCatalogDto>.Ok(Sample));
+        var catalog = new KnownShortcutCatalog(api);
+
+        KnownShortcutCatalogDto? first = await catalog.GetAsync();
+        KnownShortcutCatalogDto? second = await catalog.GetAsync();
+
+        first.Should().BeNull();
+        second.Should().BeSameAs(Sample);
+        await api.Received(2).ListAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Services/KnownShortcutsApiClientTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Services/KnownShortcutsApiClientTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using System.Net.Http.Json;
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Services;
+
+public sealed class KnownShortcutsApiClientTests
+{
+    private static KnownShortcutsApiClient ClientWith(StubHttpMessageHandler handler) =>
+        new(new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") });
+
+    private static KnownShortcutCatalogDto SampleCatalog() =>
+        new([
+            new KnownShortcutDto("windows.file-explorer", "e", false, false, false, true,
+                [new ShortcutUseDto("Windows", ShortcutProtection.Normal, ShortcutScope.Global, "open File Explorer")],
+                null),
+        ]);
+
+    [Fact]
+    public async Task ListAsync_HitsCorrectUrl()
+    {
+        var handler = StubHttpMessageHandler.JsonResponse(HttpStatusCode.OK, SampleCatalog());
+
+        await ClientWith(handler).ListAsync();
+
+        handler.LastRequest!.RequestUri!.PathAndQuery
+            .Should().Be("/api/v1/hotkeys/known-shortcuts");
+    }
+
+    [Fact]
+    public async Task ListAsync_OnSuccess_DeserializesUses()
+    {
+        var handler = StubHttpMessageHandler.JsonResponse(HttpStatusCode.OK, SampleCatalog());
+
+        ApiResult<KnownShortcutCatalogDto> result = await ClientWith(handler).ListAsync();
+
+        result.IsSuccess.Should().BeTrue();
+        ShortcutUseDto use = result.Value!.Shortcuts.Single().Uses.Single();
+        use.UsedBy.Should().Be("Windows");
+        use.Scope.Should().Be(ShortcutScope.Global);
+        use.Does.Should().Be("open File Explorer");
+    }
+
+    [Fact]
+    public async Task ListAsync_OnServerError_ReportsFailure()
+    {
+        var handler = StubHttpMessageHandler.StatusResponse(HttpStatusCode.InternalServerError);
+
+        ApiResult<KnownShortcutCatalogDto> result = await ClientWith(handler).ListAsync();
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    // Copied from CategoriesApiClientTests.cs. That copy is `private sealed` and nested in its own
+    // test class, so it cannot be reused from here. Copy it rather than widening the original —
+    // every client test file in this project carries its own.
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+        private readonly HttpResponseMessage _response;
+
+        private StubHttpMessageHandler(HttpResponseMessage response) => _response = response;
+
+        public static StubHttpMessageHandler JsonResponse<T>(HttpStatusCode status, T body) =>
+            new(new HttpResponseMessage(status) { Content = JsonContent.Create(body) });
+
+        public static StubHttpMessageHandler StatusResponse(HttpStatusCode status) =>
+            new(new HttpResponseMessage(status));
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            LastRequest = request;
+            return Task.FromResult(_response);
+        }
+    }
+}


### PR DESCRIPTION
## Hotkey shortcut warnings — Stage 1: static catalog

Warns — never blocks — when a hotkey's key and modifiers match a shortcut Windows already uses. A curated static manifest in the Application layer is served through `HotkeysController`, session-cached by a frontend catalog service, and rendered in the hotkey edit dialog as a `MudAlert`.

Implements `docs/superpowers/plans/2026-07-29-hotkey-shortcut-warnings-plan.md`, Tasks 1-6. Stage 2 (owner-recorded shortcuts, ignore and restore, the management page, and the 36 browser rows) is a separate plan and a separate branch.

### What ships

- **67 curated Windows rows**, every one pinned to a public page and dated. Two carry `Protected`, each with a Microsoft source: `windows.secure-attention` and `windows.lock`.
- `GET /api/v1/hotkeys/known-shortcuts`. `EvidenceUrl` and `EvidenceCheckedOn` stay server-side — they justify curation, and the dialog never shows them.
- `IKnownShortcutCatalog`, a session cache over the API client. **A failed fetch is never memoized**, so one bad first open cannot silence every warning for the session.
- `KnownShortcutWarning`, which composes the notice from the uses rather than switching on one value. No sentence promises an outcome.
- `IHotkeyKeyCatalog.CanonicalizeAsync`, matching the server's `HotkeyKeys.TryCanonicalize` on all three axes: alias order, vk/sc code width, and no whitespace trimming.

### Nothing is ever blocked

Save always succeeds. The feature never enters FluentValidation, so restore, revert, import and seed are untouched. No emitter change — generated `.ahk` output is byte-identical.

No warning text makes an absolute claim. Tests enforce the banned words (`never`, `will not`, `cannot`, `won't`, `can't`) on both the manifest and the composed text.

### Also in this PR

- `_combinationConflict` renamed to `_duplicateCombination`. `CONTEXT.md` now lists "conflict" as a word to avoid, and the dialog was about to gain a second meaning of it.
- New backlog item `038` — flag known-shortcut matches on the hotkeys list, so a hotkey created before this feature is not invisible until someone opens it.

### Deviation from the plan

**Letter keys are stored lowercase.** `HotkeyKeys.BuildRegistry` adds `c.ToString()` for `'a'..'z'`, so the canonical form of `E` is `e`. The plan's samples wrote `"E"`, which fails its own `All_KeysAreStoredCanonically`. Matching is case-insensitive and `HotkeyActionDisplay.ComboLabel` upper-cases a single key paired with a modifier, so the user still reads `Win+E`.

Backlog `037` (Raw-body duplicate detection) already existed with the same content, so it was left alone.

### Verification

| Slice | Result |
|---|---|
| Fast | 2,488 passed, 0 failed |
| Integration | 590 passed, 0 failed |
| E2E | 21 passed, 0 failed |
| `dotnet format --verify-no-changes` | clean |

New coverage: 15 manifest tests, 5 endpoint tests, 6 client and cache tests, 13 composer tests, 9 canonicalization rows, 7 bUnit dialog tests, 2 Playwright flows.

The stale-warning test was checked against a mutant: replacing the generation check with `if (_disposed)` makes it fail with "Expected ... to be empty, but found at least one item".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
