### PR TITLE
feat: known-shortcut management, ignore and restore

### DIFF
--- a/src/Backend/AHKFlowApp.API/Controllers/HotkeysController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/HotkeysController.cs
@@ -41,7 +41,7 @@ public sealed class HotkeysController(
     public async Task<ActionResult<HotkeyKeyCatalogDto>> Keys(CancellationToken ct) =>
         (await listHotkeyKeys.ExecuteAsync(new ListHotkeyKeysQuery(), ct)).ToProblemActionResult(this);
 
-    /// <summary>Get the curated list of shortcuts Windows already uses.</summary>
+    /// <summary>Get the curated list of shortcuts Windows or a browser already uses.</summary>
     /// <remarks>
     /// Advisory only — nothing here blocks a save. Static reference data in this release;
     /// authorized because the controller is, not because it is user-scoped.

--- a/src/Backend/AHKFlowApp.API/Controllers/HotkeysController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/HotkeysController.cs
@@ -43,10 +43,11 @@ public sealed class HotkeysController(
 
     /// <summary>Get the curated list of shortcuts Windows or a browser already uses.</summary>
     /// <remarks>
-    /// Advisory only — nothing here blocks a save. Static reference data in this release;
-    /// authorized because the controller is, not because it is user-scoped.
+    /// Advisory only — nothing here blocks a save. The answer is owner-specific: it leaves out
+    /// built-in uses this owner silenced, and adds the records they made themselves.
     /// </remarks>
     [HttpGet("known-shortcuts")]
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     [ProducesResponseType(typeof(KnownShortcutCatalogDto), StatusCodes.Status200OK)]
     public async Task<ActionResult<KnownShortcutCatalogDto>> KnownShortcuts(CancellationToken ct) =>
         (await listKnownShortcuts.ExecuteAsync(new ListKnownShortcutsQuery(), ct)).ToProblemActionResult(this);

--- a/src/Backend/AHKFlowApp.API/Controllers/KnownShortcutsController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/KnownShortcutsController.cs
@@ -1,0 +1,75 @@
+using AHKFlowApp.API.Extensions;
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.Commands.KnownShortcuts;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Queries.KnownShortcuts;
+using Ardalis.Result;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Identity.Web.Resource;
+
+namespace AHKFlowApp.API.Controllers;
+
+[ApiController]
+[Route("api/v1/[controller]")]
+[Authorize]
+[RequiredScope("access_as_user")]
+[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+[ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
+public sealed class KnownShortcutsController(
+    IUseCase<ListManagedKnownShortcutsQuery, Result<ManagedKnownShortcutCatalogDto>> list,
+    IUseCase<CreateCustomKnownShortcutCommand, Result<ManagedKnownShortcutCatalogDto>> create,
+    IUseCase<DeleteCustomKnownShortcutCommand, Result> delete,
+    IUseCase<IgnoreKnownShortcutCommand, Result> ignore,
+    IUseCase<RestoreKnownShortcutCommand, Result> restore) : ControllerBase
+{
+    /// <summary>Every known shortcut, ignored uses included so they can be brought back.</summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(ManagedKnownShortcutCatalogDto), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ManagedKnownShortcutCatalogDto>> List(CancellationToken ct) =>
+        (await list.ExecuteAsync(new ListManagedKnownShortcutsQuery(), ct)).ToProblemActionResult(this);
+
+    /// <summary>Record something the owner knows uses a combination.</summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(ManagedKnownShortcutCatalogDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<ManagedKnownShortcutCatalogDto>> Create(
+        [FromBody] CreateCustomKnownShortcutDto input, CancellationToken ct) =>
+        (await create.ExecuteAsync(new CreateCustomKnownShortcutCommand(input), ct)).ToProblemActionResult(this);
+
+    /// <summary>Remove one of the owner's own records.</summary>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        // The success branch is written by hand: on the non-generic Result, ToProblemActionResult
+        // returns 200, and these three routes advertise 204.
+        Result result = await delete.ExecuteAsync(new DeleteCustomKnownShortcutCommand(id), ct);
+        return result.IsSuccess ? NoContent() : result.ToProblemActionResult(this);
+    }
+
+    /// <summary>Stop warning about one built-in use. The others on the same keys still warn.</summary>
+    [HttpPost("ignore")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Ignore([FromBody] KnownShortcutUseRefDto input, CancellationToken ct)
+    {
+        Result result = await ignore.ExecuteAsync(
+            new IgnoreKnownShortcutCommand(input.ShortcutId, input.UsedBy), ct);
+        return result.IsSuccess ? NoContent() : result.ToProblemActionResult(this);
+    }
+
+    /// <summary>Warn about a built-in use again.</summary>
+    [HttpPost("restore")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Restore([FromBody] KnownShortcutUseRefDto input, CancellationToken ct)
+    {
+        Result result = await restore.ExecuteAsync(
+            new RestoreKnownShortcutCommand(input.ShortcutId, input.UsedBy), ct);
+        return result.IsSuccess ? NoContent() : result.ToProblemActionResult(this);
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Abstractions/IAppDbContext.cs
+++ b/src/Backend/AHKFlowApp.Application/Abstractions/IAppDbContext.cs
@@ -16,6 +16,8 @@ public interface IAppDbContext
     DbSet<HotstringCategory> HotstringCategories { get; }
     DbSet<HotkeyCategory> HotkeyCategories { get; }
     DbSet<EntityHistory> EntityHistories { get; }
+    DbSet<CustomKnownShortcut> CustomKnownShortcuts { get; }
+    DbSet<IgnoredKnownShortcut> IgnoredKnownShortcuts { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 

--- a/src/Backend/AHKFlowApp.Application/Commands/KnownShortcuts/CreateCustomKnownShortcutCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/KnownShortcuts/CreateCustomKnownShortcutCommand.cs
@@ -1,0 +1,127 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.Common;
+using AHKFlowApp.Application.Constants;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Services;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
+using Ardalis.Result;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+
+namespace AHKFlowApp.Application.Commands.KnownShortcuts;
+
+/// <summary>Records something the owner knows uses a combination.</summary>
+public sealed record CreateCustomKnownShortcutCommand(CreateCustomKnownShortcutDto Input);
+
+public sealed class CreateCustomKnownShortcutCommandValidator
+    : AbstractValidator<CreateCustomKnownShortcutCommand>
+{
+    public CreateCustomKnownShortcutCommandValidator()
+    {
+        RuleFor(x => x.Input.Key)
+            .NotEmpty().WithMessage("Pick a key.")
+            .Must(HotkeyKeys.IsValidHotkeyKey)
+            .WithMessage("That is not a key AHKFlow can use in a hotkey.");
+
+        RuleFor(x => x.Input.UsedBy)
+            .NotEmpty().WithMessage("Say what uses these keys.")
+            .MaximumLength(60);
+
+        // Does is dropped straight into "<UsedBy> uses <combo> to …", so its shape is part of the
+        // sentence, not a free-text field. Two rules keep that sentence readable and honest.
+        RuleFor(x => x.Input.Does)
+            .NotEmpty().WithMessage("Say what the keys do.")
+            .MaximumLength(200)
+            .Must(StartsLowercase)
+            .WithMessage("Start with a lowercase verb, like \"open the settings window\".")
+            .Must(MakesNoAbsoluteClaim)
+            .WithMessage("Say what the keys do, not what will or will not happen.");
+
+        // Protected means a Microsoft source says Windows itself handles the keys. An owner has
+        // no way to supply that source, so the value is not theirs to set.
+        RuleFor(x => x.Input.Protection)
+            .Must(p => p is ShortcutProtection.Normal or ShortcutProtection.Unknown)
+            .WithMessage("Only built-in records can say Windows handles the keys itself.");
+
+        RuleFor(x => x.Input.Scope).IsInEnum();
+    }
+
+    // A leading capital would read as "Windows uses Win+E to Open File Explorer." Only the first
+    // character is judged: a product name later in the phrase is fine, and often required.
+    // Anything that is not a letter — a digit, a quote — passes, because there is no case to get
+    // wrong.
+    private static bool StartsLowercase(string? does) =>
+        string.IsNullOrEmpty(does) || !char.IsUpper(does[0]);
+
+    // The same ban the built-in manifest lives under, applied to owner text. An owner record ends
+    // up in the same warning sentence as a curated one, so it inherits the same promise: describe
+    // the use, never predict the outcome. Kept in one place so the manifest test and this rule
+    // cannot drift apart.
+    private static bool MakesNoAbsoluteClaim(string? does) =>
+        does is null || !ShortcutWording.MakesAbsoluteClaim(does);
+}
+
+internal sealed class CreateCustomKnownShortcutCommandHandler(
+    IAppDbContext db,
+    ICurrentUser currentUser,
+    TimeProvider clock)
+    : IUseCaseHandler<CreateCustomKnownShortcutCommand, Result<ManagedKnownShortcutCatalogDto>>
+{
+    private const string DuplicateMessage =
+        "You have already recorded this key + modifier combination for that name.";
+
+    public async Task<Result<ManagedKnownShortcutCatalogDto>> ExecuteAsync(
+        CreateCustomKnownShortcutCommand request, CancellationToken ct)
+    {
+        if (currentUser.Oid is not Guid ownerOid)
+            return Result.Unauthorized();
+
+        CreateCustomKnownShortcutDto input = request.Input;
+        HotkeyKeys.TryCanonicalize(input.Key, out string canonicalKey);
+        string usedBy = input.UsedBy.Trim();
+        string does = input.Does.Trim();
+
+        bool duplicate = await db.CustomKnownShortcuts.AnyAsync(
+            s => s.OwnerOid == ownerOid
+              && s.Key == canonicalKey
+              && s.Ctrl == input.Ctrl
+              && s.Alt == input.Alt
+              && s.Shift == input.Shift
+              && s.Win == input.Win
+              && s.UsedBy == usedBy,
+            ct);
+
+        if (duplicate)
+            return Result.Conflict(DuplicateMessage);
+
+        db.CustomKnownShortcuts.Add(CustomKnownShortcut.Create(
+            ownerOid, canonicalKey, input.Ctrl, input.Alt, input.Shift, input.Win,
+            usedBy, input.Protection, input.Scope, does, clock));
+
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex) when (ex.IsDuplicateKeyViolation())
+        {
+            // The AnyAsync check above cannot stop two requests that pass it at the same time. The
+            // unique index does stop them, and this turns the second one into the promised 409
+            // instead of a 500.
+            return Result.Conflict(DuplicateMessage);
+        }
+
+        return await ReloadAsync(db, ownerOid, ct);
+    }
+
+    // Returns the whole merged list so the page never renders a half-updated view.
+    private static async Task<Result<ManagedKnownShortcutCatalogDto>> ReloadAsync(
+        IAppDbContext db, Guid ownerOid, CancellationToken ct)
+    {
+        (CustomKnownShortcut[] owned, IgnoredKnownShortcut[] ignored) =
+            await OwnerKnownShortcutLoader.LoadAsync(db, ownerOid, ct);
+
+        return Result<ManagedKnownShortcutCatalogDto>.Success(
+            new ManagedKnownShortcutCatalogDto(KnownShortcutMerge.ForManagement(owned, ignored)));
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Commands/KnownShortcuts/CreateCustomKnownShortcutCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/KnownShortcuts/CreateCustomKnownShortcutCommand.cs
@@ -50,9 +50,14 @@ public sealed class CreateCustomKnownShortcutCommandValidator
     // A leading capital would read as "Windows uses Win+E to Open File Explorer." Only the first
     // character is judged: a product name later in the phrase is fine, and often required.
     // Anything that is not a letter — a digit, a quote — passes, because there is no case to get
-    // wrong.
-    private static bool StartsLowercase(string? does) =>
-        string.IsNullOrEmpty(does) || !char.IsUpper(does[0]);
+    // wrong. The text is trimmed first, because the handler stores the trimmed value: without this
+    // a leading space would let a capital through.
+    private static bool StartsLowercase(string? does)
+    {
+        string trimmed = does?.Trim() ?? string.Empty;
+
+        return trimmed.Length == 0 || !char.IsUpper(trimmed[0]);
+    }
 
     // The same ban the built-in manifest lives under, applied to owner text. An owner record ends
     // up in the same warning sentence as a curated one, so it inherits the same promise: describe

--- a/src/Backend/AHKFlowApp.Application/Commands/KnownShortcuts/DeleteCustomKnownShortcutCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/KnownShortcuts/DeleteCustomKnownShortcutCommand.cs
@@ -1,0 +1,32 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Domain.Entities;
+using Ardalis.Result;
+using Microsoft.EntityFrameworkCore;
+
+namespace AHKFlowApp.Application.Commands.KnownShortcuts;
+
+/// <summary>Removes one of the owner's own records.</summary>
+public sealed record DeleteCustomKnownShortcutCommand(Guid Id);
+
+internal sealed class DeleteCustomKnownShortcutCommandHandler(IAppDbContext db, ICurrentUser currentUser)
+    : IUseCaseHandler<DeleteCustomKnownShortcutCommand, Result>
+{
+    public async Task<Result> ExecuteAsync(DeleteCustomKnownShortcutCommand request, CancellationToken ct)
+    {
+        if (currentUser.Oid is not Guid ownerOid)
+            return Result.Unauthorized();
+
+        // Filtered by owner, so another owner's record is simply not found. A separate Forbidden
+        // would confirm to a stranger that the record exists.
+        CustomKnownShortcut? record = await db.CustomKnownShortcuts
+            .FirstOrDefaultAsync(s => s.Id == request.Id && s.OwnerOid == ownerOid, ct);
+
+        if (record is null)
+            return Result.NotFound();
+
+        db.CustomKnownShortcuts.Remove(record);
+        await db.SaveChangesAsync(ct);
+
+        return Result.Success();
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Commands/KnownShortcuts/IgnoreKnownShortcutCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/KnownShortcuts/IgnoreKnownShortcutCommand.cs
@@ -1,0 +1,57 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.Common;
+using AHKFlowApp.Application.Constants;
+using AHKFlowApp.Domain.Entities;
+using Ardalis.Result;
+using Microsoft.EntityFrameworkCore;
+
+namespace AHKFlowApp.Application.Commands.KnownShortcuts;
+
+/// <summary>Stops warning about one built-in use. Other uses of the same keys still warn.</summary>
+public sealed record IgnoreKnownShortcutCommand(string ShortcutId, string UsedBy);
+
+internal sealed class IgnoreKnownShortcutCommandHandler(
+    IAppDbContext db,
+    ICurrentUser currentUser,
+    TimeProvider clock)
+    : IUseCaseHandler<IgnoreKnownShortcutCommand, Result>
+{
+    public async Task<Result> ExecuteAsync(IgnoreKnownShortcutCommand request, CancellationToken ct)
+    {
+        if (currentUser.Oid is not Guid ownerOid)
+            return Result.Unauthorized();
+
+        // Only a built-in use can be ignored. An owner removes their own record by deleting it.
+        bool builtInUseExists = KnownShortcutCatalog.All.Any(s =>
+            s.Id == request.ShortcutId && s.Uses.Any(u => u.UsedBy == request.UsedBy));
+
+        if (!builtInUseExists)
+            return Result.NotFound();
+
+        bool alreadyIgnored = await db.IgnoredKnownShortcuts.AnyAsync(
+            i => i.OwnerOid == ownerOid
+              && i.ShortcutId == request.ShortcutId
+              && i.UsedBy == request.UsedBy,
+            ct);
+
+        // The owner asked for a state, not for a transition, so already being there is success.
+        if (alreadyIgnored)
+            return Result.Success();
+
+        db.IgnoredKnownShortcuts.Add(
+            IgnoredKnownShortcut.Create(ownerOid, request.ShortcutId, request.UsedBy, clock));
+
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex) when (ex.IsDuplicateKeyViolation())
+        {
+            // Another request already wrote the same ignore. The owner asked for a state and the
+            // state is there, so this is success — the promised no-op, not a 409 and not a 500.
+            return Result.Success();
+        }
+
+        return Result.Success();
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Commands/KnownShortcuts/RestoreKnownShortcutCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/KnownShortcuts/RestoreKnownShortcutCommand.cs
@@ -23,12 +23,21 @@ internal sealed class RestoreKnownShortcutCommandHandler(IAppDbContext db, ICurr
             ct);
 
         // No row means the use already warns. The owner asked for that state, so this is success.
-        // Deleting twice needs no race guard for the same reason.
         if (ignore is null)
             return Result.Success();
 
         db.IgnoredKnownShortcuts.Remove(ignore);
-        await db.SaveChangesAsync(ct);
+
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // Two requests can read the same row and then both delete it. The second DELETE affects
+            // no rows, which EF Core reports as a concurrency conflict. The row is gone either way,
+            // so the owner got the state they asked for.
+        }
 
         return Result.Success();
     }

--- a/src/Backend/AHKFlowApp.Application/Commands/KnownShortcuts/RestoreKnownShortcutCommand.cs
+++ b/src/Backend/AHKFlowApp.Application/Commands/KnownShortcuts/RestoreKnownShortcutCommand.cs
@@ -1,0 +1,35 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Domain.Entities;
+using Ardalis.Result;
+using Microsoft.EntityFrameworkCore;
+
+namespace AHKFlowApp.Application.Commands.KnownShortcuts;
+
+/// <summary>Warns about a built-in use again.</summary>
+public sealed record RestoreKnownShortcutCommand(string ShortcutId, string UsedBy);
+
+internal sealed class RestoreKnownShortcutCommandHandler(IAppDbContext db, ICurrentUser currentUser)
+    : IUseCaseHandler<RestoreKnownShortcutCommand, Result>
+{
+    public async Task<Result> ExecuteAsync(RestoreKnownShortcutCommand request, CancellationToken ct)
+    {
+        if (currentUser.Oid is not Guid ownerOid)
+            return Result.Unauthorized();
+
+        IgnoredKnownShortcut? ignore = await db.IgnoredKnownShortcuts.FirstOrDefaultAsync(
+            i => i.OwnerOid == ownerOid
+              && i.ShortcutId == request.ShortcutId
+              && i.UsedBy == request.UsedBy,
+            ct);
+
+        // No row means the use already warns. The owner asked for that state, so this is success.
+        // Deleting twice needs no race guard for the same reason.
+        if (ignore is null)
+            return Result.Success();
+
+        db.IgnoredKnownShortcuts.Remove(ignore);
+        await db.SaveChangesAsync(ct);
+
+        return Result.Success();
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Constants/KnownShortcutCatalog.cs
+++ b/src/Backend/AHKFlowApp.Application/Constants/KnownShortcutCatalog.cs
@@ -59,9 +59,15 @@ internal static class KnownShortcutCatalog
     private const string WinLockUrl =
         "https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-desktop/win-key-remains-held-after-pressing-ctrl-win-l-in-remote-session";
 
+    private const string ChromeUrl =
+        "https://support.google.com/chrome/answer/157179?co=GENIE.Platform%3DDesktop&hl=en-en";
+
+    private const string EdgeUrl =
+        "https://support.microsoft.com/en-US/edge/keyboard-shortcuts-in-microsoft-edge";
+
     private static readonly DateOnly s_checkedOn = new(2026, 7, 29);
 
-    /// <summary>One row per combination, in design §3 order. Windows only in this release.</summary>
+    /// <summary>One row per combination, in design §3 order.</summary>
     /// <remarks>
     /// Letter keys are stored lowercase because that is what <see cref="HotkeyKeys"/> canonicalizes
     /// them to. Matching ignores case, so the stored spelling is a storage rule, not a display one.
@@ -154,8 +160,49 @@ internal static class KnownShortcutCatalog
         Windows("windows.window-menu", "Space", "open the active window's context menu", alt: true, win: false),
         Windows("windows.show-password", "F8", "show the password on the sign-in screen", alt: true, win: false),
 
-        // Browser rows (design §3) are Stage 2 — see the Stage 2 plan. They need the ignore
-        // mechanism before they are tolerable, because they cover 15 of 26 Ctrl+letter keys.
+        // ---- Browsers. Every row is Foreground and Normal, and names both Chrome and Edge. ----
+        // Each row is documented by Chrome and by Edge with the same meaning, so it carries two
+        // uses with one evidence page each. Owners silence a use they do not want, per use.
+        Browser("browser.new-tab", "t", "open a new tab", ctrl: true),
+        Browser("browser.new-window", "n", "open a new window", ctrl: true),
+        Browser("browser.close-tab", "w", "close the current tab", ctrl: true),
+        Browser("browser.close-window", "w", "close the current window", ctrl: true, shift: true),
+        Browser("browser.reopen-tab", "t", "reopen the last closed tab", ctrl: true, shift: true),
+        Browser("browser.next-tab", "Tab", "switch to the next tab", ctrl: true),
+        Browser("browser.previous-tab", "Tab", "switch to the previous tab", ctrl: true, shift: true),
+
+        // Ctrl+1 through Ctrl+8 pick a tab by position. Ctrl+9 picks the last tab, whatever its
+        // position, which is why it does not read "switch to tab 9".
+        Browser("browser.tab-1", "1", "switch to tab 1", ctrl: true),
+        Browser("browser.tab-2", "2", "switch to tab 2", ctrl: true),
+        Browser("browser.tab-3", "3", "switch to tab 3", ctrl: true),
+        Browser("browser.tab-4", "4", "switch to tab 4", ctrl: true),
+        Browser("browser.tab-5", "5", "switch to tab 5", ctrl: true),
+        Browser("browser.tab-6", "6", "switch to tab 6", ctrl: true),
+        Browser("browser.tab-7", "7", "switch to tab 7", ctrl: true),
+        Browser("browser.tab-8", "8", "switch to tab 8", ctrl: true),
+        Browser("browser.tab-9", "9", "switch to the last tab", ctrl: true),
+
+        Browser("browser.address-bar", "l", "focus the address bar", ctrl: true),
+        Browser("browser.address-bar-alt", "d", "focus the address bar", alt: true),
+        Browser("browser.search-e", "e", "search from the address bar", ctrl: true),
+        Browser("browser.search-k", "k", "search from the address bar", ctrl: true),
+        Browser("browser.devtools-i", "i", "open developer tools", ctrl: true, shift: true),
+        Browser("browser.devtools-f12", "F12", "open developer tools"),
+        Browser("browser.view-source", "u", "view the page source", ctrl: true),
+        Browser("browser.history", "h", "open history", ctrl: true),
+        Browser("browser.downloads", "j", "open downloads", ctrl: true),
+        Browser("browser.bookmark", "d", "bookmark the current tab", ctrl: true),
+        Browser("browser.bookmark-all", "d", "bookmark all open tabs", ctrl: true, shift: true),
+        Browser("browser.bookmark-manager", "o", "open the bookmark manager", ctrl: true, shift: true),
+        Browser("browser.bookmark-bar", "b", "show and hide the bookmarks bar", ctrl: true, shift: true),
+        Browser("browser.find", "f", "find text on the page", ctrl: true),
+        Browser("browser.find-next", "g", "go to the next find result", ctrl: true),
+        Browser("browser.find-previous", "g", "go to the previous find result", ctrl: true, shift: true),
+        Browser("browser.print", "p", "print the page", ctrl: true),
+        Browser("browser.save-page", "s", "save the page", ctrl: true),
+        Browser("browser.reload", "r", "reload the page", ctrl: true),
+        Browser("browser.hard-reload", "r", "reload the page and skip the cache", ctrl: true, shift: true),
     ];
 
     // Win is the default modifier because most Windows rows use it; the no-Win rows pass win: false.
@@ -172,5 +219,21 @@ internal static class KnownShortcutCatalog
         new(id, key, ctrl, alt, shift, win,
         [
             new ShortcutUse("Windows", protection, ShortcutScope.Global, does, evidenceUrl, s_checkedOn),
+        ]);
+
+    // Two uses, one per browser, because the manifest rule is one evidence page per use. That also
+    // lets an owner silence the Chrome use and keep the Edge one, which a single "Chrome, Edge"
+    // label could not offer. Both are Foreground: a browser only answers these keys while in front.
+    private static KnownShortcut Browser(
+        string id,
+        string key,
+        string does,
+        bool ctrl = false,
+        bool alt = false,
+        bool shift = false) =>
+        new(id, key, ctrl, alt, shift, Win: false,
+        [
+            new ShortcutUse("Chrome", ShortcutProtection.Normal, ShortcutScope.Foreground, does, ChromeUrl, s_checkedOn),
+            new ShortcutUse("Edge", ShortcutProtection.Normal, ShortcutScope.Foreground, does, EdgeUrl, s_checkedOn),
         ]);
 }

--- a/src/Backend/AHKFlowApp.Application/Constants/ShortcutWording.cs
+++ b/src/Backend/AHKFlowApp.Application/Constants/ShortcutWording.cs
@@ -1,0 +1,23 @@
+using System.Text.RegularExpressions;
+
+namespace AHKFlowApp.Application.Constants;
+
+/// <summary>Wording rules every shortcut warning obeys, built-in and owner-written alike.</summary>
+internal static partial class ShortcutWording
+{
+    /// <summary>
+    /// Absolute claims a warning must never make. A shortcut warning says what else uses the keys;
+    /// it never promises what will happen when they are pressed (<c>CONTEXT.md:99</c>).
+    /// </summary>
+    internal static readonly string[] BannedTerms =
+        ["never", "will not", "cannot", "won't", "can't"];
+
+    /// <summary>True if the text makes a claim about what will or will not happen.</summary>
+    internal static bool MakesAbsoluteClaim(string text) => AbsoluteClaim().IsMatch(text);
+
+    // Word boundaries, not substrings: "whenever" contains "never" and is perfectly good English
+    // for a shortcut description. \b sits between a word character and a non-word character, and
+    // there is none inside "whenever", so that word passes while a bare "never" does not.
+    [GeneratedRegex(@"\b(never|will not|cannot|won't|can't)\b", RegexOptions.IgnoreCase)]
+    private static partial Regex AbsoluteClaim();
+}

--- a/src/Backend/AHKFlowApp.Application/DTOs/ManagedKnownShortcutDtos.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/ManagedKnownShortcutDtos.cs
@@ -3,10 +3,10 @@ using AHKFlowApp.Domain.Enums;
 namespace AHKFlowApp.Application.DTOs;
 
 /// <summary>One use as the management page needs it, with the state that page can change.</summary>
-/// <param name="UsedBy"></param>
-/// <param name="Protection"></param>
-/// <param name="Scope"></param>
-/// <param name="Does"></param>
+/// <param name="UsedBy">Windows, a named application, or a label the owner typed.</param>
+/// <param name="Protection">How hard the keys are to take over.</param>
+/// <param name="Scope">Whether the use fires anywhere, or only while its application is in front.</param>
+/// <param name="Does">Lowercase verb phrase the warning composer completes a sentence with.</param>
 /// <param name="Origin">BuiltIn or Owner. Decides which action the row offers.</param>
 /// <param name="OwnerRecordId">Set for an Owner use, so the page can delete it. Null for BuiltIn.</param>
 /// <param name="IsIgnored">True when the owner has silenced this BuiltIn use. Always false for Owner uses.</param>
@@ -20,13 +20,13 @@ public sealed record ManagedShortcutUseDto(
     bool IsIgnored);
 
 /// <summary>One combination and every use of it, ignored ones included so they can be restored.</summary>
-/// <param name="Id"></param>
-/// <param name="Key"></param>
-/// <param name="Ctrl"></param>
-/// <param name="Alt"></param>
-/// <param name="Shift"></param>
-/// <param name="Win"></param>
-/// <param name="Uses"></param>
+/// <param name="Id">Built-in id such as "windows.file-explorer", or "owner.&lt;guid&gt;" for an owner-only combination.</param>
+/// <param name="Key">Canonical key spelling. Letter keys are lowercase.</param>
+/// <param name="Ctrl">True when the combination needs Ctrl.</param>
+/// <param name="Alt">True when the combination needs Alt.</param>
+/// <param name="Shift">True when the combination needs Shift.</param>
+/// <param name="Win">True when the combination needs the Windows key.</param>
+/// <param name="Uses">Every use of this combination, ignored ones included.</param>
 /// <param name="WarningText">
 /// The built-in override text, carried straight through from the catalog. Null for an owner-only
 /// combination, which has no built-in row to take it from. It rides along so the dialog list can
@@ -43,9 +43,19 @@ public sealed record ManagedKnownShortcutDto(
     string? WarningText);
 
 /// <summary>The whole management list.</summary>
+/// <param name="Shortcuts">Every combination, built-in and owner-recorded alike.</param>
 public sealed record ManagedKnownShortcutCatalogDto(IReadOnlyList<ManagedKnownShortcutDto> Shortcuts);
 
 /// <summary>An owner's new record of something that uses a combination.</summary>
+/// <param name="Key">Key name. The handler canonicalizes it before saving.</param>
+/// <param name="Ctrl">True when the combination needs Ctrl.</param>
+/// <param name="Alt">True when the combination needs Alt.</param>
+/// <param name="Shift">True when the combination needs Shift.</param>
+/// <param name="Win">True when the combination needs the Windows key.</param>
+/// <param name="UsedBy">What uses the keys — a product name, or any label the owner types.</param>
+/// <param name="Scope">Whether the use fires anywhere, or only while its application is in front.</param>
+/// <param name="Does">Lowercase verb phrase completing "&lt;UsedBy&gt; uses &lt;combo&gt; to …".</param>
+/// <param name="Protection">Normal or Unknown. An owner cannot claim Protected.</param>
 public sealed record CreateCustomKnownShortcutDto(
     string Key,
     bool Ctrl,
@@ -58,4 +68,6 @@ public sealed record CreateCustomKnownShortcutDto(
     ShortcutProtection Protection = ShortcutProtection.Unknown);
 
 /// <summary>Names one built-in use to silence or bring back.</summary>
+/// <param name="ShortcutId">Built-in id, for example "windows.file-explorer".</param>
+/// <param name="UsedBy">Which use of that shortcut, for example "Windows" or "Chrome".</param>
 public sealed record KnownShortcutUseRefDto(string ShortcutId, string UsedBy);

--- a/src/Backend/AHKFlowApp.Application/DTOs/ManagedKnownShortcutDtos.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/ManagedKnownShortcutDtos.cs
@@ -1,0 +1,61 @@
+using AHKFlowApp.Domain.Enums;
+
+namespace AHKFlowApp.Application.DTOs;
+
+/// <summary>One use as the management page needs it, with the state that page can change.</summary>
+/// <param name="UsedBy"></param>
+/// <param name="Protection"></param>
+/// <param name="Scope"></param>
+/// <param name="Does"></param>
+/// <param name="Origin">BuiltIn or Owner. Decides which action the row offers.</param>
+/// <param name="OwnerRecordId">Set for an Owner use, so the page can delete it. Null for BuiltIn.</param>
+/// <param name="IsIgnored">True when the owner has silenced this BuiltIn use. Always false for Owner uses.</param>
+public sealed record ManagedShortcutUseDto(
+    string UsedBy,
+    ShortcutProtection Protection,
+    ShortcutScope Scope,
+    string Does,
+    ShortcutRecordOrigin Origin,
+    Guid? OwnerRecordId,
+    bool IsIgnored);
+
+/// <summary>One combination and every use of it, ignored ones included so they can be restored.</summary>
+/// <param name="Id"></param>
+/// <param name="Key"></param>
+/// <param name="Ctrl"></param>
+/// <param name="Alt"></param>
+/// <param name="Shift"></param>
+/// <param name="Win"></param>
+/// <param name="Uses"></param>
+/// <param name="WarningText">
+/// The built-in override text, carried straight through from the catalog. Null for an owner-only
+/// combination, which has no built-in row to take it from. It rides along so the dialog list can
+/// keep it — see <c>KnownShortcutMerge.ForDialog</c>.
+/// </param>
+public sealed record ManagedKnownShortcutDto(
+    string Id,
+    string Key,
+    bool Ctrl,
+    bool Alt,
+    bool Shift,
+    bool Win,
+    IReadOnlyList<ManagedShortcutUseDto> Uses,
+    string? WarningText);
+
+/// <summary>The whole management list.</summary>
+public sealed record ManagedKnownShortcutCatalogDto(IReadOnlyList<ManagedKnownShortcutDto> Shortcuts);
+
+/// <summary>An owner's new record of something that uses a combination.</summary>
+public sealed record CreateCustomKnownShortcutDto(
+    string Key,
+    bool Ctrl,
+    bool Alt,
+    bool Shift,
+    bool Win,
+    string UsedBy,
+    ShortcutScope Scope,
+    string Does,
+    ShortcutProtection Protection = ShortcutProtection.Unknown);
+
+/// <summary>Names one built-in use to silence or bring back.</summary>
+public sealed record KnownShortcutUseRefDto(string ShortcutId, string UsedBy);

--- a/src/Backend/AHKFlowApp.Application/DependencyInjection.cs
+++ b/src/Backend/AHKFlowApp.Application/DependencyInjection.cs
@@ -4,6 +4,7 @@ using AHKFlowApp.Application.Commands.Categories;
 using AHKFlowApp.Application.Commands.Dev;
 using AHKFlowApp.Application.Commands.Hotkeys;
 using AHKFlowApp.Application.Commands.Hotstrings;
+using AHKFlowApp.Application.Commands.KnownShortcuts;
 using AHKFlowApp.Application.Commands.Preferences;
 using AHKFlowApp.Application.Commands.Profiles;
 using AHKFlowApp.Application.DTOs;
@@ -12,6 +13,7 @@ using AHKFlowApp.Application.Queries.Dashboard;
 using AHKFlowApp.Application.Queries.Downloads;
 using AHKFlowApp.Application.Queries.Hotkeys;
 using AHKFlowApp.Application.Queries.Hotstrings;
+using AHKFlowApp.Application.Queries.KnownShortcuts;
 using AHKFlowApp.Application.Queries.Preferences;
 using AHKFlowApp.Application.Queries.Profiles;
 using AHKFlowApp.Application.Services;
@@ -54,6 +56,11 @@ public static class DependencyInjection
             .AddUseCase<GetHotstringPreviewQuery, Result<HotstringPreviewDto>, GetHotstringPreviewQueryHandler>()
             .AddUseCase<ListHotkeyKeysQuery, Result<HotkeyKeyCatalogDto>, ListHotkeyKeysQueryHandler>()
             .AddUseCase<ListKnownShortcutsQuery, Result<KnownShortcutCatalogDto>, ListKnownShortcutsQueryHandler>()
+            .AddUseCase<ListManagedKnownShortcutsQuery, Result<ManagedKnownShortcutCatalogDto>, ListManagedKnownShortcutsQueryHandler>()
+            .AddUseCase<CreateCustomKnownShortcutCommand, Result<ManagedKnownShortcutCatalogDto>, CreateCustomKnownShortcutCommandHandler>()
+            .AddUseCase<DeleteCustomKnownShortcutCommand, Result, DeleteCustomKnownShortcutCommandHandler>()
+            .AddUseCase<IgnoreKnownShortcutCommand, Result, IgnoreKnownShortcutCommandHandler>()
+            .AddUseCase<RestoreKnownShortcutCommand, Result, RestoreKnownShortcutCommandHandler>()
             .AddUseCase<CreateHotkeyCommand, Result<HotkeyDto>, CreateHotkeyCommandHandler>()
             .AddUseCase<UpdateHotkeyCommand, Result<HotkeyDto>, UpdateHotkeyCommandHandler>()
             .AddUseCase<DeleteHotkeyCommand, Result, DeleteHotkeyCommandHandler>()

--- a/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListKnownShortcutsQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Hotkeys/ListKnownShortcutsQuery.cs
@@ -1,28 +1,27 @@
-using AHKFlowApp.Application.Abstractions;
-using AHKFlowApp.Application.Constants;
+﻿using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Services;
+using AHKFlowApp.Domain.Entities;
 using Ardalis.Result;
 
 namespace AHKFlowApp.Application.Queries.Hotkeys;
 
-/// <summary>Returns the curated known-shortcut list the hotkey dialog warns from. Static reference data.</summary>
+/// <summary>Known shortcuts the dialog should warn about — built-ins the owner has not silenced, plus their own records.</summary>
 public sealed record ListKnownShortcutsQuery();
 
-internal sealed class ListKnownShortcutsQueryHandler
+internal sealed class ListKnownShortcutsQueryHandler(IAppDbContext db, ICurrentUser currentUser)
     : IUseCaseHandler<ListKnownShortcutsQuery, Result<KnownShortcutCatalogDto>>
 {
-    // Projected once: the manifest is immutable for the process lifetime.
-    private static readonly KnownShortcutCatalogDto s_catalog = Project();
+    public async Task<Result<KnownShortcutCatalogDto>> ExecuteAsync(
+        ListKnownShortcutsQuery request, CancellationToken ct)
+    {
+        if (currentUser.Oid is not Guid ownerOid)
+            return Result.Unauthorized();
 
-    public Task<Result<KnownShortcutCatalogDto>> ExecuteAsync(
-        ListKnownShortcutsQuery request, CancellationToken ct) =>
-        Task.FromResult(Result<KnownShortcutCatalogDto>.Success(s_catalog));
+        (CustomKnownShortcut[] owned, IgnoredKnownShortcut[] ignored) =
+            await OwnerKnownShortcutLoader.LoadAsync(db, ownerOid, ct);
 
-    private static KnownShortcutCatalogDto Project() => new(
-    [
-        .. KnownShortcutCatalog.All.Select(s => new KnownShortcutDto(
-            s.Id, s.Key, s.Ctrl, s.Alt, s.Shift, s.Win,
-            [.. s.Uses.Select(u => new ShortcutUseDto(u.UsedBy, u.Protection, u.Scope, u.Does))],
-            s.WarningText))
-    ]);
+        return Result<KnownShortcutCatalogDto>.Success(
+            new KnownShortcutCatalogDto(KnownShortcutMerge.ForDialog(owned, ignored)));
+    }
 }

--- a/src/Backend/AHKFlowApp.Application/Queries/KnownShortcuts/ListManagedKnownShortcutsQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/KnownShortcuts/ListManagedKnownShortcutsQuery.cs
@@ -1,0 +1,27 @@
+﻿using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Services;
+using AHKFlowApp.Domain.Entities;
+using Ardalis.Result;
+
+namespace AHKFlowApp.Application.Queries.KnownShortcuts;
+
+/// <summary>Every known shortcut for the management page, ignored uses included so they can be brought back.</summary>
+public sealed record ListManagedKnownShortcutsQuery();
+
+internal sealed class ListManagedKnownShortcutsQueryHandler(IAppDbContext db, ICurrentUser currentUser)
+    : IUseCaseHandler<ListManagedKnownShortcutsQuery, Result<ManagedKnownShortcutCatalogDto>>
+{
+    public async Task<Result<ManagedKnownShortcutCatalogDto>> ExecuteAsync(
+        ListManagedKnownShortcutsQuery request, CancellationToken ct)
+    {
+        if (currentUser.Oid is not Guid ownerOid)
+            return Result.Unauthorized();
+
+        (CustomKnownShortcut[] owned, IgnoredKnownShortcut[] ignored) =
+            await OwnerKnownShortcutLoader.LoadAsync(db, ownerOid, ct);
+
+        return Result<ManagedKnownShortcutCatalogDto>.Success(
+            new ManagedKnownShortcutCatalogDto(KnownShortcutMerge.ForManagement(owned, ignored)));
+    }
+}

--- a/src/Backend/AHKFlowApp.Application/Services/KnownShortcutMerge.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/KnownShortcutMerge.cs
@@ -1,0 +1,132 @@
+using AHKFlowApp.Application.Constants;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
+
+namespace AHKFlowApp.Application.Services;
+
+/// <summary>
+/// Folds the curated manifest, an owner's own records, and their ignores into one list.
+/// </summary>
+/// <remarks>
+/// Aggregates, never replaces. An owner record adds a use to a combination; it cannot remove or
+/// weaken a built-in fact. The dialog and the management page need different answers — the
+/// dialog must not warn about an ignored use, the page must show it so it can be brought back —
+/// so this class offers one method each rather than one method with a flag.
+/// </remarks>
+internal static class KnownShortcutMerge
+{
+    // Grouping key only, never shown. MatchKey is uppercased so "e" and "E" collapse into one row.
+    // The spelling the page displays travels separately, in the DTO's own Key.
+    private readonly record struct Combo(string MatchKey, bool Ctrl, bool Alt, bool Shift, bool Win);
+
+    /// <summary>Active uses only. Combinations left with no visible use are dropped.</summary>
+    public static IReadOnlyList<KnownShortcutDto> ForDialog(
+        IReadOnlyList<CustomKnownShortcut> owned,
+        IReadOnlyList<IgnoredKnownShortcut> ignored) =>
+        ForDialog(KnownShortcutCatalog.All, owned, ignored);
+
+    /// <inheritdoc cref="ForDialog(IReadOnlyList{CustomKnownShortcut}, IReadOnlyList{IgnoredKnownShortcut})"/>
+    /// <param name="builtIns">
+    /// The built-in rows to merge against. Production always passes <see cref="KnownShortcutCatalog.All"/>
+    /// through the two-argument overload; tests pass a hand-built list so they can exercise a row
+    /// shape the shipped manifest does not contain yet, such as a non-null <c>WarningText</c>.
+    /// </param>
+    /// <param name="owned">The owner's own records.</param>
+    /// <param name="ignored">The built-in uses the owner has silenced.</param>
+    internal static IReadOnlyList<KnownShortcutDto> ForDialog(
+        IReadOnlyList<KnownShortcut> builtIns,
+        IReadOnlyList<CustomKnownShortcut> owned,
+        IReadOnlyList<IgnoredKnownShortcut> ignored) =>
+    [
+        .. ForManagement(builtIns, owned, ignored)
+            .Select(s => new KnownShortcutDto(
+                s.Id, s.Key, s.Ctrl, s.Alt, s.Shift, s.Win,
+                [
+                    .. s.Uses.Where(u => !u.IsIgnored)
+                        .Select(u => new ShortcutUseDto(u.UsedBy, u.Protection, u.Scope, u.Does))
+                ],
+                // Carried through, never dropped. The frontend returns this verbatim when it is
+                // set, so hardcoding null here would silently discard a catalog override.
+                s.WarningText))
+            .Where(s => s.Uses.Count > 0)
+    ];
+
+    /// <summary>Every use, ignored ones included, each carrying the state the page can change.</summary>
+    public static IReadOnlyList<ManagedKnownShortcutDto> ForManagement(
+        IReadOnlyList<CustomKnownShortcut> owned,
+        IReadOnlyList<IgnoredKnownShortcut> ignored) =>
+        ForManagement(KnownShortcutCatalog.All, owned, ignored);
+
+    /// <inheritdoc cref="ForManagement(IReadOnlyList{CustomKnownShortcut}, IReadOnlyList{IgnoredKnownShortcut})"/>
+    /// <param name="builtIns">See the matching parameter on <see cref="ForDialog(IReadOnlyList{KnownShortcut}, IReadOnlyList{CustomKnownShortcut}, IReadOnlyList{IgnoredKnownShortcut})"/>.</param>
+    /// <param name="owned">The owner's own records.</param>
+    /// <param name="ignored">The built-in uses the owner has silenced.</param>
+    internal static IReadOnlyList<ManagedKnownShortcutDto> ForManagement(
+        IReadOnlyList<KnownShortcut> builtIns,
+        IReadOnlyList<CustomKnownShortcut> owned,
+        IReadOnlyList<IgnoredKnownShortcut> ignored)
+    {
+        // (shortcut id, used-by) is the ignore key: ignoring is per use, not per combination.
+        HashSet<(string, string)> silenced =
+            [.. ignored.Select(i => (i.ShortcutId, i.UsedBy))];
+
+        Dictionary<Combo, ManagedKnownShortcutDto> byCombo = [];
+
+        foreach (KnownShortcut builtIn in builtIns)
+        {
+            string key = Canonical(builtIn.Key);
+            byCombo[ComboOf(key, builtIn.Ctrl, builtIn.Alt, builtIn.Shift, builtIn.Win)] =
+                new ManagedKnownShortcutDto(
+                    builtIn.Id, key, builtIn.Ctrl, builtIn.Alt, builtIn.Shift, builtIn.Win,
+                    [
+                        .. builtIn.Uses.Select(u => new ManagedShortcutUseDto(
+                            u.UsedBy, u.Protection, u.Scope, u.Does,
+                            ShortcutRecordOrigin.BuiltIn,
+                            OwnerRecordId: null,
+                            IsIgnored: silenced.Contains((builtIn.Id, u.UsedBy))))
+                    ],
+                    builtIn.WarningText);
+        }
+
+        foreach (CustomKnownShortcut record in owned)
+        {
+            string key = Canonical(record.Key);
+            Combo combo = ComboOf(key, record.Ctrl, record.Alt, record.Shift, record.Win);
+
+            ManagedShortcutUseDto use = new(
+                record.UsedBy, record.Protection, record.Scope, record.Does,
+                ShortcutRecordOrigin.Owner,
+                OwnerRecordId: record.Id,
+                IsIgnored: false);
+
+            if (byCombo.TryGetValue(combo, out ManagedKnownShortcutDto? existing))
+            {
+                // Adds a use to the built-in row. Its Key and WarningText both stay as they were —
+                // an owner record never overwrites a built-in fact.
+                byCombo[combo] = existing with { Uses = [.. existing.Uses, use] };
+            }
+            else
+            {
+                // Owner-only combination. The id is synthetic and never sent back to the server.
+                // No built-in row exists, so there is no WarningText to carry.
+                byCombo[combo] = new ManagedKnownShortcutDto(
+                    $"owner.{record.Id}", key, record.Ctrl, record.Alt, record.Shift, record.Win,
+                    [use],
+                    WarningText: null);
+            }
+        }
+
+        return [.. byCombo.Values];
+    }
+
+    // Canonicalize before every comparison, or "Esc" and "Escape" produce two rows for one key.
+    // TryCanonicalize writes an empty string when it fails, so keep the caller's spelling instead:
+    // an unrecognised key must still show as itself, never as a blank cell.
+    private static string Canonical(string key) =>
+        HotkeyKeys.TryCanonicalize(key, out string canonical) ? canonical : key;
+
+    // Uppercase only inside the grouping key. The canonical spelling passed in is untouched.
+    private static Combo ComboOf(string canonicalKey, bool ctrl, bool alt, bool shift, bool win) =>
+        new(canonicalKey.ToUpperInvariant(), ctrl, alt, shift, win);
+}

--- a/src/Backend/AHKFlowApp.Application/Services/OwnerKnownShortcutLoader.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/OwnerKnownShortcutLoader.cs
@@ -1,0 +1,25 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace AHKFlowApp.Application.Services;
+
+/// <summary>
+/// Reads the two owner-scoped tables the merge needs. Three call sites want the same pair — the
+/// dialog query, the management query, and the create command's reload — so the read lives here
+/// and each of them cannot drift into a different owner filter.
+/// </summary>
+internal static class OwnerKnownShortcutLoader
+{
+    internal static async Task<(CustomKnownShortcut[] Owned, IgnoredKnownShortcut[] Ignored)> LoadAsync(
+        IAppDbContext db, Guid ownerOid, CancellationToken ct)
+    {
+        CustomKnownShortcut[] owned = await db.CustomKnownShortcuts
+            .Where(s => s.OwnerOid == ownerOid).AsNoTracking().ToArrayAsync(ct);
+
+        IgnoredKnownShortcut[] ignored = await db.IgnoredKnownShortcuts
+            .Where(i => i.OwnerOid == ownerOid).AsNoTracking().ToArrayAsync(ct);
+
+        return (owned, ignored);
+    }
+}

--- a/src/Backend/AHKFlowApp.Domain/Entities/CustomKnownShortcut.cs
+++ b/src/Backend/AHKFlowApp.Domain/Entities/CustomKnownShortcut.cs
@@ -1,0 +1,89 @@
+using AHKFlowApp.Domain.Enums;
+
+namespace AHKFlowApp.Domain.Entities;
+
+/// <summary>
+/// One use of a key combination that an owner recorded themselves. Record origin is the owner;
+/// what uses the keys is <see cref="UsedBy"/> — an owner recording a Visual Studio shortcut has
+/// not become the user of it.
+/// </summary>
+public sealed class CustomKnownShortcut
+{
+    private CustomKnownShortcut()
+    {
+        Key = string.Empty;
+        UsedBy = string.Empty;
+        Does = string.Empty;
+    }
+
+    public Guid Id { get; private set; }
+    public Guid OwnerOid { get; private set; }
+
+    /// <summary>Canonical key. Canonicalized by the handler before this is built.</summary>
+    public string Key { get; private set; }
+
+    public bool Ctrl { get; private set; }
+    public bool Alt { get; private set; }
+    public bool Shift { get; private set; }
+    public bool Win { get; private set; }
+
+    /// <summary>What uses the keys — a product name, or any label the owner typed.</summary>
+    public string UsedBy { get; private set; }
+
+    /// <summary>Never Protected: that claim needs a pinned Microsoft source, which an owner cannot supply.</summary>
+    public ShortcutProtection Protection { get; private set; }
+
+    public ShortcutScope Scope { get; private set; }
+
+    /// <summary>Lowercase verb phrase completing "&lt;UsedBy&gt; uses &lt;combo&gt; to …".</summary>
+    public string Does { get; private set; }
+
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    public static CustomKnownShortcut Create(
+        Guid ownerOid,
+        string key,
+        bool ctrl,
+        bool alt,
+        bool shift,
+        bool win,
+        string usedBy,
+        ShortcutProtection protection,
+        ShortcutScope scope,
+        string does,
+        TimeProvider clock)
+    {
+        DateTimeOffset now = clock.GetUtcNow();
+        return new CustomKnownShortcut
+        {
+            Id = Guid.NewGuid(),
+            OwnerOid = ownerOid,
+            Key = key,
+            Ctrl = ctrl,
+            Alt = alt,
+            Shift = shift,
+            Win = win,
+            UsedBy = usedBy,
+            Protection = protection,
+            Scope = scope,
+            Does = does,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public void Update(
+        string usedBy,
+        ShortcutProtection protection,
+        ShortcutScope scope,
+        string does,
+        TimeProvider clock)
+    {
+        UsedBy = usedBy;
+        Protection = protection;
+        Scope = scope;
+        Does = does;
+        UpdatedAt = clock.GetUtcNow();
+    }
+}

--- a/src/Backend/AHKFlowApp.Domain/Entities/IgnoredKnownShortcut.cs
+++ b/src/Backend/AHKFlowApp.Domain/Entities/IgnoredKnownShortcut.cs
@@ -1,0 +1,36 @@
+namespace AHKFlowApp.Domain.Entities;
+
+/// <summary>
+/// One built-in shortcut use an owner has silenced. Per use, not per combination: silencing the
+/// Windows use of Win+E leaves any other use of the same keys still warning. Owner-recorded uses
+/// are removed by deleting the record, so they are never ignored.
+/// </summary>
+public sealed class IgnoredKnownShortcut
+{
+    private IgnoredKnownShortcut()
+    {
+        ShortcutId = string.Empty;
+        UsedBy = string.Empty;
+    }
+
+    public Guid Id { get; private set; }
+    public Guid OwnerOid { get; private set; }
+
+    /// <summary>Built-in id, for example "windows.file-explorer". A later release may retire one.</summary>
+    public string ShortcutId { get; private set; }
+
+    /// <summary>Which use of that shortcut is silenced.</summary>
+    public string UsedBy { get; private set; }
+
+    public DateTimeOffset CreatedAt { get; private set; }
+
+    public static IgnoredKnownShortcut Create(Guid ownerOid, string shortcutId, string usedBy, TimeProvider clock) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            OwnerOid = ownerOid,
+            ShortcutId = shortcutId,
+            UsedBy = usedBy,
+            CreatedAt = clock.GetUtcNow(),
+        };
+}

--- a/src/Backend/AHKFlowApp.Domain/Enums/ShortcutRecordOrigin.cs
+++ b/src/Backend/AHKFlowApp.Domain/Enums/ShortcutRecordOrigin.cs
@@ -1,0 +1,14 @@
+namespace AHKFlowApp.Domain.Enums;
+
+/// <summary>
+/// Where a known-shortcut record came from. Provenance, not a use: an owner who records a
+/// Visual Studio shortcut produces an Owner record whose UsedBy is still "Visual Studio".
+/// </summary>
+public enum ShortcutRecordOrigin
+{
+    /// <summary>Shipped in the curated manifest.</summary>
+    BuiltIn = 0,
+
+    /// <summary>Recorded by the owner.</summary>
+    Owner = 1,
+}

--- a/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260729151833_AddKnownShortcuts.Designer.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260729151833_AddKnownShortcuts.Designer.cs
@@ -4,6 +4,7 @@ using AHKFlowApp.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AHKFlowApp.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729151833_AddKnownShortcuts")]
+    partial class AddKnownShortcuts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260729151833_AddKnownShortcuts.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Migrations/20260729151833_AddKnownShortcuts.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AHKFlowApp.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddKnownShortcuts : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "CustomKnownShortcuts",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                OwnerOid = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                Key = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                Ctrl = table.Column<bool>(type: "bit", nullable: false),
+                Alt = table.Column<bool>(type: "bit", nullable: false),
+                Shift = table.Column<bool>(type: "bit", nullable: false),
+                Win = table.Column<bool>(type: "bit", nullable: false),
+                UsedBy = table.Column<string>(type: "nvarchar(60)", maxLength: 60, nullable: false),
+                Protection = table.Column<int>(type: "int", nullable: false),
+                Scope = table.Column<int>(type: "int", nullable: false),
+                Does = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_CustomKnownShortcuts", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "IgnoredKnownShortcuts",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                OwnerOid = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                ShortcutId = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                UsedBy = table.Column<string>(type: "nvarchar(60)", maxLength: 60, nullable: false),
+                CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_IgnoredKnownShortcuts", x => x.Id);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_CustomKnownShortcut_Owner_Combo_UsedBy",
+            table: "CustomKnownShortcuts",
+            columns: new[] { "OwnerOid", "Key", "Ctrl", "Alt", "Shift", "Win", "UsedBy" },
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_IgnoredKnownShortcut_Owner_Shortcut_UsedBy",
+            table: "IgnoredKnownShortcuts",
+            columns: new[] { "OwnerOid", "ShortcutId", "UsedBy" },
+            unique: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "CustomKnownShortcuts");
+
+        migrationBuilder.DropTable(
+            name: "IgnoredKnownShortcuts");
+    }
+}

--- a/src/Backend/AHKFlowApp.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Persistence/AppDbContext.cs
@@ -17,6 +17,8 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
     public DbSet<HotstringCategory> HotstringCategories => Set<HotstringCategory>();
     public DbSet<HotkeyCategory> HotkeyCategories => Set<HotkeyCategory>();
     public DbSet<EntityHistory> EntityHistories => Set<EntityHistory>();
+    public DbSet<CustomKnownShortcut> CustomKnownShortcuts => Set<CustomKnownShortcut>();
+    public DbSet<IgnoredKnownShortcut> IgnoredKnownShortcuts => Set<IgnoredKnownShortcut>();
 
     public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
         => Database.BeginTransactionAsync(cancellationToken);

--- a/src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/CustomKnownShortcutConfiguration.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/CustomKnownShortcutConfiguration.cs
@@ -1,0 +1,28 @@
+using AHKFlowApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace AHKFlowApp.Infrastructure.Persistence.Configurations;
+
+internal sealed class CustomKnownShortcutConfiguration : IEntityTypeConfiguration<CustomKnownShortcut>
+{
+    public void Configure(EntityTypeBuilder<CustomKnownShortcut> builder)
+    {
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.OwnerOid).IsRequired();
+        builder.Property(x => x.Key).IsRequired().HasMaxLength(50);
+        builder.Property(x => x.UsedBy).IsRequired().HasMaxLength(60);
+        builder.Property(x => x.Does).IsRequired().HasMaxLength(200);
+        builder.Property(x => x.Protection).IsRequired();
+        builder.Property(x => x.Scope).IsRequired();
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+
+        // One label per combination per owner. Two labels on one combination are allowed and
+        // expected — that is how a combination gains a second use.
+        builder.HasIndex(x => new { x.OwnerOid, x.Key, x.Ctrl, x.Alt, x.Shift, x.Win, x.UsedBy })
+            .IsUnique()
+            .HasDatabaseName("IX_CustomKnownShortcut_Owner_Combo_UsedBy");
+    }
+}

--- a/src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/IgnoredKnownShortcutConfiguration.cs
+++ b/src/Backend/AHKFlowApp.Infrastructure/Persistence/Configurations/IgnoredKnownShortcutConfiguration.cs
@@ -1,0 +1,22 @@
+using AHKFlowApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace AHKFlowApp.Infrastructure.Persistence.Configurations;
+
+internal sealed class IgnoredKnownShortcutConfiguration : IEntityTypeConfiguration<IgnoredKnownShortcut>
+{
+    public void Configure(EntityTypeBuilder<IgnoredKnownShortcut> builder)
+    {
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.OwnerOid).IsRequired();
+        builder.Property(x => x.ShortcutId).IsRequired().HasMaxLength(100);
+        builder.Property(x => x.UsedBy).IsRequired().HasMaxLength(60);
+        builder.Property(x => x.CreatedAt).IsRequired();
+
+        builder.HasIndex(x => new { x.OwnerOid, x.ShortcutId, x.UsedBy })
+            .IsUnique()
+            .HasDatabaseName("IX_IgnoredKnownShortcut_Owner_Shortcut_UsedBy");
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
@@ -1,4 +1,4 @@
-@using AHKFlowApp.UI.Blazor.Components.Common
+﻿@using AHKFlowApp.UI.Blazor.Components.Common
 @using AHKFlowApp.UI.Blazor.DTOs
 @using AHKFlowApp.UI.Blazor.Helpers
 @using AHKFlowApp.UI.Blazor.Services
@@ -51,6 +51,11 @@
                     @_shortcutWarning
                 </MudAlert>
             }
+            @* Outside the @if, so it renders on every pass. It is how an E2E test can tell
+               "no warning" apart from "not decided yet". Hidden: it is not for the reader. *@
+            <span data-test="shortcut-warning-checked"
+                  data-combination="@_shortcutChecked"
+                  style="display:none"></span>
 
             @* ---- Action selector. Generated from the enum so the set cannot drift.
                  The wrapper div carries the CSS-isolation scope for the wrapping rule. ---- *@
@@ -342,6 +347,13 @@
     // gates Save. The list behind it is session-cached by IKnownShortcutCatalog, the same way
     // IHotkeyKeyCatalog caches the key registry.
     private string? _shortcutWarning;
+
+    // The combination the notice above was last decided for, or "" before the first decision. Set
+    // together with _shortcutWarning and under the same generation check, so it never announces a
+    // decision that a newer combination has already replaced. Read only by the E2E tests: it is
+    // how a test can tell "no warning" apart from "not evaluated yet".
+    private string _shortcutChecked = "";
+
     private CancellationTokenSource? _shortcutCts;
     private int _shortcutGeneration;
 
@@ -409,6 +421,9 @@
                 // next open retries.
                 Logger.LogWarning("Known-shortcut list could not be read; showing no warning.");
                 _shortcutWarning = null;
+                // A list that will not load has still finished deciding, and it decides "no
+                // warning". Saying so keeps the E2E wait honest instead of hanging.
+                _shortcutChecked = HotkeyActionDisplay.ComboLabel(Item);
                 StateHasChanged();
                 return;
             }
@@ -419,6 +434,7 @@
             _shortcutWarning = match is null
                 ? null
                 : KnownShortcutWarning.TextFor(match, HotkeyActionDisplay.ComboLabel(Item));
+            _shortcutChecked = HotkeyActionDisplay.ComboLabel(Item);
 
             StateHasChanged();
         }
@@ -432,6 +448,7 @@
             if (generation == _shortcutGeneration && !_disposed)
             {
                 _shortcutWarning = null;
+                _shortcutChecked = HotkeyActionDisplay.ComboLabel(Item);
                 StateHasChanged();
             }
         }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/KnownShortcutDtos.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/KnownShortcutDtos.cs
@@ -20,3 +20,52 @@ public sealed record KnownShortcutDto(
 
 /// <summary>The whole known-shortcut list the dialog matches against.</summary>
 public sealed record KnownShortcutCatalogDto(IReadOnlyList<KnownShortcutDto> Shortcuts);
+
+/// <summary>Where a known-shortcut record came from. Client copy of the API enum.</summary>
+public enum ShortcutRecordOrigin
+{
+    /// <summary>Shipped in the curated manifest.</summary>
+    BuiltIn = 0,
+
+    /// <summary>Recorded by the owner.</summary>
+    Owner = 1,
+}
+
+/// <summary>One use as the management page needs it, with the state that page can change.</summary>
+public sealed record ManagedShortcutUseDto(
+    string UsedBy,
+    ShortcutProtection Protection,
+    ShortcutScope Scope,
+    string Does,
+    ShortcutRecordOrigin Origin,
+    Guid? OwnerRecordId,
+    bool IsIgnored);
+
+/// <summary>One combination and every use of it, ignored ones included so they can be restored.</summary>
+public sealed record ManagedKnownShortcutDto(
+    string Id,
+    string Key,
+    bool Ctrl,
+    bool Alt,
+    bool Shift,
+    bool Win,
+    IReadOnlyList<ManagedShortcutUseDto> Uses,
+    string? WarningText);
+
+/// <summary>The whole management list.</summary>
+public sealed record ManagedKnownShortcutCatalogDto(IReadOnlyList<ManagedKnownShortcutDto> Shortcuts);
+
+/// <summary>An owner's new record of something that uses a combination.</summary>
+public sealed record CreateCustomKnownShortcutDto(
+    string Key,
+    bool Ctrl,
+    bool Alt,
+    bool Shift,
+    bool Win,
+    string UsedBy,
+    ShortcutScope Scope,
+    string Does,
+    ShortcutProtection Protection = ShortcutProtection.Unknown);
+
+/// <summary>Names one built-in use to silence or bring back.</summary>
+public sealed record KnownShortcutUseRefDto(string ShortcutId, string UsedBy);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/HotkeyActionDisplay.cs
@@ -111,7 +111,11 @@ internal static class HotkeyActionDisplay
     public static string ComboLabel(DeletedHotkeyDto dto) =>
         ComboLabel(dto.Key, dto.Ctrl, dto.Alt, dto.Shift, dto.Win);
 
-    private static string ComboLabel(string key, bool ctrl, bool alt, bool shift, bool win)
+    /// <summary>
+    /// Combo label from loose parts — see <see cref="ComboLabel(HotkeyEditModel)"/>. Used by the
+    /// known-shortcuts page, whose rows are catalog records rather than hotkeys.
+    /// </summary>
+    public static string ComboLabel(string key, bool ctrl, bool alt, bool shift, bool win)
     {
         List<string> parts = [];
         if (ctrl) parts.Add("Ctrl");

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Layout/NavMenu.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Layout/NavMenu.razor
@@ -23,6 +23,10 @@
                 Icon="@Icons.Material.Filled.Label">
         Categories
     </MudNavLink>
+    <MudNavLink Href="known-shortcuts"
+                Icon="@Icons.Material.Filled.KeyboardAlt">
+        Known shortcuts
+    </MudNavLink>
     <MudNavLink Href="recycle-bin"
                 Icon="@Icons.Material.Filled.RestoreFromTrash">
         Recycle Bin

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
@@ -1,0 +1,318 @@
+﻿@page "/known-shortcuts"
+@using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Helpers
+@using AHKFlowApp.UI.Blazor.Services
+@using MudBlazor
+@implements IDisposable
+
+<PageTitle>Known shortcuts</PageTitle>
+
+<MudText Typo="Typo.h4" GutterBottom="true">Known shortcuts</MudText>
+
+<MudText Typo="Typo.body2" Class="mb-3">
+    These are the shortcuts AHKFlow warns you about when you pick the same keys for a hotkey.
+    Add the ones your own programs use. Silence any warning you do not want.
+</MudText>
+
+<MudPaper Class="pa-4">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap" Class="mb-4">
+        <MudButton Class="add-known-shortcut" Variant="Variant.Filled" Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.Add" OnClick="StartAdd" Disabled="@_adding">
+            Add
+        </MudButton>
+        <MudButton Class="reload-known-shortcuts" Variant="Variant.Filled" Color="Color.Secondary"
+                   StartIcon="@Icons.Material.Filled.Refresh" OnClick="ReloadAsync" Disabled="@_loading">
+            Reload
+        </MudButton>
+        <MudTextField T="string" @bind-Value="_search" Immediate="true" Clearable="true"
+                      Placeholder="Search" Adornment="Adornment.Start"
+                      AdornmentIcon="@Icons.Material.Filled.Search"
+                      UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "known-shortcut-search" })" />
+    </MudStack>
+
+    @if (_adding)
+    {
+        <MudPaper Class="pa-4 mb-4" Outlined="true">
+            <MudText Typo="Typo.subtitle1" GutterBottom="true">Record a shortcut you know about</MudText>
+            <MudStack Spacing="3">
+                <KeyPicker Role="HotkeyKey" Label="Key"
+                           Value="@_draft.Key" ValueChanged="@(v => _draft.Key = v ?? "")"
+                           HelperText="Pick a key, or type a vk/sc code such as vk1B."
+                           DataTest="known-shortcut-key-picker" />
+                <MudStack Row="true" Spacing="2">
+                    <MudCheckBox @bind-Value="_draft.Ctrl" T="bool" Label="Ctrl"
+                                 UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "ctrl-checkbox" })" />
+                    <MudCheckBox @bind-Value="_draft.Alt" T="bool" Label="Alt"
+                                 UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "alt-checkbox" })" />
+                    <MudCheckBox @bind-Value="_draft.Shift" T="bool" Label="Shift"
+                                 UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "shift-checkbox" })" />
+                    <MudCheckBox @bind-Value="_draft.Win" T="bool" Label="Win"
+                                 UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "win-checkbox" })" />
+                </MudStack>
+                <MudTextField @bind-Value="_draft.UsedBy" Label="Used by" MaxLength="60" Immediate="true"
+                              HelperText="What uses these keys, for example Visual Studio."
+                              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "known-shortcut-usedby-input" })" />
+                <MudTextField @bind-Value="_draft.Does" Label="What it does" MaxLength="200" Immediate="true"
+                              HelperText="Start with a lowercase verb, for example open the settings window."
+                              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "known-shortcut-does-input" })" />
+                <MudSelect @bind-Value="_draft.Scope" T="ShortcutScope" Label="Where it applies"
+                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "known-shortcut-scope-select" })">
+                    <MudSelectItem Value="@ShortcutScope.Foreground">Only while that program is in front</MudSelectItem>
+                    <MudSelectItem Value="@ShortcutScope.Global">Anywhere in Windows</MudSelectItem>
+                </MudSelect>
+                @if (_formError is not null)
+                {
+                    <MudAlert Severity="Severity.Error" Class="mb-2">@_formError</MudAlert>
+                }
+                <MudStack Row="true" Spacing="2">
+                    <MudButton Class="commit-edit" Variant="Variant.Filled" Color="Color.Primary"
+                               OnClick="CommitAddAsync" Disabled="@_saving">
+                        Save
+                    </MudButton>
+                    <MudButton Class="cancel-edit" Variant="Variant.Text" OnClick="CancelAdd" Disabled="@_saving">
+                        Cancel
+                    </MudButton>
+                </MudStack>
+            </MudStack>
+        </MudPaper>
+    }
+
+    <MudTable T="UseRow" Items="_rows" Filter="MatchesSearch" Dense="true" Hover="true" Loading="_loading">
+        <HeaderContent>
+            <MudTh>Combination</MudTh>
+            <MudTh>Used by</MudTh>
+            <MudTh>What it does</MudTh>
+            <MudTh>Where it applies</MudTh>
+            <MudTh>Source</MudTh>
+            <MudTh Style="width:120px">Actions</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            @* One row per use, never per combination: a browser combination holds a Chrome use
+               and an Edge use, and each is silenced on its own. The Combination cell repeats. *@
+            <MudTd DataLabel="Combination">
+                <span data-test="known-shortcut-row"
+                      data-shortcut-id="@context.ShortcutId"
+                      data-used-by="@context.Use.UsedBy">@context.ComboLabel</span>
+            </MudTd>
+            <MudTd DataLabel="Used by">@context.Use.UsedBy</MudTd>
+            <MudTd DataLabel="What it does">@context.Use.Does</MudTd>
+            <MudTd DataLabel="Where it applies">@ScopeLabel(context.Use.Scope)</MudTd>
+            <MudTd DataLabel="Source">
+                @if (context.Use.IsIgnored)
+                {
+                    <MudChip T="string" Size="Size.Small" Color="Color.Default">Silenced</MudChip>
+                }
+                else
+                {
+                    <MudChip T="string" Size="Size.Small"
+                             Color="@(context.Use.Origin == ShortcutRecordOrigin.Owner ? Color.Primary : Color.Default)">
+                        @(context.Use.Origin == ShortcutRecordOrigin.Owner ? "Yours" : "Built in")
+                    </MudChip>
+                }
+            </MudTd>
+            <MudTd DataLabel="Actions">
+                @if (context.Use.Origin == ShortcutRecordOrigin.Owner)
+                {
+                    <MudIconButton Class="delete-use" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
+                                   OnClick="() => DeleteAsync(context)"
+                                   UserAttributes='@UseAttributes(context, "Delete this record")' />
+                }
+                else if (context.Use.IsIgnored)
+                {
+                    <MudIconButton Class="restore-use" Icon="@Icons.Material.Filled.NotificationsActive"
+                                   OnClick="() => RestoreAsync(context)"
+                                   UserAttributes='@UseAttributes(context, "Warn about this again")' />
+                }
+                else
+                {
+                    <MudIconButton Class="ignore-use" Icon="@Icons.Material.Filled.NotificationsOff"
+                                   OnClick="() => IgnoreAsync(context)"
+                                   UserAttributes='@UseAttributes(context, "Stop warning about this")' />
+                }
+            </MudTd>
+        </RowTemplate>
+        <NoRecordsContent>
+            @if (_loadError is not null)
+            {
+                <MudAlert Severity="Severity.Error">@_loadError</MudAlert>
+            }
+            else
+            {
+                <MudText>No known shortcuts.</MudText>
+            }
+        </NoRecordsContent>
+        <PagerContent>
+            <MudTablePager PageSizeOptions="@(new[] { 25, 50, 100 })" />
+        </PagerContent>
+    </MudTable>
+</MudPaper>
+
+@code {
+    [Inject] private IKnownShortcutsApiClient Api { get; set; } = default!;
+    [Inject] private IKnownShortcutCatalog Catalog { get; set; } = default!;
+    [Inject] private ISnackbar Snackbar { get; set; } = default!;
+
+    /// <summary>One use, flattened out of its combination so MudTable stays one row per item.</summary>
+    private sealed record UseRow(string ShortcutId, string ComboLabel, ManagedShortcutUseDto Use);
+
+    private sealed class DraftModel
+    {
+        public string Key { get; set; } = "";
+        public bool Ctrl { get; set; }
+        public bool Alt { get; set; }
+        public bool Shift { get; set; }
+        public bool Win { get; set; }
+        public string UsedBy { get; set; } = "";
+        public string Does { get; set; } = "";
+        public ShortcutScope Scope { get; set; } = ShortcutScope.Foreground;
+
+        public CreateCustomKnownShortcutDto ToDto() =>
+            new(Key, Ctrl, Alt, Shift, Win, UsedBy, Scope, Does);
+    }
+
+    private List<UseRow> _rows = [];
+    private DraftModel _draft = new();
+    private string? _search;
+    private string? _loadError;
+    private string? _formError;
+    private bool _adding;
+    private bool _loading;
+    private bool _saving;
+    private readonly CancellationTokenSource _cts = new();
+
+    protected override Task OnInitializedAsync() => LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        _loadError = null;
+
+        ApiResult<ManagedKnownShortcutCatalogDto> result = await Api.ListManagedAsync(_cts.Token);
+
+        _loading = false;
+
+        if (!result.IsSuccess)
+        {
+            _loadError = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+            _rows = [];
+            return;
+        }
+
+        Flatten(result.Value!);
+    }
+
+    private Task ReloadAsync() => LoadAsync();
+
+    private void Flatten(ManagedKnownShortcutCatalogDto catalog) =>
+        _rows =
+        [
+            .. catalog.Shortcuts
+                .SelectMany(s => s.Uses.Select(u => new UseRow(
+                    s.Id,
+                    HotkeyActionDisplay.ComboLabel(s.Key, s.Ctrl, s.Alt, s.Shift, s.Win),
+                    u)))
+                .OrderBy(r => r.ComboLabel, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(r => r.Use.UsedBy, StringComparer.OrdinalIgnoreCase)
+        ];
+
+    private bool MatchesSearch(UseRow row)
+    {
+        if (string.IsNullOrWhiteSpace(_search))
+            return true;
+
+        string term = _search.Trim();
+        return row.ComboLabel.Contains(term, StringComparison.OrdinalIgnoreCase)
+            || row.Use.UsedBy.Contains(term, StringComparison.OrdinalIgnoreCase)
+            || row.Use.Does.Contains(term, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ScopeLabel(ShortcutScope scope) =>
+        scope == ShortcutScope.Global ? "Anywhere" : "Only in front";
+
+    // Every action button carries the pair that names its use, so a selector can tell the Chrome
+    // row from the Edge row on the same combination. Tooltip text rides along as a plain title
+    // attribute: MudIconButton has no Title parameter.
+    private static Dictionary<string, object?> UseAttributes(UseRow row, string title) => new()
+    {
+        ["data-shortcut-id"] = row.ShortcutId,
+        ["data-used-by"] = row.Use.UsedBy,
+        ["title"] = title,
+    };
+
+    private void StartAdd()
+    {
+        _draft = new DraftModel();
+        _formError = null;
+        _adding = true;
+    }
+
+    private void CancelAdd()
+    {
+        _adding = false;
+        _formError = null;
+    }
+
+    private async Task CommitAddAsync()
+    {
+        _saving = true;
+        _formError = null;
+
+        ApiResult<ManagedKnownShortcutCatalogDto> result = await Api.CreateAsync(_draft.ToDto(), _cts.Token);
+
+        _saving = false;
+
+        if (!result.IsSuccess)
+        {
+            // The form stays open, holding what was typed, so the message can be acted on.
+            _formError = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+            return;
+        }
+
+        _adding = false;
+        Snackbar.Add("Shortcut recorded.", Severity.Success);
+
+        // Create returns the whole merged list, so this one needs no extra round trip.
+        Flatten(result.Value!);
+        Catalog.Invalidate();
+    }
+
+    private async Task DeleteAsync(UseRow row)
+    {
+        if (row.Use.OwnerRecordId is not Guid recordId)
+            return;
+
+        ApiResult result = await Api.DeleteAsync(recordId, _cts.Token);
+        await AfterMutationAsync(result, "Record deleted.");
+    }
+
+    private async Task IgnoreAsync(UseRow row)
+    {
+        ApiResult result = await Api.IgnoreAsync(row.ShortcutId, row.Use.UsedBy, _cts.Token);
+        await AfterMutationAsync(result, "Warning silenced.");
+    }
+
+    private async Task RestoreAsync(UseRow row)
+    {
+        ApiResult result = await Api.RestoreAsync(row.ShortcutId, row.Use.UsedBy, _cts.Token);
+        await AfterMutationAsync(result, "Warning turned back on.");
+    }
+
+    // These three routes answer 204 with no body, so the page holds no fresh state and reloads.
+    // The dialog holds its own cached copy, so it is invalidated here too — reloading _rows
+    // refreshes this page only. A failed call invalidates nothing: throwing the cache away would
+    // cost a refetch for no reason and hide the failure behind a slow dialog.
+    private async Task AfterMutationAsync(ApiResult result, string successMessage)
+    {
+        if (!result.IsSuccess)
+        {
+            Snackbar.Add(ApiErrorMessageFactory.Build(result.Status, result.Problem), Severity.Error);
+            return;
+        }
+
+        Snackbar.Add(successMessage, Severity.Success);
+        Catalog.Invalidate();
+        await LoadAsync();
+    }
+
+    public void Dispose() { _cts.Cancel(); _cts.Dispose(); }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/ApiClientBase.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/ApiClientBase.cs
@@ -26,11 +26,15 @@ public abstract class ApiClientBase(HttpClient httpClient)
         catch (HttpRequestException) { return ApiResult<T>.Failure(ApiResultStatus.NetworkError, null); }
     }
 
-    protected async Task<ApiResult> SendNoContentAsync(HttpMethod method, string path, CancellationToken ct)
+    protected Task<ApiResult> SendNoContentAsync(HttpMethod method, string path, CancellationToken ct) =>
+        SendNoContentAsync(method, path, content: null, ct);
+
+    protected async Task<ApiResult> SendNoContentAsync(
+        HttpMethod method, string path, HttpContent? content, CancellationToken ct)
     {
         try
         {
-            using var req = new HttpRequestMessage(method, path);
+            using var req = new HttpRequestMessage(method, path) { Content = content };
             using HttpResponseMessage resp = await HttpClient.SendAsync(req, ct);
             if (resp.StatusCode == HttpStatusCode.NoContent) return ApiResult.Ok();
             ApiProblemDetails? problem = await TryReadProblem(resp, ct);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/IKnownShortcutCatalog.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/IKnownShortcutCatalog.cs
@@ -13,4 +13,11 @@ public interface IKnownShortcutCatalog
     /// failed — the caller shows no warning, and the next call tries again.
     /// </summary>
     ValueTask<KnownShortcutCatalogDto?> GetAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Throws the cached catalog away, so the next <see cref="GetAsync"/> fetches again. Called
+    /// after an owner creates, deletes, ignores, or restores — each one changes what the dialog
+    /// should say, and a stale catalog would warn about a use the owner just silenced.
+    /// </summary>
+    void Invalidate();
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/IKnownShortcutsApiClient.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/IKnownShortcutsApiClient.cs
@@ -2,9 +2,25 @@ using AHKFlowApp.UI.Blazor.DTOs;
 
 namespace AHKFlowApp.UI.Blazor.Services;
 
-/// <summary>Reads the curated list of shortcuts something outside AHKFlow already uses.</summary>
+/// <summary>Reads the list of shortcuts something outside AHKFlow already uses, and edits the owner's part of it.</summary>
 public interface IKnownShortcutsApiClient
 {
-    /// <summary>Every known shortcut the dialog may warn about.</summary>
+    /// <summary>Every known shortcut the dialog may warn about. Ignored uses are left out.</summary>
     Task<ApiResult<KnownShortcutCatalogDto>> ListAsync(CancellationToken ct = default);
+
+    /// <summary>Every known shortcut for the management page, ignored uses included.</summary>
+    Task<ApiResult<ManagedKnownShortcutCatalogDto>> ListManagedAsync(CancellationToken ct = default);
+
+    /// <summary>Records something the owner knows uses a combination. Returns the whole merged list.</summary>
+    Task<ApiResult<ManagedKnownShortcutCatalogDto>> CreateAsync(
+        CreateCustomKnownShortcutDto input, CancellationToken ct = default);
+
+    /// <summary>Removes one of the owner's own records.</summary>
+    Task<ApiResult> DeleteAsync(Guid id, CancellationToken ct = default);
+
+    /// <summary>Stops warning about one built-in use. Other uses of the same keys still warn.</summary>
+    Task<ApiResult> IgnoreAsync(string shortcutId, string usedBy, CancellationToken ct = default);
+
+    /// <summary>Warns about a built-in use again.</summary>
+    Task<ApiResult> RestoreAsync(string shortcutId, string usedBy, CancellationToken ct = default);
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/KnownShortcutCatalog.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/KnownShortcutCatalog.cs
@@ -8,10 +8,20 @@ public sealed class KnownShortcutCatalog(IKnownShortcutsApiClient api) : IKnownS
     private readonly SemaphoreSlim _gate = new(1, 1);
     private KnownShortcutCatalogDto? _catalog;
 
+    // Bumped by Invalidate. A fetch that started before the bump must not write its result back:
+    // it read the server before the mutation, so caching it would undo the invalidation.
+    private int _generation;
+
+    public void Invalidate()
+    {
+        _catalog = null;
+        _generation++;
+    }
+
     public async ValueTask<KnownShortcutCatalogDto?> GetAsync(CancellationToken ct = default)
     {
-        // Fast path, no gate: _catalog is written once and never mutated, and WASM's single
-        // thread cannot tear the read.
+        // Fast path, no gate: the field holds a whole immutable catalog, and WASM's single thread
+        // cannot tear the read. Invalidate only ever replaces the reference with null.
         if (_catalog is not null)
             return _catalog;
 
@@ -22,16 +32,20 @@ public sealed class KnownShortcutCatalog(IKnownShortcutsApiClient api) : IKnownS
             if (_catalog is not null)
                 return _catalog;
 
+            int generation = _generation;
             ApiResult<KnownShortcutCatalogDto> result = await api.ListAsync(ct);
 
             // Assign only on success. Caching a failure would silence every warning for the rest
             // of the session, even after the server recovers — the trap HotkeyKeyCatalog
             // documents on EnsureCatalogAsync. Leaving _catalog null makes the next dialog open
             // retry.
-            if (result.IsSuccess)
+            // Assign only if nothing invalidated while the request was in flight, too. The caller
+            // still gets this response — it is the freshest thing anyone has — it just does not
+            // become the cached one.
+            if (result.IsSuccess && generation == _generation)
                 _catalog = result.Value;
 
-            return _catalog;
+            return result.IsSuccess ? result.Value : _catalog;
         }
         finally
         {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/KnownShortcutsApiClient.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/KnownShortcutsApiClient.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Json;
 using AHKFlowApp.UI.Blazor.DTOs;
 
 namespace AHKFlowApp.UI.Blazor.Services;
@@ -6,9 +7,37 @@ namespace AHKFlowApp.UI.Blazor.Services;
 public sealed class KnownShortcutsApiClient(HttpClient httpClient)
     : ApiClientBase(httpClient), IKnownShortcutsApiClient
 {
-    // Stage 1 serves the list from the hotkeys controller, beside the key registry.
-    private const string ListPath = "api/v1/hotkeys/known-shortcuts";
+    // The dialog list is served from the hotkeys controller, beside the key registry.
+    private const string DialogListPath = "api/v1/hotkeys/known-shortcuts";
+
+    // The owner's own view of the list, and their edits to it, live on their own controller.
+    private const string BasePath = "api/v1/knownshortcuts";
 
     public Task<ApiResult<KnownShortcutCatalogDto>> ListAsync(CancellationToken ct = default) =>
-        SendAsync<KnownShortcutCatalogDto>(HttpMethod.Get, ListPath, content: null, ct);
+        SendAsync<KnownShortcutCatalogDto>(HttpMethod.Get, DialogListPath, content: null, ct);
+
+    public Task<ApiResult<ManagedKnownShortcutCatalogDto>> ListManagedAsync(CancellationToken ct = default) =>
+        SendAsync<ManagedKnownShortcutCatalogDto>(HttpMethod.Get, BasePath, content: null, ct);
+
+    public Task<ApiResult<ManagedKnownShortcutCatalogDto>> CreateAsync(
+        CreateCustomKnownShortcutDto input, CancellationToken ct = default) =>
+        SendAsync<ManagedKnownShortcutCatalogDto>(
+            HttpMethod.Post, BasePath, JsonContent.Create(input), ct);
+
+    public Task<ApiResult> DeleteAsync(Guid id, CancellationToken ct = default) =>
+        SendNoContentAsync(HttpMethod.Delete, $"{BasePath}/{id}", ct);
+
+    public Task<ApiResult> IgnoreAsync(string shortcutId, string usedBy, CancellationToken ct = default) =>
+        SendNoContentAsync(
+            HttpMethod.Post,
+            $"{BasePath}/ignore",
+            JsonContent.Create(new KnownShortcutUseRefDto(shortcutId, usedBy)),
+            ct);
+
+    public Task<ApiResult> RestoreAsync(string shortcutId, string usedBy, CancellationToken ct = default) =>
+        SendNoContentAsync(
+            HttpMethod.Post,
+            $"{BasePath}/restore",
+            JsonContent.Create(new KnownShortcutUseRefDto(shortcutId, usedBy)),
+            ct);
 }

--- a/tests/AHKFlowApp.API.Tests/Hotkeys/KnownShortcutsEndpointTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Hotkeys/KnownShortcutsEndpointTests.cs
@@ -53,6 +53,24 @@ public sealed class KnownShortcutsEndpointTests(ApiTestFixture fixture)
     }
 
     [Fact]
+    public async Task GetKnownShortcuts_BrowserRowCarriesTwoForegroundUses()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+
+        KnownShortcutCatalogDto? catalog =
+            await client.GetFromJsonAsync<KnownShortcutCatalogDto>("/api/v1/hotkeys/known-shortcuts");
+
+        KnownShortcutDto newWindow = catalog!.Shortcuts.Single(s => s.Id == "browser.new-window");
+        newWindow.Key.Should().Be("n");
+        newWindow.Ctrl.Should().BeTrue();
+        newWindow.Win.Should().BeFalse();
+
+        newWindow.Uses.Select(u => u.UsedBy).Should().BeEquivalentTo(["Chrome", "Edge"]);
+        newWindow.Uses.Should().OnlyContain(u => u.Scope == ShortcutScope.Foreground);
+        newWindow.Uses.Should().OnlyContain(u => u.Does == "open a new window");
+    }
+
+    [Fact]
     public async Task GetKnownShortcuts_ProtectedRowIsMarkedProtected()
     {
         HttpClient client = _factory.CreateAuthenticatedClient();

--- a/tests/AHKFlowApp.API.Tests/KnownShortcuts/KnownShortcutsControllerTests.cs
+++ b/tests/AHKFlowApp.API.Tests/KnownShortcuts/KnownShortcutsControllerTests.cs
@@ -278,6 +278,45 @@ public sealed class KnownShortcutsControllerTests(ApiTestFixture fixture)
     }
 
     [Fact]
+    public async Task Restore_ByAnotherOwner_LeavesTheFirstOwnersIgnoreInPlace()
+    {
+        using HttpClient owner = CreateAuthed();
+        using HttpClient stranger = CreateAuthed();
+        await owner.PostAsJsonAsync(
+            "/api/v1/knownshortcuts/ignore", new KnownShortcutUseRefDto(ExplorerId, "Windows"));
+
+        HttpResponseMessage response = await stranger.PostAsJsonAsync(
+            "/api/v1/knownshortcuts/restore", new KnownShortcutUseRefDto(ExplorerId, "Windows"));
+
+        // The stranger owns no ignore row, so restore is a no-op success for them.
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        ManagedKnownShortcutCatalogDto? catalog =
+            await owner.GetFromJsonAsync<ManagedKnownShortcutCatalogDto>("/api/v1/knownshortcuts");
+        catalog!.Shortcuts.Single(s => s.Id == ExplorerId).Uses.Single().IsIgnored.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Restore_SentConcurrently_AllSucceed()
+    {
+        using HttpClient client = CreateAuthed();
+        await client.PostAsJsonAsync(
+            "/api/v1/knownshortcuts/ignore", new KnownShortcutUseRefDto(ExplorerId, "Windows"));
+
+        // Several requests read the same ignore row, then all try to delete it. Only one delete
+        // affects a row; the rest must still report success instead of a 500.
+        HttpResponseMessage[] responses = await Task.WhenAll(
+            Enumerable.Range(0, 8).Select(_ => client.PostAsJsonAsync(
+                "/api/v1/knownshortcuts/restore", new KnownShortcutUseRefDto(ExplorerId, "Windows"))));
+
+        responses.Should().OnlyContain(r => r.StatusCode == HttpStatusCode.NoContent);
+
+        ManagedKnownShortcutCatalogDto? catalog =
+            await client.GetFromJsonAsync<ManagedKnownShortcutCatalogDto>("/api/v1/knownshortcuts");
+        catalog!.Shortcuts.Single(s => s.Id == ExplorerId).Uses.Single().IsIgnored.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task Ignore_SentConcurrently_AllSucceedAndWriteOneRow()
     {
         using HttpClient client = CreateAuthed();

--- a/tests/AHKFlowApp.API.Tests/KnownShortcuts/KnownShortcutsControllerTests.cs
+++ b/tests/AHKFlowApp.API.Tests/KnownShortcuts/KnownShortcutsControllerTests.cs
@@ -1,0 +1,299 @@
+using System.Net;
+using System.Net.Http.Json;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Enums;
+using AHKFlowApp.TestUtilities.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.API.Tests.KnownShortcuts;
+
+[Collection("WebApi")]
+public sealed class KnownShortcutsControllerTests(ApiTestFixture fixture)
+{
+    private const string ExplorerId = "windows.file-explorer";
+
+    private readonly CustomWebApplicationFactory _factory = fixture.Factory;
+
+    private HttpClient CreateAuthed(Guid? oid = null) =>
+        _factory.CreateAuthenticatedClient(b => b.WithOid(oid ?? Guid.NewGuid()));
+
+    private static CreateCustomKnownShortcutDto NewRecord(
+        string key = "F7",
+        bool ctrl = true,
+        string usedBy = "My notes tool",
+        string does = "open my notes",
+        ShortcutProtection protection = ShortcutProtection.Unknown) =>
+        new(key, ctrl, Alt: false, Shift: false, Win: false,
+            usedBy, ShortcutScope.Foreground, does, protection);
+
+    [Fact]
+    public async Task List_WithoutAuth_IsRefused()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/knownshortcuts");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task List_WithAuth_ReturnsTheManifestPlusOwnerRows()
+    {
+        using HttpClient client = CreateAuthed();
+
+        ManagedKnownShortcutCatalogDto? before =
+            await client.GetFromJsonAsync<ManagedKnownShortcutCatalogDto>("/api/v1/knownshortcuts");
+
+        await client.PostAsJsonAsync("/api/v1/knownshortcuts", NewRecord());
+
+        ManagedKnownShortcutCatalogDto? after =
+            await client.GetFromJsonAsync<ManagedKnownShortcutCatalogDto>("/api/v1/knownshortcuts");
+
+        before!.Shortcuts.Should().NotBeEmpty();
+        after!.Shortcuts.Should().HaveCount(before.Shortcuts.Count + 1);
+    }
+
+    [Fact]
+    public async Task Create_ValidRecord_ReturnsTheMergedListContainingTheNewUse()
+    {
+        using HttpClient client = CreateAuthed();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/v1/knownshortcuts", NewRecord());
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        ManagedKnownShortcutCatalogDto? catalog =
+            await response.Content.ReadFromJsonAsync<ManagedKnownShortcutCatalogDto>();
+
+        ManagedShortcutUseDto use = catalog!.Shortcuts
+            .SelectMany(s => s.Uses)
+            .Single(u => u.UsedBy == "My notes tool");
+
+        use.Origin.Should().Be(ShortcutRecordOrigin.Owner);
+        use.OwnerRecordId.Should().NotBeNull();
+        use.Does.Should().Be("open my notes");
+    }
+
+    [Fact]
+    public async Task Create_SameCombinationAndUsedByTwice_IsAConflict()
+    {
+        using HttpClient client = CreateAuthed();
+
+        await client.PostAsJsonAsync("/api/v1/knownshortcuts", NewRecord());
+        HttpResponseMessage second = await client.PostAsJsonAsync("/api/v1/knownshortcuts", NewRecord());
+
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Create_ClaimingProtected_IsRejected()
+    {
+        using HttpClient client = CreateAuthed();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/v1/knownshortcuts", NewRecord(protection: ShortcutProtection.Protected));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should()
+            .Contain("Only built-in records can say Windows handles the keys itself.");
+    }
+
+    [Fact]
+    public async Task Create_UnknownKey_IsRejected()
+    {
+        using HttpClient client = CreateAuthed();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/v1/knownshortcuts", NewRecord(key: "NotAKey"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Create_SentConcurrently_YieldsOneCreatedAndTheRestConflict()
+    {
+        // A sequential duplicate never reaches the handler's catch: the AnyAsync check returns
+        // first. Only overlapping requests can, and the invariant asserted here — never a 500,
+        // never a second row — is what the race guard exists for.
+        using HttpClient client = CreateAuthed();
+
+        HttpResponseMessage[] responses = await Task.WhenAll(
+            Enumerable.Range(0, 4).Select(_ =>
+                client.PostAsJsonAsync("/api/v1/knownshortcuts", NewRecord())));
+
+        responses.Count(r => r.StatusCode == HttpStatusCode.OK).Should().Be(1);
+        responses.Count(r => r.StatusCode == HttpStatusCode.Conflict).Should().Be(3);
+
+        ManagedKnownShortcutCatalogDto? catalog =
+            await client.GetFromJsonAsync<ManagedKnownShortcutCatalogDto>("/api/v1/knownshortcuts");
+        catalog!.Shortcuts.SelectMany(s => s.Uses)
+            .Count(u => u.UsedBy == "My notes tool").Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Delete_OwnRecord_Returns204AndRemovesIt()
+    {
+        using HttpClient client = CreateAuthed();
+
+        HttpResponseMessage created = await client.PostAsJsonAsync("/api/v1/knownshortcuts", NewRecord());
+        ManagedKnownShortcutCatalogDto? catalog =
+            await created.Content.ReadFromJsonAsync<ManagedKnownShortcutCatalogDto>();
+        Guid recordId = catalog!.Shortcuts.SelectMany(s => s.Uses)
+            .Single(u => u.UsedBy == "My notes tool").OwnerRecordId!.Value;
+
+        HttpResponseMessage response = await client.DeleteAsync($"/api/v1/knownshortcuts/{recordId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        ManagedKnownShortcutCatalogDto? after =
+            await client.GetFromJsonAsync<ManagedKnownShortcutCatalogDto>("/api/v1/knownshortcuts");
+        after!.Shortcuts.SelectMany(s => s.Uses).Should().NotContain(u => u.UsedBy == "My notes tool");
+    }
+
+    [Fact]
+    public async Task Delete_AnotherOwnersRecord_IsNotFound()
+    {
+        using HttpClient ownerA = CreateAuthed();
+        using HttpClient ownerB = CreateAuthed();
+
+        HttpResponseMessage created = await ownerA.PostAsJsonAsync("/api/v1/knownshortcuts", NewRecord());
+        ManagedKnownShortcutCatalogDto? catalog =
+            await created.Content.ReadFromJsonAsync<ManagedKnownShortcutCatalogDto>();
+        Guid recordId = catalog!.Shortcuts.SelectMany(s => s.Uses)
+            .Single(u => u.UsedBy == "My notes tool").OwnerRecordId!.Value;
+
+        HttpResponseMessage response = await ownerB.DeleteAsync($"/api/v1/knownshortcuts/{recordId}");
+
+        // Not 403: a different status would confirm the record exists.
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task List_AsAnotherOwner_DoesNotShowTheFirstOwnersRecords()
+    {
+        using HttpClient ownerA = CreateAuthed();
+        using HttpClient ownerB = CreateAuthed();
+
+        await ownerA.PostAsJsonAsync("/api/v1/knownshortcuts", NewRecord(usedBy: "Owner A tool"));
+
+        ManagedKnownShortcutCatalogDto? catalog =
+            await ownerB.GetFromJsonAsync<ManagedKnownShortcutCatalogDto>("/api/v1/knownshortcuts");
+
+        catalog!.Shortcuts.SelectMany(s => s.Uses).Should().NotContain(u => u.UsedBy == "Owner A tool");
+    }
+
+    [Fact]
+    public async Task Ignore_ThenList_StillShowsTheUseAsIgnored()
+    {
+        using HttpClient client = CreateAuthed();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/v1/knownshortcuts/ignore", new KnownShortcutUseRefDto(ExplorerId, "Windows"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        ManagedKnownShortcutCatalogDto? catalog =
+            await client.GetFromJsonAsync<ManagedKnownShortcutCatalogDto>("/api/v1/knownshortcuts");
+        catalog!.Shortcuts.Single(s => s.Id == ExplorerId).Uses.Single().IsIgnored.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Ignore_ThenReadTheDialogList_DropsTheUse()
+    {
+        using HttpClient client = CreateAuthed();
+
+        await client.PostAsJsonAsync(
+            "/api/v1/knownshortcuts/ignore", new KnownShortcutUseRefDto(ExplorerId, "Windows"));
+
+        KnownShortcutCatalogDto? dialog =
+            await client.GetFromJsonAsync<KnownShortcutCatalogDto>("/api/v1/hotkeys/known-shortcuts");
+
+        dialog!.Shortcuts.Should().NotContain(s => s.Id == ExplorerId);
+    }
+
+    [Fact]
+    public async Task Ignore_OneBrowserUse_LeavesTheOtherBrowserWarning()
+    {
+        using HttpClient client = CreateAuthed();
+
+        await client.PostAsJsonAsync(
+            "/api/v1/knownshortcuts/ignore", new KnownShortcutUseRefDto("browser.new-window", "Chrome"));
+
+        KnownShortcutCatalogDto? dialog =
+            await client.GetFromJsonAsync<KnownShortcutCatalogDto>("/api/v1/hotkeys/known-shortcuts");
+
+        dialog!.Shortcuts.Single(s => s.Id == "browser.new-window")
+            .Uses.Select(u => u.UsedBy).Should().BeEquivalentTo(["Edge"]);
+    }
+
+    [Fact]
+    public async Task Restore_MakesTheUseActiveAgain()
+    {
+        using HttpClient client = CreateAuthed();
+        await client.PostAsJsonAsync(
+            "/api/v1/knownshortcuts/ignore", new KnownShortcutUseRefDto(ExplorerId, "Windows"));
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/v1/knownshortcuts/restore", new KnownShortcutUseRefDto(ExplorerId, "Windows"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        ManagedKnownShortcutCatalogDto? catalog =
+            await client.GetFromJsonAsync<ManagedKnownShortcutCatalogDto>("/api/v1/knownshortcuts");
+        catalog!.Shortcuts.Single(s => s.Id == ExplorerId).Uses.Single().IsIgnored.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Restore_WhenNothingWasIgnored_IsStillNoContent()
+    {
+        using HttpClient client = CreateAuthed();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/v1/knownshortcuts/restore", new KnownShortcutUseRefDto(ExplorerId, "Windows"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Ignore_UnknownShortcutId_IsNotFound()
+    {
+        using HttpClient client = CreateAuthed();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/v1/knownshortcuts/ignore",
+            new KnownShortcutUseRefDto("windows.retired-in-a-later-release", "Windows"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Ignore_UnknownUseOnAKnownShortcut_IsNotFound()
+    {
+        using HttpClient client = CreateAuthed();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/v1/knownshortcuts/ignore", new KnownShortcutUseRefDto(ExplorerId, "Chrome"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Ignore_SentConcurrently_AllSucceedAndWriteOneRow()
+    {
+        using HttpClient client = CreateAuthed();
+
+        HttpResponseMessage[] responses = await Task.WhenAll(
+            Enumerable.Range(0, 4).Select(_ => client.PostAsJsonAsync(
+                "/api/v1/knownshortcuts/ignore", new KnownShortcutUseRefDto(ExplorerId, "Windows"))));
+
+        responses.Should().OnlyContain(r => r.StatusCode == HttpStatusCode.NoContent);
+
+        // One row: a second would survive the restore below and leave the use silenced.
+        await client.PostAsJsonAsync(
+            "/api/v1/knownshortcuts/restore", new KnownShortcutUseRefDto(ExplorerId, "Windows"));
+
+        ManagedKnownShortcutCatalogDto? catalog =
+            await client.GetFromJsonAsync<ManagedKnownShortcutCatalogDto>("/api/v1/knownshortcuts");
+        catalog!.Shortcuts.Single(s => s.Id == ExplorerId).Uses.Single().IsIgnored.Should().BeFalse();
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Constants/KnownShortcutCatalogTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Constants/KnownShortcutCatalogTests.cs
@@ -157,16 +157,16 @@ public sealed class KnownShortcutCatalogTests
     [Fact]
     public void Manifest_TextMakesNoAbsoluteClaim()
     {
-        string[] banned = ["never", "will not", "cannot", "won't", "can't"];
-
+        // One rule, shared with the owner-input validator through ShortcutWording. Two copies
+        // would let the manifest ban a term the validator still accepts.
         foreach (KnownShortcut shortcut in KnownShortcutCatalog.All)
         {
-            foreach (string term in banned)
-            {
-                shortcut.WarningText?.ToLowerInvariant().Should().NotContain(term);
-                foreach (ShortcutUse use in shortcut.Uses)
-                    use.Does.ToLowerInvariant().Should().NotContain(term, $"{shortcut.Id} / {use.UsedBy}");
-            }
+            if (shortcut.WarningText is string text)
+                ShortcutWording.MakesAbsoluteClaim(text).Should().BeFalse(shortcut.Id);
+
+            foreach (ShortcutUse use in shortcut.Uses)
+                ShortcutWording.MakesAbsoluteClaim(use.Does).Should()
+                    .BeFalse($"{shortcut.Id} / {use.UsedBy}");
         }
     }
 }

--- a/tests/AHKFlowApp.Application.Tests/Constants/KnownShortcutCatalogTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Constants/KnownShortcutCatalogTests.cs
@@ -10,18 +10,18 @@ public sealed class KnownShortcutCatalogTests
     [Fact]
     public void All_HasExpectedRecordCount()
     {
-        // 67 Windows rows, per design §3. The 36 browser rows are Stage 2 — when they land,
-        // this becomes 103. Recount from the manifest then; do not guess a new number.
-        KnownShortcutCatalog.All.Should().HaveCount(67);
+        // 67 Windows rows plus 36 browser rows, per design §3.
+        KnownShortcutCatalog.All.Should().HaveCount(103);
     }
 
     [Fact]
-    public void All_ContainsOnlyWindowsRows()
+    public void All_RowIdsUseAKnownPrefix()
     {
-        // Guards the stage boundary. A browser row appearing here means Stage 2 work leaked in
-        // without the ignore mechanism that makes it tolerable.
-        KnownShortcutCatalog.All.Should()
-            .OnlyContain(s => s.Id.StartsWith("windows.", StringComparison.Ordinal));
+        // Two sources ship today. A third one gets its own prefix and its own line here, so a
+        // typo in an id cannot quietly create a source nothing else knows about.
+        KnownShortcutCatalog.All.Should().OnlyContain(s =>
+            s.Id.StartsWith("windows.", StringComparison.Ordinal) ||
+            s.Id.StartsWith("browser.", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -115,11 +115,35 @@ public sealed class KnownShortcutCatalogTests
     }
 
     [Fact]
-    public void All_RowsCarryExactlyOneUse()
+    public void Browser_RowsAreForegroundNormalAndNameBothBrowsers()
     {
-        // True only while the manifest is Windows-only. Stage 2's browser rows carry two uses
-        // each, so that plan replaces this test rather than adding rows around it.
-        KnownShortcutCatalog.All.Should().OnlyContain(s => s.Uses.Count == 1);
+        KnownShortcut[] browserRows =
+        [
+            .. KnownShortcutCatalog.All.Where(s => s.Id.StartsWith("browser.", StringComparison.Ordinal))
+        ];
+
+        browserRows.Should().HaveCount(36);
+
+        foreach (KnownShortcut shortcut in browserRows)
+        {
+            shortcut.Uses.Select(u => u.UsedBy).Should()
+                .BeEquivalentTo(["Chrome", "Edge"], $"{shortcut.Id} is documented by both");
+            shortcut.Uses.Should().OnlyContain(u => u.Scope == ShortcutScope.Foreground);
+            shortcut.Uses.Should().OnlyContain(u => u.Protection == ShortcutProtection.Normal);
+        }
+    }
+
+    [Fact]
+    public void Browser_EachUseCitesItsOwnBrowsersPage()
+    {
+        // One evidence page per use is the manifest rule. Both uses pointing at one page would
+        // mean one of the two claims is unproven.
+        foreach (KnownShortcut shortcut in KnownShortcutCatalog.All
+                     .Where(s => s.Id.StartsWith("browser.", StringComparison.Ordinal)))
+        {
+            shortcut.Uses.Single(u => u.UsedBy == "Chrome").EvidenceUrl.Should().Contain("google.com");
+            shortcut.Uses.Single(u => u.UsedBy == "Edge").EvidenceUrl.Should().Contain("microsoft.com");
+        }
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Dev/RunBeforeNthSaveDbContext.cs
+++ b/tests/AHKFlowApp.Application.Tests/Dev/RunBeforeNthSaveDbContext.cs
@@ -1,4 +1,4 @@
-using AHKFlowApp.Application.Abstractions;
+﻿using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Domain.Entities;
 using AHKFlowApp.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -25,6 +25,8 @@ internal sealed class RunBeforeNthSaveDbContext(AppDbContext inner, int runBefor
     public DbSet<HotstringCategory> HotstringCategories => inner.HotstringCategories;
     public DbSet<HotkeyCategory> HotkeyCategories => inner.HotkeyCategories;
     public DbSet<EntityHistory> EntityHistories => inner.EntityHistories;
+    public DbSet<CustomKnownShortcut> CustomKnownShortcuts => inner.CustomKnownShortcuts;
+    public DbSet<IgnoredKnownShortcut> IgnoredKnownShortcuts => inner.IgnoredKnownShortcuts;
 
     public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
     {

--- a/tests/AHKFlowApp.Application.Tests/Dev/ThrowOnNthSaveDbContext.cs
+++ b/tests/AHKFlowApp.Application.Tests/Dev/ThrowOnNthSaveDbContext.cs
@@ -1,4 +1,4 @@
-using AHKFlowApp.Application.Abstractions;
+﻿using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Domain.Entities;
 using AHKFlowApp.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -23,6 +23,8 @@ internal sealed class ThrowOnNthSaveDbContext(AppDbContext inner, int failOnCall
     public DbSet<HotstringCategory> HotstringCategories => inner.HotstringCategories;
     public DbSet<HotkeyCategory> HotkeyCategories => inner.HotkeyCategories;
     public DbSet<EntityHistory> EntityHistories => inner.EntityHistories;
+    public DbSet<CustomKnownShortcut> CustomKnownShortcuts => inner.CustomKnownShortcuts;
+    public DbSet<IgnoredKnownShortcut> IgnoredKnownShortcuts => inner.IgnoredKnownShortcuts;
 
     public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
     {

--- a/tests/AHKFlowApp.Application.Tests/History/HistorySaveRetryTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/History/HistorySaveRetryTests.cs
@@ -1,4 +1,4 @@
-using AHKFlowApp.Application.Abstractions;
+﻿using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.Common;
 using AHKFlowApp.Domain.Entities;
 using AHKFlowApp.Domain.Enums;
@@ -135,6 +135,8 @@ public sealed class HistorySaveRetryTests(HistoryDbFixture fx)
         public DbSet<HotstringCategory> HotstringCategories => inner.HotstringCategories;
         public DbSet<HotkeyCategory> HotkeyCategories => inner.HotkeyCategories;
         public DbSet<EntityHistory> EntityHistories => inner.EntityHistories;
+        public DbSet<CustomKnownShortcut> CustomKnownShortcuts => inner.CustomKnownShortcuts;
+        public DbSet<IgnoredKnownShortcut> IgnoredKnownShortcuts => inner.IgnoredKnownShortcuts;
 
         public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
         {

--- a/tests/AHKFlowApp.Application.Tests/Services/KnownShortcutMergeTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/KnownShortcutMergeTests.cs
@@ -1,0 +1,205 @@
+using AHKFlowApp.Application.Constants;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Services;
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
+using AHKFlowApp.TestUtilities.Builders;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Services;
+
+public sealed class KnownShortcutMergeTests
+{
+    private static readonly Guid Owner = Guid.NewGuid();
+
+    // The manifest count is read, never hard-coded: a catalog change must not break this file.
+    private static int ManifestCount => KnownShortcutCatalog.All.Count;
+
+    [Fact]
+    public void ForDialog_WithNoOverlay_ReturnsTheWholeManifest()
+    {
+        IReadOnlyList<KnownShortcutDto> merged = KnownShortcutMerge.ForDialog([], []);
+
+        merged.Should().HaveCount(ManifestCount);
+    }
+
+    [Fact]
+    public void ForDialog_OwnerRecordOnABuiltInCombination_AddsAUse()
+    {
+        CustomKnownShortcut owned = new CustomKnownShortcutBuilder()
+            .ForOwner(Owner)
+            .WithCombination("E", win: true)
+            .UsedBy("My notes tool")
+            .Does("open my notes")
+            .Build();
+
+        KnownShortcutDto merged = KnownShortcutMerge.ForDialog([owned], [])
+            .Single(s => s.Id == "windows.file-explorer");
+
+        merged.Uses.Select(u => u.UsedBy).Should().BeEquivalentTo(["Windows", "My notes tool"]);
+    }
+
+    [Fact]
+    public void ForDialog_OwnerRecordOnAProtectedCombination_CannotWeakenIt()
+    {
+        CustomKnownShortcut owned = new CustomKnownShortcutBuilder()
+            .ForOwner(Owner)
+            .WithCombination("L", win: true)
+            .UsedBy("My tool")
+            .WithProtection(ShortcutProtection.Unknown)
+            .Build();
+
+        KnownShortcutDto merged = KnownShortcutMerge.ForDialog([owned], [])
+            .Single(s => s.Id == "windows.lock");
+
+        merged.Uses.Should().Contain(u => u.Protection == ShortcutProtection.Protected);
+    }
+
+    [Fact]
+    public void ForDialog_IgnoringOneUse_LeavesTheOtherUsesWarning()
+    {
+        CustomKnownShortcut owned = new CustomKnownShortcutBuilder()
+            .ForOwner(Owner).WithCombination("E", win: true).UsedBy("My notes tool").Build();
+        IgnoredKnownShortcut ignore = new IgnoredKnownShortcutBuilder()
+            .ForOwner(Owner).ForShortcut("windows.file-explorer").UsedBy("Windows").Build();
+
+        KnownShortcutDto merged = KnownShortcutMerge.ForDialog([owned], [ignore])
+            .Single(s => s.Id == "windows.file-explorer");
+
+        merged.Uses.Select(u => u.UsedBy).Should().BeEquivalentTo(["My notes tool"]);
+    }
+
+    [Fact]
+    public void ForDialog_IgnoringOneBrowserUse_LeavesTheOtherBrowser()
+    {
+        // A browser combination has a Chrome use and an Edge use, silenced separately.
+        IgnoredKnownShortcut ignore = new IgnoredKnownShortcutBuilder()
+            .ForOwner(Owner).ForShortcut("browser.new-window").UsedBy("Chrome").Build();
+
+        KnownShortcutDto merged = KnownShortcutMerge.ForDialog([], [ignore])
+            .Single(s => s.Id == "browser.new-window");
+
+        merged.Uses.Select(u => u.UsedBy).Should().BeEquivalentTo(["Edge"]);
+    }
+
+    [Fact]
+    public void ForDialog_IgnoringEveryUse_DropsTheShortcutEntirely()
+    {
+        IgnoredKnownShortcut ignore = new IgnoredKnownShortcutBuilder()
+            .ForOwner(Owner).ForShortcut("windows.file-explorer").UsedBy("Windows").Build();
+
+        KnownShortcutMerge.ForDialog([], [ignore])
+            .Should().NotContain(s => s.Id == "windows.file-explorer");
+    }
+
+    [Fact]
+    public void ForDialog_IgnoreNamingAnUnknownId_IsSkipped()
+    {
+        IgnoredKnownShortcut ignore = new IgnoredKnownShortcutBuilder()
+            .ForOwner(Owner).ForShortcut("windows.retired-in-a-later-release").UsedBy("Windows").Build();
+
+        Action act = () => KnownShortcutMerge.ForDialog([], [ignore]);
+
+        act.Should().NotThrow();
+        KnownShortcutMerge.ForDialog([], [ignore]).Should().HaveCount(ManifestCount);
+    }
+
+    [Fact]
+    public void ForDialog_OwnerRecordSpellsTheKeyDifferently_StillMatchesTheBuiltIn()
+    {
+        // "Esc" canonicalizes to "Escape", so this must land on the existing Win+Escape row.
+        CustomKnownShortcut owned = new CustomKnownShortcutBuilder()
+            .ForOwner(Owner).WithCombination("Esc", win: true).UsedBy("My tool").Build();
+
+        KnownShortcutMerge.ForDialog([owned], [])
+            .Should().HaveCount(ManifestCount, "an alias spelling must not create a second row");
+    }
+
+    [Fact]
+    public void ForDialog_OwnerRecordOnANewCombination_AddsAShortcut()
+    {
+        CustomKnownShortcut owned = new CustomKnownShortcutBuilder()
+            .ForOwner(Owner).WithCombination("F7", ctrl: true, alt: true).UsedBy("My tool").Build();
+
+        KnownShortcutMerge.ForDialog([owned], []).Should().HaveCount(ManifestCount + 1);
+    }
+
+    [Fact]
+    public void ForManagement_ReturnsIgnoredUsesSoTheyCanBeRestored()
+    {
+        IgnoredKnownShortcut ignore = new IgnoredKnownShortcutBuilder()
+            .ForOwner(Owner).ForShortcut("windows.file-explorer").UsedBy("Windows").Build();
+
+        ManagedShortcutUseDto use = KnownShortcutMerge.ForManagement([], [ignore])
+            .Single(s => s.Id == "windows.file-explorer").Uses.Single();
+
+        use.IsIgnored.Should().BeTrue();
+        use.Origin.Should().Be(ShortcutRecordOrigin.BuiltIn);
+        use.OwnerRecordId.Should().BeNull();
+    }
+
+    [Fact]
+    public void ForManagement_OwnerUseCarriesItsRecordIdSoItCanBeDeleted()
+    {
+        CustomKnownShortcut owned = new CustomKnownShortcutBuilder()
+            .ForOwner(Owner).WithCombination("F7", ctrl: true).UsedBy("My tool").Build();
+
+        ManagedShortcutUseDto use = KnownShortcutMerge.ForManagement([owned], [])
+            .Single(s => s.Uses.Any(u => u.UsedBy == "My tool")).Uses.Single();
+
+        use.Origin.Should().Be(ShortcutRecordOrigin.Owner);
+        use.OwnerRecordId.Should().Be(owned.Id);
+        use.IsIgnored.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ForManagement_KeepsCanonicalCasing_ForNamedKeys()
+    {
+        IReadOnlyList<ManagedKnownShortcutDto> merged = KnownShortcutMerge.ForManagement([], []);
+
+        merged.Single(s => s.Id == "windows.close-magnifier").Key.Should().Be("Escape");
+        merged.Single(s => s.Id == "windows.file-explorer").Key.Should().Be("e");
+    }
+
+    [Fact]
+    public void ForDialog_KeepsCanonicalCasing_ForNamedKeys()
+    {
+        IReadOnlyList<KnownShortcutDto> merged = KnownShortcutMerge.ForDialog([], []);
+
+        merged.Single(s => s.Id == "windows.close-magnifier").Key.Should().Be("Escape");
+        merged.Single(s => s.Id == "windows.file-explorer").Key.Should().Be("e");
+    }
+
+    [Fact]
+    public void ForDialog_CarriesWarningText_FromTheBuiltInRow()
+    {
+        // No shipped row sets WarningText, so the built-in list is hand-built here. Without this
+        // the dialog path could drop the override and no test would notice.
+        KnownShortcut[] builtIns =
+        [
+            new("test.row", "F7", Ctrl: true, Alt: false, Shift: false, Win: false,
+                [
+                    new ShortcutUse("Test app", ShortcutProtection.Normal, ShortcutScope.Foreground,
+                        "do the thing", "https://example.test/evidence", new DateOnly(2026, 7, 29)),
+                ],
+                "Hand-written text for this row."),
+        ];
+
+        KnownShortcutMerge.ForDialog(builtIns, [], []).Single().WarningText
+            .Should().Be("Hand-written text for this row.");
+    }
+
+    [Fact]
+    public void ForManagement_GroupsCaseVariants_IntoOneRow()
+    {
+        // The built-in row stores "e"; the owner typed "E". One row, two uses.
+        CustomKnownShortcut owned = new CustomKnownShortcutBuilder()
+            .ForOwner(Owner).WithCombination("E", win: true).UsedBy("My tool").Build();
+
+        IReadOnlyList<ManagedKnownShortcutDto> merged = KnownShortcutMerge.ForManagement([owned], []);
+
+        merged.Should().HaveCount(ManifestCount);
+        merged.Single(s => s.Id == "windows.file-explorer").Uses.Should().HaveCount(2);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Validation/CreateCustomKnownShortcutCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Validation/CreateCustomKnownShortcutCommandValidatorTests.cs
@@ -1,0 +1,126 @@
+using AHKFlowApp.Application.Commands.KnownShortcuts;
+using AHKFlowApp.Application.Constants;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Enums;
+using FluentAssertions;
+using FluentValidation.Results;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Validation;
+
+public sealed class CreateCustomKnownShortcutCommandValidatorTests
+{
+    private readonly CreateCustomKnownShortcutCommandValidator _validator = new();
+
+    public static TheoryData<string> BannedTerms()
+    {
+        TheoryData<string> data = [];
+        foreach (string term in ShortcutWording.BannedTerms)
+            data.Add(term);
+        return data;
+    }
+
+    [Fact]
+    public void Validate_ValidRecord_Passes()
+    {
+        _validator.Validate(Command()).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyKey_Fails()
+    {
+        Result(Command(key: "")).Should().Contain(e => e.ErrorMessage == "Pick a key.");
+    }
+
+    [Fact]
+    public void Validate_UnknownKey_Fails()
+    {
+        Result(Command(key: "NotAKey")).Should()
+            .Contain(e => e.ErrorMessage == "That is not a key AHKFlow can use in a hotkey.");
+    }
+
+    [Fact]
+    public void Validate_EmptyUsedBy_Fails()
+    {
+        Result(Command(usedBy: "")).Should().Contain(e => e.ErrorMessage == "Say what uses these keys.");
+    }
+
+    [Fact]
+    public void Validate_UsedByOverSixtyCharacters_Fails()
+    {
+        _validator.Validate(Command(usedBy: new string('a', 61))).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_EmptyDoes_Fails()
+    {
+        Result(Command(does: "")).Should().Contain(e => e.ErrorMessage == "Say what the keys do.");
+    }
+
+    [Fact]
+    public void Validate_DoesOverTwoHundredCharacters_Fails()
+    {
+        _validator.Validate(Command(does: new string('a', 201))).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_ProtectionProtected_Fails()
+    {
+        Result(Command(protection: ShortcutProtection.Protected)).Should()
+            .Contain(e => e.ErrorMessage == "Only built-in records can say Windows handles the keys itself.");
+    }
+
+    [Theory]
+    [InlineData(ShortcutProtection.Normal)]
+    [InlineData(ShortcutProtection.Unknown)]
+    public void Validate_ProtectionAnOwnerCanClaim_Passes(ShortcutProtection protection)
+    {
+        _validator.Validate(Command(protection: protection)).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_DoesStartsWithACapital_Fails()
+    {
+        Result(Command(does: "Open the settings window")).Should()
+            .Contain(e => e.ErrorMessage.StartsWith("Start with a lowercase verb", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("open the settings window")]
+    [InlineData("open Visual Studio")]
+    [InlineData("3D view toggle")]
+    [InlineData("open whenever the window is focused")]
+    [InlineData("open the window")]
+    public void Validate_AcceptableDoesPhrases_Pass(string does)
+    {
+        _validator.Validate(Command(does: does)).IsValid.Should().BeTrue(does);
+    }
+
+    [Theory]
+    [MemberData(nameof(BannedTerms))]
+    public void Validate_DoesMakesAnAbsoluteClaim_Fails(string term)
+    {
+        Result(Command(does: $"open the window and {term} close it")).Should()
+            .Contain(e => e.ErrorMessage == "Say what the keys do, not what will or will not happen.");
+    }
+
+    [Fact]
+    public void BannedTerms_AreAllCaughtByTheRule()
+    {
+        // The array and the regex list the same terms. A term added to one and not the other
+        // would otherwise be silently unenforced.
+        ShortcutWording.BannedTerms.Should().OnlyContain(t => ShortcutWording.MakesAbsoluteClaim(t));
+    }
+
+    private List<ValidationFailure> Result(CreateCustomKnownShortcutCommand command) =>
+        _validator.Validate(command).Errors;
+
+    private static CreateCustomKnownShortcutCommand Command(
+        string key = "F7",
+        string usedBy = "Visual Studio",
+        string does = "open the command palette",
+        ShortcutProtection protection = ShortcutProtection.Unknown) =>
+        new(new CreateCustomKnownShortcutDto(
+            key, Ctrl: true, Alt: false, Shift: false, Win: false,
+            usedBy, ShortcutScope.Foreground, does, protection));
+}

--- a/tests/AHKFlowApp.Application.Tests/Validation/CreateCustomKnownShortcutCommandValidatorTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Validation/CreateCustomKnownShortcutCommandValidatorTests.cs
@@ -85,6 +85,14 @@ public sealed class CreateCustomKnownShortcutCommandValidatorTests
             .Contain(e => e.ErrorMessage.StartsWith("Start with a lowercase verb", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void Validate_DoesStartsWithACapitalAfterASpace_Fails()
+    {
+        // The handler trims before storing, so leading whitespace must not hide the capital.
+        Result(Command(does: "  Open the settings window")).Should()
+            .Contain(e => e.ErrorMessage.StartsWith("Start with a lowercase verb", StringComparison.Ordinal));
+    }
+
     [Theory]
     [InlineData("open the settings window")]
     [InlineData("open Visual Studio")]

--- a/tests/AHKFlowApp.Domain.Tests/Entities/CustomKnownShortcutTests.cs
+++ b/tests/AHKFlowApp.Domain.Tests/Entities/CustomKnownShortcutTests.cs
@@ -1,0 +1,46 @@
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace AHKFlowApp.Domain.Tests.Entities;
+
+public sealed class CustomKnownShortcutTests
+{
+    private static readonly Guid Owner = Guid.NewGuid();
+
+    [Fact]
+    public void Create_StampsBothTimesFromTheClock()
+    {
+        FakeTimeProvider clock = new(new DateTimeOffset(2026, 7, 29, 10, 0, 0, TimeSpan.Zero));
+
+        var record = CustomKnownShortcut.Create(
+            Owner, "K", ctrl: true, alt: false, shift: false, win: false,
+            "Visual Studio", ShortcutProtection.Normal, ShortcutScope.Foreground,
+            "open the comment menu", clock);
+
+        record.OwnerOid.Should().Be(Owner);
+        record.CreatedAt.Should().Be(clock.GetUtcNow());
+        record.UpdatedAt.Should().Be(clock.GetUtcNow());
+    }
+
+    [Fact]
+    public void Update_MovesUpdatedAtOnly()
+    {
+        FakeTimeProvider clock = new(new DateTimeOffset(2026, 7, 29, 10, 0, 0, TimeSpan.Zero));
+        var record = CustomKnownShortcut.Create(
+            Owner, "K", true, false, false, false,
+            "Visual Studio", ShortcutProtection.Normal, ShortcutScope.Foreground, "open the menu", clock);
+        DateTimeOffset created = record.CreatedAt;
+
+        clock.Advance(TimeSpan.FromMinutes(5));
+        record.Update("Visual Studio Code", ShortcutProtection.Unknown, ShortcutScope.Foreground,
+            "open the command palette", clock);
+
+        record.CreatedAt.Should().Be(created);
+        record.UpdatedAt.Should().Be(clock.GetUtcNow());
+        record.UsedBy.Should().Be("Visual Studio Code");
+        record.Does.Should().Be("open the command palette");
+    }
+}

--- a/tests/AHKFlowApp.E2E.Tests/Fixtures/StackFixture.cs
+++ b/tests/AHKFlowApp.E2E.Tests/Fixtures/StackFixture.cs
@@ -26,6 +26,8 @@ public sealed class StackFixture : IAsyncLifetime
         AppDbContext db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
         await db.EntityHistories.ExecuteDeleteAsync();
+        await db.CustomKnownShortcuts.ExecuteDeleteAsync();
+        await db.IgnoredKnownShortcuts.ExecuteDeleteAsync();
         await db.HotstringCategories.ExecuteDeleteAsync();
         await db.HotkeyCategories.ExecuteDeleteAsync();
         await db.HotstringProfiles.ExecuteDeleteAsync();

--- a/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
@@ -1,4 +1,4 @@
-using AHKFlowApp.E2E.Tests.Fixtures;
+﻿using AHKFlowApp.E2E.Tests.Fixtures;
 using Microsoft.Playwright;
 using Xunit;
 
@@ -53,6 +53,99 @@ public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifet
         await page.UncheckAsync(".hotkey-edit-dialog input[data-test=\"win-checkbox\"]");
         await page.WaitForSelectorAsync(".hotkey-edit-dialog [data-test=\"shortcut-warning\"]",
             new PageWaitForSelectorOptions { State = WaitForSelectorState.Detached });
+    }
+
+    // Addresses the Windows use of Win+E by id and use label, not by row text. A combination can
+    // hold several uses, and each has its own buttons.
+    private const string WindowsFileExplorerUse =
+        "[data-shortcut-id=\"windows.file-explorer\"][data-used-by=\"Windows\"]";
+
+    [Fact]
+    public async Task IgnoringTheWindowsUse_SilencesTheWarning_AndRestoringBringsItBack()
+    {
+        await using IBrowserContext context = await fixture.Browser.NewContextAsync();
+        IPage page = await context.NewPageAsync();
+
+        // Silence the Windows use of Win+E.
+        await OpenKnownShortcutsAsync(page, "Win+E");
+        await page.ClickAsync($"button.ignore-use{WindowsFileExplorerUse}");
+        await page.WaitForSelectorAsync($"button.restore-use{WindowsFileExplorerUse}");
+
+        // The dialog no longer warns. Arm the wait before the dialog opens: the catalog request
+        // fires as it loads, and a fixed delay would let a slow response assert on an empty page.
+        Task<IResponse> catalogLoaded = page.WaitForResponseAsync(response =>
+            response.Url.Contains("/api/v1/hotkeys/known-shortcuts", StringComparison.OrdinalIgnoreCase) &&
+            response.Status == 200);
+
+        await OpenCreateDialogAsync(page);
+        await CommitKeyAsync(page, "e");
+        await page.CheckAsync(".hotkey-edit-dialog input[data-test=\"win-checkbox\"]");
+        await catalogLoaded;
+
+        // Wait for the dialog to say it has decided, for this exact combination. Only then is the
+        // absence below a real answer. State.Attached is required: the hook is display:none, so
+        // the default Visible would never match. Detached on the warning itself cannot do this
+        // job — the warning has never existed, so Playwright would return at once and the test
+        // would pass without the feature working.
+        await page.WaitForSelectorAsync(
+            ".hotkey-edit-dialog [data-test=\"shortcut-warning-checked\"][data-combination=\"Win+E\"]",
+            new PageWaitForSelectorOptions { State = WaitForSelectorState.Attached });
+
+        Assert.Null(await page.QuerySelectorAsync(".hotkey-edit-dialog [data-test=\"shortcut-warning\"]"));
+
+        // Bring it back.
+        await OpenKnownShortcutsAsync(page, "Win+E");
+        await page.ClickAsync($"button.restore-use{WindowsFileExplorerUse}");
+        await page.WaitForSelectorAsync($"button.ignore-use{WindowsFileExplorerUse}");
+
+        await OpenCreateDialogAsync(page);
+        await CommitKeyAsync(page, "e");
+        await page.CheckAsync(".hotkey-edit-dialog input[data-test=\"win-checkbox\"]");
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog [data-test=\"shortcut-warning\"]");
+    }
+
+    [Fact]
+    public async Task AnOwnerRecord_WarnsOnItsOwnCombination()
+    {
+        await using IBrowserContext context = await fixture.Browser.NewContextAsync();
+        IPage page = await context.NewPageAsync();
+
+        await OpenKnownShortcutsAsync(page);
+        await page.ClickAsync("button.add-known-shortcut");
+
+        ILocator keyInput = page.Locator("input[data-test=\"known-shortcut-key-picker\"]");
+        await keyInput.ClickAsync();
+        await keyInput.FillAsync("F7");
+        await keyInput.PressAsync("Tab");
+
+        await page.CheckAsync("input[data-test=\"ctrl-checkbox\"]");
+        await page.FillAsync("input[data-test=\"known-shortcut-usedby-input\"]", "My notes tool");
+        await page.FillAsync("input[data-test=\"known-shortcut-does-input\"]", "open my notes");
+        await page.ClickAsync("button.commit-edit");
+
+        // The table paginates 103 built-in rows plus this one, so search for the new row rather
+        // than hunting for it across pages.
+        await page.FillAsync("input[data-test=\"known-shortcut-search\"]", "My notes tool");
+        await page.WaitForSelectorAsync("text=My notes tool");
+
+        await OpenCreateDialogAsync(page);
+        await CommitKeyAsync(page, "F7");
+        await page.CheckAsync(".hotkey-edit-dialog input[data-test=\"ctrl-checkbox\"]");
+
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog [data-test=\"shortcut-warning\"]");
+        string warning = await page.InnerTextAsync(".hotkey-edit-dialog [data-test=\"shortcut-warning\"]");
+        Assert.Contains("My notes tool uses Ctrl+F7 to open my notes", warning, StringComparison.Ordinal);
+    }
+
+    // The table holds a row per use, over a hundred of them, and pages at 25. Every row this file
+    // acts on is addressed through the search box, never by paging to it.
+    private async Task OpenKnownShortcutsAsync(IPage page, string? search = null)
+    {
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/known-shortcuts");
+        await page.WaitForSelectorAsync("button.reload-known-shortcuts");
+
+        if (search is not null)
+            await page.FillAsync("input[data-test=\"known-shortcut-search\"]", search);
     }
 
     private async Task OpenCreateDialogAsync(IPage page)

--- a/tests/AHKFlowApp.TestUtilities/Builders/CustomKnownShortcutBuilder.cs
+++ b/tests/AHKFlowApp.TestUtilities/Builders/CustomKnownShortcutBuilder.cs
@@ -1,0 +1,45 @@
+using AHKFlowApp.Domain.Entities;
+using AHKFlowApp.Domain.Enums;
+
+namespace AHKFlowApp.TestUtilities.Builders;
+
+public sealed class CustomKnownShortcutBuilder
+{
+    private Guid _ownerOid = Guid.NewGuid();
+    private string _key = "K";
+    private bool _ctrl = true;
+    private bool _alt;
+    private bool _shift;
+    private bool _win;
+    private string _usedBy = "Visual Studio";
+    private ShortcutProtection _protection = ShortcutProtection.Unknown;
+    private ShortcutScope _scope = ShortcutScope.Foreground;
+    private string _does = "do something";
+    private TimeProvider _clock = TimeProvider.System;
+
+    public CustomKnownShortcutBuilder ForOwner(Guid ownerOid) { _ownerOid = ownerOid; return this; }
+
+    public CustomKnownShortcutBuilder WithCombination(
+        string key, bool ctrl = false, bool alt = false, bool shift = false, bool win = false)
+    {
+        _key = key; _ctrl = ctrl; _alt = alt; _shift = shift; _win = win;
+        return this;
+    }
+
+    public CustomKnownShortcutBuilder UsedBy(string usedBy) { _usedBy = usedBy; return this; }
+
+    public CustomKnownShortcutBuilder WithProtection(ShortcutProtection protection)
+    {
+        _protection = protection;
+        return this;
+    }
+
+    public CustomKnownShortcutBuilder WithScope(ShortcutScope scope) { _scope = scope; return this; }
+
+    public CustomKnownShortcutBuilder Does(string does) { _does = does; return this; }
+
+    public CustomKnownShortcutBuilder WithClock(TimeProvider clock) { _clock = clock; return this; }
+
+    public CustomKnownShortcut Build() => CustomKnownShortcut.Create(
+        _ownerOid, _key, _ctrl, _alt, _shift, _win, _usedBy, _protection, _scope, _does, _clock);
+}

--- a/tests/AHKFlowApp.TestUtilities/Builders/IgnoredKnownShortcutBuilder.cs
+++ b/tests/AHKFlowApp.TestUtilities/Builders/IgnoredKnownShortcutBuilder.cs
@@ -1,0 +1,22 @@
+using AHKFlowApp.Domain.Entities;
+
+namespace AHKFlowApp.TestUtilities.Builders;
+
+public sealed class IgnoredKnownShortcutBuilder
+{
+    private Guid _ownerOid = Guid.NewGuid();
+    private string _shortcutId = "windows.file-explorer";
+    private string _usedBy = "Windows";
+    private TimeProvider _clock = TimeProvider.System;
+
+    public IgnoredKnownShortcutBuilder ForOwner(Guid ownerOid) { _ownerOid = ownerOid; return this; }
+
+    public IgnoredKnownShortcutBuilder ForShortcut(string shortcutId) { _shortcutId = shortcutId; return this; }
+
+    public IgnoredKnownShortcutBuilder UsedBy(string usedBy) { _usedBy = usedBy; return this; }
+
+    public IgnoredKnownShortcutBuilder WithClock(TimeProvider clock) { _clock = clock; return this; }
+
+    public IgnoredKnownShortcut Build() =>
+        IgnoredKnownShortcut.Create(_ownerOid, _shortcutId, _usedBy, _clock);
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyEditDialogTests.cs
@@ -774,6 +774,18 @@ public sealed class HotkeyEditDialogTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
+    public async Task Open_AfterDeciding_AnnouncesTheCombinationItDecidedFor()
+    {
+        // The E2E flows read this hook to tell "no warning" apart from "not decided yet".
+        IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(
+            new HotkeyEditModel { Key = "F1", Ctrl = true });
+
+        provider.WaitForAssertion(() =>
+            provider.Find("[data-test=\"shortcut-warning-checked\"]")
+                .GetAttribute("data-combination").Should().Be("Ctrl+F1"));
+    }
+
+    [Fact]
     public async Task Open_CombinationWithNoKnownShortcut_ShowsNoWarning()
     {
         IRenderedComponent<MudDialogProvider> provider = await ShowDialogAsync(

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
@@ -1,0 +1,329 @@
+﻿using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Pages;
+using AHKFlowApp.UI.Blazor.Services;
+using AngleSharp.Dom;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using NSubstitute;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Pages;
+
+public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
+{
+    private readonly IKnownShortcutsApiClient _api = Substitute.For<IKnownShortcutsApiClient>();
+    private readonly IKnownShortcutCatalog _catalog = Substitute.For<IKnownShortcutCatalog>();
+
+    // The add form holds a KeyPicker, which reads the key registry through this.
+    private readonly IHotkeyKeyCatalog _keys = Substitute.For<IHotkeyKeyCatalog>();
+
+    public KnownShortcutsPageTests()
+    {
+        Services.AddSingleton(_api);
+        Services.AddSingleton(_catalog);
+        Services.AddSingleton(_keys);
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+
+    async Task IAsyncLifetime.DisposeAsync() => await DisposeAsync();
+
+    private static ManagedShortcutUseDto BuiltInUse(string usedBy = "Windows", bool ignored = false) =>
+        new(usedBy, ShortcutProtection.Normal, ShortcutScope.Global, "open File Explorer",
+            ShortcutRecordOrigin.BuiltIn, OwnerRecordId: null, IsIgnored: ignored);
+
+    private static ManagedShortcutUseDto OwnerUse(Guid recordId, string usedBy = "My notes tool") =>
+        new(usedBy, ShortcutProtection.Unknown, ShortcutScope.Foreground, "open my notes",
+            ShortcutRecordOrigin.Owner, OwnerRecordId: recordId, IsIgnored: false);
+
+    private static ManagedKnownShortcutDto Shortcut(
+        string id, string key, params ManagedShortcutUseDto[] uses) =>
+        new(id, key, Ctrl: false, Alt: false, Shift: false, Win: true, uses, WarningText: null);
+
+    private static ManagedKnownShortcutDto BrowserShortcut() =>
+        new("browser.new-window", "n", Ctrl: true, Alt: false, Shift: false, Win: false,
+            [
+                new("Chrome", ShortcutProtection.Normal, ShortcutScope.Foreground, "open a new window",
+                    ShortcutRecordOrigin.BuiltIn, null, false),
+                new("Edge", ShortcutProtection.Normal, ShortcutScope.Foreground, "open a new window",
+                    ShortcutRecordOrigin.BuiltIn, null, false),
+            ],
+            WarningText: null);
+
+    private void StubList(params ManagedKnownShortcutDto[] shortcuts) =>
+        _api.ListManagedAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult<ManagedKnownShortcutCatalogDto>.Ok(new ManagedKnownShortcutCatalogDto(shortcuts)));
+
+    private void StubListFailure() =>
+        _api.ListManagedAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult<ManagedKnownShortcutCatalogDto>.Failure(ApiResultStatus.ServerError, null));
+
+    private IRenderedComponent<KnownShortcuts> RenderPage()
+    {
+        Render<MudPopoverProvider>();
+        return Render<KnownShortcuts>();
+    }
+
+    private static IElement Button(IRenderedComponent<KnownShortcuts> page, string css, string shortcutId, string usedBy) =>
+        page.Find($"button.{css}[data-shortcut-id=\"{shortcutId}\"][data-used-by=\"{usedBy}\"]");
+
+    [Fact]
+    public void Page_RendersOneRowPerUse()
+    {
+        StubList(BrowserShortcut());
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+
+        page.FindAll("[data-test=\"known-shortcut-row\"]").Should().HaveCount(2);
+        page.FindAll("[data-test=\"known-shortcut-row\"]").Should()
+            .OnlyContain(r => r.TextContent == "Ctrl+N");
+        page.FindAll("button.ignore-use").Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void BuiltInUse_OffersIgnore_AndCallsItWithThatUse()
+    {
+        StubList(BrowserShortcut());
+        _api.IgnoreAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Ok());
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        Button(page, "ignore-use", "browser.new-window", "Chrome").Click();
+
+        _api.Received(1).IgnoreAsync("browser.new-window", "Chrome", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void IgnoredUse_OffersRestore_AndCallsIt()
+    {
+        StubList(Shortcut("windows.file-explorer", "e", BuiltInUse(ignored: true)));
+        _api.RestoreAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Ok());
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        page.FindAll("button.ignore-use").Should().BeEmpty();
+        Button(page, "restore-use", "windows.file-explorer", "Windows").Click();
+
+        _api.Received(1).RestoreAsync("windows.file-explorer", "Windows", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void OwnerUse_OffersDelete_AndCallsItWithTheRecordId()
+    {
+        var recordId = Guid.NewGuid();
+        StubList(Shortcut("owner.1", "F7", OwnerUse(recordId)));
+        _api.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(ApiResult.Ok());
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        page.Find("button.delete-use").Click();
+
+        _api.Received(1).DeleteAsync(recordId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void OwnerUse_DoesNotOfferIgnore_AndBuiltInDoesNotOfferDelete()
+    {
+        StubList(
+            Shortcut("owner.1", "F7", OwnerUse(Guid.NewGuid())),
+            Shortcut("windows.file-explorer", "e", BuiltInUse()));
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+
+        page.FindAll("button.ignore-use").Should().ContainSingle()
+            .Which.GetAttribute("data-shortcut-id").Should().Be("windows.file-explorer");
+        page.FindAll("button.delete-use").Should().ContainSingle()
+            .Which.GetAttribute("data-shortcut-id").Should().Be("owner.1");
+    }
+
+    [Fact]
+    public void CombinationWithABuiltInAndAnOwnerUse_RendersBothActions()
+    {
+        StubList(Shortcut("windows.file-explorer", "e", BuiltInUse(), OwnerUse(Guid.NewGuid())));
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+
+        page.FindAll("[data-test=\"known-shortcut-row\"]").Should().HaveCount(2);
+        page.FindAll("button.ignore-use").Should().ContainSingle();
+        page.FindAll("button.delete-use").Should().ContainSingle();
+    }
+
+    [Fact]
+    public void IgnoringOneUse_LeavesTheOtherUseActive()
+    {
+        StubList(BrowserShortcut());
+        _api.IgnoreAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Ok());
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+
+        // The reload after the mutation returns Chrome silenced and Edge untouched.
+        _api.ListManagedAsync(Arg.Any<CancellationToken>()).Returns(
+            ApiResult<ManagedKnownShortcutCatalogDto>.Ok(new ManagedKnownShortcutCatalogDto(
+            [
+                new("browser.new-window", "n", false, false, false, false,
+                    [
+                        new("Chrome", ShortcutProtection.Normal, ShortcutScope.Foreground, "open a new window",
+                            ShortcutRecordOrigin.BuiltIn, null, true),
+                        new("Edge", ShortcutProtection.Normal, ShortcutScope.Foreground, "open a new window",
+                            ShortcutRecordOrigin.BuiltIn, null, false),
+                    ],
+                    null),
+            ])));
+
+        Button(page, "ignore-use", "browser.new-window", "Chrome").Click();
+
+        Button(page, "restore-use", "browser.new-window", "Chrome").Should().NotBeNull();
+        Button(page, "ignore-use", "browser.new-window", "Edge").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AfterASuccessfulIgnore_TheListIsReloadedAndTheRowOffersRestore()
+    {
+        StubList(Shortcut("windows.file-explorer", "e", BuiltInUse()));
+        _api.IgnoreAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Ok());
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        StubList(Shortcut("windows.file-explorer", "e", BuiltInUse(ignored: true)));
+
+        Button(page, "ignore-use", "windows.file-explorer", "Windows").Click();
+
+        _api.Received(2).ListManagedAsync(Arg.Any<CancellationToken>());
+        page.FindAll("button.restore-use").Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Add_SavesThroughCreate_AndShowsTheReturnedList()
+    {
+        StubList();
+        _api.CreateAsync(Arg.Any<CreateCustomKnownShortcutDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<ManagedKnownShortcutCatalogDto>.Ok(new ManagedKnownShortcutCatalogDto(
+                [Shortcut("owner.1", "F7", OwnerUse(Guid.NewGuid()))])));
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        page.Find("button.add-known-shortcut").Click();
+        page.Find("[data-test=\"known-shortcut-usedby-input\"]").Input("My notes tool");
+        page.Find("[data-test=\"known-shortcut-does-input\"]").Input("open my notes");
+        page.Find("button.commit-edit").Click();
+
+        _api.Received(1).CreateAsync(
+            Arg.Is<CreateCustomKnownShortcutDto>(d => d.UsedBy == "My notes tool" && d.Does == "open my notes"),
+            Arg.Any<CancellationToken>());
+        page.FindAll("[data-test=\"known-shortcut-row\"]").Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Add_WhenTheServerConflicts_ShowsTheMessageAndKeepsTheFormOpen()
+    {
+        StubList();
+        _api.CreateAsync(Arg.Any<CreateCustomKnownShortcutDto>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult<ManagedKnownShortcutCatalogDto>.Failure(
+                ApiResultStatus.Conflict,
+                new ApiProblemDetails(null, "Conflict", 409, "You have already recorded this one.", null, null)));
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        page.Find("button.add-known-shortcut").Click();
+        page.Find("button.commit-edit").Click();
+
+        page.Markup.Should().Contain("You have already recorded this one.");
+        page.FindAll("button.commit-edit").Should().ContainSingle("the form stays open");
+    }
+
+    [Fact]
+    public void FailedLoad_ShowsAnErrorAndAnEmptyTable()
+    {
+        StubListFailure();
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+
+        page.FindAll("[data-test=\"known-shortcut-row\"]").Should().BeEmpty();
+        page.FindAll("div.mud-alert").Should().NotBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("ignore")]
+    [InlineData("restore")]
+    [InlineData("delete")]
+    [InlineData("create")]
+    public void EverySuccessfulMutation_InvalidatesTheDialogCache(string mutation)
+    {
+        ArrangeMutation(mutation, succeeds: true);
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        PerformMutation(page, mutation);
+
+        _catalog.Received(1).Invalidate();
+    }
+
+    [Theory]
+    [InlineData("ignore")]
+    [InlineData("restore")]
+    [InlineData("delete")]
+    [InlineData("create")]
+    public void AFailedMutation_DoesNotInvalidateTheDialogCache(string mutation)
+    {
+        // Throwing the cache away on a failure costs a refetch for no reason, and hides the
+        // failure behind a slow dialog.
+        ArrangeMutation(mutation, succeeds: false);
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        PerformMutation(page, mutation);
+
+        _catalog.DidNotReceive().Invalidate();
+    }
+
+    private void ArrangeMutation(string mutation, bool succeeds)
+    {
+        ApiResult result = succeeds ? ApiResult.Ok() : ApiResult.Failure(ApiResultStatus.ServerError, null);
+
+        switch (mutation)
+        {
+            case "ignore":
+                StubList(Shortcut("windows.file-explorer", "e", BuiltInUse()));
+                _api.IgnoreAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                    .Returns(result);
+                break;
+            case "restore":
+                StubList(Shortcut("windows.file-explorer", "e", BuiltInUse(ignored: true)));
+                _api.RestoreAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                    .Returns(result);
+                break;
+            case "delete":
+                StubList(Shortcut("owner.1", "F7", OwnerUse(Guid.NewGuid())));
+                _api.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(result);
+                break;
+            default:
+                StubList();
+                _api.CreateAsync(Arg.Any<CreateCustomKnownShortcutDto>(), Arg.Any<CancellationToken>())
+                    .Returns(succeeds
+                        ? ApiResult<ManagedKnownShortcutCatalogDto>.Ok(new ManagedKnownShortcutCatalogDto([]))
+                        : ApiResult<ManagedKnownShortcutCatalogDto>.Failure(ApiResultStatus.ServerError, null));
+                break;
+        }
+    }
+
+    private static void PerformMutation(IRenderedComponent<KnownShortcuts> page, string mutation)
+    {
+        switch (mutation)
+        {
+            case "ignore":
+                page.Find("button.ignore-use").Click();
+                break;
+            case "restore":
+                page.Find("button.restore-use").Click();
+                break;
+            case "delete":
+                page.Find("button.delete-use").Click();
+                break;
+            default:
+                page.Find("button.add-known-shortcut").Click();
+                page.Find("button.commit-edit").Click();
+                break;
+        }
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Services/KnownShortcutCatalogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Services/KnownShortcutCatalogTests.cs
@@ -48,6 +48,62 @@ public sealed class KnownShortcutCatalogTests
     }
 
     [Fact]
+    public async Task GetAsync_AfterInvalidate_FetchesAgain()
+    {
+        KnownShortcutCatalogDto second = new([]);
+        IKnownShortcutsApiClient api = Substitute.For<IKnownShortcutsApiClient>();
+        api.ListAsync(Arg.Any<CancellationToken>()).Returns(
+            ApiResult<KnownShortcutCatalogDto>.Ok(Sample),
+            ApiResult<KnownShortcutCatalogDto>.Ok(second));
+        var catalog = new KnownShortcutCatalog(api);
+
+        await catalog.GetAsync();
+        catalog.Invalidate();
+        KnownShortcutCatalogDto? after = await catalog.GetAsync();
+
+        await api.Received(2).ListAsync(Arg.Any<CancellationToken>());
+        after.Should().BeSameAs(second);
+    }
+
+    [Fact]
+    public async Task GetAsync_InvalidatedMidFetch_DoesNotCacheTheStaleResponse()
+    {
+        // The regression test for the generation counter. Without it the in-flight response is
+        // written back after the invalidation and the next call serves pre-mutation data.
+        TaskCompletionSource<KnownShortcutCatalogDto> pending = new();
+        IKnownShortcutsApiClient api = Substitute.For<IKnownShortcutsApiClient>();
+        api.ListAsync(Arg.Any<CancellationToken>()).Returns(_ => WaitThenOkAsync(pending));
+        var catalog = new KnownShortcutCatalog(api);
+
+        ValueTask<KnownShortcutCatalogDto?> inFlight = catalog.GetAsync();
+        catalog.Invalidate();
+        pending.SetResult(Sample);
+        await inFlight;
+
+        await catalog.GetAsync();
+
+        await api.Received(2).ListAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invalidate_BeforeAnyGet_IsHarmless()
+    {
+        IKnownShortcutsApiClient api = ApiReturning(Sample);
+        var catalog = new KnownShortcutCatalog(api);
+
+        catalog.Invalidate();
+
+        (await catalog.GetAsync()).Should().BeSameAs(Sample);
+    }
+
+    private static async Task<ApiResult<KnownShortcutCatalogDto>> WaitThenOkAsync(
+        TaskCompletionSource<KnownShortcutCatalogDto> tcs)
+    {
+        KnownShortcutCatalogDto catalog = await tcs.Task;
+        return ApiResult<KnownShortcutCatalogDto>.Ok(catalog);
+    }
+
+    [Fact]
     public async Task GetAsync_AfterFailure_RetriesOnNextCall()
     {
         // The regression test for the caching trap: a memoized failure would silence every warning

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Services/KnownShortcutsApiClientTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Services/KnownShortcutsApiClientTests.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using System.Net.Http.Json;
 using AHKFlowApp.UI.Blazor.DTOs;
 using AHKFlowApp.UI.Blazor.Services;
@@ -50,6 +50,85 @@ public sealed class KnownShortcutsApiClientTests
         var handler = StubHttpMessageHandler.StatusResponse(HttpStatusCode.InternalServerError);
 
         ApiResult<KnownShortcutCatalogDto> result = await ClientWith(handler).ListAsync();
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ListManagedAsync_HitsCorrectUrl()
+    {
+        var handler = StubHttpMessageHandler.JsonResponse(
+            HttpStatusCode.OK, new ManagedKnownShortcutCatalogDto([]));
+
+        await ClientWith(handler).ListManagedAsync();
+
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Get);
+        handler.LastRequest.RequestUri!.PathAndQuery.Should().Be("/api/v1/knownshortcuts");
+    }
+
+    [Fact]
+    public async Task CreateAsync_PostsToTheBasePath()
+    {
+        var handler = StubHttpMessageHandler.JsonResponse(
+            HttpStatusCode.OK, new ManagedKnownShortcutCatalogDto([]));
+
+        await ClientWith(handler).CreateAsync(new CreateCustomKnownShortcutDto(
+            "F7", true, false, false, false, "My tool", ShortcutScope.Foreground, "open my notes"));
+
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.PathAndQuery.Should().Be("/api/v1/knownshortcuts");
+        handler.LastRequest.Content.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_HitsTheRecordUrl()
+    {
+        var handler = StubHttpMessageHandler.StatusResponse(HttpStatusCode.NoContent);
+        var id = Guid.NewGuid();
+
+        ApiResult result = await ClientWith(handler).DeleteAsync(id);
+
+        result.IsSuccess.Should().BeTrue();
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Delete);
+        handler.LastRequest.RequestUri!.PathAndQuery.Should().Be($"/api/v1/knownshortcuts/{id}");
+    }
+
+    [Fact]
+    public async Task IgnoreAsync_PostsTheUseAsABody()
+    {
+        // The body is the whole point of the content-carrying no-content overload. A test that
+        // only checked the URL would pass with the body dropped.
+        var handler = StubHttpMessageHandler.StatusResponse(HttpStatusCode.NoContent);
+
+        ApiResult result = await ClientWith(handler).IgnoreAsync("windows.file-explorer", "Windows");
+
+        result.IsSuccess.Should().BeTrue();
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.PathAndQuery.Should().Be("/api/v1/knownshortcuts/ignore");
+        handler.LastRequest.Content.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task RestoreAsync_PostsTheUseAsABody()
+    {
+        var handler = StubHttpMessageHandler.StatusResponse(HttpStatusCode.NoContent);
+
+        ApiResult result = await ClientWith(handler).RestoreAsync("windows.file-explorer", "Windows");
+
+        result.IsSuccess.Should().BeTrue();
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.PathAndQuery.Should().Be("/api/v1/knownshortcuts/restore");
+        handler.LastRequest.Content.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task IgnoreAsync_WhenTheServerAnswers200_IsAFailure()
+    {
+        // The exact-204 check is deliberate: it makes the client fail loudly if a route the
+        // client treats as no-content ever goes back to returning 200.
+        var handler = StubHttpMessageHandler.StatusResponse(HttpStatusCode.OK);
+
+        ApiResult result = await ClientWith(handler).IgnoreAsync("windows.file-explorer", "Windows");
 
         result.IsSuccess.Should().BeFalse();
     }


### PR DESCRIPTION
## What

Stage 2 of hotkey shortcut warnings: a known-shortcuts management page, owner-created records, and per-use ignore/restore.

- Overlay entities `CustomKnownShortcut` and `IgnoredKnownShortcut` plus migration
- Merge rules that fold owner records and ignores into the built-in manifest
- Queries and commands: list, create, delete, ignore, restore
- `KnownShortcutsController`
- Management page in the Blazor UI

## Review fixes (39fef170)

Three findings from review, all confirmed and fixed:

1. Concurrent restore returned 500. Two requests could read the same ignore row and both delete it. The second DELETE affected no rows, so EF Core threw `DbUpdateConcurrencyException`. Restore is meant to be idempotent, so the handler now catches it and reports success.
2. Leading whitespace bypassed the lowercase rule on `Does`. The validator judged the original text, but the handler stored the trimmed text. `" Open the settings window"` passed validation and was stored capitalized, breaking the warning sentence. The validator now trims before it checks the first character.
3. Restore had no owner-isolation test. Added one. Verified by deleting the `OwnerOid` predicate and watching the test fail.

## Testing

Canonical pre-PR gate:

- Release build: 17 projects, 0 errors, 0 warnings
- `dotnet format --verify-no-changes`: pass
- `test-fast.ps1 -Mode Coverage`: 3192 passed, 0 failed, all thresholds met
- `git diff --check main...HEAD`: pass

New tests: `Restore_SentConcurrently_AllSucceed`, `Restore_ByAnotherOwner_LeavesTheFirstOwnersIgnoreInPlace`, `Validate_DoesStartsWithACapitalAfterASpace_Fails`.

## Known gap

The restore button in `KnownShortcuts.razor` is not disabled during the request. The server is idempotent now, so a double-click cannot fail — it only costs one extra round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
