### PR TITLE
fix: shortcut warning wording and API error text

### DIFF
--- a/.claude/backlog/039-no-auth-frontend-profile-broken.md
+++ b/.claude/backlog/039-no-auth-frontend-profile-broken.md
@@ -1,0 +1,39 @@
+# 039 - Make the no-auth frontend profile work in the main checkout
+
+## Metadata
+
+- **Epic**: Developer experience
+- **Type**: Fix
+- **Interfaces**: UI
+
+## Summary
+
+The `http (No Auth)` launch profile no longer produces a signed-in frontend in the main checkout. The app still boots into MSAL, so a local browser drive stops at the login screen and every Add button stays disabled.
+
+## User story
+
+As a developer, I want the no-auth launch profile to sign me in as the test user, so that I can drive the local UI without an Azure AD login.
+
+## Evidence
+
+- Started the frontend with `--launch-profile "http (No Auth)"`: the app rendered **LOG IN** and `button.add-hotkey` was `disabled`.
+- Started it again with `ASPNETCORE_ENVIRONMENT=NoAuth` set directly. The host log confirmed `Hosting environment: NoAuth`, and the app still rendered **LOG IN**.
+- The cause is already written down in this repository, at `tests/AHKFlowApp.E2E.Tests/Fixtures/SpaHost.cs:27-32`: in .NET 10 the Blazor WebAssembly boot configuration is baked into `blazor.webassembly.js` at build time. The dev server's environment does not change which `appsettings.{Environment}.json` the WebAssembly app loads, so `wwwroot/appsettings.NoAuth.json` is never read.
+- `Program.cs:27` reads `Auth:UseTestProvider` from configuration, so a file that never loads leaves the flag false.
+
+## Acceptance criteria
+
+- [ ] Running the frontend on its no-auth profile signs the browser in as the test user, with no Azure AD round trip
+- [ ] `button.add-hotkey` is enabled on that profile
+- [ ] `.claude/CLAUDE.md`, `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md`, and `docs/development/playwright-setup.md` describe what actually works
+- [ ] The E2E fixture keeps working unchanged — it already solves this by intercepting every `appsettings*.json` request
+
+## Out of scope
+
+- Changing how agent worktrees get no-auth. `setup-worktree-local-dev.ps1` writes `appsettings.Development.json`, which does load, so worktrees are unaffected.
+- Any change to production authentication.
+
+## Notes / dependencies
+
+- Two candidate fixes: write the flag into `wwwroot/appsettings.Development.json` from a script, the way the worktree setup already does; or set `WasmApplicationEnvironmentName` at build time for a no-auth build.
+- Found while driving the hotkey shortcut warnings feature in the main checkout on 2026-07-29. Worked around for that session by intercepting `**/appsettings*.json` in Playwright.

--- a/.claude/backlog/040-known-shortcuts-mobile-layout.md
+++ b/.claude/backlog/040-known-shortcuts-mobile-layout.md
@@ -1,0 +1,33 @@
+# 040 - Mobile layout for the known shortcuts page
+
+## Metadata
+
+- **Epic**: Hotkey safety
+- **Type**: Feature
+- **Interfaces**: UI
+
+## Summary
+
+The known shortcuts page renders one `MudTable` for every screen size. Every other list page in the app renders a desktop branch and a mobile branch. On a phone the table has six columns, and the Actions column is the one most likely to be pushed out of reach.
+
+## User story
+
+As an owner on a phone, I want the known shortcuts list to read like the other list pages, so that I can silence a warning without fighting a wide table.
+
+## Acceptance criteria
+
+- [ ] The page renders a `.desktop-branch` and a `.mobile-branch`, gated in `Pages/KnownShortcuts.razor.css` at `959.95px`, matching `Pages/Hotkeys.razor` and `Pages/Hotstrings.razor`
+- [ ] The mobile branch shows the combination, what uses it, and what it does, plus the row's one action
+- [ ] Search still filters both branches
+- [ ] An E2E flow test at a phone viewport silences a use and brings it back
+
+## Out of scope
+
+- Changing the desktop table.
+- Adding an edit action. Owner records are delete-and-recreate, as decided in the Stage 2 plan.
+
+## Notes / dependencies
+
+- Convention is described in `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md`, under the list-page bullet.
+- Existing mobile flows to copy from: `tests/AHKFlowApp.E2E.Tests/HotkeysMobileFlowTests.cs`.
+- Raised while reviewing the hotkey shortcut warnings feature on 2026-07-29. The current table does carry `DataLabel` on every cell, so it degrades rather than breaking — this is polish, not a defect.

--- a/docs/development/playwright-setup.md
+++ b/docs/development/playwright-setup.md
@@ -44,6 +44,16 @@ These are the **main checkout** ports only:
 
 Worktrees also run no-auth automatically (`Auth:UseTestProvider=true`, always signed in as "Test User"), so a browser drive gets full CRUD with no login.
 
+**Known problem in the main checkout:** the `http (No Auth)` frontend profile does not sign you in. In
+.NET 10 the WebAssembly boot environment is fixed at build time, so `wwwroot/appsettings.NoAuth.json`
+is never loaded and the app boots into MSAL. Worktrees are unaffected — their setup script writes
+`appsettings.Development.json`, which does load. Tracked in `.claude/backlog/039-no-auth-frontend-profile-broken.md`.
+Until it is fixed, drive the main checkout with a real login, or intercept the config request:
+
+```bash
+playwright-cli route "**/appsettings*.json" --body='{"Auth":{"UseTestProvider":true},"ApiHttpClient":{"BaseAddress":"http://localhost:5600"}}'
+```
+
 ## Notes
 
 - The browser opens headless by default. Add `--headed` to see the browser window.

--- a/src/Backend/AHKFlowApp.Application/Constants/KnownShortcutCatalog.cs
+++ b/src/Backend/AHKFlowApp.Application/Constants/KnownShortcutCatalog.cs
@@ -90,14 +90,14 @@ internal static class KnownShortcutCatalog
         Windows("windows.file-explorer", "e", "open File Explorer"),
         Windows("windows.feedback-hub", "f", "open Feedback Hub"),
         Windows("windows.game-bar", "g", "open Game Bar"),
-        Windows("windows.voice-dictation", "h", "open voice dictation"),
+        Windows("windows.voice-dictation", "h", "open voice typing"),
         Windows("windows.settings", "i", "open Settings"),
         Windows("windows.recall", "j", "open Recall"),
         Windows("windows.cast", "k", "open Cast"),
         Windows("windows.minimize-all", "m", "minimize all windows"),
-        Windows("windows.notification-center", "n", "open notification center and calendar"),
-        Windows("windows.lock-orientation", "o", "lock device orientation"),
-        Windows("windows.project", "p", "open presentation display modes"),
+        Windows("windows.notification-center", "n", "open the notification center and calendar"),
+        Windows("windows.lock-orientation", "o", "lock the device orientation"),
+        Windows("windows.project", "p", "choose a presentation display mode"),
         Windows("windows.search-q", "q", "open search"),
         Windows("windows.run", "r", "open the Run dialog"),
         Windows("windows.search-s", "s", "open search"),
@@ -111,13 +111,13 @@ internal static class KnownShortcutCatalog
         // Win + named key.
         Windows("windows.task-view", "Tab", "open Task View"),
         Windows("windows.close-magnifier", "Escape", "close Magnifier"),
-        Windows("windows.about", "Pause", "open Settings to System > About"),
+        Windows("windows.about", "Pause", "open the About page in Settings"),
         Windows("windows.screenshot-file", "PrintScreen", "save a full-screen screenshot to a file"),
         Windows("windows.minimize-others", "Home", "minimize or restore all but the active window"),
         Windows("windows.maximize", "Up", "maximize the active window"),
         Windows("windows.minimize", "Down", "minimize the active window"),
-        Windows("windows.snap-left", "Left", "snap the window left"),
-        Windows("windows.snap-right", "Right", "snap the window right"),
+        Windows("windows.snap-left", "Left", "snap the window to the left half"),
+        Windows("windows.snap-right", "Right", "snap the window to the right half"),
         Windows("windows.input-next", "Space", "switch to the next input language or layout"),
 
         // Win + Shift.
@@ -134,7 +134,7 @@ internal static class KnownShortcutCatalog
         Windows("windows.input-previous", "Space", "switch to the previous input language or layout", shift: true),
 
         // Win + Ctrl. windows.wake-display carries Shift as well, so it lives here.
-        Windows("windows.color-filters", "c", "toggle color filters", ctrl: true),
+        Windows("windows.color-filters", "c", "turn color filters on and off", ctrl: true),
         Windows("windows.narrator", "Enter", "open Narrator", ctrl: true),
         Windows("windows.find-devices", "f", "search for devices on a network", ctrl: true),
         Windows("windows.quick-assist", "q", "open Quick Assist", ctrl: true),
@@ -143,7 +143,7 @@ internal static class KnownShortcutCatalog
         Windows("windows.input-recent", "Space", "switch to the previous input option", ctrl: true),
 
         // Win + Alt.
-        Windows("windows.hdr", "b", "toggle high dynamic range", alt: true),
+        Windows("windows.hdr", "b", "turn high dynamic range on and off", alt: true),
         Windows("windows.desktop-clock", "d", "show and hide date and time on the desktop", alt: true),
         Windows("windows.voice-keyboard-focus", "h", "focus the keyboard during voice typing", alt: true),
         Windows("windows.mute-mic", "k", "mute or unmute the microphone", alt: true),
@@ -155,7 +155,7 @@ internal static class KnownShortcutCatalog
         Windows("windows.start-menu", "Escape", "open the Start menu", ctrl: true, win: false),
         Windows("windows.switch-windows", "Tab", "switch between open windows", alt: true, win: false),
         Windows("windows.app-thumbnails", "Tab", "view thumbnails of all open apps", ctrl: true, alt: true, win: false),
-        Windows("windows.cycle-windows", "Escape", "cycle windows in the order opened", alt: true, win: false),
+        Windows("windows.cycle-windows", "Escape", "cycle through windows in the order they were opened", alt: true, win: false),
         Windows("windows.close-window", "F4", "close the active window", alt: true, win: false),
         Windows("windows.window-menu", "Space", "open the active window's context menu", alt: true, win: false),
         Windows("windows.show-password", "F8", "show the password on the sign-in screen", alt: true, win: false),

--- a/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
@@ -40,6 +40,12 @@ cp wwwroot/appsettings.Development.json.example wwwroot/appsettings.Development.
 `Auth:UseTestProvider=true`), paired with the API's `Docker SQL (No Auth)` profile. Git worktrees
 get this automatically via `setup-worktree-local-dev.ps1` (no example copy needed).
 
+> **This profile does not work in the main checkout right now.** .NET 10 fixes the WebAssembly boot
+> environment at build time, so `appsettings.NoAuth.json` is never read and the app boots into MSAL.
+> Worktrees are unaffected, because their script writes `appsettings.Development.json` instead. See
+> `.claude/backlog/039-no-auth-frontend-profile-broken.md` and the workaround in
+> `docs/development/playwright-setup.md`.
+
 ## Adding a Page
 
 1. Create `Pages/MyPage.razor` with `@page "/my-page"` directive

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyEditDialog.razor
@@ -43,19 +43,10 @@
                              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "win-checkbox" })" />
             </MudStack>
 
-            @* ---- Known-shortcut notice. Advisory only — it never gates Save. ---- *@
-            @if (_shortcutWarning is not null)
-            {
-                <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-2"
-                          UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "shortcut-warning" })">
-                    @_shortcutWarning
-                </MudAlert>
-            }
-            @* Outside the @if, so it renders on every pass. It is how an E2E test can tell
-               "no warning" apart from "not decided yet". Hidden: it is not for the reader. *@
-            <span data-test="shortcut-warning-checked"
-                  data-combination="@_shortcutChecked"
-                  style="display:none"></span>
+            @* ---- Known-shortcut notice. Advisory only — it never gates Save. The grid's inline
+                 row renders the same component, so both places the keys can change warn. ---- *@
+            <ShortcutWarning Key="@Item.Key" Ctrl="@Item.Ctrl" Alt="@Item.Alt"
+                             Shift="@Item.Shift" Win="@Item.Win" />
 
             @* ---- Action selector. Generated from the enum so the set cannot drift.
                  The wrapper div carries the CSS-isolation scope for the wrapping rule. ---- *@
@@ -285,7 +276,6 @@
     [Inject] private IJSRuntime JS { get; set; } = default!;
     [Inject] private ISnackbar Snackbar { get; set; } = default!;
     [Inject] private ILogger<HotkeyEditDialog> Logger { get; set; } = default!;
-    [Inject] private IKnownShortcutCatalog KnownShortcuts { get; set; } = default!;
 
     [Parameter] public HotkeyEditModel Item { get; set; } = new();
     [Parameter] public IReadOnlyList<ProfileDto> Profiles { get; set; } = [];
@@ -343,20 +333,6 @@
     private int _previewGeneration;
     private bool _disposed;
 
-    // The known-shortcut notice for the current combination, or null. Advisory only: it never
-    // gates Save. The list behind it is session-cached by IKnownShortcutCatalog, the same way
-    // IHotkeyKeyCatalog caches the key registry.
-    private string? _shortcutWarning;
-
-    // The combination the notice above was last decided for, or "" before the first decision. Set
-    // together with _shortcutWarning and under the same generation check, so it never announces a
-    // decision that a newer combination has already replaced. Read only by the E2E tests: it is
-    // how a test can tell "no warning" apart from "not evaluated yet".
-    private string _shortcutChecked = "";
-
-    private CancellationTokenSource? _shortcutCts;
-    private int _shortcutGeneration;
-
     protected override void OnParametersSet()
     {
         _profileOptions = [.. Profiles.Select(p => new EntityOption(p.Id, p.Name))];
@@ -367,9 +343,6 @@
             _lastItem = Item;
             if (Item.ActionKind == HotkeyActionKind.SendKeys)
                 DecomposeSendKeys();
-
-            _shortcutWarning = null;
-            _ = RefreshShortcutWarningAsync();
         }
     }
 
@@ -379,79 +352,6 @@
         _cts.Cancel();
         _cts.Dispose();
         CancelPendingPreview();
-        _shortcutCts?.Cancel();
-        _shortcutCts?.Dispose();
-        _shortcutCts = null;
-    }
-
-    /// <summary>
-    /// Refreshes the known-shortcut notice for the current combination. Fire-and-forget from the
-    /// change handlers: the notice is advisory, so nothing waits on it.
-    /// </summary>
-    /// <remarks>
-    /// Follows the preview's generation-counter pattern. A response for an older combination is
-    /// dropped rather than rendered, so holding a modifier key down cannot leave a stale notice
-    /// on screen. A failed fetch clears the notice and says nothing — a list that will not load
-    /// must never confuse saving.
-    /// </remarks>
-    private async Task RefreshShortcutWarningAsync()
-    {
-        _shortcutCts?.Cancel();
-        _shortcutCts?.Dispose();
-        CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
-        _shortcutCts = cts;
-        int generation = ++_shortcutGeneration;
-
-        try
-        {
-            string canonical = await Catalog.CanonicalizeAsync(Item.Key, cts.Token);
-
-            // Session-cached: only the first call in a session reaches the network. The
-            // generation check below still earns its place, because that first call can be slow
-            // enough for the user to change the combination while it is in flight.
-            KnownShortcutCatalogDto? catalog = await KnownShortcuts.GetAsync(cts.Token);
-
-            if (generation != _shortcutGeneration || _disposed)
-                return;
-
-            if (catalog is null)
-            {
-                // The fetch failed. Say nothing to the user — the feature is advisory — but leave
-                // a trace in the browser console. The cache does not memoize the failure, so the
-                // next open retries.
-                Logger.LogWarning("Known-shortcut list could not be read; showing no warning.");
-                _shortcutWarning = null;
-                // A list that will not load has still finished deciding, and it decides "no
-                // warning". Saying so keeps the E2E wait honest instead of hanging.
-                _shortcutChecked = HotkeyActionDisplay.ComboLabel(Item);
-                StateHasChanged();
-                return;
-            }
-
-            KnownShortcutDto? match = KnownShortcutWarning.Match(
-                catalog, canonical, Item.Ctrl, Item.Alt, Item.Shift, Item.Win);
-
-            _shortcutWarning = match is null
-                ? null
-                : KnownShortcutWarning.TextFor(match, HotkeyActionDisplay.ComboLabel(Item));
-            _shortcutChecked = HotkeyActionDisplay.ComboLabel(Item);
-
-            StateHasChanged();
-        }
-        catch (OperationCanceledException)
-        {
-            // Superseded by a newer combination, or the dialog closed. Nothing to show.
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "Known-shortcut list could not be read; showing no warning.");
-            if (generation == _shortcutGeneration && !_disposed)
-            {
-                _shortcutWarning = null;
-                _shortcutChecked = HotkeyActionDisplay.ComboLabel(Item);
-                StateHasChanged();
-            }
-        }
     }
 
     /// <summary>
@@ -585,9 +485,9 @@
         ClearSaveError(nameof(HotkeyEditModel.Key));
         _duplicateCombination = null;
         // The key is half the emitted line, so a stale preview here is worse than a stale
-        // payload preview — it shows the wrong binding entirely.
+        // payload preview — it shows the wrong binding entirely. The known-shortcut notice needs
+        // no call: ShortcutWarning re-decides from its parameters.
         RefreshPreview();
-        _ = RefreshShortcutWarningAsync();
     }
 
     /// <summary>
@@ -597,9 +497,10 @@
     /// </summary>
     private void OnModifierChanged()
     {
+        // The known-shortcut notice needs no call here: ShortcutWarning takes the combination as
+        // parameters and re-decides whenever this render changes them.
         _duplicateCombination = null;
         RefreshPreview();
-        _ = RefreshShortcutWarningAsync();
     }
 
     private void OnRunTargetKindChanged(RunTargetKind? kind)

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/ShortcutWarning.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/ShortcutWarning.razor
@@ -1,0 +1,135 @@
+@using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Helpers
+@using AHKFlowApp.UI.Blazor.Services
+@using MudBlazor
+@implements IDisposable
+
+@* Advisory only — this never gates a save. Both places a hotkey's keys can be changed render
+   it: the edit dialog and the grid's inline row. *@
+@if (_warning is not null)
+{
+    <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-2"
+              UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "shortcut-warning" })">
+        @_warning
+    </MudAlert>
+}
+@* Outside the @if, so it renders on every pass. It is how an E2E test can tell "no warning"
+   apart from "not decided yet". Hidden: it is not for the reader. *@
+<span data-test="shortcut-warning-checked"
+      data-combination="@_checked"
+      style="display:none"></span>
+
+@code {
+    [Parameter] public string? Key { get; set; }
+    [Parameter] public bool Ctrl { get; set; }
+    [Parameter] public bool Alt { get; set; }
+    [Parameter] public bool Shift { get; set; }
+    [Parameter] public bool Win { get; set; }
+
+    [Inject] private IHotkeyKeyCatalog Keys { get; set; } = default!;
+    [Inject] private IKnownShortcutCatalog KnownShortcuts { get; set; } = default!;
+    [Inject] private ILogger<ShortcutWarning> Logger { get; set; } = default!;
+
+    // The notice for the current combination, or null when nothing uses these keys.
+    private string? _warning;
+
+    // The combination the notice above was last decided for, or "" before the first decision. Set
+    // together with _warning and under the same generation check, so it never announces a decision
+    // that a newer combination has already replaced. Read only by the E2E tests: it is how a test
+    // can tell "no warning" apart from "not evaluated yet".
+    private string _checked = "";
+
+    // The combination the last evaluation ran for. Parameters are re-set on every parent render,
+    // and most of those renders change something else entirely.
+    private string? _evaluated;
+
+    private readonly CancellationTokenSource _cts = new();
+    private CancellationTokenSource? _shortcutCts;
+    private int _generation;
+    private bool _disposed;
+
+    protected override void OnParametersSet()
+    {
+        string combination = HotkeyActionDisplay.ComboLabel(Key ?? "", Ctrl, Alt, Shift, Win);
+
+        if (combination == _evaluated)
+            return;
+
+        _evaluated = combination;
+        _ = RefreshAsync(combination);
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        _cts.Cancel();
+        _cts.Dispose();
+        _shortcutCts?.Cancel();
+        _shortcutCts?.Dispose();
+        _shortcutCts = null;
+    }
+
+    /// <summary>
+    /// Refreshes the notice for one combination. Fire-and-forget from <c>OnParametersSet</c>: the
+    /// notice is advisory, so nothing waits on it.
+    /// </summary>
+    /// <remarks>
+    /// A response for an older combination is dropped rather than rendered, so holding a modifier
+    /// key down cannot leave a stale notice on screen. A failed fetch clears the notice and says
+    /// nothing — a list that will not load must never confuse saving.
+    /// </remarks>
+    private async Task RefreshAsync(string combination)
+    {
+        _shortcutCts?.Cancel();
+        _shortcutCts?.Dispose();
+        CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+        _shortcutCts = cts;
+        int generation = ++_generation;
+
+        try
+        {
+            string canonical = await Keys.CanonicalizeAsync(Key, cts.Token);
+
+            // Session-cached: only the first call in a session reaches the network. The generation
+            // check below still earns its place, because that first call can be slow enough for the
+            // user to change the combination while it is in flight.
+            KnownShortcutCatalogDto? catalog = await KnownShortcuts.GetAsync(cts.Token);
+
+            if (generation != _generation || _disposed)
+                return;
+
+            if (catalog is null)
+            {
+                // The fetch failed. Say nothing to the user — the feature is advisory — but leave a
+                // trace in the browser console. The cache does not memoize the failure, so the next
+                // evaluation retries.
+                Logger.LogWarning("Known-shortcut list could not be read; showing no warning.");
+                Decide(warning: null, combination);
+                return;
+            }
+
+            KnownShortcutDto? match = KnownShortcutWarning.Match(catalog, canonical, Ctrl, Alt, Shift, Win);
+
+            Decide(match is null ? null : KnownShortcutWarning.TextFor(match, combination), combination);
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer combination, or the host went away. Nothing to show.
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Known-shortcut list could not be read; showing no warning.");
+            if (generation == _generation && !_disposed)
+                Decide(warning: null, combination);
+        }
+    }
+
+    // A list that will not load has still finished deciding, and it decides "no warning". Saying so
+    // keeps the E2E wait honest instead of hanging.
+    private void Decide(string? warning, string combination)
+    {
+        _warning = warning;
+        _checked = combination;
+        StateHasChanged();
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/KnownShortcutWarning.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/KnownShortcutWarning.cs
@@ -30,7 +30,11 @@ internal static class KnownShortcutWarning
     private const string UnknownClosing =
         "What happens when you press these keys depends on what else is installed.";
 
-    private const string ForegroundTail = ", but only while that application is in front.";
+    // Agrees with the subject. One sentence can name several products — "Chrome and Edge use
+    // Ctrl+T …" — and a fixed singular tail made that sentence disagree with itself.
+    private const string ForegroundTailOne = ", but only while that application is in front.";
+
+    private const string ForegroundTailMany = ", but only while those applications are in front.";
 
     /// <summary>
     /// The known shortcut this combination matches, or null. The key must already be canonical —
@@ -67,7 +71,9 @@ internal static class KnownShortcutWarning
             string[] labels = [.. group.Select(u => u.UsedBy)];
             string subject = JoinLabels(labels);
             string verb = labels.Length == 1 ? "uses" : "use";
-            string tail = group.Key.Scope == ShortcutScope.Foreground ? ForegroundTail : ".";
+            string tail = group.Key.Scope == ShortcutScope.Foreground
+                ? labels.Length == 1 ? ForegroundTailOne : ForegroundTailMany
+                : ".";
 
             sentences.Add($"{subject} {verb} {comboLabel} to {group.Key.Does}{tail}");
         }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
@@ -729,20 +729,26 @@
         _cachedListPage = null;
     }
 
-    private RenderFragment RenderKeyEditor(HotkeyEditModel edit) => @<MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Wrap="Wrap.Wrap">
-        <KeyPicker Role="HotkeyKey" Dense="true"
-                   Value="@edit.Key" ValueChanged="value => edit.Key = value ?? string.Empty"
-                   Error="@(_commitAttempted && ValidateKey(edit.Key) is not null)"
-                   ErrorText="@(_commitAttempted ? ValidateKey(edit.Key) : null)"
-                   DataTest="key-input" />
-        <MudCheckBox T="bool" Dense="true" Label="Ctrl" @bind-Value="edit.Ctrl"
-                     UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "ctrl-checkbox" })" />
-        <MudCheckBox T="bool" Dense="true" Label="Alt" @bind-Value="edit.Alt"
-                     UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "alt-checkbox" })" />
-        <MudCheckBox T="bool" Dense="true" Label="Shift" @bind-Value="edit.Shift"
-                     UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "shift-checkbox" })" />
-        <MudCheckBox T="bool" Dense="true" Label="Win" @bind-Value="edit.Win"
-                     UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "win-checkbox" })" />
+    private RenderFragment RenderKeyEditor(HotkeyEditModel edit) => @<MudStack Spacing="1">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Wrap="Wrap.Wrap">
+            <KeyPicker Role="HotkeyKey" Dense="true"
+                       Value="@edit.Key" ValueChanged="value => edit.Key = value ?? string.Empty"
+                       Error="@(_commitAttempted && ValidateKey(edit.Key) is not null)"
+                       ErrorText="@(_commitAttempted ? ValidateKey(edit.Key) : null)"
+                       DataTest="key-input" />
+            <MudCheckBox T="bool" Dense="true" Label="Ctrl" @bind-Value="edit.Ctrl"
+                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "ctrl-checkbox" })" />
+            <MudCheckBox T="bool" Dense="true" Label="Alt" @bind-Value="edit.Alt"
+                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "alt-checkbox" })" />
+            <MudCheckBox T="bool" Dense="true" Label="Shift" @bind-Value="edit.Shift"
+                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "shift-checkbox" })" />
+            <MudCheckBox T="bool" Dense="true" Label="Win" @bind-Value="edit.Win"
+                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "win-checkbox" })" />
+        </MudStack>
+        @* The row edits the keys, so the row warns about them — the same component the dialog
+           renders. Without it, re-keying an existing hotkey to Win+E said nothing. *@
+        <ShortcutWarning Key="@edit.Key" Ctrl="@edit.Ctrl" Alt="@edit.Alt"
+                         Shift="@edit.Shift" Win="@edit.Win" />
     </MudStack>;
 
     // Only the two single-field kinds reach inline edit (HotkeyEditModel.IsInlineEditable), so
@@ -857,6 +863,11 @@
             <MudIconButton Class="start-edit" Icon="@Icons.Material.Filled.Edit"
                            OnClick="() => StartEditAsync(item)"
                            UserAttributes="@(new Dictionary<string, object?> { ["aria-label"] = $"Edit {item.Description}" })" />
+            @* Inline edit covers the two single-field kinds, and it cannot change the action kind.
+               This is how those rows reach the full editor, which can. *@
+            <MudIconButton Class="open-full-editor" Icon="@Icons.Material.Filled.OpenInFull"
+                           OnClick="() => OpenEditDialogAsync(item)"
+                           UserAttributes="@(new Dictionary<string, object?> { ["aria-label"] = $"Open the full editor for {item.Description}", ["title"] = "Open the full editor" })" />
         }
     </text>;
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
@@ -3,6 +3,7 @@
 @using AHKFlowApp.UI.Blazor.Helpers
 @using AHKFlowApp.UI.Blazor.Services
 @using MudBlazor
+@using Microsoft.AspNetCore.Components.Authorization
 @implements IDisposable
 
 <PageTitle>Known shortcuts</PageTitle>
@@ -17,11 +18,13 @@
 <MudPaper Class="pa-4">
     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap" Class="mb-4">
         <MudButton Class="add-known-shortcut" Variant="Variant.Filled" Color="Color.Primary"
-                   StartIcon="@Icons.Material.Filled.Add" OnClick="StartAdd" Disabled="@_adding">
+                   StartIcon="@Icons.Material.Filled.Add" OnClick="StartAdd"
+                   Disabled="@(!_isAuthenticated || _adding || _busy)">
             Add
         </MudButton>
         <MudButton Class="reload-known-shortcuts" Variant="Variant.Filled" Color="Color.Secondary"
-                   StartIcon="@Icons.Material.Filled.Refresh" OnClick="ReloadAsync" Disabled="@_loading">
+                   StartIcon="@Icons.Material.Filled.Refresh" OnClick="ReloadAsync"
+                   Disabled="@(!_isAuthenticated || _loading || _busy)">
             Reload
         </MudButton>
         <MudTextField T="string" @bind-Value="_search" Immediate="true" Clearable="true"
@@ -29,6 +32,11 @@
                       AdornmentIcon="@Icons.Material.Filled.Search"
                       UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "known-shortcut-search" })" />
     </MudStack>
+
+    @if (!_isAuthenticated)
+    {
+        <MudAlert Severity="Severity.Info" Class="mb-3">You are not signed in.</MudAlert>
+    }
 
     @if (_adding)
     {
@@ -111,22 +119,24 @@
                 }
             </MudTd>
             <MudTd DataLabel="Actions">
+                @* Every action is disabled while one is running. Two overlapping writes each end
+                   with their own reload, and the older answer could land last. *@
                 @if (context.Use.Origin == ShortcutRecordOrigin.Owner)
                 {
                     <MudIconButton Class="delete-use" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
-                                   OnClick="() => DeleteAsync(context)"
+                                   OnClick="() => DeleteAsync(context)" Disabled="@_busy"
                                    UserAttributes='@UseAttributes(context, "Delete this record")' />
                 }
                 else if (context.Use.IsIgnored)
                 {
                     <MudIconButton Class="restore-use" Icon="@Icons.Material.Filled.NotificationsActive"
-                                   OnClick="() => RestoreAsync(context)"
+                                   OnClick="() => RestoreAsync(context)" Disabled="@_busy"
                                    UserAttributes='@UseAttributes(context, "Warn about this again")' />
                 }
                 else
                 {
                     <MudIconButton Class="ignore-use" Icon="@Icons.Material.Filled.NotificationsOff"
-                                   OnClick="() => IgnoreAsync(context)"
+                                   OnClick="() => IgnoreAsync(context)" Disabled="@_busy"
                                    UserAttributes='@UseAttributes(context, "Stop warning about this")' />
                 }
             </MudTd>
@@ -148,9 +158,11 @@
 </MudPaper>
 
 @code {
+    [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
     [Inject] private IKnownShortcutsApiClient Api { get; set; } = default!;
     [Inject] private IKnownShortcutCatalog Catalog { get; set; } = default!;
     [Inject] private ISnackbar Snackbar { get; set; } = default!;
+    [Inject] private IDialogService DialogService { get; set; } = default!;
 
     /// <summary>One use, flattened out of its combination so MudTable stays one row per item.</summary>
     private sealed record UseRow(string ShortcutId, string ComboLabel, ManagedShortcutUseDto Use);
@@ -175,12 +187,30 @@
     private string? _search;
     private string? _loadError;
     private string? _formError;
+    private bool _isAuthenticated;
     private bool _adding;
     private bool _loading;
     private bool _saving;
+
+    // True while a write is in flight. Every action button reads it, so a second write cannot
+    // start before the first one has reloaded the list. Reload watches _loading for the same
+    // reason: one read and one write at a time means two answers can never arrive out of order.
+    private bool _busy;
+
     private readonly CancellationTokenSource _cts = new();
 
-    protected override Task OnInitializedAsync() => LoadAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        if (AuthState is not null)
+        {
+            AuthenticationState state = await AuthState;
+            _isAuthenticated = state.User.Identity?.IsAuthenticated ?? false;
+        }
+
+        // Signed out, every call comes back 401. Say so once instead of asking and reporting.
+        if (_isAuthenticated)
+            await LoadAsync();
+    }
 
     private async Task LoadAsync()
     {
@@ -281,31 +311,62 @@
         if (row.Use.OwnerRecordId is not Guid recordId)
             return;
 
-        ApiResult result = await Api.DeleteAsync(recordId, _cts.Token);
-        await AfterMutationAsync(result, "Record deleted.");
+        // Asked first, like every other delete in the app. There is no recycle bin for these, so
+        // a mis-click would mean typing the record again.
+        bool? confirmed = await DialogService.ShowMessageBoxAsync(
+            title: "Delete this record?",
+            message: $"Stop recording that {row.Use.UsedBy} uses {row.ComboLabel}? This cannot be undone.",
+            yesText: "Delete", cancelText: "Cancel");
+
+        if (confirmed != true)
+            return;
+
+        await RunMutationAsync(() => Api.DeleteAsync(recordId, _cts.Token), "Record deleted.");
     }
 
-    private async Task IgnoreAsync(UseRow row)
-    {
-        ApiResult result = await Api.IgnoreAsync(row.ShortcutId, row.Use.UsedBy, _cts.Token);
-        await AfterMutationAsync(result, "Warning silenced.");
-    }
+    private Task IgnoreAsync(UseRow row) => RunMutationAsync(
+        () => Api.IgnoreAsync(row.ShortcutId, row.Use.UsedBy, _cts.Token), "Warning silenced.");
 
-    private async Task RestoreAsync(UseRow row)
+    private Task RestoreAsync(UseRow row) => RunMutationAsync(
+        () => Api.RestoreAsync(row.ShortcutId, row.Use.UsedBy, _cts.Token), "Warning turned back on.");
+
+    // One write at a time. Every action button is disabled while _busy, so two writes cannot
+    // overlap and race their reloads.
+    private async Task RunMutationAsync(Func<Task<ApiResult>> call, string successMessage)
     {
-        ApiResult result = await Api.RestoreAsync(row.ShortcutId, row.Use.UsedBy, _cts.Token);
-        await AfterMutationAsync(result, "Warning turned back on.");
+        if (_busy)
+            return;
+
+        _busy = true;
+
+        try
+        {
+            await AfterMutationAsync(await call(), successMessage);
+        }
+        finally
+        {
+            _busy = false;
+        }
     }
 
     // These three routes answer 204 with no body, so the page holds no fresh state and reloads.
     // The dialog holds its own cached copy, so it is invalidated here too — reloading _rows
-    // refreshes this page only. A failed call invalidates nothing: throwing the cache away would
-    // cost a refetch for no reason and hide the failure behind a slow dialog.
+    // refreshes this page only.
     private async Task AfterMutationAsync(ApiResult result, string successMessage)
     {
         if (!result.IsSuccess)
         {
             Snackbar.Add(ApiErrorMessageFactory.Build(result.Status, result.Problem), Severity.Error);
+
+            // A failure the server answered changed nothing, so the page is still right and the
+            // cache is still worth keeping. A lost response is different: the write may have
+            // landed, so the only honest thing to show is what the server says now.
+            if (result.Status == ApiResultStatus.NetworkError)
+            {
+                Catalog.Invalidate();
+                await LoadAsync();
+            }
+
             return;
         }
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
@@ -127,15 +127,19 @@
                                    OnClick="() => DeleteAsync(context)" Disabled="@_busy"
                                    UserAttributes='@UseAttributes(context, "Delete this record")' />
                 }
+                @* The bell shows the state of the row, matching its chip: crossed out on a
+                   silenced use, ringing on one that still warns. It used to show the action
+                   instead, which put a ringing bell next to the word "Silenced". The tooltip
+                   carries what the click does. *@
                 else if (context.Use.IsIgnored)
                 {
-                    <MudIconButton Class="restore-use" Icon="@Icons.Material.Filled.NotificationsActive"
+                    <MudIconButton Class="restore-use" Icon="@Icons.Material.Filled.NotificationsOff"
                                    OnClick="() => RestoreAsync(context)" Disabled="@_busy"
                                    UserAttributes='@UseAttributes(context, "Warn about this again")' />
                 }
                 else
                 {
-                    <MudIconButton Class="ignore-use" Icon="@Icons.Material.Filled.NotificationsOff"
+                    <MudIconButton Class="ignore-use" Icon="@Icons.Material.Filled.NotificationsActive"
                                    OnClick="() => IgnoreAsync(context)" Disabled="@_busy"
                                    UserAttributes='@UseAttributes(context, "Stop warning about this")' />
                 }
@@ -251,10 +255,20 @@
             return true;
 
         string term = _search.Trim();
-        return row.ComboLabel.Contains(term, StringComparison.OrdinalIgnoreCase)
+        return MatchesCombination(row.ComboLabel, term)
             || row.Use.UsedBy.Contains(term, StringComparison.OrdinalIgnoreCase)
             || row.Use.Does.Contains(term, StringComparison.OrdinalIgnoreCase);
     }
+
+    // A combination gets written several ways. The label is "Ctrl+T", and people type "Ctrl + T"
+    // or "ctrl t". Spaces and plus signs are dropped from both sides before comparing, so every
+    // spelling finds the same row. Only this field is treated that way — the other two are
+    // ordinary text, where a space is part of what was typed.
+    private static bool MatchesCombination(string comboLabel, string term) =>
+        Squeeze(comboLabel).Contains(Squeeze(term), StringComparison.OrdinalIgnoreCase);
+
+    private static string Squeeze(string value) =>
+        value.Replace(" ", "", StringComparison.Ordinal).Replace("+", "", StringComparison.Ordinal);
 
     private static string ScopeLabel(ShortcutScope scope) =>
         scope == ShortcutScope.Global ? "Anywhere" : "Only in front";

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/ApiErrorMessageFactory.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/ApiErrorMessageFactory.cs
@@ -7,13 +7,29 @@ public static class ApiErrorMessageFactory
     public static string Build(ApiResultStatus status, ApiProblemDetails? problem) => status switch
     {
         ApiResultStatus.Validation when problem?.Errors is { Count: > 0 } errors =>
-            string.Join("; ", errors.SelectMany(kv => kv.Value.Select(v => $"{kv.Key}: {v}"))),
+            string.Join("; ", errors.SelectMany(kv => kv.Value.Select(v => $"{FieldLabel(kv.Key)}: {v}"))),
         ApiResultStatus.Validation => problem?.Detail ?? "The request was invalid.",
-        ApiResultStatus.NotFound => problem?.Detail ?? "Hotstring not found.",
-        ApiResultStatus.Conflict => problem?.Detail ?? "A hotstring with that trigger already exists.",
+        // Entity-neutral fallbacks. Every page uses this helper, so naming one entity here put
+        // "Hotstring not found." in front of someone deleting a known shortcut.
+        ApiResultStatus.NotFound => problem?.Detail ?? "That item was not found.",
+        ApiResultStatus.Conflict => problem?.Detail ?? "That item already exists.",
         ApiResultStatus.Unauthorized => "You are not signed in.",
         ApiResultStatus.Forbidden => "You do not have permission to perform this action.",
         ApiResultStatus.NetworkError => "Unable to reach the API. Check your connection and try again.",
         _ => problem?.Detail ?? "An unexpected error occurred.",
     };
+
+    /// <summary>
+    /// The part of a validation key a reader can use. FluentValidation names a nested property by
+    /// its whole path, so a command wrapping a DTO produces "Input.Does" — the shape of the
+    /// request object, which means nothing to the person reading the message. Only the last
+    /// segment names the field they filled in.
+    /// </summary>
+    private static string FieldLabel(string key)
+    {
+        int lastDot = key.LastIndexOf('.');
+
+        // A trailing dot leaves nothing to show, so keep the key as it came.
+        return lastDot >= 0 && lastDot < key.Length - 1 ? key[(lastDot + 1)..] : key;
+    }
 }

--- a/tests/AHKFlowApp.Application.Tests/Constants/KnownShortcutCatalogTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Constants/KnownShortcutCatalogTests.cs
@@ -88,6 +88,23 @@ public sealed class KnownShortcutCatalogTests
     }
 
     [Fact]
+    public void All_DoesPhrasesUsePlainEnglish()
+    {
+        // Each phrase lands in a sentence a reader has to understand at a glance, so the manifest
+        // holds itself to AGENTS.md's Plain English rules. "toggle" is the one word that kept
+        // creeping in; "turn X on and off" says the same thing in common words. A phrase also
+        // reads as a whole sentence with "Windows uses Win+E to …" in front of it, which is why
+        // it must not start with "to".
+        foreach (KnownShortcut shortcut in KnownShortcutCatalog.All)
+            foreach (ShortcutUse use in shortcut.Uses)
+            {
+                use.Does.Should().NotStartWith("toggle", $"{shortcut.Id} / {use.UsedBy}");
+                use.Does.Should().NotStartWith("to ", $"{shortcut.Id} / {use.UsedBy}");
+                use.Does.Should().NotEndWith(".", $"{shortcut.Id} / {use.UsedBy}");
+            }
+    }
+
+    [Fact]
     public void Protected_IsClaimedByExactlyTheTwoDocumentedRows()
     {
         KnownShortcutCatalog.All

--- a/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
@@ -55,6 +55,62 @@ public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifet
             new PageWaitForSelectorOptions { State = WaitForSelectorState.Detached });
     }
 
+    [Fact]
+    public async Task RekeyingAnExistingHotkeyInline_WarnsInTheRow()
+    {
+        await using IBrowserContext context = await fixture.Browser.NewContextAsync();
+        IPage page = await context.NewPageAsync();
+
+        // A SendText hotkey edits inline, in the grid row, never in the dialog. The row changes the
+        // key and every modifier, so the row has to warn about them too.
+        await OpenCreateDialogAsync(page);
+        await CommitKeyAsync(page, "F13");
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"description-input\"]", "E2E inline rekey");
+        await page.FillAsync(".hotkey-edit-dialog [data-test=\"text-input\"]", "my notes");
+        await page.ClickAsync(".hotkey-edit-dialog button.commit-edit");
+        await page.WaitForSelectorAsync("text=Hotkey created.");
+
+        // Scoped to the desktop branch: the mobile branch renders too and is hidden by CSS only.
+        await page.Locator(".desktop-branch tr", new() { HasTextString = "E2E inline rekey" })
+            .Locator("button.start-edit").ClickAsync();
+
+        // The editing row is addressed by its own class from here on. Its cells hold inputs now, so
+        // the description no longer appears as row text and a HasText filter stops matching it —
+        // the same reason VersionHistoryFlowTests uses tr.edit-row.
+        ILocator row = page.Locator("tr.edit-row");
+        await page.WaitForSelectorAsync("tr.edit-row");
+
+        ILocator keyInput = row.Locator("input[data-test=\"key-input\"]");
+        await keyInput.ClickAsync();
+        await keyInput.FillAsync("e");
+        await keyInput.PressAsync("Tab");
+        await row.Locator("input[data-test=\"win-checkbox\"]").CheckAsync();
+
+        await Assertions.Expect(row.Locator("[data-test=\"shortcut-warning\"]"))
+            .ToContainTextAsync("Windows uses Win+E to open File Explorer.");
+    }
+
+    [Fact]
+    public async Task AnInlineEditableRow_CanStillOpenTheFullEditor()
+    {
+        await using IBrowserContext context = await fixture.Browser.NewContextAsync();
+        IPage page = await context.NewPageAsync();
+
+        await OpenCreateDialogAsync(page);
+        await CommitKeyAsync(page, "F14");
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"description-input\"]", "E2E full editor");
+        await page.FillAsync(".hotkey-edit-dialog [data-test=\"text-input\"]", "my notes");
+        await page.ClickAsync(".hotkey-edit-dialog button.commit-edit");
+        await page.WaitForSelectorAsync("text=Hotkey created.");
+
+        // Edit sends this row inline, which cannot change the action kind. This button is the way
+        // back to the editor that can.
+        ILocator row = page.Locator(".desktop-branch tr", new() { HasTextString = "E2E full editor" });
+        await row.Locator("button.open-full-editor").ClickAsync();
+
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog [data-test=\"action-kind-selector\"]");
+    }
+
     // Addresses the Windows use of Win+E by id and use label, not by row text. A combination can
     // hold several uses, and each has its own buttons.
     private const string WindowsFileExplorerUse =

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/KnownShortcutWarningTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/KnownShortcutWarningTests.cs
@@ -69,7 +69,28 @@ public sealed class KnownShortcutWarningTests
             Use("Edge", ShortcutProtection.Normal, ShortcutScope.Foreground, "open a new tab"));
 
         KnownShortcutWarning.TextFor(shortcut, "Ctrl+T").Should().StartWith(
-            "Chrome and Edge use Ctrl+T to open a new tab, but only while that application is in front.");
+            "Chrome and Edge use Ctrl+T to open a new tab, but only while those applications are in front.");
+    }
+
+    [Fact]
+    public void TextFor_ForegroundTail_AgreesWithTheNumberOfLabels()
+    {
+        // One label keeps the singular tail. Two share one sentence, so the tail turns plural —
+        // "Chrome and Edge use … while that application is in front" disagreed with itself.
+        KnownShortcutDto one = Shortcut("browser.new-tab", "t", true, false, false, false,
+            Use("Chrome", ShortcutProtection.Normal, ShortcutScope.Foreground, "open a new tab"));
+
+        KnownShortcutDto two = Shortcut("browser.new-tab", "t", true, false, false, false,
+            Use("Chrome", ShortcutProtection.Normal, ShortcutScope.Foreground, "open a new tab"),
+            Use("Edge", ShortcutProtection.Normal, ShortcutScope.Foreground, "open a new tab"));
+
+        KnownShortcutWarning.TextFor(one, "Ctrl+T")
+            .Should().Contain("but only while that application is in front.")
+            .And.NotContain("those applications");
+
+        KnownShortcutWarning.TextFor(two, "Ctrl+T")
+            .Should().Contain("but only while those applications are in front.")
+            .And.NotContain("that application");
     }
 
     [Fact]

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
@@ -1,9 +1,11 @@
-﻿using AHKFlowApp.UI.Blazor.DTOs;
+﻿using System.Security.Claims;
+using AHKFlowApp.UI.Blazor.DTOs;
 using AHKFlowApp.UI.Blazor.Pages;
 using AHKFlowApp.UI.Blazor.Services;
 using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
 using MudBlazor.Services;
@@ -63,10 +65,35 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         _api.ListManagedAsync(Arg.Any<CancellationToken>())
             .Returns(ApiResult<ManagedKnownShortcutCatalogDto>.Failure(ApiResultStatus.ServerError, null));
 
+    private static readonly Task<AuthenticationState> AuthenticatedState =
+        Task.FromResult(new AuthenticationState(
+            new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "testuser")], "test"))));
+
+    private static readonly Task<AuthenticationState> AnonymousState =
+        Task.FromResult(new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity())));
+
     private IRenderedComponent<KnownShortcuts> RenderPage()
     {
         Render<MudPopoverProvider>();
-        return Render<KnownShortcuts>();
+        return Render<KnownShortcuts>(p => p.AddCascadingValue(AuthenticatedState));
+    }
+
+    private IRenderedComponent<KnownShortcuts> RenderSignedOutPage()
+    {
+        Render<MudPopoverProvider>();
+        return Render<KnownShortcuts>(p => p.AddCascadingValue(AnonymousState));
+    }
+
+    // Confirms or cancels the delete message box. Registered before the page renders, because the
+    // page resolves IDialogService once.
+    private void StubDeleteConfirmation(bool confirmed)
+    {
+        IDialogService dialogService = Substitute.For<IDialogService>();
+        dialogService.ShowMessageBoxAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<DialogOptions>())
+            .Returns(Task.FromResult<bool?>(confirmed ? true : null));
+        Services.AddSingleton(dialogService);
     }
 
     private static IElement Button(IRenderedComponent<KnownShortcuts> page, string css, string shortcutId, string usedBy) =>
@@ -116,13 +143,15 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
     public void OwnerUse_OffersDelete_AndCallsItWithTheRecordId()
     {
         var recordId = Guid.NewGuid();
+        StubDeleteConfirmation(confirmed: true);
         StubList(Shortcut("owner.1", "F7", OwnerUse(recordId)));
         _api.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(ApiResult.Ok());
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
         page.Find("button.delete-use").Click();
 
-        _api.Received(1).DeleteAsync(recordId, Arg.Any<CancellationToken>());
+        page.WaitForAssertion(() =>
+            _api.Received(1).DeleteAsync(recordId, Arg.Any<CancellationToken>()));
     }
 
     [Fact]
@@ -245,6 +274,105 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         page.FindAll("div.mud-alert").Should().NotBeEmpty();
     }
 
+    [Fact]
+    public void SignedOut_SaysSo_AndReadsNothing()
+    {
+        // Same shape as the categories page: no request goes out, and the two toolbar buttons are
+        // dead until there is someone to act as.
+        StubList(Shortcut("windows.file-explorer", "e", BuiltInUse()));
+
+        IRenderedComponent<KnownShortcuts> page = RenderSignedOutPage();
+
+        _api.DidNotReceive().ListManagedAsync(Arg.Any<CancellationToken>());
+        page.Markup.Should().Contain("You are not signed in.");
+        page.Find("button.add-known-shortcut").HasAttribute("disabled").Should().BeTrue();
+        page.Find("button.reload-known-shortcuts").HasAttribute("disabled").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Delete_WhenTheConfirmationIsCancelled_RemovesNothing()
+    {
+        StubDeleteConfirmation(confirmed: false);
+        StubList(Shortcut("owner.1", "F7", OwnerUse(Guid.NewGuid())));
+        _api.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(ApiResult.Ok());
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        page.Find("button.delete-use").Click();
+
+        _api.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        page.FindAll("[data-test=\"known-shortcut-row\"]").Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Delete_WhenConfirmed_RemovesTheRecord()
+    {
+        var recordId = Guid.NewGuid();
+        StubDeleteConfirmation(confirmed: true);
+        StubList(Shortcut("owner.1", "F7", OwnerUse(recordId)));
+        _api.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(ApiResult.Ok());
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        page.Find("button.delete-use").Click();
+
+        page.WaitForAssertion(() =>
+            _api.Received(1).DeleteAsync(recordId, Arg.Any<CancellationToken>()));
+    }
+
+    [Fact]
+    public void WhileAMutationIsInFlight_TheRowActionsAreDisabled()
+    {
+        // Two clicks on one row used to send two requests, and their two reloads then raced.
+        TaskCompletionSource<ApiResult> pending = new();
+        StubList(Shortcut("windows.file-explorer", "e", BuiltInUse()));
+        _api.IgnoreAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(pending.Task);
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        page.Find("button.ignore-use").Click();
+
+        page.Find("button.ignore-use").HasAttribute("disabled").Should().BeTrue();
+        page.Find("button.reload-known-shortcuts").HasAttribute("disabled").Should().BeTrue();
+
+        pending.SetResult(ApiResult.Ok());
+        page.WaitForAssertion(() =>
+            page.Find("button.reload-known-shortcuts").HasAttribute("disabled").Should().BeFalse());
+    }
+
+    [Fact]
+    public void WhileAReadIsInFlight_ReloadIsDisabled()
+    {
+        // The other half of "one at a time": a second read cannot start while the first is out,
+        // so two answers can never arrive in the wrong order.
+        TaskCompletionSource<ApiResult<ManagedKnownShortcutCatalogDto>> pending = new();
+        _api.ListManagedAsync(Arg.Any<CancellationToken>()).Returns(pending.Task);
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+
+        page.Find("button.reload-known-shortcuts").HasAttribute("disabled").Should().BeTrue();
+
+        pending.SetResult(ApiResult<ManagedKnownShortcutCatalogDto>.Ok(
+            new ManagedKnownShortcutCatalogDto([BrowserShortcut()])));
+
+        page.WaitForAssertion(() =>
+            page.Find("button.reload-known-shortcuts").HasAttribute("disabled").Should().BeFalse());
+    }
+
+    [Fact]
+    public void AMutationLostToTheNetwork_ReconcilesWithTheServer()
+    {
+        // No response came back, so the write may or may not have landed. The page and the dialog
+        // cache both have to be re-read, or a silenced use keeps warning until a hard reload.
+        StubList(Shortcut("windows.file-explorer", "e", BuiltInUse()));
+        _api.IgnoreAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Failure(ApiResultStatus.NetworkError, null));
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        page.Find("button.ignore-use").Click();
+
+        page.WaitForAssertion(() => _catalog.Received(1).Invalidate());
+        _api.Received(2).ListManagedAsync(Arg.Any<CancellationToken>());
+    }
+
     [Theory]
     [InlineData("ignore")]
     [InlineData("restore")]
@@ -257,7 +385,7 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         IRenderedComponent<KnownShortcuts> page = RenderPage();
         PerformMutation(page, mutation);
 
-        _catalog.Received(1).Invalidate();
+        page.WaitForAssertion(() => _catalog.Received(1).Invalidate());
     }
 
     [Theory]
@@ -267,8 +395,10 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
     [InlineData("create")]
     public void AFailedMutation_DoesNotInvalidateTheDialogCache(string mutation)
     {
-        // Throwing the cache away on a failure costs a refetch for no reason, and hides the
-        // failure behind a slow dialog.
+        // A failure the server answered — 500 here — changed nothing the page is showing, so
+        // throwing the cache away costs a refetch for no reason and hides the failure behind a
+        // slow dialog. A lost response is the other case, and
+        // AMutationLostToTheNetwork_ReconcilesWithTheServer covers it.
         ArrangeMutation(mutation, succeeds: false);
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
@@ -280,6 +410,9 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
     private void ArrangeMutation(string mutation, bool succeeds)
     {
         ApiResult result = succeeds ? ApiResult.Ok() : ApiResult.Failure(ApiResultStatus.ServerError, null);
+
+        // Delete asks first. Both theories drive the confirmed path.
+        StubDeleteConfirmation(confirmed: true);
 
         switch (mutation)
         {

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
@@ -274,6 +274,58 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         page.FindAll("div.mud-alert").Should().NotBeEmpty();
     }
 
+    [Theory]
+    [InlineData("Ctrl+N")]
+    [InlineData("Ctrl + N")]
+    [InlineData("ctrl n")]
+    public void Search_MatchesACombinationHoweverItIsSpaced(string term)
+    {
+        StubList(BrowserShortcut(), Shortcut("windows.file-explorer", "e", BuiltInUse()));
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        page.Find("[data-test=\"known-shortcut-search\"]").Input(term);
+
+        page.FindAll("[data-test=\"known-shortcut-row\"]").Should()
+            .HaveCount(2, "Ctrl+N carries a Chrome use and an Edge use");
+    }
+
+    [Fact]
+    public void Search_OnTheOtherFields_KeepsSpacesMeaningful()
+    {
+        StubList(BrowserShortcut());
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        page.Find("[data-test=\"known-shortcut-search\"]").Input("new window");
+
+        page.FindAll("[data-test=\"known-shortcut-row\"]").Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void TheBellIconShowsTheState_NotTheAction()
+    {
+        // A ringing bell beside the word "Silenced" read as a contradiction. The icon agrees with
+        // the chip now, and the tooltip says what the click does.
+        StubList(
+            Shortcut("windows.file-explorer", "e", BuiltInUse()),
+            Shortcut("windows.lock", "l", BuiltInUse(ignored: true)));
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+
+        page.Find("button.ignore-use").InnerHtml
+            .Should().Contain(IconPath(Icons.Material.Filled.NotificationsActive));
+        page.Find("button.restore-use").InnerHtml
+            .Should().Contain(IconPath(Icons.Material.Filled.NotificationsOff));
+    }
+
+    // MudBlazor icons are whole SVG strings. Only the path data survives rendering unchanged, so
+    // that is what the assertion compares — and it comes from the constant, never retyped.
+    private static string IconPath(string icon)
+    {
+        int start = icon.IndexOf("d=\"", StringComparison.Ordinal) + 3;
+        int end = icon.IndexOf('"', start);
+        return icon[start..end];
+    }
+
     [Fact]
     public void SignedOut_SaysSo_AndReadsNothing()
     {

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Services/ApiErrorMessageFactoryTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Services/ApiErrorMessageFactoryTests.cs
@@ -20,6 +20,28 @@ public sealed class ApiErrorMessageFactoryTests
     }
 
     [Fact]
+    public void Build_ForValidation_ShowsOnlyTheLastSegmentOfANestedKey()
+    {
+        // FluentValidation names a nested property by its whole path. "Input.Does" describes the
+        // request object, not anything the reader typed into.
+        var problem = new ApiProblemDetails(null, "Validation failed", 400, null, null,
+            new Dictionary<string, string[]> { ["Input.Does"] = ["Say what the keys do."] });
+
+        string msg = ApiErrorMessageFactory.Build(ApiResultStatus.Validation, problem);
+
+        msg.Should().Be("Does: Say what the keys do.");
+    }
+
+    [Fact]
+    public void Build_ForNotFoundWithoutDetail_NamesNoEntity()
+    {
+        // Every page shares this helper, so the fallback must not name one entity.
+        string msg = ApiErrorMessageFactory.Build(ApiResultStatus.NotFound, null);
+
+        msg.Should().NotContain("otstring");
+    }
+
+    [Fact]
     public void Build_ForConflict_UsesProblemDetailOrFallback()
     {
         var problem = new ApiProblemDetails(null, "Conflict", 409, "Trigger already exists for this profile", null, null);


### PR DESCRIPTION
Three small fixes and two backlog items, all found while reviewing the hotkey shortcut warnings feature (Stage 1 PR #232, Stage 2 PR #233) with the E2E suite and a live Playwright drive.

## What the review found

The feature itself is sound. Fast (2558), Integration (611) and E2E (23) all passed on `main` before any change here. The live drive confirmed the Protected closing, the two-use browser sentence, per-use silencing, owner records, the duplicate conflict, and both validator rules. These three are the rough edges it turned up.

## 1. Plural foreground tail

`KnownShortcutWarning` used one fixed tail, so a sentence naming two products disagreed with itself:

> Chrome and Edge use Ctrl+T to open a new tab, but only while **that application** is in front.

Now the tail agrees with the number of labels — `those applications are in front` when a sentence names more than one. The existing two-label test asserted the old wording, so it moved with the fix, and a new test pins both forms.

## 2. Readable API error text

Two problems in `ApiErrorMessageFactory`, both visible on the new Known shortcuts page:

- Validation messages carried the whole FluentValidation property path. A command wrapping a DTO produced `Input.Does: Start with a lowercase verb…` — that prefix describes the request object, not the field the reader filled in. Only the last segment is shown now, so it reads `Does: …`. A key with no dot, such as `Trigger`, is unchanged.
- The `NotFound` and `Conflict` fallbacks named one entity: `Hotstring not found.` and `A hotstring with that trigger already exists.` Every page shares this helper, so deleting a known-shortcut record that another tab already deleted produced **"Hotstring not found."** The fallbacks are entity-neutral now. Handlers that pass their own message are unaffected, which is most of them.

## 3. Docs for a broken no-auth profile

The `http (No Auth)` frontend profile does not sign you in from the main checkout. Verified twice: once through the profile, once with `ASPNETCORE_ENVIRONMENT=NoAuth` set directly, with the host log confirming the environment. The cause is already documented in this repository at `tests/AHKFlowApp.E2E.Tests/Fixtures/SpaHost.cs:27-32` — .NET 10 fixes the WebAssembly boot environment at build time, so `appsettings.NoAuth.json` is never read.

This PR only records the problem and the workaround, in `docs/development/playwright-setup.md` and the frontend `CLAUDE.md`. The fix is backlog item 039. Worktrees are unaffected: their setup script writes `appsettings.Development.json`, which does load.

## Backlog items added

- **039** — make the no-auth frontend profile work in the main checkout
- **040** — mobile layout for the Known shortcuts page. It renders one `MudTable` for all screen sizes, where every other list page renders a desktop and a mobile branch. Every cell carries `DataLabel`, so it degrades rather than breaking — polish, not a defect.

## Verification

Canonical pre-PR gate, all green:

- `dotnet build AHKFlowApp.slnx --configuration Release` — 17 projects, 0 errors, 0 warnings
- `dotnet format AHKFlowApp.slnx --verify-no-changes` — clean
- `pwsh .\scripts\test-fast.ps1 -Mode Coverage` — all per-assembly thresholds met, line 94.1%, branch 80.9%
- `git diff --check main...HEAD` — clean

Slices run separately as well: Fast 2561, Integration 611, E2E 23 — no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
