### PR TITLE
fix: scope agent Git guard to collision risk, add in-session prompts

### DIFF
--- a/.agents/worktrees/SKILL.md
+++ b/.agents/worktrees/SKILL.md
@@ -189,10 +189,23 @@ scripts/agents/setup-cross-agent-skills.ps1 to regenerate them. -->
 
 ## Git guardrails: mutate only in a managed worktree
 
-Agents may inspect, edit, build, test, and format in the main checkout, but **Git mutations**
-(branch, add, commit, merge, rebase, push, tag, reset, …) for this repository are allowed only
-from a **managed** linked worktree. This is enforced by the `PreToolUse` command hook and, after
-merge, a `pre-commit` backstop. See `docs/agents/cross-agent-git-guardrails.md`.
+Agents may inspect, edit, build, test, and format in the main checkout. Most **Git mutations**
+(branch, add, commit, merge, rebase, push, tag, reset, …) for this repository still need either a
+**managed** linked worktree, or — new — an in-session approval prompt if run from the main
+checkout. This is enforced by the `PreToolUse` command hook and, after merge, a `pre-commit`
+backstop. See `docs/agents/cross-agent-git-guardrails.md`.
+
+A short list of operations is always allowed, even from the main checkout, with no worktree and no
+prompt: `git worktree prune`; `git worktree add`/`remove` without `--force`/`-f`; `git branch
+-d`/`--delete` without any force spelling; a plain `git branch <name>` create with no flags; `git
+remote prune <name>`. Force or destructive variants of these are **not** on this list — for example
+`git worktree remove --force`, `git branch -D`, and `git branch -m`/`-M` still need the prompt
+below, like every other guarded operation.
+
+`git commit` is the one exception that always needs a worktree, or a session-wide
+`AHKFLOW_ALLOW_MAIN=1` (see below). It can never be approved through the prompt: a separate
+`.githooks/pre-commit.ps1` backstop runs after a prompt would be approved, and that backstop has no
+way to know the prompt happened — it would still block the commit.
 
 A worktree is **managed** only when all three hold:
 
@@ -202,7 +215,9 @@ A worktree is **managed** only when all three hold:
 
 ### Recovering from a denial
 
-The stderr message is `BLOCKED: agent Git mutations are allowed only in a managed linked worktree.`
+The stderr message for a hard denial is `BLOCKED: agent Git mutations are allowed only in a
+managed linked worktree.` Most other denials show up as an in-session permission prompt instead —
+read on for which is which.
 
 1. Create a proper worktree and run the command there:
 
@@ -210,14 +225,19 @@ The stderr message is `BLOCKED: agent Git mutations are allowed only in a manage
    pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name>
    ```
 
-2. For a one-off intentional main mutation, prefix the command with the scoped override — a
-   warning prints and destructive-command rules still apply:
+2. For most guarded commands, a permission prompt appears in the session. Approve it if you want
+   the command to run in the main checkout right now — no restart needed. This does not apply to
+   `git commit`, which is always a hard denial and never prompts (see above).
 
-   ```bash
-   AHKFLOW_ALLOW_MAIN=1 git commit -m "..."
-   ```
+3. `AHKFLOW_ALLOW_MAIN=1` still exists, and still silences prompts — and unblocks `commit` — for a
+   whole session, including from the main checkout. It has to be set in the shell environment
+   *before* the agent session starts. An inline `AHKFLOW_ALLOW_MAIN=1 git ...` prefix does nothing:
+   this guard runs in its own process and reads the command as text before any child `git` process
+   would see the prefix. (The prefix does work for the separate `.githooks/pre-commit.ps1`
+   backstop, which git spawns and which does inherit the parent process's environment — but that
+   backstop is not what denies or prompts here.)
 
-3. Emergency only — a broken hook that blocks everything. In a human PowerShell terminal set
+4. Emergency only — a broken hook that blocks everything. In a human PowerShell terminal set
    `$env:AHKFLOW_GUARD_DISABLE = '1'`, start a new agent session from it, repair the hook, then
    unset it. If a syntax error stops even the kill switch, hand-edit `.claude/settings.json`
    (or `.github/hooks/hooks.json` / `.codex/hooks.json`) to remove the hook object.

--- a/.agents/worktrees/SKILL.md
+++ b/.agents/worktrees/SKILL.md
@@ -187,7 +187,7 @@ Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-w
 <!-- Edit this source file, not the synchronized copies under other agent surfaces; run
 scripts/agents/setup-cross-agent-skills.ps1 to regenerate them. -->
 
-## Git guardrails: mutate only in a managed worktree
+## Git guardrails: most mutations need a worktree or a prompt
 
 Agents may inspect, edit, build, test, and format in the main checkout. Most **Git mutations**
 (branch, add, commit, merge, rebase, push, tag, reset, …) for this repository still need either a
@@ -196,11 +196,12 @@ checkout. This is enforced by the `PreToolUse` command hook and, after merge, a 
 backstop. See `docs/agents/cross-agent-git-guardrails.md`.
 
 A short list of operations is always allowed, even from the main checkout, with no worktree and no
-prompt: `git worktree prune`; `git worktree add`/`remove` without `--force`/`-f`; `git branch
--d`/`--delete` without any force spelling; a plain `git branch <name>` create with no flags; `git
-remote prune <name>`. Force or destructive variants of these are **not** on this list — for example
-`git worktree remove --force`, `git branch -D`, and `git branch -m`/`-M` still need the prompt
-below, like every other guarded operation.
+prompt: `git worktree prune`; `git worktree add` without `--force`/`-f`/`-B` (`-B` is git's own
+force spelling — it resets an existing branch's tip, unlike safe `-b`); `git worktree remove`
+without `--force`/`-f`; `git branch -d`/`--delete` without any force spelling; a plain `git branch
+<name>` create with no flags; `git remote prune <name>`. Force or destructive variants of these are
+**not** on this list — for example `git worktree remove --force`, `git branch -D`, and `git branch
+-m`/`-M` still need the prompt below, like every other guarded operation.
 
 `git commit` is the one exception that always needs a worktree, or a session-wide
 `AHKFLOW_ALLOW_MAIN=1` (see below). It can never be approved through the prompt: a separate
@@ -215,9 +216,11 @@ A worktree is **managed** only when all three hold:
 
 ### Recovering from a denial
 
-The stderr message for a hard denial is `BLOCKED: agent Git mutations are allowed only in a
-managed linked worktree.` Most other denials show up as an in-session permission prompt instead —
-read on for which is which.
+The denial message itself (`BLOCKED: agent Git mutations are allowed only in a managed linked
+worktree.`) does not always land on stderr. For Claude it travels as JSON (`permissionDecisionReason`)
+on stdout, with exit 0. Stderr only ever carries a short diagnostic line, like
+`[agent-guard:Claude] deny [agent-main-git-mutation]`. Most other denials show up as an in-session
+permission prompt instead — read on for which is which.
 
 1. Create a proper worktree and run the command there:
 
@@ -226,8 +229,17 @@ read on for which is which.
    ```
 
 2. For most guarded commands, a permission prompt appears in the session. Approve it if you want
-   the command to run in the main checkout right now — no restart needed. This does not apply to
-   `git commit`, which is always a hard denial and never prompts (see above).
+   the command to run in the main checkout right now — no restart needed.
+
+   Three cases never get a prompt, and need a worktree (or `AHKFLOW_ALLOW_MAIN=1`) instead:
+   - `git commit` — always a hard denial (see above).
+   - A call from a subagent — the guard downgrades the prompt to a hard denial, because a subagent
+     prompt cannot reach you. Retry from the main conversation thread instead, where it prompts
+     normally.
+   - Codex, or Copilot without an interactive user — neither adapter can show a real prompt at all.
+
+   See "Adapter matrix for `Ask`" in `docs/agents/cross-agent-git-guardrails.md` for the full
+   breakdown.
 
 3. `AHKFLOW_ALLOW_MAIN=1` still exists, and still silences prompts — and unblocks `commit` — for a
    whole session, including from the main checkout. It has to be set in the shell environment

--- a/.claude/backlog/039-agent-git-guard-wrapper-bypass.md
+++ b/.claude/backlog/039-agent-git-guard-wrapper-bypass.md
@@ -1,0 +1,85 @@
+# 039 - Agent Git guard is bypassed by a command-rewriting wrapper hook
+
+## Metadata
+
+- **Epic**: Agent tooling
+- **Type**: Bug
+- **Interfaces**: None (agent guardrails / repo tooling)
+
+## Summary
+
+A `PreToolUse` hook registered outside this repository rewrites `git ...` into `rtk git ...`, and
+the agent Git guard identifies a git invocation from each command segment's leading word. That word
+becomes `rtk`, so the guard finds no git invocation and allows the command. Every location rule is
+bypassed, including the `git commit` hard denial.
+
+## User story
+
+As the owner of the main checkout, I want the Git guard to keep protecting my HEAD, index, and
+working tree even when an agent's git commands pass through a wrapper, so that the guard's
+protection does not depend on how the shell command happens to be spelled.
+
+## Detail
+
+Found while trying to run the manual `Ask`-path verification for the guard-scope change
+(PR #235). Measured directly against the policy core, `Cwd` = the main checkout:
+
+| Command | Action | Rule |
+|---|---|---|
+| `git worktree repair` | Ask | `agent-main-git-mutation` |
+| `rtk git worktree repair` | **Allow** | `none` |
+| `git commit -m x` | Deny | `agent-main-git-mutation` |
+| `rtk git commit -m x` | **Allow** | `none` |
+| `git branch -D topic` | Ask | `agent-main-git-mutation` |
+| `rtk git branch -D topic` | **Allow** | `none` |
+
+The wrapper here is `rtk hook claude`, registered as a `PreToolUse` Bash hook in the user-level
+`~/.claude/settings.json` — outside this repository, so the repo cannot see or version it.
+
+This is **not** a regression from PR #235. The old guard behaves identically, because segment
+classification by leading word predates that change. `docs/agents/cross-agent-git-guardrails.md`
+already lists wrappers under accepted limitations. What makes this worth an item is scale: the
+limitation was written for a user deliberately invoking a wrapper script, whereas here the wrapper
+is the **default path for every git command** in the environment, which leaves the guard largely
+inert rather than occasionally bypassable.
+
+Only the first word of a command gets the prefix, so safety rules that match a later segment still
+fire — a `gh pr create` whose body text contained recursive-force delete flags was correctly caught
+by `dangerous-rm` during the same session.
+
+## Acceptance criteria
+
+- [ ] Decide the approach: teach the guard to look through a known wrapper prefix, or exclude `git`
+      from the wrapper's rewrite (or both). Record the decision and its reasoning.
+- [ ] A wrapped mutating command targeting the main checkout gets the same decision as its bare
+      equivalent — in particular `rtk git commit -m x` from main is denied.
+- [ ] Regression tests in `tests/AgentWorktreeGuard.Tests.ps1` cover the wrapped form for at least
+      one Tier 2 allow, one Tier 1a Ask, and the Tier 1b `commit` denial.
+- [ ] If prefix-skipping is chosen, the allowed prefix list is explicit and narrow — a wrapper must
+      not be able to escalate what the guard permits, only stay transparent to it.
+- [ ] `docs/agents/cross-agent-git-guardrails.md` accepted-limitations wording updated: an
+      externally registered command-rewriting hook can silently neutralise the guard, which differs
+      from a user knowingly invoking a wrapper.
+
+## Out of scope
+
+- Changing the tier model or any tier boundary — PR #235 settled those.
+- Guarding file edits in main (`Edit`/`Write`), already recorded as a separate accepted limitation.
+- Any change to `rtk` itself beyond repo-side configuration, if the chosen fix is configuration.
+
+## Notes / dependencies
+
+- Discovered during PR #235; full writeup is in that PR's comments.
+- **Separate unexplained observation, needs its own investigation before or alongside this work:** a
+  path-qualified probe (`"C:/Program Files/Git/cmd/git.exe" -C <main> worktree repair`), which the
+  wrapper's matcher should not rewrite, also completed with no prompt and no denial — although both
+  the pre-PR-235 copy (Deny) and the PR-235 copy (Ask) classify it as blocking when evaluated in
+  process. Why the decision did not reach the harness is not established. It may share a root cause
+  with this item or may be independent.
+- Also relevant to anyone testing guard behaviour by hand: `.claude/settings.json` pre-approves
+  `Bash(git branch *)`, `Bash(git checkout *)`, `Bash(git add *)`, `Bash(git commit *)`, and
+  `Bash(git stash *)`. Most Tier 1a commands are therefore pre-approved and may never prompt
+  regardless of what the guard returns, so a manual probe must use a non-allow-listed command.
+- Consequence for PR #235: the live `Ask` prompt render was never verified. The per-adapter payload
+  shape is asserted in process by the guard test suite, but no manual run confirmed that Claude
+  turns `permissionDecision: "ask"` into a visible prompt. Worth confirming once this item lands.

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -7,7 +7,9 @@
 #
 # The optional first argument is an explicit adapter override (Codex uses it). Without one,
 # Copilot is inferred from a top-level "toolArgs" key and Claude is assumed otherwise.
-# Exit 2 = block the command, exit 0 = allow.
+# Exit 2 = block (legacy stderr protocol). Exit 0 does not always mean allow: for Claude, a
+# deny or ask decision from the location rules travels as JSON on stdout instead, still with
+# exit 0. See invoke-agent-worktree-guard.ps1 for each adapter's exact protocol.
 
 if [[ "${AHKFLOW_GUARD_DISABLE:-}" == "1" ]]; then
   echo "WARNING: AHKFLOW_GUARD_DISABLE=1; all agent command guardrails are disabled." >&2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,12 +271,15 @@ an open branch produces a diff full of unrelated commits after the first rebase.
 worktree creation cannot pass a base ref, so stacked work must call the script directly; see the
 `worktrees` skill.
 
-The AHKFlowApp main checkout is human-owned for Git mutations. Agents may inspect, edit, build,
-test, and format there, but must branch, add, commit, merge, rebase, and push for this repository
-only from a managed linked worktree. Use `scripts/new-worktree.ps1`, or the native `EnterWorktree`
-tool — that tool fires the `WorktreeCreate` hook, which runs the same script.
-`AHKFLOW_ALLOW_MAIN=1` is an explicit location override; destructive-command protections still
-apply. See `docs/agents/cross-agent-git-guardrails.md`.
+The AHKFlowApp main checkout is human-owned. Agents may inspect, edit, build, test, and format
+there. The guard gates a Git command only when it could change the human's HEAD, index, or
+working tree in main. Most of these mutations need a managed linked worktree. Run from main
+instead, and most now get an in-session approval prompt. A short list of operations — such as
+`git worktree prune` or deleting an already-merged branch — always run from main, no prompt.
+`git commit` is the one exception. It always needs a worktree, or a session-wide
+`AHKFLOW_ALLOW_MAIN=1` set before the session starts. It never gets a prompt. Use
+`scripts/new-worktree.ps1`, or the native `EnterWorktree` tool — that tool fires the
+`WorktreeCreate` hook, which runs the same script. See `docs/agents/cross-agent-git-guardrails.md`.
 
 ## Agent skills
 

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -96,14 +96,21 @@ human's HEAD, index, or working tree:
 - `git remote prune <name>`.
 - `git fetch` — already unguarded before this change, still unaffected.
 
-**Tier 1a — Ask.** Everything else that is currently guarded and is not `commit`: `checkout`,
-`switch`, `restore`, `reset`, `stash`, `add`, `mv`, `rm`, `merge`, `rebase`, `pull`,
-`cherry-pick`, `revert`, `push` (kept in this tier on purpose — TEST auto-deploys on push to
-`main`, so an unprompted push could trigger a live deployment, a risk on top of the
-HEAD/index/working-tree test), `tag` create/delete, `config` writes, `gc`/`repack`/`maintenance`,
-`reflog expire`/`delete`, `worktree add`/`remove` with `--force`/`-f`/`-B`, `worktree
-move`/`repair`/`lock`/`unlock` in every form, `branch -D`/`-m`/`-M`/`-f`/`-u`/`--set-upstream-to`,
-and any `-d` carrying a force flag. These need an in-session approval prompt to run from main.
+**Tier 1a — Ask.** The rule: every currently-guarded Git subcommand that is not on the Tier 2 list
+above, and is not `commit`, falls in Tier 1a. This is the complement of two closed sets, so the
+rule cannot go stale the way a hand-typed list can — a subcommand this rule misses cannot exist by
+construction.
+
+For example, Tier 1a covers `checkout`, `reset`, `stash`, `push`, `tag` create/delete, and
+`worktree move`/`repair`, plus roughly two dozen more. This is a sample for readability, not the
+full list. For the full, authoritative set, read `$script:AgentGuardMutatingSubcommands` and the
+conditional-subcommand `switch` inside `Test-AgentGitMutation`, both in
+`scripts/agents/agent-worktree-guard.common.ps1`.
+
+`push` stays in Tier 1a on purpose: TEST auto-deploys on push to `main`. An unprompted push could
+trigger a live deployment. That is a risk on top of the HEAD/index/working-tree test.
+
+Every Tier 1a operation needs an in-session approval prompt to run from main.
 
 **Tier 1b — hard denial, no prompt, ever.** `git commit` is the only Git-mutation subcommand here.
 `commit` can never become a prompt. A `PreToolUse` approval happens before the command runs. The
@@ -252,11 +259,19 @@ The stderr diagnostic names the resolved adapter, action, and rule, e.g.
 1. If the command triggered an approval prompt, decide right there: approve it to run in main now,
    or create a worktree with `scripts/new-worktree.ps1` and re-run the command there instead.
 2. If the command was denied outright by the location guard (rule `agent-main-git-mutation` and
-   similar), it needs a worktree. This is always `git commit`, the one subcommand that never
-   prompts. Create a worktree with `scripts/new-worktree.ps1` and re-run it there. A denial from a
-   different rule (force-push, `git reset --hard`, an unparseable command, and the like) is a
-   destructive-command safety rule, not a location rule. A worktree will not change its outcome —
-   discuss the command with the user instead.
+   similar), with no prompt at all, two different cases land here:
+   - **`git commit`.** `commit` never prompts, no matter where it runs from. Create a worktree
+     with `scripts/new-worktree.ps1` and re-run it there (or set `AHKFLOW_ALLOW_MAIN=1` in
+     advance — see item 3 below).
+   - **Any other guarded operation, run by a subagent.** A Task/Agent-tool call would normally get
+     `Ask`, but the guard downgrades that to a hard `Deny` when the call comes from a subagent
+     rather than the main conversation thread (see "Subagents never see `Ask`" above). Retry the
+     same command from the main thread — it gets a real prompt there — or run it from a managed
+     worktree instead, which never produces a prompt in the first place.
+
+   A denial from a different rule (force-push, `git reset --hard`, an unparseable command, and the
+   like) is a destructive-command safety rule, not a location rule. A worktree will not change its
+   outcome — discuss the command with the user instead.
 3. Expect several main-checkout mutations this session and do not want to approve each one? Set
    `AHKFLOW_ALLOW_MAIN=1` in the session environment before starting the agent (see "Where
    `AHKFLOW_ALLOW_MAIN=1` has to be set" — an inline prefix does **not** reach the `PreToolUse`

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -1,8 +1,12 @@
 # Cross-Agent Git Guardrails
 
-Local Claude Code, Codex, and GitHub Copilot agent sessions must not mutate Git state in the
-human-owned main checkout of this repository. Agents may still **read, edit, build, test, and
-format** in main — this is a Git-mutation guard, not a filesystem sandbox.
+The human works directly in the main checkout of this repository. They do not want an agent
+changing state under them — especially the branch they are standing on. Local Claude Code, Codex,
+and GitHub Copilot agent sessions gate every Git command the same way. The test: could it change
+the human's HEAD, index, or working tree in the main checkout? A command that cannot is allowed
+even from main. Most commands that can need a managed linked worktree, or an in-session approval
+prompt. See "Location tiers" below for the full breakdown. Agents may still **read, edit, build,
+test, and format** in main — this is a Git-mutation guard, not a filesystem sandbox.
 
 ## What "managed" means
 
@@ -19,6 +23,10 @@ tool — that tool fires the `WorktreeCreate` hook, which runs the same script.
 A raw `git worktree add` run by an agent is itself a guarded mutation — denied from main — and it
 skips the manifest and no-auth setup, so the result would fail the managed check anyway. Use the
 tool, whose child Git calls the payload never exposes to the guard.
+
+This "managed worktree" requirement applies only to Tier 1a and Tier 1b operations (see "Location
+tiers" below). Tier 2 operations never need a managed worktree — for example `git worktree prune`,
+or a safe `git branch -d` on an already-merged branch. They run from main with no prompt.
 
 ## How enforcement works
 
@@ -45,7 +53,7 @@ Policy input:
   Command + Cwd + ProtectedRepoRoot + AHKFLOW_ALLOW_MAIN.
 
 Policy output:
-  { Action = Allow|Warn|Deny, Rule, Message }
+  { Action = Allow|Warn|Deny|Ask, Rule, Message }
 
 Adapter output:
   The agent's native allow/warn/deny response.
@@ -66,6 +74,66 @@ Rule:
 - **Codex** registers `.codex/hooks.json` with a Bash matcher only. On Windows the `commandWindows`
   variant runs one explicit PowerShell process and resolves the repository root inside it. Codex
   reviews project hooks when a repository becomes trusted.
+
+### Location tiers
+
+The location rule sorts every mutating Git invocation into one of three tiers. The test: could
+this command change the human's HEAD, index, or working tree in the main checkout?
+
+**Tier 2 — always allowed, even from main, no worktree, no prompt.** None of these can touch the
+human's HEAD, index, or working tree:
+
+- `git worktree prune`, in any form.
+- `git worktree add <path> <branch>` — unless it carries `--force`/`-f`, or `-B`. `-B` is git's
+  own force spelling for `worktree add`: it resets an existing branch's tip, which is not the same
+  as the safe `-b`.
+- `git worktree remove <path>` — unless `--force`/`-f`.
+- `git worktree list` — already read-only, unaffected by this change.
+- `git branch -d`/`--delete <name>` — unless it carries any force spelling, including bare `-D`
+  (git treats `-D` as `-d --force` combined — it is not the same flag as `-d`) or a clustered
+  short option such as `-df`/`-fd`.
+- A plain `git branch <name>` create — only when it carries zero flags at all.
+- `git remote prune <name>`.
+- `git fetch` — already unguarded before this change, still unaffected.
+
+**Tier 1a — Ask.** Everything else that is currently guarded and is not `commit`: `checkout`,
+`switch`, `restore`, `reset`, `stash`, `add`, `mv`, `rm`, `merge`, `rebase`, `pull`,
+`cherry-pick`, `revert`, `push` (kept in this tier on purpose — TEST auto-deploys on push to
+`main`, so an unprompted push could trigger a live deployment, a risk on top of the
+HEAD/index/working-tree test), `tag` create/delete, `config` writes, `gc`/`repack`/`maintenance`,
+`reflog expire`/`delete`, `worktree add`/`remove` with `--force`/`-f`/`-B`, `worktree
+move`/`repair`/`lock`/`unlock` in every form, `branch -D`/`-m`/`-M`/`-f`/`-u`/`--set-upstream-to`,
+and any `-d` carrying a force flag. These need an in-session approval prompt to run from main.
+
+**Tier 1b — hard denial, no prompt, ever.** `git commit` is the only Git-mutation subcommand here.
+`commit` can never become a prompt. A `PreToolUse` approval happens before the command runs. The
+separate `.githooks/pre-commit` backstop runs after, and it has no way to know a prompt was
+approved. An approved-then-backstop-blocked commit would be worse than today's outright denial, so
+`commit` stays a hard denial regardless of location.
+
+Two more hard denials exist outside the tier system entirely. This change does not touch them: a
+destructive-command safety-rule match (force-push, `reset --hard`, `clean -f`, `checkout .`, a
+dangerous `rm -rf`), and an unparseable `ambiguous-git-command`. Neither was ever gated by
+location logic.
+
+**Adapter matrix for `Ask`.** Each adapter renders `Ask` differently:
+
+- **Claude** sets `hookSpecificOutput.permissionDecision = "ask"` and exits 0, which escalates to
+  a real permission prompt in the session.
+- **Copilot** also sends `permissionDecision = "ask"`. Without an interactive user — cloud or pipe
+  mode — Copilot degrades that to a deny, which is safe.
+- **Codex never receives `ask`.** Codex's hook contract marks `ask` "parsed but not supported
+  yet." It treats an unsupported value as a failed hook run. A failed hook run lets the tool call
+  proceed, so Codex fails *open* on it. The guard renders every `Ask`-tier decision as `deny` on
+  Codex instead. Codex agents get a hard denial where Claude and Copilot agents get a prompt; that
+  is deliberate, not a gap.
+- An unrecognized decision action fails closed (denies) on every adapter.
+
+**Subagents never see `Ask`.** A Task/Agent-tool call carries `agent_id` in Claude's hook payload
+only when it originates inside a subagent. The guard reads that field and downgrades an `Ask` to
+`Deny` for a subagent call, on every adapter. It is unclear whether a subagent's permission
+prompt reaches the human the same way a main-thread prompt does. A blocked subagent should report
+back that the command needs a retry from the main thread, where it gets a real prompt.
 
 ### Measured latency
 
@@ -97,7 +165,14 @@ starting PowerShell for every command (rejected — it would cost the ~54 ms com
 
 | Switch | Effect |
 | --- | --- |
-| `AHKFLOW_ALLOW_MAIN=1` | Overrides the **location** rule only (turns a location Deny into a warned Allow). Force-push, destructive-Git, and dangerous-file rules still apply. |
+| `AHKFLOW_ALLOW_MAIN=1` | Overrides the **location** rule for every tier, including `commit` (turns a location Deny, or what would otherwise be an Ask prompt, into a warned Allow). Force-push, destructive-Git, and dangerous-file rules still apply. |
+| `AHKFLOW_GUARD_DISABLE=1` | Emergency kill switch. Short-circuits the **entire** command guard before strict mode, module loading, stdin parsing, or Git probes, and warns loudly. Never set it persistently. |
+
+`AHKFLOW_ALLOW_MAIN=1` is no longer the main way to handle a one-off main-checkout mutation. For
+everything except `commit`, the in-session approval prompt handles that now — see "Location
+tiers" above. Set `AHKFLOW_ALLOW_MAIN=1` instead when you expect several main-checkout mutations
+in one session and do not want to approve each one. It is also the only way through when the
+mutation is `commit`, which never prompts.
 
 ### Where `AHKFLOW_ALLOW_MAIN=1` has to be set
 
@@ -116,9 +191,9 @@ call.
 The `pre-commit` backstop behaves differently: git spawns it and passes its own environment down,
 so there an inline `AHKFLOW_ALLOW_MAIN=1 git commit ...` does take effect.
 
-A human's own shell is never subject to the `PreToolUse` guard at all — it is an agent hook. Main
-checkout maintenance (`git worktree remove`, `git branch -D`) is simply run directly.
-| `AHKFLOW_GUARD_DISABLE=1` | Emergency kill switch. Short-circuits the **entire** command guard before strict mode, module loading, stdin parsing, or Git probes, and warns loudly. Never set it persistently. |
+A human's own shell is never subject to the `PreToolUse` guard at all — it is an agent hook. A
+human's own shell can still run main-checkout maintenance directly — for example `git branch -D`.
+An agent running the same command would need a prompt or override.
 
 ## Accepted limitations
 
@@ -148,6 +223,9 @@ checkout maintenance (`git worktree remove`, `git branch -D`) is simply run dire
   Git after such a `cd` is unaffected. Pass an explicit `git -C <path>` to be classified normally.
 - `commit --no-verify` and `--git-dir`/`--work-tree` targeting cannot be safely inferred, so a
   mutating invocation using `--git-dir`/`--work-tree` is denied outright (unless `AHKFLOW_ALLOW_MAIN=1`).
+- File edits in main are not guarded by this mechanism at all. An `Edit`/`Write` tool call can
+  change the human's files under them the same way a Git mutation can, but this guard only covers
+  Git commands. Closing that gap is separate work, not part of this change.
 
 ## Version-skew and authoritative main
 
@@ -165,17 +243,26 @@ pwsh -NoProfile -File tests/AgentPreCommitHook.Tests.ps1
 
 Both also run under Windows PowerShell 5.1 and in the `worktree-powershell-tests` CI job.
 
-## Diagnosing a denial without disabling hooks globally
+## Diagnosing a denial or approval prompt without disabling hooks globally
 
-The stderr diagnostic names the resolved adapter and rule, e.g.
+The stderr diagnostic names the resolved adapter, action, and rule, e.g.
+`[agent-guard:Claude] ask [agent-main-git-mutation]` or
 `[agent-guard:Claude] deny [agent-main-git-mutation]`. To act on it:
 
-1. If the command genuinely belongs in a worktree, create one with `scripts/new-worktree.ps1` and
-   re-run it there.
-2. For a one-off intentional main mutation, set `AHKFLOW_ALLOW_MAIN=1` in the session environment
-   before starting the agent (see "Where `AHKFLOW_ALLOW_MAIN=1` has to be set" — an inline prefix
-   does **not** reach the `PreToolUse` guard). A warning is printed; destructive rules still apply.
-3. Only for a broken hook, use the emergency recovery procedure below.
+1. If the command triggered an approval prompt, decide right there: approve it to run in main now,
+   or create a worktree with `scripts/new-worktree.ps1` and re-run the command there instead.
+2. If the command was denied outright by the location guard (rule `agent-main-git-mutation` and
+   similar), it needs a worktree. This is always `git commit`, the one subcommand that never
+   prompts. Create a worktree with `scripts/new-worktree.ps1` and re-run it there. A denial from a
+   different rule (force-push, `git reset --hard`, an unparseable command, and the like) is a
+   destructive-command safety rule, not a location rule. A worktree will not change its outcome —
+   discuss the command with the user instead.
+3. Expect several main-checkout mutations this session and do not want to approve each one? Set
+   `AHKFLOW_ALLOW_MAIN=1` in the session environment before starting the agent (see "Where
+   `AHKFLOW_ALLOW_MAIN=1` has to be set" — an inline prefix does **not** reach the `PreToolUse`
+   guard). It is also the only way through for `git commit`, which never prompts. A warning is
+   printed; destructive rules still apply.
+4. Only for a broken hook, use the emergency recovery procedure below.
 
 ### Emergency recovery
 

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -259,7 +259,7 @@ The stderr diagnostic names the resolved adapter, action, and rule, e.g.
 1. If the command triggered an approval prompt, decide right there: approve it to run in main now,
    or create a worktree with `scripts/new-worktree.ps1` and re-run the command there instead.
 2. If the command was denied outright by the location guard (rule `agent-main-git-mutation` and
-   similar), with no prompt at all, two different cases land here:
+   similar), with no prompt at all, several different cases land here, including:
    - **`git commit`.** `commit` never prompts, no matter where it runs from. Create a worktree
      with `scripts/new-worktree.ps1` and re-run it there (or set `AHKFLOW_ALLOW_MAIN=1` in
      advance — see item 3 below).
@@ -268,10 +268,19 @@ The stderr diagnostic names the resolved adapter, action, and rule, e.g.
      rather than the main conversation thread (see "Subagents never see `Ask`" above). Retry the
      same command from the main thread — it gets a real prompt there — or run it from a managed
      worktree instead, which never produces a prompt in the first place.
+   - **Any other guarded operation, run from Codex, or from Copilot without an interactive user.**
+     Both adapters would normally get `Ask` too, but neither can show a real prompt there: Codex's
+     hook contract does not support `ask` yet, so the guard renders every `Ask`-tier decision as
+     `deny` for Codex instead; Copilot does emit a real `ask`, but in cloud or pipe mode — with no
+     interactive user to answer it — Copilot itself degrades that to a deny (see "Adapter matrix
+     for `Ask`" above). Retrying does not help here, since the cause is the adapter, not the
+     caller. Create a managed worktree, or set `AHKFLOW_ALLOW_MAIN=1` in advance for the session
+     (see item 3 below) — the prompt itself is never available in this case, by design.
 
-   A denial from a different rule (force-push, `git reset --hard`, an unparseable command, and the
-   like) is a destructive-command safety rule, not a location rule. A worktree will not change its
-   outcome — discuss the command with the user instead.
+   This list is not exhaustive — other combinations of adapter and caller may hard-deny the same
+   way. A denial from a different rule (force-push, `git reset --hard`, an unparseable command, and
+   the like) is a destructive-command safety rule, not a location rule. A worktree will not change
+   its outcome — discuss the command with the user instead.
 3. Expect several main-checkout mutations this session and do not want to approve each one? Set
    `AHKFLOW_ALLOW_MAIN=1` in the session environment before starting the agent (see "Where
    `AHKFLOW_ALLOW_MAIN=1` has to be set" — an inline prefix does **not** reach the `PreToolUse`

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -10,7 +10,7 @@ test, and format** in main — this is a Git-mutation guard, not a filesystem sa
 
 ## What "managed" means
 
-A Git mutation is allowed only from a **managed linked worktree**, which is all three of:
+Most Git mutations are allowed only from a **managed linked worktree**, which is all three of:
 
 1. a **linked** worktree (its `--git-dir` differs from the repository's `--git-common-dir`);
 2. located as a **direct child** of `<main>/.claude/worktrees` or `<main>/.worktrees`;
@@ -20,9 +20,10 @@ A Git mutation is allowed only from a **managed linked worktree**, which is all 
 
 The supported way to create one is `scripts/new-worktree.ps1`, or the agent's native `EnterWorktree`
 tool — that tool fires the `WorktreeCreate` hook, which runs the same script.
-A raw `git worktree add` run by an agent is itself a guarded mutation — denied from main — and it
-skips the manifest and no-auth setup, so the result would fail the managed check anyway. Use the
-tool, whose child Git calls the payload never exposes to the guard.
+A raw `git worktree add` run by an agent is Tier 2 — allowed even from main, with no prompt (see
+"Location tiers" below). It skips the manifest and no-auth setup that `scripts/new-worktree.ps1`
+performs, though, so the resulting worktree would still fail the managed check. Use the script, or
+the `EnterWorktree` tool, whose child Git calls the payload never exposes to the guard.
 
 This "managed worktree" requirement applies only to Tier 1a and Tier 1b operations (see "Location
 tiers" below). Tier 2 operations never need a managed worktree — for example `git worktree prune`,
@@ -116,7 +117,9 @@ Every Tier 1a operation needs an in-session approval prompt to run from main.
 `commit` can never become a prompt. A `PreToolUse` approval happens before the command runs. The
 separate `.githooks/pre-commit` backstop runs after, and it has no way to know a prompt was
 approved. An approved-then-backstop-blocked commit would be worse than today's outright denial, so
-`commit` stays a hard denial regardless of location.
+`commit` stays a hard denial regardless of location. This dominates the whole chained command, not
+just the `commit` segment: `git add . && git commit -m x` is denied outright, even though `git add`
+alone would only need a prompt.
 
 Two more hard denials exist outside the tier system entirely. This change does not touch them: a
 destructive-command safety-rule match (force-push, `reset --hard`, `clean -f`, `checkout .`, a
@@ -138,9 +141,13 @@ location logic.
 
 **Subagents never see `Ask`.** A Task/Agent-tool call carries `agent_id` in Claude's hook payload
 only when it originates inside a subagent. The guard reads that field and downgrades an `Ask` to
-`Deny` for a subagent call, on every adapter. It is unclear whether a subagent's permission
-prompt reaches the human the same way a main-thread prompt does. A blocked subagent should report
-back that the command needs a retry from the main thread, where it gets a real prompt.
+`Deny` for a subagent call, on every adapter that can detect it. In practice, `agent_id` is
+extracted only from the non-Copilot payload branch (see the adapter contract above), so on Copilot
+this downgrade can never fire — a Copilot subagent call is never detected as one, and instead
+surfaces as whatever Copilot's own `Ask` handling decides (see "Adapter matrix for `Ask`" above).
+It is unclear whether a subagent's permission prompt reaches the human the same way a main-thread
+prompt does. A blocked subagent should report back that the command needs a retry from the main
+thread, where it gets a real prompt.
 
 ### Measured latency
 

--- a/plugins/ahkflowapp/.codex-plugin/plugin.json
+++ b/plugins/ahkflowapp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ahkflowapp",
-  "version": "0.1.0+codex.b27f31c5820c",
+  "version": "0.1.0+codex.e13a937c0065",
   "description": "Repo-local Codex plugin exposing focused AHKFlowApp project skills.",
   "author": {
     "name": "AHKFlowApp maintainers",

--- a/plugins/ahkflowapp/.codex-plugin/plugin.json
+++ b/plugins/ahkflowapp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ahkflowapp",
-  "version": "0.1.0+codex.e13a937c0065",
+  "version": "0.1.0+codex.25770f1c2c51",
   "description": "Repo-local Codex plugin exposing focused AHKFlowApp project skills.",
   "author": {
     "name": "AHKFlowApp maintainers",

--- a/plugins/ahkflowapp/skills/worktrees/SKILL.md
+++ b/plugins/ahkflowapp/skills/worktrees/SKILL.md
@@ -189,10 +189,23 @@ scripts/agents/setup-cross-agent-skills.ps1 to regenerate them. -->
 
 ## Git guardrails: mutate only in a managed worktree
 
-Agents may inspect, edit, build, test, and format in the main checkout, but **Git mutations**
-(branch, add, commit, merge, rebase, push, tag, reset, …) for this repository are allowed only
-from a **managed** linked worktree. This is enforced by the `PreToolUse` command hook and, after
-merge, a `pre-commit` backstop. See `docs/agents/cross-agent-git-guardrails.md`.
+Agents may inspect, edit, build, test, and format in the main checkout. Most **Git mutations**
+(branch, add, commit, merge, rebase, push, tag, reset, …) for this repository still need either a
+**managed** linked worktree, or — new — an in-session approval prompt if run from the main
+checkout. This is enforced by the `PreToolUse` command hook and, after merge, a `pre-commit`
+backstop. See `docs/agents/cross-agent-git-guardrails.md`.
+
+A short list of operations is always allowed, even from the main checkout, with no worktree and no
+prompt: `git worktree prune`; `git worktree add`/`remove` without `--force`/`-f`; `git branch
+-d`/`--delete` without any force spelling; a plain `git branch <name>` create with no flags; `git
+remote prune <name>`. Force or destructive variants of these are **not** on this list — for example
+`git worktree remove --force`, `git branch -D`, and `git branch -m`/`-M` still need the prompt
+below, like every other guarded operation.
+
+`git commit` is the one exception that always needs a worktree, or a session-wide
+`AHKFLOW_ALLOW_MAIN=1` (see below). It can never be approved through the prompt: a separate
+`.githooks/pre-commit.ps1` backstop runs after a prompt would be approved, and that backstop has no
+way to know the prompt happened — it would still block the commit.
 
 A worktree is **managed** only when all three hold:
 
@@ -202,7 +215,9 @@ A worktree is **managed** only when all three hold:
 
 ### Recovering from a denial
 
-The stderr message is `BLOCKED: agent Git mutations are allowed only in a managed linked worktree.`
+The stderr message for a hard denial is `BLOCKED: agent Git mutations are allowed only in a
+managed linked worktree.` Most other denials show up as an in-session permission prompt instead —
+read on for which is which.
 
 1. Create a proper worktree and run the command there:
 
@@ -210,14 +225,19 @@ The stderr message is `BLOCKED: agent Git mutations are allowed only in a manage
    pwsh -NoProfile -File scripts/new-worktree.ps1 -Name <name>
    ```
 
-2. For a one-off intentional main mutation, prefix the command with the scoped override — a
-   warning prints and destructive-command rules still apply:
+2. For most guarded commands, a permission prompt appears in the session. Approve it if you want
+   the command to run in the main checkout right now — no restart needed. This does not apply to
+   `git commit`, which is always a hard denial and never prompts (see above).
 
-   ```bash
-   AHKFLOW_ALLOW_MAIN=1 git commit -m "..."
-   ```
+3. `AHKFLOW_ALLOW_MAIN=1` still exists, and still silences prompts — and unblocks `commit` — for a
+   whole session, including from the main checkout. It has to be set in the shell environment
+   *before* the agent session starts. An inline `AHKFLOW_ALLOW_MAIN=1 git ...` prefix does nothing:
+   this guard runs in its own process and reads the command as text before any child `git` process
+   would see the prefix. (The prefix does work for the separate `.githooks/pre-commit.ps1`
+   backstop, which git spawns and which does inherit the parent process's environment — but that
+   backstop is not what denies or prompts here.)
 
-3. Emergency only — a broken hook that blocks everything. In a human PowerShell terminal set
+4. Emergency only — a broken hook that blocks everything. In a human PowerShell terminal set
    `$env:AHKFLOW_GUARD_DISABLE = '1'`, start a new agent session from it, repair the hook, then
    unset it. If a syntax error stops even the kill switch, hand-edit `.claude/settings.json`
    (or `.github/hooks/hooks.json` / `.codex/hooks.json`) to remove the hook object.

--- a/plugins/ahkflowapp/skills/worktrees/SKILL.md
+++ b/plugins/ahkflowapp/skills/worktrees/SKILL.md
@@ -187,7 +187,7 @@ Worktrees deleted with plain git skip the `WorktreeRemove` hook; the next `new-w
 <!-- Edit this source file, not the synchronized copies under other agent surfaces; run
 scripts/agents/setup-cross-agent-skills.ps1 to regenerate them. -->
 
-## Git guardrails: mutate only in a managed worktree
+## Git guardrails: most mutations need a worktree or a prompt
 
 Agents may inspect, edit, build, test, and format in the main checkout. Most **Git mutations**
 (branch, add, commit, merge, rebase, push, tag, reset, …) for this repository still need either a
@@ -196,11 +196,12 @@ checkout. This is enforced by the `PreToolUse` command hook and, after merge, a 
 backstop. See `docs/agents/cross-agent-git-guardrails.md`.
 
 A short list of operations is always allowed, even from the main checkout, with no worktree and no
-prompt: `git worktree prune`; `git worktree add`/`remove` without `--force`/`-f`; `git branch
--d`/`--delete` without any force spelling; a plain `git branch <name>` create with no flags; `git
-remote prune <name>`. Force or destructive variants of these are **not** on this list — for example
-`git worktree remove --force`, `git branch -D`, and `git branch -m`/`-M` still need the prompt
-below, like every other guarded operation.
+prompt: `git worktree prune`; `git worktree add` without `--force`/`-f`/`-B` (`-B` is git's own
+force spelling — it resets an existing branch's tip, unlike safe `-b`); `git worktree remove`
+without `--force`/`-f`; `git branch -d`/`--delete` without any force spelling; a plain `git branch
+<name>` create with no flags; `git remote prune <name>`. Force or destructive variants of these are
+**not** on this list — for example `git worktree remove --force`, `git branch -D`, and `git branch
+-m`/`-M` still need the prompt below, like every other guarded operation.
 
 `git commit` is the one exception that always needs a worktree, or a session-wide
 `AHKFLOW_ALLOW_MAIN=1` (see below). It can never be approved through the prompt: a separate
@@ -215,9 +216,11 @@ A worktree is **managed** only when all three hold:
 
 ### Recovering from a denial
 
-The stderr message for a hard denial is `BLOCKED: agent Git mutations are allowed only in a
-managed linked worktree.` Most other denials show up as an in-session permission prompt instead —
-read on for which is which.
+The denial message itself (`BLOCKED: agent Git mutations are allowed only in a managed linked
+worktree.`) does not always land on stderr. For Claude it travels as JSON (`permissionDecisionReason`)
+on stdout, with exit 0. Stderr only ever carries a short diagnostic line, like
+`[agent-guard:Claude] deny [agent-main-git-mutation]`. Most other denials show up as an in-session
+permission prompt instead — read on for which is which.
 
 1. Create a proper worktree and run the command there:
 
@@ -226,8 +229,17 @@ read on for which is which.
    ```
 
 2. For most guarded commands, a permission prompt appears in the session. Approve it if you want
-   the command to run in the main checkout right now — no restart needed. This does not apply to
-   `git commit`, which is always a hard denial and never prompts (see above).
+   the command to run in the main checkout right now — no restart needed.
+
+   Three cases never get a prompt, and need a worktree (or `AHKFLOW_ALLOW_MAIN=1`) instead:
+   - `git commit` — always a hard denial (see above).
+   - A call from a subagent — the guard downgrades the prompt to a hard denial, because a subagent
+     prompt cannot reach you. Retry from the main conversation thread instead, where it prompts
+     normally.
+   - Codex, or Copilot without an interactive user — neither adapter can show a real prompt at all.
+
+   See "Adapter matrix for `Ask`" in `docs/agents/cross-agent-git-guardrails.md` for the full
+   breakdown.
 
 3. `AHKFLOW_ALLOW_MAIN=1` still exists, and still silences prompts — and unblocks `commit` — for a
    whole session, including from the main checkout. It has to be set in the shell environment

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1102,7 +1102,6 @@ function Get-AgentGitLocationDecision {
     $directoryStack = New-Object System.Collections.Generic.List[string]
     $blockingState = ''
     $blockingTarget = ''
-    $blockingSubcommand = ''
     # Tracks whether ANY blocking segment in the whole chain is a commit, independent of which
     # segment blocked first. commit must never resolve to Ask under any condition (see the
     # Deny-vs-Ask branch below), so the scan cannot stop at the first block: an earlier `git add .`
@@ -1172,7 +1171,6 @@ function Get-AgentGitLocationDecision {
             if ($blockingState -eq '') {
                 $blockingState = 'ExplicitGitDir'
                 $blockingTarget = $Cwd
-                $blockingSubcommand = $parts.Subcommand
             }
             if ($parts.Subcommand -ieq 'commit') { $commitBlocks = $true }
             continue
@@ -1187,7 +1185,6 @@ function Get-AgentGitLocationDecision {
             if ($blockingState -eq '') {
                 $blockingState = 'UnresolvedDirectoryChange'
                 $blockingTarget = $Cwd
-                $blockingSubcommand = $parts.Subcommand
             }
             if ($parts.Subcommand -ieq 'commit') { $commitBlocks = $true }
             continue
@@ -1200,7 +1197,6 @@ function Get-AgentGitLocationDecision {
             if ($blockingState -eq '') {
                 $blockingState = $state
                 $blockingTarget = $targetDir
-                $blockingSubcommand = $parts.Subcommand
             }
             if ($parts.Subcommand -ieq 'commit') { $commitBlocks = $true }
             continue
@@ -1224,9 +1220,16 @@ function Get-AgentGitLocationDecision {
             ("WARNING: AHKFLOW_ALLOW_MAIN=1 overrode the --git-dir/--work-tree restriction for: $blockingTarget")
         }
         $action = if ($isTier1b) { 'Deny' } else { 'Ask' }
-        return New-AgentGuardDecision -Action $action -Rule 'agent-git-dir-mutation' -Message `
-        ('BLOCKED: agent Git mutations with --git-dir or --work-tree are not allowed; the ' +
-            'target cannot be verified. Run the command from inside a managed linked worktree instead.')
+        $message = if ($isTier1b) {
+            ('BLOCKED: agent Git mutations with --git-dir or --work-tree are not allowed; the ' +
+                'target cannot be verified. Run the command from inside a managed linked worktree instead.')
+        }
+        else {
+            ('This command uses --git-dir or --work-tree, so the guard cannot verify its target ' +
+                'from the command text alone. Approve only if you want it to run here. To avoid ' +
+                'the ambiguity, run it from inside a managed linked worktree instead.')
+        }
+        return New-AgentGuardDecision -Action $action -Rule 'agent-git-dir-mutation' -Message $message
     }
 
     if ($blockingState -eq 'UnresolvedDirectoryChange') {
@@ -1235,10 +1238,18 @@ function Get-AgentGitLocationDecision {
             ("WARNING: AHKFLOW_ALLOW_MAIN=1 overrode an unverifiable directory change before a git mutation.")
         }
         $action = if ($isTier1b) { 'Deny' } else { 'Ask' }
-        return New-AgentGuardDecision -Action $action -Rule 'agent-unresolved-git-target' -Message `
-        ('BLOCKED: this command changes directory to a target the guard cannot expand, so the ' +
-            'git mutation cannot be verified. Run git from a managed linked worktree, or pass an ' +
-            'explicit `git -C <path>`.')
+        $message = if ($isTier1b) {
+            ('BLOCKED: this command changes directory to a target the guard cannot expand, so the ' +
+                'git mutation cannot be verified. Run git from a managed linked worktree, or pass an ' +
+                'explicit `git -C <path>`.')
+        }
+        else {
+            ('This command changes directory to a target the guard cannot expand, so it cannot ' +
+                'verify where the git mutation would run. Approve only if you want it to run here ' +
+                'anyway. To avoid the ambiguity, pass an explicit `git -C <path>`, or run it from ' +
+                'inside a managed linked worktree.')
+        }
+        return New-AgentGuardDecision -Action $action -Rule 'agent-unresolved-git-target' -Message $message
     }
 
     if ($AllowMain) {

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -155,9 +155,10 @@ function ConvertFrom-AgentHookInput {
             if (Test-AgentGuardProperty $toolInput 'command') { $command = [string] $toolInput.command }
         }
 
-        # Present at the top level only when the call originates inside a subagent or --agent
-        # session (https://code.claude.com/docs/en/hooks). Codex's payload shape may not carry
-        # them at all - Test-AgentGuardProperty returns $false and both stay ''.
+        # agent_id is present at the top level only when the call originates inside a subagent
+        # call; agent_type is present for a subagent call OR an --agent session
+        # (https://code.claude.com/docs/en/hooks). Codex's payload shape may not carry either at
+        # all - Test-AgentGuardProperty returns $false and both stay ''.
         if (Test-AgentGuardProperty $payload 'agent_id') { $agentId = [string] $payload.agent_id }
         if (Test-AgentGuardProperty $payload 'agent_type') { $agentType = [string] $payload.agent_type }
     }

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -852,7 +852,16 @@ function Test-AgentGitTier2Allowed {
     switch ($subcommand) {
         'worktree' {
             if ($first -eq 'prune') { return $true }
-            if ($first -in @('add', 'remove')) {
+            if ($first -eq 'add') {
+                # -B is git's own force spelling for worktree add (resets an existing branch's tip
+                # to the given commit-ish, unlike -b which refuses if the branch already exists) -
+                # the same discard/move-history risk -D already covers for branch below. worktree
+                # add does not accept clustered short options, so a plain case-sensitive exact match
+                # is enough; -b (lowercase, the safe non-destructive form) stays Tier 2-eligible.
+                if (@($Arguments | Where-Object { $_ -ceq '-B' }).Count -gt 0) { return $false }
+                return -not (Test-AgentGuardHasForceFlag -Arguments $Arguments)
+            }
+            if ($first -eq 'remove') {
                 return -not (Test-AgentGuardHasForceFlag -Arguments $Arguments)
             }
             return $false
@@ -1093,6 +1102,11 @@ function Get-AgentGitLocationDecision {
     $blockingState = ''
     $blockingTarget = ''
     $blockingSubcommand = ''
+    # Tracks whether ANY blocking segment in the whole chain is a commit, independent of which
+    # segment blocked first. commit must never resolve to Ask under any condition (see the
+    # Deny-vs-Ask branch below), so the scan cannot stop at the first block: an earlier `git add .`
+    # blocking first must not hide a `git commit` blocking later in the same command.
+    $commitBlocks = $false
 
     foreach ($segment in $Segments) {
         if ($segment.Kind -eq 'PopDirectory') {
@@ -1154,10 +1168,13 @@ function Get-AgentGitLocationDecision {
         }
 
         if ($parts.UsesGitDirOrWorkTree) {
-            $blockingState = 'ExplicitGitDir'
-            $blockingTarget = $Cwd
-            $blockingSubcommand = $parts.Subcommand
-            break
+            if ($blockingState -eq '') {
+                $blockingState = 'ExplicitGitDir'
+                $blockingTarget = $Cwd
+                $blockingSubcommand = $parts.Subcommand
+            }
+            if ($parts.Subcommand -ieq 'commit') { $commitBlocks = $true }
+            continue
         }
 
         # Only an absolute `git -C <path>` re-anchors the target independently of the shell's cwd.
@@ -1166,20 +1183,26 @@ function Get-AgentGitLocationDecision {
         # any -C in the chain is absolute, git discards the base, so the result is cwd-independent.
         $dashCReanchors = @($parts.DashC | Where-Object { [System.IO.Path]::IsPathRooted($_) }).Count -gt 0
         if ($unresolvedDirectory -and -not $dashCReanchors) {
-            $blockingState = 'UnresolvedDirectoryChange'
-            $blockingTarget = $Cwd
-            $blockingSubcommand = $parts.Subcommand
-            break
+            if ($blockingState -eq '') {
+                $blockingState = 'UnresolvedDirectoryChange'
+                $blockingTarget = $Cwd
+                $blockingSubcommand = $parts.Subcommand
+            }
+            if ($parts.Subcommand -ieq 'commit') { $commitBlocks = $true }
+            continue
         }
 
         $targetDir = Resolve-AgentGitTargetDirectory -Parts $parts -BaseCwd $effectiveCwd
         $state = Get-ManagedWorktreeState -Cwd $targetDir -ProtectedRepoRoot $ProtectedRepoRoot
 
         if ($state -inotin $script:AgentGuardAllowedStates) {
-            $blockingState = $state
-            $blockingTarget = $targetDir
-            $blockingSubcommand = $parts.Subcommand
-            break
+            if ($blockingState -eq '') {
+                $blockingState = $state
+                $blockingTarget = $targetDir
+                $blockingSubcommand = $parts.Subcommand
+            }
+            if ($parts.Subcommand -ieq 'commit') { $commitBlocks = $true }
+            continue
         }
     }
 
@@ -1187,7 +1210,12 @@ function Get-AgentGitLocationDecision {
         return New-AgentGuardDecision -Action Allow
     }
 
-    $isTier1b = ($blockingSubcommand -ieq 'commit')
+    # Commit dominates regardless of scan order. If a commit blocks anywhere in the chain, the
+    # overall decision is Tier 1b (Deny), never Ask - even when a different segment (e.g. `git add
+    # .`) blocked first and supplied the message/target above. Approving an Ask here would let the
+    # earlier mutation run, then commit would die at the separate pre-commit backstop, leaving the
+    # owner's index staged with the agent's files - exactly the failure mode Ask must never produce.
+    $isTier1b = $commitBlocks
 
     if ($blockingState -eq 'ExplicitGitDir') {
         if ($AllowMain) {

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -37,7 +37,7 @@ $script:AgentGuardEnvAssignmentPattern = '^[A-Za-z_][A-Za-z0-9_]*='
 function New-AgentGuardDecision {
     [CmdletBinding()]
     param(
-        [ValidateSet('Allow', 'Warn', 'Deny')]
+        [ValidateSet('Allow', 'Warn', 'Deny', 'Ask')]
         [string] $Action = 'Allow',
         [string] $Rule = 'none',
         [string] $Message = ''
@@ -127,6 +127,8 @@ function ConvertFrom-AgentHookInput {
 
     $rawToolName = ''
     $command = ''
+    $agentId = ''
+    $agentType = ''
 
     if ($resolvedAdapter -eq 'Copilot') {
         if (Test-AgentGuardProperty $payload 'toolName') { $rawToolName = [string] $payload.toolName }
@@ -152,6 +154,12 @@ function ConvertFrom-AgentHookInput {
             $toolInput = $payload.tool_input
             if (Test-AgentGuardProperty $toolInput 'command') { $command = [string] $toolInput.command }
         }
+
+        # Present at the top level only when the call originates inside a subagent or --agent
+        # session (https://code.claude.com/docs/en/hooks). Codex's payload shape may not carry
+        # them at all - Test-AgentGuardProperty returns $false and both stay ''.
+        if (Test-AgentGuardProperty $payload 'agent_id') { $agentId = [string] $payload.agent_id }
+        if (Test-AgentGuardProperty $payload 'agent_type') { $agentType = [string] $payload.agent_type }
     }
 
     $cwd = ''
@@ -163,10 +171,12 @@ function ConvertFrom-AgentHookInput {
     }
 
     return [pscustomobject]@{
-        Adapter  = $resolvedAdapter
-        ToolName = $normalizedToolName
-        Command  = $command
-        Cwd      = (ConvertTo-AgentGuardNormalizedPath $cwd)
+        Adapter   = $resolvedAdapter
+        ToolName  = $normalizedToolName
+        Command   = $command
+        Cwd       = (ConvertTo-AgentGuardNormalizedPath $cwd)
+        AgentId   = $agentId
+        AgentType = $agentType
     }
 }
 
@@ -603,6 +613,13 @@ agent session. An inline "AHKFLOW_ALLOW_MAIN=1 git ..." prefix does not work: th
 its own process and never sees it.
 '@
 
+$script:AgentGuardAskMessage = @'
+This command changes Git state in the main checkout you are working in: {0}
+Approve only if you want it to run here. To run it in an isolated workspace instead, create one
+with scripts/new-worktree.ps1 or the agent WorktreeCreate tool.
+Read-only Git and ordinary edit/build/test commands are unaffected.
+'@
+
 # Global options that consume the following token, so the subcommand scan skips their argument.
 $script:AgentGuardValueGlobalOptions = @('-C', '-c', '--git-dir', '--work-tree', '--namespace', '--exec-path')
 
@@ -672,6 +689,27 @@ function Test-AgentGitArgsContainAny {
         foreach ($option in $Options) {
             if ($arg -ieq $option -or $arg -ilike "$option=*") { return $true }
         }
+    }
+    return $false
+}
+
+<#
+.SYNOPSIS
+True when any argument carries a force flag, including a clustered short option.
+
+.DESCRIPTION
+Test-AgentGitArgsContainAny only matches a complete option token or opt=*, so it misses a
+clustered short option such as -df or -fd. This inspects each argument independently for
+--force, --force-*, or any short-option cluster containing a lowercase f. Case-sensitive
+(-c operators): -F is a different option to git in several subcommands, matching the discipline
+the safety rules already use at common.ps1:300 and :316.
+#>
+function Test-AgentGuardHasForceFlag {
+    param([string[]] $Arguments)
+    foreach ($arg in $Arguments) {
+        if ($arg -ceq '--force') { return $true }
+        if ($arg -clike '--force-*') { return $true }
+        if ($arg -cmatch '^-[a-zA-Z]*f') { return $true }
     }
     return $false
 }
@@ -785,6 +823,60 @@ function Test-AgentGitMutation {
         'init' {
             # init always mutates; its effective target decides whether the location allows it.
             return $true
+        }
+        default {
+            return $false
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+True when a mutating git invocation is Tier 2: safe to run from the main checkout with no prompt,
+because it cannot disturb the owner's HEAD, index, or working tree.
+
+.DESCRIPTION
+Every rule here is force-conditional except worktree prune and remote prune, which have no force
+variant that changes their risk. `-D` is git's own shorthand for "-d --force" on `branch`, so it
+is checked explicitly and case-sensitively alongside the generic force-cluster helper - a plain
+case-insensitive match would treat -D as equal to -d and wrongly allow it.
+#>
+function Test-AgentGitTier2Allowed {
+    [CmdletBinding()]
+    param([string] $Subcommand, [string[]] $Arguments)
+
+    $subcommand = $Subcommand.ToLowerInvariant()
+    $positionals = @(Get-AgentGitPositionals -Arguments $Arguments)
+    $first = if ($positionals.Count -gt 0) { ([string] $positionals[0]).ToLowerInvariant() } else { '' }
+
+    switch ($subcommand) {
+        'worktree' {
+            if ($first -eq 'prune') { return $true }
+            if ($first -in @('add', 'remove')) {
+                return -not (Test-AgentGuardHasForceFlag -Arguments $Arguments)
+            }
+            return $false
+        }
+        'branch' {
+            $hasForce = (Test-AgentGuardHasForceFlag -Arguments $Arguments) -or
+                (@($Arguments | Where-Object { $_ -ceq '-D' }).Count -gt 0)
+            $hasDelete = @($Arguments | Where-Object {
+                    $_ -ceq '-d' -or $_ -ceq '--delete' -or $_ -clike '--delete=*'
+                }).Count -gt 0
+            $hasOtherFlag = @($Arguments | Where-Object {
+                    $_ -like '-*' -and $_ -cne '-d' -and $_ -cne '--delete' -and $_ -cnotlike '--delete=*'
+                }).Count -gt 0
+
+            if ($hasDelete -and -not $hasForce -and -not $hasOtherFlag) { return $true }
+
+            # Plain create: only the branch name (and optional start-point), no flags at all.
+            $hasAnyFlag = @($Arguments | Where-Object { $_ -like '-*' }).Count -gt 0
+            if (-not $hasAnyFlag -and $positionals.Count -ge 1) { return $true }
+
+            return $false
+        }
+        'remote' {
+            return $first -eq 'prune'
         }
         default {
             return $false
@@ -1000,6 +1092,7 @@ function Get-AgentGitLocationDecision {
     $directoryStack = New-Object System.Collections.Generic.List[string]
     $blockingState = ''
     $blockingTarget = ''
+    $blockingSubcommand = ''
 
     foreach ($segment in $Segments) {
         if ($segment.Kind -eq 'PopDirectory') {
@@ -1056,9 +1149,14 @@ function Get-AgentGitLocationDecision {
             continue
         }
 
+        if (Test-AgentGitTier2Allowed -Subcommand $parts.Subcommand -Arguments $parts.Args) {
+            continue
+        }
+
         if ($parts.UsesGitDirOrWorkTree) {
             $blockingState = 'ExplicitGitDir'
             $blockingTarget = $Cwd
+            $blockingSubcommand = $parts.Subcommand
             break
         }
 
@@ -1070,6 +1168,7 @@ function Get-AgentGitLocationDecision {
         if ($unresolvedDirectory -and -not $dashCReanchors) {
             $blockingState = 'UnresolvedDirectoryChange'
             $blockingTarget = $Cwd
+            $blockingSubcommand = $parts.Subcommand
             break
         }
 
@@ -1079,6 +1178,7 @@ function Get-AgentGitLocationDecision {
         if ($state -inotin $script:AgentGuardAllowedStates) {
             $blockingState = $state
             $blockingTarget = $targetDir
+            $blockingSubcommand = $parts.Subcommand
             break
         }
     }
@@ -1087,12 +1187,15 @@ function Get-AgentGitLocationDecision {
         return New-AgentGuardDecision -Action Allow
     }
 
+    $isTier1b = ($blockingSubcommand -ieq 'commit')
+
     if ($blockingState -eq 'ExplicitGitDir') {
         if ($AllowMain) {
             return New-AgentGuardDecision -Action Warn -Rule 'agent-git-dir-override-overridden' -Message `
             ("WARNING: AHKFLOW_ALLOW_MAIN=1 overrode the --git-dir/--work-tree restriction for: $blockingTarget")
         }
-        return New-AgentGuardDecision -Action Deny -Rule 'agent-git-dir-mutation' -Message `
+        $action = if ($isTier1b) { 'Deny' } else { 'Ask' }
+        return New-AgentGuardDecision -Action $action -Rule 'agent-git-dir-mutation' -Message `
         ('BLOCKED: agent Git mutations with --git-dir or --work-tree are not allowed; the ' +
             'target cannot be verified. Run the command from inside a managed linked worktree instead.')
     }
@@ -1102,7 +1205,8 @@ function Get-AgentGitLocationDecision {
             return New-AgentGuardDecision -Action Warn -Rule 'agent-unresolved-cd-overridden' -Message `
             ("WARNING: AHKFLOW_ALLOW_MAIN=1 overrode an unverifiable directory change before a git mutation.")
         }
-        return New-AgentGuardDecision -Action Deny -Rule 'agent-unresolved-git-target' -Message `
+        $action = if ($isTier1b) { 'Deny' } else { 'Ask' }
+        return New-AgentGuardDecision -Action $action -Rule 'agent-unresolved-git-target' -Message `
         ('BLOCKED: this command changes directory to a target the guard cannot expand, so the ' +
             'git mutation cannot be verified. Run git from a managed linked worktree, or pass an ' +
             'explicit `git -C <path>`.')
@@ -1114,8 +1218,13 @@ function Get-AgentGitLocationDecision {
             "($blockingState) for: $blockingTarget")
     }
 
-    $message = [string]::Format($script:AgentGuardDenialMessage, $blockingTarget)
-    return New-AgentGuardDecision -Action Deny -Rule 'agent-main-git-mutation' -Message $message
+    if ($isTier1b) {
+        $message = [string]::Format($script:AgentGuardDenialMessage, $blockingTarget)
+        return New-AgentGuardDecision -Action Deny -Rule 'agent-main-git-mutation' -Message $message
+    }
+
+    $message = [string]::Format($script:AgentGuardAskMessage, $blockingTarget)
+    return New-AgentGuardDecision -Action Ask -Rule 'agent-main-git-mutation' -Message $message
 }
 
 <#

--- a/scripts/agents/invoke-agent-worktree-guard.ps1
+++ b/scripts/agents/invoke-agent-worktree-guard.ps1
@@ -81,14 +81,23 @@ $decision = Invoke-AgentGuardPolicy `
     -ProtectedRepoRoot $protectedRepoRoot `
     -AllowMain ($env:AHKFLOW_ALLOW_MAIN -eq '1')
 
+if ($decision.Action -eq 'Ask' -and -not [string]::IsNullOrWhiteSpace($normalized.AgentId)) {
+    $decision = New-AgentGuardDecision -Action Deny -Rule $decision.Rule -Message `
+        ($decision.Message + ' This call originated from a subagent and cannot show an interactive prompt. Report this back so the main-thread agent can retry it, which will prompt correctly.')
+}
+
 if ($decision.Action -ne 'Allow') {
     # Names the resolved adapter so a real-session probe can prove which contract was selected.
     Write-GuardDiagnostic "$($decision.Action.ToLowerInvariant()) [$($decision.Rule)]"
 }
 
+$locationDecisionRules = @('agent-main-git-mutation', 'agent-git-dir-mutation', 'agent-unresolved-git-target')
+
 switch ($Adapter) {
     'Codex' {
-        if ($decision.Action -eq 'Deny') {
+        # Codex: 'ask' is parsed but not supported yet - emitting it marks the hook run failed and
+        # the tool call proceeds (fails OPEN). Treat Ask exactly like Deny here, never emit 'ask'.
+        if ($decision.Action -in @('Deny', 'Ask')) {
             @{
                 hookSpecificOutput = @{
                     hookEventName            = 'PreToolUse'
@@ -101,8 +110,19 @@ switch ($Adapter) {
 
         if ($decision.Action -eq 'Warn') {
             @{ systemMessage = $decision.Message } | ConvertTo-Json -Compress -Depth 4 | Write-Output
+            exit 0
         }
 
+        if ($decision.Action -eq 'Allow') { exit 0 }
+
+        Write-GuardDiagnostic "unrecognized decision action '$($decision.Action)'; denying to fail closed."
+        @{
+            hookSpecificOutput = @{
+                hookEventName            = 'PreToolUse'
+                permissionDecision       = 'deny'
+                permissionDecisionReason = 'BLOCKED: the guard produced an unrecognized decision; denying to fail closed.'
+            }
+        } | ConvertTo-Json -Compress -Depth 4 | Write-Output
         exit 0
     }
 
@@ -115,18 +135,48 @@ switch ($Adapter) {
             exit 0
         }
 
+        if ($decision.Action -eq 'Ask') {
+            @{
+                permissionDecision       = 'ask'
+                permissionDecisionReason = $decision.Message
+            } | ConvertTo-Json -Compress -Depth 4 | Write-Output
+            exit 0
+        }
+
         if ($decision.Action -eq 'Warn') {
             @{
                 permissionDecision       = 'allow'
                 permissionDecisionReason = $decision.Message
             } | ConvertTo-Json -Compress -Depth 4 | Write-Output
+            exit 0
         }
 
+        if ($decision.Action -eq 'Allow') { exit 0 }
+
+        Write-GuardDiagnostic "unrecognized decision action '$($decision.Action)'; denying to fail closed."
+        @{
+            permissionDecision       = 'deny'
+            permissionDecisionReason = 'BLOCKED: the guard produced an unrecognized decision; denying to fail closed.'
+        } | ConvertTo-Json -Compress -Depth 4 | Write-Output
         exit 0
     }
 
     default {
-        # Claude: stderr plus exit 2 blocks; exit 0 allows.
+        # Claude. Ask and Deny outcomes from the three location rules use the JSON
+        # hookSpecificOutput protocol (this is what makes Ask possible at all); everything else
+        # (safety-rule Deny, ambiguous-git-command Deny) keeps the legacy stderr + exit 2 protocol.
+        if ($decision.Rule -in $locationDecisionRules -and $decision.Action -in @('Ask', 'Deny')) {
+            $permissionDecision = if ($decision.Action -eq 'Ask') { 'ask' } else { 'deny' }
+            @{
+                hookSpecificOutput = @{
+                    hookEventName            = 'PreToolUse'
+                    permissionDecision       = $permissionDecision
+                    permissionDecisionReason = $decision.Message
+                }
+            } | ConvertTo-Json -Compress -Depth 4 | Write-Output
+            exit 0
+        }
+
         if ($decision.Action -eq 'Deny') {
             [Console]::Error.WriteLine($decision.Message)
             exit 2
@@ -134,8 +184,13 @@ switch ($Adapter) {
 
         if ($decision.Action -eq 'Warn') {
             [Console]::Error.WriteLine($decision.Message)
+            exit 0
         }
 
-        exit 0
+        if ($decision.Action -eq 'Allow') { exit 0 }
+
+        Write-GuardDiagnostic "unrecognized decision action '$($decision.Action)'; denying to fail closed."
+        [Console]::Error.WriteLine('BLOCKED: the guard produced an unrecognized decision; denying to fail closed.')
+        exit 2
     }
 }

--- a/tests/AgentPreCommitHook.Tests.ps1
+++ b/tests/AgentPreCommitHook.Tests.ps1
@@ -17,11 +17,34 @@ $ErrorActionPreference = 'Stop'
 
 $suiteRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
 
+# The real AHKFlowApp checkout's own policy core - used only for the PreToolUse-layer pin below,
+# which asserts against the guard's decision object directly rather than a real commit attempt.
+# Every actual commit attempt in this suite still runs against a disposable fixture repository,
+# never this checkout.
+. (Join-Path $suiteRoot 'scripts\agents\agent-worktree-guard.common.ps1')
+
+# $suiteRoot is this file's own location, which is the *main checkout* only when the suite is run
+# from there - a run from inside a managed linked worktree (as agent sessions do) makes $suiteRoot
+# a worktree instead, and Get-ManagedWorktreeState would then read it as ManagedWorktree, not
+# MainCheckout. Same derivation AgentWorktreeGuard.Tests.ps1 uses for $script:RealMainCheckout:
+# walk up from the git-common-dir, which always resolves to the true main checkout regardless of
+# which worktree the suite happens to run from.
+$script:RealMainCheckout = Split-Path -Parent (
+    (& git -C $suiteRoot rev-parse --path-format=absolute --git-common-dir).Trim())
+$script:RealMainCheckout = (Resolve-Path -LiteralPath $script:RealMainCheckout).Path
+
 $script:Failures = New-Object System.Collections.Generic.List[string]
 
 function Assert-True {
     param([bool] $Condition, [string] $Message)
     if (-not $Condition) { throw $Message }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string] $Message)
+    if (-not [string]::Equals([string] $Expected, [string] $Actual, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "$Message (expected '$Expected', got '$Actual')"
+    }
 }
 
 function Invoke-Git {
@@ -190,6 +213,17 @@ $markers = @(
 $fixture = $null
 try {
     $fixture = New-CommitFixture
+
+    # Pins that the PreToolUse layer denies commit from main before the pre-commit backstop this
+    # file otherwise tests is ever reached. Uses the real AHKFlowApp checkout
+    # ($script:RealMainCheckout) as both -Cwd and -ProtectedRepoRoot, the same pattern
+    # AgentWorktreeGuard.Tests.ps1 uses for its Claude/Codex/Copilot adapter-output tests.
+    Invoke-TestCase 'PreToolUse denies commit from main before the backstop is ever reached' {
+        $decision = Invoke-AgentGuardPolicy -Command 'git commit -m test' `
+            -Cwd $script:RealMainCheckout -ProtectedRepoRoot $script:RealMainCheckout
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
+    }
 
     Invoke-TestCase 'Human commit in main (no agent marker) succeeds' {
         $result = Invoke-CommitAttempt -RepoRoot $fixture.Main

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -623,6 +623,7 @@ try {
         'git worktree prune -n',
         "git worktree remove $somewhere",
         "git worktree add $somewhere sometopic",
+        "git worktree add -b topic $somewhere", # lowercase -b is the safe, non-destructive spelling
         'git worktree list', # already allowed today (read-only) - pin, not a new behavior
         'git branch -d topic',
         'git branch --delete topic',

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -604,6 +604,176 @@ try {
         Assert-Equal 'ambiguous-git-command' $decision.Rule 'Rule'
     }
 
+    Write-Host 'Tier reclassification' -ForegroundColor Cyan
+
+    $somewhere = Join-Path $fixture.TestRoot 'somewhere'
+    $somewhereElse = Join-Path $fixture.TestRoot 'somewhere-else'
+
+    # Tier 2: cannot disturb the owner's HEAD, index, or working tree - unconditional Allow, even
+    # from the main checkout, with no AllowMain. Nothing here touches the filesystem: Tier 2
+    # short-circuits before the location decision ever resolves a target directory.
+    $tier2AllowCases = @(
+        'git worktree prune',
+        'git worktree prune -n',
+        "git worktree remove $somewhere",
+        "git worktree add $somewhere sometopic",
+        'git worktree list', # already allowed today (read-only) - pin, not a new behavior
+        'git branch -d topic',
+        'git branch --delete topic',
+        'git branch newtopic',
+        'git remote prune origin',
+        'git fetch --prune' # already unguarded (not a recognized mutating subcommand) - pin
+    )
+    foreach ($command in $tier2AllowCases) {
+        Invoke-TestCase "Tier 2 unconditional allow from main: $command" {
+            $decision = Invoke-AgentGuardPolicy -Command $command -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+            Assert-Equal 'Allow' $decision.Action 'Action'
+        }
+    }
+
+    # The force/destructive sibling of each Tier 2 case above can disturb the working tree (or, for
+    # branch -D et al, discard unmerged work), so it drops out of Tier 2 into ordinary Tier 1a Ask.
+    $forceVariantAskCases = @(
+        "git worktree remove --force $somewhere",
+        "git worktree remove -f $somewhere",
+        "git worktree add --force $somewhere sometopic",
+        "git worktree move $somewhere $somewhereElse",
+        'git worktree repair',
+        "git worktree lock $somewhere",
+        "git worktree unlock $somewhere",
+        'git branch -D topic',
+        'git branch -d -f topic',
+        'git branch -df topic',
+        'git branch -fd topic',
+        'git branch --delete --force topic',
+        'git branch -m a b',
+        'git branch -M a b'
+    )
+    foreach ($command in $forceVariantAskCases) {
+        Invoke-TestCase "Force/destructive variant asks (not Tier 2) from main: $command" {
+            $decision = Invoke-AgentGuardPolicy -Command $command -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+            Assert-Equal 'Ask' $decision.Action 'Action'
+            Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
+        }
+    }
+
+    # Tier 1a: guarded, not Tier 2, not commit - a permission prompt instead of a silent Deny.
+    $tier1aAskCases = @(
+        'git checkout other', 'git switch other', 'git reset HEAD~1', 'git stash', 'git push',
+        'git tag v1.0.0', 'git add .', 'git config user.name x'
+    )
+    foreach ($command in $tier1aAskCases) {
+        Invoke-TestCase "Tier 1a asks from main: $command" {
+            $decision = Invoke-AgentGuardPolicy -Command $command -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+            Assert-Equal 'Ask' $decision.Action 'Action'
+        }
+    }
+
+    # Tier 1b: only commit stays a silent Deny. `git commit -m test` and the unbalanced-quote case
+    # are already covered above; this adds the one commit variant that was not: --amend.
+    Invoke-TestCase 'git commit --amend from main is still denied (Tier 1b, unchanged)' {
+        $decision = Invoke-AgentGuardPolicy -Command 'git commit --amend' -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
+    }
+
+    # Safety rules (force-push, reset --hard, clean -f, checkout ., dangerous rm) short-circuit
+    # Invoke-AgentGuardPolicy before the location decision ever runs (see common.ps1:1147), so Ask
+    # is structurally unreachable for them. $safetyCases/$indirectSafetyCases above already pin
+    # Get-AgentCommandSafetyDecision's Action/Rule; this confirms the same end to end through the
+    # full policy, never downgraded to Ask.
+    $safetyStillDenyEndToEndCases = @(
+        'git push --force', 'git push -f', 'git reset --hard', 'git clean -fd', 'git checkout .', 'rm -rf src'
+    )
+    foreach ($command in $safetyStillDenyEndToEndCases) {
+        Invoke-TestCase "Safety rule still denies end to end, never Ask: $command" {
+            $decision = Invoke-AgentGuardPolicy -Command $command -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+            Assert-Equal 'Deny' $decision.Action 'Action'
+        }
+    }
+
+    # No regression inside a managed worktree: every Tier 1a and Tier 2 command above must still be
+    # a plain Allow when it is not targeting the main checkout at all.
+    foreach ($command in (@($tier2AllowCases) + @($forceVariantAskCases) + @($tier1aAskCases))) {
+        Invoke-TestCase "No regression in a managed worktree: $command" {
+            $decision = Invoke-AgentGuardPolicy -Command $command -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main
+            Assert-Equal 'Allow' $decision.Action 'Action'
+        }
+    }
+
+    Invoke-TestCase 'AHKFLOW_ALLOW_MAIN=1 downgrades a Tier 1a Ask to Warn' {
+        $decision = Invoke-AgentGuardPolicy -Command 'git checkout other' `
+            -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main -AllowMain $true
+        Assert-Equal 'Warn' $decision.Action 'Action'
+    }
+
+    # Resolved design decision: AHKFLOW_ALLOW_MAIN=1 keeps its exact current behavior for commit -
+    # a warned Allow, not a Deny. This task only changes whether a prompt is offered when it's unset.
+    Invoke-TestCase 'AHKFLOW_ALLOW_MAIN=1 still turns a commit Deny into a warned Allow' {
+        $decision = Invoke-AgentGuardPolicy -Command 'git commit -m test' `
+            -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main -AllowMain $true
+        Assert-Equal 'Warn' $decision.Action 'Action'
+    }
+
+    Write-Host 'Tier reclassification: adapter matrix' -ForegroundColor Cyan
+
+    Invoke-TestCase 'Claude: a Tier 1a decision emits permissionDecision ask' {
+        $result = Invoke-Entrypoint -StdIn (New-ClaudePayload 'git checkout other' $script:RealMainCheckout) -Adapter 'Claude'
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+        $json = $result.StdOut | ConvertFrom-Json
+        Assert-Equal 'ask' $json.hookSpecificOutput.permissionDecision 'permissionDecision'
+    }
+
+    Invoke-TestCase 'Codex: a Tier 1a decision is translated to deny, never ask' {
+        $result = Invoke-Entrypoint -StdIn (New-CodexPayload 'git checkout other' $script:RealMainCheckout) -Adapter 'Codex'
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+        $json = $result.StdOut | ConvertFrom-Json
+        Assert-Equal 'deny' $json.hookSpecificOutput.permissionDecision 'permissionDecision'
+    }
+
+    Invoke-TestCase 'Copilot: a Tier 1a decision emits permissionDecision ask' {
+        $result = Invoke-Entrypoint -StdIn (New-CopilotPayload 'git checkout other' $script:RealMainCheckout) -Adapter 'Copilot'
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+        $json = $result.StdOut | ConvertFrom-Json
+        Assert-Equal 'ask' $json.permissionDecision 'permissionDecision'
+    }
+
+    Invoke-TestCase 'Unknown decision action fails closed, verified structurally on every adapter branch' {
+        # New-AgentGuardDecision's ValidateSet (Allow/Warn/Deny/Ask) makes an "unrecognized" Action
+        # structurally unreachable through any real policy input - it can only come from a defect in
+        # the decision engine itself. Invoke-Entrypoint runs the entrypoint as a real subprocess
+        # (Invoke-CapturedProcess), so a function shadow defined in this test process cannot reach
+        # it; calling Invoke-AgentGuardPolicy directly cannot exercise the adapter's own JSON/exit
+        # translation, which is exactly what is under test. There is no seam to inject a fault into
+        # the subprocess without adding a test-only hook to the product code, which is not
+        # proportionate for this one case (see task-1-brief.md, section C1). This instead asserts
+        # the fail-closed *structure* by inspecting the entrypoint's source: every adapter branch
+        # must explicitly deny on any action it does not recognize, rather than falling through to
+        # an implicit allow.
+        $source = Get-Content -LiteralPath $entrypointScript -Raw
+
+        $codexStart = $source.IndexOf("'Codex' {")
+        $copilotStart = $source.IndexOf("'Copilot' {")
+        $claudeStart = $source.IndexOf('default {')
+        Assert-True ($codexStart -ge 0 -and $copilotStart -gt $codexStart -and $claudeStart -gt $copilotStart) `
+            'expected the switch to contain Codex, then Copilot, then the default (Claude) branch in that order'
+
+        $branches = @(
+            @{ Name = 'Codex'; Text = $source.Substring($codexStart, $copilotStart - $codexStart) },
+            @{ Name = 'Copilot'; Text = $source.Substring($copilotStart, $claudeStart - $copilotStart) },
+            @{ Name = 'Claude (default)'; Text = $source.Substring($claudeStart) }
+        )
+
+        foreach ($branch in $branches) {
+            Assert-True ($branch.Text.Contains("if (`$decision.Action -eq 'Allow') { exit 0 }")) `
+                "$($branch.Name): a recognized Allow must exit before the fail-closed fallback is reached"
+            Assert-True ($branch.Text.Contains('unrecognized decision action')) `
+                "$($branch.Name): must diagnose an unrecognized action rather than silently falling through"
+            Assert-True ($branch.Text.ToLowerInvariant().Contains('deny')) `
+                "$($branch.Name): must deny an unrecognized action (fail closed)"
+        }
+    }
+
     Write-Host 'Mutation detection' -ForegroundColor Cyan
 
     $mutatingCommands = @(
@@ -761,7 +931,9 @@ try {
     }
 
     Invoke-TestCase 'Set-Location into main before a git mutation is denied' {
-        $command = "Set-Location -LiteralPath `"$($fixture.Main)`"; git branch review-bypass"
+        # git commit is the go-to probe for "any location mutation" here: a plain `git branch
+        # <name>` create is now Tier 2 Allow, so it no longer demonstrates a location denial.
+        $command = "Set-Location -LiteralPath `"$($fixture.Main)`"; git commit -m test"
         $decision = Invoke-AgentGuardPolicy -Command $command -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main
         Assert-Equal 'Deny' $decision.Action 'Action'
         Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
@@ -868,9 +1040,10 @@ try {
         Assert-Equal 'Deny' $decision.Action 'Action'
     }
 
-    Invoke-TestCase 'git init inside the protected checkout is denied' {
+    Invoke-TestCase 'git init inside the protected checkout is asked (Tier 1a, not commit)' {
         $decision = Invoke-AgentGuardPolicy -Command 'git init .' -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
-        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'Ask' $decision.Action 'Action'
+        Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
     }
 
     Invoke-TestCase 'git init in an unrelated empty temp directory is allowed' {
@@ -882,10 +1055,22 @@ try {
 
     Write-Host 'Adapter output contracts' -ForegroundColor Cyan
 
-    Invoke-TestCase 'Claude denial writes stderr and exits 2' {
+    Invoke-TestCase 'Claude commit denial (a location rule) emits hookSpecificOutput deny and exits 0' {
+        # Commit stays Tier 1b Deny, but the wire protocol for the three location rules is now the
+        # JSON hookSpecificOutput contract on every action (Ask included), not the legacy
+        # stderr + exit 2 pair - that pair is reserved for safety-rule and ambiguous-command denials.
         $result = Invoke-Entrypoint -StdIn (New-ClaudePayload 'git commit -m test' $script:RealMainCheckout) -Adapter 'Claude'
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+        $json = $result.StdOut | ConvertFrom-Json
+        Assert-Equal 'PreToolUse' $json.hookSpecificOutput.hookEventName 'hookEventName'
+        Assert-Equal 'deny' $json.hookSpecificOutput.permissionDecision 'permissionDecision'
+        Assert-Match 'BLOCKED: agent Git mutations' $json.hookSpecificOutput.permissionDecisionReason 'reason'
+    }
+
+    Invoke-TestCase 'Claude safety-rule denial still uses the legacy stderr + exit 2 protocol' {
+        $result = Invoke-Entrypoint -StdIn (New-ClaudePayload 'git reset --hard' $script:RealMainCheckout) -Adapter 'Claude'
         Assert-Equal 2 $result.ExitCode 'ExitCode'
-        Assert-Match 'BLOCKED: agent Git mutations' $result.StdErr 'StdErr'
+        Assert-Match 'BLOCKED: git reset --hard' $result.StdErr 'StdErr'
     }
 
     Invoke-TestCase 'Codex denial emits hookSpecificOutput and exits 0' {
@@ -950,9 +1135,12 @@ try {
     foreach ($command in $candidateCommands) {
         Invoke-TestCase "Bash shim forwards candidate command: $command" {
             $result = Invoke-BashShim -StdIn (New-ClaudePayload $command $script:RealMainCheckout) -ShimArguments @('Claude')
-            # Reaching PowerShell is what is under test: every candidate above either denies or warns.
-            $reachedPolicy = $result.ExitCode -eq 2 -or $result.StdErr -match 'BLOCKED|WARNING'
-            Assert-True $reachedPolicy "expected the command to reach the policy core (exit $($result.ExitCode), stderr '$($result.StdErr)')"
+            # Reaching PowerShell is what is under test: every candidate above either denies (legacy
+            # stderr + exit 2, or the JSON hookSpecificOutput protocol for a location-rule commit
+            # denial) or warns.
+            $reachedPolicy = $result.ExitCode -eq 2 -or $result.StdErr -match 'BLOCKED|WARNING' -or
+            $result.StdOut -match 'permissionDecision'
+            Assert-True $reachedPolicy "expected the command to reach the policy core (exit $($result.ExitCode), stdout '$($result.StdOut)', stderr '$($result.StdErr)')"
         }
     }
 
@@ -963,8 +1151,10 @@ try {
         '{"command":"cd f&&git commit -m test"},"cwd":"' +
         ($script:RealMainCheckout -replace '\\', '\\') + '"}'
         $result = Invoke-BashShim -StdIn $escaped -ShimArguments @('Claude')
-        Assert-Equal 2 $result.ExitCode 'ExitCode'
-        Assert-Match 'BLOCKED: agent Git mutations' $result.StdErr 'StdErr'
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+        $json = $result.StdOut | ConvertFrom-Json
+        Assert-Equal 'deny' $json.hookSpecificOutput.permissionDecision 'permissionDecision'
+        Assert-Match 'BLOCKED: agent Git mutations' $json.hookSpecificOutput.permissionDecisionReason 'reason'
     }
 
     Invoke-TestCase 'Bash shim exits fast for a noncandidate command despite a matching cwd' {
@@ -1015,8 +1205,10 @@ try {
 
         $result = Invoke-BashShim -StdIn (New-ClaudePayload 'git commit -m test' $script:RealMainCheckout) `
             -ShimArguments @('Claude') -EnvironmentOverrides @{ PATH = $pathWithoutPwsh }
-        Assert-Equal 2 $result.ExitCode 'ExitCode'
-        Assert-Match 'BLOCKED: agent Git mutations' $result.StdErr 'StdErr'
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+        $json = $result.StdOut | ConvertFrom-Json
+        Assert-Equal 'deny' $json.hookSpecificOutput.permissionDecision 'permissionDecision'
+        Assert-Match 'BLOCKED: agent Git mutations' $json.hookSpecificOutput.permissionDecisionReason 'reason'
     }
 
     Invoke-TestCase 'Bash shim warns and allows when no PowerShell host exists' {

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -192,13 +192,19 @@ function Invoke-BashShim {
 }
 
 function New-ClaudePayload {
-    param([string] $Command, [string] $Cwd)
-    return @{
+    param([string] $Command, [string] $Cwd, [string] $AgentId = '')
+    $payload = @{
         hook_event_name = 'PreToolUse'
         tool_name       = 'Bash'
         tool_input      = @{ command = $Command }
         cwd             = $Cwd
-    } | ConvertTo-Json -Compress -Depth 4
+    }
+    # Present at the top level only when the call originates inside a subagent - see
+    # ConvertFrom-AgentHookInput. Optional so every existing caller is unaffected.
+    if (-not [string]::IsNullOrWhiteSpace($AgentId)) {
+        $payload.agent_id = $AgentId
+    }
+    return $payload | ConvertTo-Json -Compress -Depth 4
 }
 
 function New-CodexPayload {
@@ -647,7 +653,10 @@ try {
         'git branch -fd topic',
         'git branch --delete --force topic',
         'git branch -m a b',
-        'git branch -M a b'
+        'git branch -M a b',
+        # -B is git's own force spelling for worktree add (resets an existing branch's tip); the
+        # lowercase -b clustered/exact-match test coverage above (via $tier2AllowCases) stays Allow.
+        "git worktree add -B topic $somewhere"
     )
     foreach ($command in $forceVariantAskCases) {
         Invoke-TestCase "Force/destructive variant asks (not Tier 2) from main: $command" {
@@ -675,6 +684,25 @@ try {
         $decision = Invoke-AgentGuardPolicy -Command 'git commit --amend' -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
         Assert-Equal 'Deny' $decision.Action 'Action'
         Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
+    }
+
+    # Critical regression: the location scan used to break at the FIRST blocking segment and derive
+    # the Tier1b-vs-Ask decision from that one segment alone. So a non-commit mutation blocking
+    # earlier in a chain (e.g. `git add .`) hid a `commit` blocking later, misclassifying the whole
+    # command as Ask. commit must never be reachable behind an Ask prompt: approving the prompt
+    # would run the earlier mutation in the owner's checkout, then commit would die at the separate
+    # pre-commit backstop, leaving the owner's index staged with the agent's files.
+    $commitDominatesCases = @(
+        'git add . && git commit -m x',
+        'git add .; git commit -m x',
+        'git commit -m x && git add .'
+    )
+    foreach ($command in $commitDominatesCases) {
+        Invoke-TestCase "Commit dominates regardless of scan order: $command" {
+            $decision = Invoke-AgentGuardPolicy -Command $command -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+            Assert-Equal 'Deny' $decision.Action 'Action'
+            Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
+        }
     }
 
     # Safety rules (force-push, reset --hard, clean -f, checkout ., dangerous rm) short-circuit
@@ -736,6 +764,27 @@ try {
         Assert-Equal 0 $result.ExitCode 'ExitCode'
         $json = $result.StdOut | ConvertFrom-Json
         Assert-Equal 'ask' $json.permissionDecision 'permissionDecision'
+    }
+
+    Write-Host 'Subagent Ask->Deny downgrade' -ForegroundColor Cyan
+
+    # Binding security control (plan-mandated): a subagent cannot show an interactive prompt, so a
+    # Tier 1a hit from a subagent call must resolve to Deny, never Ask, on every adapter.
+    Invoke-TestCase 'Claude: a subagent Tier 1a hit is denied, never asked' {
+        $result = Invoke-Entrypoint -StdIn (New-ClaudePayload 'git checkout other' $script:RealMainCheckout -AgentId 'subagent-test-1') -Adapter 'Claude'
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+        $json = $result.StdOut | ConvertFrom-Json
+        Assert-Equal 'deny' $json.hookSpecificOutput.permissionDecision 'permissionDecision'
+        Assert-Match 'subagent' $json.hookSpecificOutput.permissionDecisionReason 'reason'
+    }
+
+    # Control: the identical command with no agent_id must still Ask - otherwise the Deny assertion
+    # above could pass vacuously (e.g. if the command were Deny for an unrelated reason).
+    Invoke-TestCase 'Claude: the same Tier 1a command without agent_id still asks (control)' {
+        $result = Invoke-Entrypoint -StdIn (New-ClaudePayload 'git checkout other' $script:RealMainCheckout) -Adapter 'Claude'
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+        $json = $result.StdOut | ConvertFrom-Json
+        Assert-Equal 'ask' $json.hookSpecificOutput.permissionDecision 'permissionDecision'
     }
 
     Invoke-TestCase 'Unknown decision action fails closed, verified structurally on every adapter branch' {


### PR DESCRIPTION
## Summary

Relaxes the agent Git guard so it gates on **collision risk**, not on "is this authoring?".

The guard previously blocked every mutating Git command in the human-owned main
checkout unless the agent was inside a managed linked worktree. That scope was drawn
against the wrong threat and was measurably too wide — it denied `git worktree
remove -h`, a help flag that changes nothing, and a routine `/clean_gone` run was
denied at `git branch -D <gone-branch>` with no way forward inside the session.

The new test: **can this command change the human's HEAD, index, or working tree in
main?** Three tiers:

- **Tier 2 — always allowed, even from main, no prompt.** `worktree prune`;
  `worktree add`/`remove` without `--force`/`-f` (and, for `add`, without `-B`);
  `branch -d`/`--delete` without any force spelling; a plain `branch <name>` create
  with zero flags; `remote prune <name>`.
- **Tier 1a — in-session permission prompt** instead of a silent denial. Everything
  else currently guarded. `push` stays here deliberately: TEST auto-deploys on push
  to `main`, a separate risk axis from the collision test.
- **Tier 1b — hard denial, never a prompt.** `git commit` only. A `PreToolUse`
  approval cannot reach the `.githooks/pre-commit` backstop that runs after, so
  offering a prompt would produce a worse failure than today's: the user approves,
  and the commit dies anyway at the backstop.

Destructive-command safety rules (force push, hard reset, forced clean, discarding
`checkout .`, recursive-force file deletion) are untouched and still evaluate first.
`AHKFLOW_ALLOW_MAIN=1` keeps its exact previous meaning for every tier including
`commit`.

Adapter behaviour differs by necessity: Claude and Copilot emit
`permissionDecision: "ask"`; **Codex must not** — `ask` there is "parsed but not
supported yet" and makes the hook run fail *open*, letting the mutation through, so
every Ask-tier decision renders as `deny` on Codex. Subagent calls also never get a
prompt (they hard-deny and report back for a main-thread retry), and any unrecognized
decision action fails closed on all three adapters.

Also fixes the docs that asserted the old policy — including one instruction that
could never work: `.agents/worktrees/SKILL.md` told agents to recover with an inline
`AHKFLOW_ALLOW_MAIN=1 git commit -m "..."` prefix, which the guard never sees, because
it runs in its own process and reads the command as text.

## Checklist

- [x] [Canonical pre-PR gate](../docs/development/testing-workflow.md#canonical-pre-pr-gate) passes (build, format, coverage, `git diff --check`)
- [x] The change was exercised, not just compiled — name the test or verification below
- [x] No new warnings introduced
- [x] Breaking changes documented (if any) — none; the change only widens what is permitted

## Verification

Gate, run on `07541fbd`:

- `dotnet build AHKFlowApp.slnx --configuration Release` — succeeded, 0 warnings
- `dotnet format AHKFlowApp.slnx --verify-no-changes` — clean
- `pwsh .\scripts\test-fast.ps1 -Mode Coverage` — all per-assembly thresholds met (line 94.1%, branch 80.7%)
- `git diff --check main...HEAD` — clean

Guard behaviour (the surface this PR actually changes):

- `tests/AgentWorktreeGuard.Tests.ps1` — **301/301**. New coverage pins every tier
  boundary: Tier 2 allows; each force variant returning Ask rather than Allow
  (`-D`, `-d -f`, `-df`, `-fd`, `--delete --force`, `-m`/`-M`, `worktree add -B`,
  forced `worktree remove`, `move`/`repair`/`lock`/`unlock`); `-b` staying Tier 2 so
  the deliberate case-sensitivity of the `-B` check is pinned in both directions;
  safety rules never downgrading to Ask; the per-adapter Ask contract (Claude `ask`,
  Copilot `ask`, Codex `deny`); the subagent Ask-to-Deny downgrade with a
  no-`agent_id` control; and commit dominance across chained commands (a staging
  command followed by `git commit` denies as a whole, in both orderings and with a
  semicolon separator).
- `tests/AgentPreCommitHook.Tests.ps1` — **11/11**, including a new case pinning that
  `commit` from main is denied at the `PreToolUse` layer *before* the backstop is
  reached, so nobody later converts `commit` to a prompt.
- `tests/SkillParity.Tests.ps1`, `tests/SkillLayout.Tests.ps1` — pass (25 active
  skills). `tests/CodexSkillsHashParity.Tests.ps1` self-skips on Windows by design
  (Linux-only bash comparison); it runs in CI.

**Outstanding, deliberately not claimed:** the `Ask` path has not yet been exercised
in a live agent session — all Ask evidence above is the JSON contract asserted
in-process. Tests cannot cover whether `permissionDecision: "ask"` actually renders
as a prompt. Two manual checks from the main checkout are the last gate before merge:
`git worktree prune` should run with no prompt, and `git branch -D <gone-branch>`
should raise an approval prompt. Reviewer/author to confirm before merging.

### Footnote from writing this PR

Creating this PR was itself blocked by the guard's `dangerous-rm` rule: the summary
above originally spelled out the recursive-force deletion flags in backticks, and the
tokenizer treats a backtick as a segment separator without understanding heredocs, so
it read the prose as an invocation. Consistent with the documented "the command
tokenizer is not a full Bash/PowerShell parser" limitation, and harmless here — the
body was passed via a file instead. Noted in case it recurs often enough to be worth
addressing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
