### PR TITLE
fix: guard reads past the rtk wrapper prefix

### DIFF
--- a/.claude/backlog/done/039-agent-git-guard-wrapper-bypass.md
+++ b/.claude/backlog/done/039-agent-git-guard-wrapper-bypass.md
@@ -49,17 +49,41 @@ by `dangerous-rm` during the same session.
 
 ## Acceptance criteria
 
-- [ ] Decide the approach: teach the guard to look through a known wrapper prefix, or exclude `git`
+- [x] Decide the approach: teach the guard to look through a known wrapper prefix, or exclude `git`
       from the wrapper's rewrite (or both). Record the decision and its reasoning.
-- [ ] A wrapped mutating command targeting the main checkout gets the same decision as its bare
+- [x] A wrapped mutating command targeting the main checkout gets the same decision as its bare
       equivalent — in particular `rtk git commit -m x` from main is denied.
-- [ ] Regression tests in `tests/AgentWorktreeGuard.Tests.ps1` cover the wrapped form for at least
+- [x] Regression tests in `tests/AgentWorktreeGuard.Tests.ps1` cover the wrapped form for at least
       one Tier 2 allow, one Tier 1a Ask, and the Tier 1b `commit` denial.
-- [ ] If prefix-skipping is chosen, the allowed prefix list is explicit and narrow — a wrapper must
+- [x] If prefix-skipping is chosen, the allowed prefix list is explicit and narrow — a wrapper must
       not be able to escalate what the guard permits, only stay transparent to it.
-- [ ] `docs/agents/cross-agent-git-guardrails.md` accepted-limitations wording updated: an
+- [x] `docs/agents/cross-agent-git-guardrails.md` accepted-limitations wording updated: an
       externally registered command-rewriting hook can silently neutralise the guard, which differs
       from a user knowingly invoking a wrapper.
+
+## Resolution
+
+Two commits on `fix/wt-agent-git-guard-wrapper-bypass`:
+
+1. `Remove-AgentWrapperPrefix` (commit `6b0164a7`) strips a leading `rtk`/`rtk.exe` prefix, its
+   leading global options, and one pass-through subcommand, before the guard classifies the
+   command. `$script:AgentGuardTransparentWrappers` and
+   `$script:AgentGuardWrapperPassThroughSubcommands` are the explicit, narrow allow-lists — adding
+   a name to either can only expose more of a command to classification, never permit more than the
+   bare command would.
+2. A review-cleanup commit (`c8d131f0`) added `err`, `summary`, and `test` to the pass-through list
+   — rtk 0.43.0 ships five subcommands that run a raw command, not two — fixed a comment that
+   misdescribed `Remove-AgentWrapperPrefix`'s return value on a multi-pass strip, replaced a
+   vacuous test case, and pinned `rtk FOO=1 git commit -m x` as a documented remaining bypass.
+
+Two smaller gaps stay deliberately unmodelled, each pinned by a test: a wrapper option that
+consumes the next token as its value (rtk has none today), and a `NAME=value` assignment placed
+after the wrapper. `docs/agents/cross-agent-git-guardrails.md` records both, plus the deeper risk
+that any externally registered command-rewriting hook not on the transparent-wrapper list still
+bypasses the guard exactly as before.
+
+The path-qualified-probe observation in Notes below is **not** addressed by this item. It is still
+open and needs its own investigation.
 
 ## Out of scope
 

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -217,9 +217,21 @@ An agent running the same command would need a prompt or override.
   ref write, and is too blunt for this guardrail.
 - No general shell-command allowlist. Unknown non-Git commands and unknown Git subcommands are
   allowed; mutation detection is a denylist, not an allowlist.
-- `git commit --no-verify`, a replaced `core.hooksPath`, shell aliases, and wrappers such as
-  `pwsh -File custom.ps1` (whose child Git calls the outer payload never exposes) remain bypasses.
-  This is also why calling `new-worktree.ps1` / `remove-worktree-local-dev.ps1` does not self-lock.
+- `git commit --no-verify`, a replaced `core.hooksPath`, and shell aliases remain bypasses. This is
+  also why calling `new-worktree.ps1` / `remove-worktree-local-dev.ps1` does not self-lock.
+- The guard now sees through `rtk`, including its leading global options and its pass-through
+  subcommands (`proxy`, `run`, `err`, `summary`, `test`). A wrapper that hides the command inside a
+  quoted string still bypasses the guard, because the tokenizer keeps a quoted string as one token:
+  `sh -c '...'`, `rtk run "..."`, and `pwsh -File custom.ps1` all bypass the guard this way. Two
+  smaller gaps are pinned by tests instead of fixed: a wrapper option that consumes the next token
+  as its value (`rtk --out foo git commit`, which rtk has no option for today), and a `NAME=value`
+  assignment placed after the wrapper (`rtk FOO=1 git commit -m x`).
+- An externally registered command-rewriting `PreToolUse` hook can quietly turn the guard off. This
+  differs from a person knowingly typing a wrapper, because the hook runs on every command by
+  default, not only when someone chooses to type it. `rtk hook claude` is one example; the
+  transparent-wrapper list is the mitigation.
+- The transparent-wrapper list is hard-coded and narrow on purpose. Any wrapper that is not on the
+  list hides its child git calls exactly as before.
 - Adapter parse errors and unexpected location-policy errors **fail open** with a warning; only an
   explicit safety-rule match (or a safety-rule evaluation fault) **fails closed**.
 - Main-tree edits, builds, tests, and formatters are allowed and can dirty the working tree. The

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -219,13 +219,18 @@ An agent running the same command would need a prompt or override.
   allowed; mutation detection is a denylist, not an allowlist.
 - `git commit --no-verify`, a replaced `core.hooksPath`, and shell aliases remain bypasses. This is
   also why calling `new-worktree.ps1` / `remove-worktree-local-dev.ps1` does not self-lock.
-- The guard now sees through `rtk`, including its leading global options and its pass-through
-  subcommands (`proxy`, `run`, `err`, `summary`, `test`). A wrapper that hides the command inside a
-  quoted string still bypasses the guard, because the tokenizer keeps a quoted string as one token:
-  `sh -c '...'`, `rtk run "..."`, and `pwsh -File custom.ps1` all bypass the guard this way. Two
-  smaller gaps are pinned by tests instead of fixed: a wrapper option that consumes the next token
-  as its value (`rtk --out foo git commit`, which rtk has no option for today), and a `NAME=value`
-  assignment placed after the wrapper (`rtk FOO=1 git commit -m x`).
+- The guard now reads past `rtk`, including its leading global options and its pass-through
+  subcommands (`proxy`, `run`, `err`, `summary`, `test`).
+- A wrapper can still hide the command inside a quoted string. The tokenizer keeps a quoted string
+  as one token, so the guard cannot classify the git word inside it. `sh -c '...'` and
+  `rtk run "..."` bypass the guard this way.
+- `pwsh -File custom.ps1` bypasses the guard for a different reason: it runs git from inside a
+  script file, not from a quoted string. The guard only reads the command line the hook reports,
+  not any file that command line points to.
+- Tests pin two smaller gaps here instead of fixing them. A wrapper option can consume the next
+  token as its value, for example `rtk --out foo git commit`. rtk has no such option today. A
+  `NAME=value` assignment placed after the wrapper also bypasses the guard, for example
+  `rtk FOO=1 git commit -m x`.
 - An externally registered command-rewriting `PreToolUse` hook can quietly turn the guard off. This
   differs from a person knowingly typing a wrapper, because the hook runs on every command by
   default, not only when someone chooses to type it. `rtk hook claude` is one example; the

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -31,6 +31,13 @@ $script:AgentGuardChangeDirectoryCommands = @('cd', 'chdir', 'set-location')
 $script:AgentGuardPushDirectoryCommands = @('pushd', 'push-location')
 $script:AgentGuardPopDirectoryCommands = @('popd', 'pop-location')
 
+# Transparent command wrappers: tools that run the rest of the line as a child process without
+# changing the shell's own state. Deliberately narrow - a wrapper here must only make the guard
+# see through it, never let it permit more than the bare command would.
+$script:AgentGuardTransparentWrappers = @('rtk', 'rtk.exe')
+# rtk subcommands that take a raw command as their remaining arguments.
+$script:AgentGuardWrapperPassThroughSubcommands = @('proxy', 'run')
+
 # A leading NAME=value assignment is a prefix, not the command being run.
 $script:AgentGuardEnvAssignmentPattern = '^[A-Za-z_][A-Za-z0-9_]*='
 
@@ -439,6 +446,67 @@ function Split-AgentCommandSegment {
 
 <#
 .SYNOPSIS
+Strips a leading transparent-wrapper prefix (currently just rtk) so the guard classifies the
+command the wrapper actually runs, not the wrapper itself.
+
+.DESCRIPTION
+rtk rewrites `git ...` into `rtk git ...` without changing the shell's own state, so without
+this the guard saw `rtk` as the leading word and never recognized the git invocation underneath.
+Matches on the leaf of the leading token, the same way the git leaf check does a few lines below,
+so `rtk`, `rtk.exe`, and a full path like `C:\tools\rtk.exe` all match. Skips every leading option
+token (anything starting with `-`) before looking for one pass-through subcommand (`proxy`,
+`run`), then repeats, so a repeated wrapper such as `rtk rtk git commit` loses both. Skipping any
+`-*` token, not an enumerated list, means a future rtk global option cannot silently reopen this
+hole.
+
+Never strips ahead of a directory-change command (`cd`, `chdir`, `set-location`, `pushd`,
+`push-location`, `popd`, `pop-location`). rtk cannot move the calling shell's own working
+directory, so treating `rtk cd X` as a real directory change would let the guard track an
+effective working directory the shell never actually reached - the only way this helper could
+relax a decision instead of just seeing through a wrapper. When that happens, the tokens are
+returned unchanged and the caller classifies the segment as `Other`.
+
+A wrapper option that consumes the next token as its value (for example a hypothetical
+`rtk --out foo git commit`) is not modelled: the token after the option is inspected for a
+pass-through subcommand or, failing that, becomes the new leading word. rtk has no such option
+today; this is a documented, deliberately accepted gap, not a bug.
+#>
+function Remove-AgentWrapperPrefix {
+    [CmdletBinding()]
+    param([string[]] $Tokens)
+
+    $current = @($Tokens)
+
+    while ($current.Count -gt 0) {
+        $leaf = (([string] $current[0]).ToLowerInvariant() -split '[\\/]')[-1]
+        if ($script:AgentGuardTransparentWrappers -notcontains $leaf) { return $current }
+
+        $index = 1
+        while ($index -lt $current.Count -and ([string] $current[$index]) -like '-*') { $index++ }
+
+        if ($index -lt $current.Count) {
+            $subcommand = ([string] $current[$index]).ToLowerInvariant()
+            if ($script:AgentGuardWrapperPassThroughSubcommands -contains $subcommand) { $index++ }
+        }
+
+        if ($index -ge $current.Count) { return @() }
+
+        $remainder = @($current[$index..($current.Count - 1)])
+        $remainderName = ([string] $remainder[0]).ToLowerInvariant()
+        if ($script:AgentGuardChangeDirectoryCommands -contains $remainderName -or
+            $script:AgentGuardPushDirectoryCommands -contains $remainderName -or
+            $script:AgentGuardPopDirectoryCommands -contains $remainderName) {
+            return $current
+        }
+
+        $current = $remainder
+    }
+
+    return $current
+}
+
+<#
+.SYNOPSIS
 Classifies each top-level segment as a git invocation, a directory change, or something else.
 
 .DESCRIPTION
@@ -470,6 +538,12 @@ function Get-AgentCommandSegment {
         if ($start -ge $tokens.Count) { continue }
 
         $effective = @($tokens[$start..($tokens.Count - 1)])
+
+        # Strip a transparent wrapper (rtk) after the NAME=value prefix, not before: order
+        # matters so `SKIP_COVERAGE_HOOK=1 rtk git push` loses the assignment first, then rtk.
+        $effective = @(Remove-AgentWrapperPrefix -Tokens $effective)
+        if ($effective.Count -eq 0) { continue }
+
         $name = ([string] $effective[0]).ToLowerInvariant()
         $leaf = ($name -split '[\\/]')[-1]
 

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -457,29 +457,34 @@ Strips a leading transparent-wrapper prefix (currently just rtk) so the guard cl
 command the wrapper actually runs, not the wrapper itself.
 
 .DESCRIPTION
-rtk rewrites `git ...` into `rtk git ...` without changing the shell's own state, so without
-this the guard saw `rtk` as the leading word and never recognized the git invocation underneath.
-Matches on the leaf of the leading token, the same way the git leaf check does a few lines below,
-so `rtk`, `rtk.exe`, and a full path like `C:\tools\rtk.exe` all match. Skips every leading option
-token (anything starting with `-`) before looking for one pass-through subcommand (`proxy`, `run`,
-`err`, `summary`, `test`), then repeats, so a repeated wrapper such as `rtk rtk git commit` loses
-both. Skipping any `-*` token, not an enumerated list, means a future rtk global option cannot make
-the guard permit more than it does today.
+rtk rewrites `git ...` into `rtk git ...`. It does not change the shell's own state. Without this
+function, the guard saw `rtk` as the leading word. It never recognized the git invocation
+underneath.
 
-Never strips ahead of a directory-change command (`cd`, `chdir`, `set-location`, `pushd`,
-`push-location`, `popd`, `pop-location`). rtk cannot move the calling shell's own working
-directory, so treating `rtk cd X` as a real directory change would let the guard track an
-effective working directory the shell never actually reached - the only way this helper could
-relax a decision instead of just reading past a wrapper. When that happens, this returns the
-tokens as stripped so far, not the original list unchanged: for `rtk rtk cd X` it returns
-`rtk cd X`, because the outer `rtk` was already removed by an earlier pass of the loop. This is
-still safe, because the returned leading token (`rtk`) is still a wrapper name, so the caller
-classifies the segment as `Other`, not as a directory change.
+This matches on the leaf of the leading token. It uses the same check as the git leaf check a few
+lines below. So `rtk`, `rtk.exe`, and a full path like `C:\tools\rtk.exe` all match.
 
-A wrapper option that consumes the next token as its value (for example a hypothetical
-`rtk --out foo git commit`) is not modelled: the token after the option is inspected for a
-pass-through subcommand or, failing that, becomes the new leading word. rtk has no such option
-today; this is a documented, deliberately accepted gap, not a bug.
+The function skips every leading option token first (any token starting with `-`). Then it looks
+for one pass-through subcommand: `proxy`, `run`, `err`, `summary`, or `test`. Then it repeats this
+whole process. A repeated wrapper such as `rtk rtk git commit` loses both copies of `rtk`. The
+function skips any `-*` token, not a fixed list of known options. This means a future rtk global
+option cannot make the guard permit more than it does today.
+
+The function never strips a wrapper ahead of a directory-change command: `cd`, `chdir`,
+`set-location`, `pushd`, `push-location`, `popd`, or `pop-location`. rtk cannot move the calling
+shell's own working directory. If the guard treated `rtk cd X` as a real directory change, it
+would track an effective working directory the shell never actually reached. That is the only way
+this function could relax a decision, instead of just reading past a wrapper.
+
+When the function stops before a directory-change command, it returns the tokens it already
+stripped, not the original list. For `rtk rtk cd X`, it returns `rtk cd X`, because the outer `rtk`
+was already removed on an earlier pass. This is still safe. The returned leading token (`rtk`) is
+still a wrapper name, so the caller classifies the segment as `Other`, not as a directory change.
+
+The function does not model a wrapper option that consumes the next token as its value (for
+example, a hypothetical `rtk --out foo git commit`). It inspects the token after the option for a
+pass-through subcommand. If that fails, the token becomes the new leading word instead. rtk has no
+such option today. This is a documented, deliberately accepted gap, not a bug.
 #>
 function Remove-AgentWrapperPrefix {
     [CmdletBinding()]

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -37,11 +37,12 @@ $script:AgentGuardPopDirectoryCommands = @('popd', 'pop-location')
 # Adding a wrapper to this list can only expose more of a command to classification.
 # It must never let the guard allow something the bare command would deny.
 $script:AgentGuardTransparentWrappers = @('rtk', 'rtk.exe')
-# rtk subcommands that take a raw command as their remaining arguments. Confirmed against
-# rtk 0.43.0 --help: proxy and run were the original two; err, summary, and test also run a raw
-# command and show only part of its output. rtk's global options (-v/--verbose, --ultra-compact,
-# --skip-env, -h/--help, -V/--version) never consume a following token, so none of them needs to
-# be skipped separately from the generic leading-option scan below.
+# rtk subcommands that take a raw command as their remaining arguments.
+# Confirmed against rtk 0.43.0 --help. proxy and run were the original two.
+# err, summary, and test also run a raw command, showing only part of its output.
+# rtk's global options never consume a following token: -v/--verbose, --ultra-compact,
+# --skip-env, -h/--help, -V/--version. So the generic leading-option scan below does not
+# need to skip any of them separately.
 $script:AgentGuardWrapperPassThroughSubcommands = @('proxy', 'run', 'err', 'summary', 'test')
 
 # A leading NAME=value assignment is a prefix, not the command being run.
@@ -460,16 +461,16 @@ rtk rewrites `git ...` into `rtk git ...` without changing the shell's own state
 this the guard saw `rtk` as the leading word and never recognized the git invocation underneath.
 Matches on the leaf of the leading token, the same way the git leaf check does a few lines below,
 so `rtk`, `rtk.exe`, and a full path like `C:\tools\rtk.exe` all match. Skips every leading option
-token (anything starting with `-`) before looking for one pass-through subcommand (`proxy`,
-`run`), then repeats, so a repeated wrapper such as `rtk rtk git commit` loses both. Skipping any
-`-*` token, not an enumerated list, means a future rtk global option cannot silently reopen this
-hole.
+token (anything starting with `-`) before looking for one pass-through subcommand (`proxy`, `run`,
+`err`, `summary`, `test`), then repeats, so a repeated wrapper such as `rtk rtk git commit` loses
+both. Skipping any `-*` token, not an enumerated list, means a future rtk global option cannot make
+the guard permit more than it does today.
 
 Never strips ahead of a directory-change command (`cd`, `chdir`, `set-location`, `pushd`,
 `push-location`, `popd`, `pop-location`). rtk cannot move the calling shell's own working
 directory, so treating `rtk cd X` as a real directory change would let the guard track an
 effective working directory the shell never actually reached - the only way this helper could
-relax a decision instead of just seeing through a wrapper. When that happens, this returns the
+relax a decision instead of just reading past a wrapper. When that happens, this returns the
 tokens as stripped so far, not the original list unchanged: for `rtk rtk cd X` it returns
 `rtk cd X`, because the outer `rtk` was already removed by an earlier pass of the loop. This is
 still safe, because the returned leading token (`rtk`) is still a wrapper name, so the caller

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -31,12 +31,18 @@ $script:AgentGuardChangeDirectoryCommands = @('cd', 'chdir', 'set-location')
 $script:AgentGuardPushDirectoryCommands = @('pushd', 'push-location')
 $script:AgentGuardPopDirectoryCommands = @('popd', 'pop-location')
 
-# Transparent command wrappers: tools that run the rest of the line as a child process without
-# changing the shell's own state. Deliberately narrow - a wrapper here must only make the guard
-# see through it, never let it permit more than the bare command would.
+# A transparent command wrapper runs the rest of the command line as a child process.
+# It does not change the shell's own state, such as its working directory.
+# The guard reads past the wrapper to classify the command the wrapper runs.
+# Adding a wrapper to this list can only expose more of a command to classification.
+# It must never let the guard allow something the bare command would deny.
 $script:AgentGuardTransparentWrappers = @('rtk', 'rtk.exe')
-# rtk subcommands that take a raw command as their remaining arguments.
-$script:AgentGuardWrapperPassThroughSubcommands = @('proxy', 'run')
+# rtk subcommands that take a raw command as their remaining arguments. Confirmed against
+# rtk 0.43.0 --help: proxy and run were the original two; err, summary, and test also run a raw
+# command and show only part of its output. rtk's global options (-v/--verbose, --ultra-compact,
+# --skip-env, -h/--help, -V/--version) never consume a following token, so none of them needs to
+# be skipped separately from the generic leading-option scan below.
+$script:AgentGuardWrapperPassThroughSubcommands = @('proxy', 'run', 'err', 'summary', 'test')
 
 # A leading NAME=value assignment is a prefix, not the command being run.
 $script:AgentGuardEnvAssignmentPattern = '^[A-Za-z_][A-Za-z0-9_]*='
@@ -463,8 +469,11 @@ Never strips ahead of a directory-change command (`cd`, `chdir`, `set-location`,
 `push-location`, `popd`, `pop-location`). rtk cannot move the calling shell's own working
 directory, so treating `rtk cd X` as a real directory change would let the guard track an
 effective working directory the shell never actually reached - the only way this helper could
-relax a decision instead of just seeing through a wrapper. When that happens, the tokens are
-returned unchanged and the caller classifies the segment as `Other`.
+relax a decision instead of just seeing through a wrapper. When that happens, this returns the
+tokens as stripped so far, not the original list unchanged: for `rtk rtk cd X` it returns
+`rtk cd X`, because the outer `rtk` was already removed by an earlier pass of the loop. This is
+still safe, because the returned leading token (`rtk`) is still a wrapper name, so the caller
+classifies the segment as `Other`, not as a directory change.
 
 A wrapper option that consumes the next token as its value (for example a hypothetical
 `rtk --out foo git commit`) is not modelled: the token after the option is inspected for a

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -765,6 +765,14 @@ try {
         }
     }
 
+    # No wrapped-command case above ever runs from a managed worktree - every Cwd is $fixture.Main.
+    # Pin that a wrapped commit is a plain Allow there too, the same as its bare form.
+    Invoke-TestCase 'Wrapped commit is Allow from a managed worktree' {
+        $decision = Invoke-AgentGuardPolicy -Command 'rtk git commit -m x' `
+            -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Allow' $decision.Action 'Action'
+    }
+
     # Every spelling below must still deny a commit exactly the way the bare command does. This
     # covers rtk 0.43.0's global options (-v/-vv/-vvv/--verbose/--ultra-compact/--skip-env), all
     # five pass-through subcommands (proxy/run/err/summary/test), a repeated wrapper, a leading
@@ -821,6 +829,44 @@ try {
     # the unrelated directory rtk was told to cd into, when the real shell never left main.
     Invoke-TestCase 'rtk cd to an outside directory does not escalate a commit in main to Allow' {
         $command = "rtk cd `"$($fixture.Unrelated)`" && git commit -m x"
+        $decision = Invoke-AgentGuardPolicy -Command $command -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
+    }
+
+    # Same escalation guard, the pushd/push-location spelling. A bare `pushd <dir>` really can move
+    # the shell (Get-AgentGitLocationDecision tracks it as PushDirectory), which is exactly why the
+    # concrete gap in the finding matters: `pushd C:/Windows && git commit -m x` resolves as Allow
+    # today, because Windows already has that directory and it sits outside the protected repo. A
+    # wrapped `rtk pushd ...` must still deny, the same way `rtk cd ...` does above.
+    Invoke-TestCase 'rtk pushd to an outside directory does not escalate a commit in main to Allow' {
+        $command = "rtk pushd `"$($fixture.Unrelated)`" && git commit -m x"
+        $decision = Invoke-AgentGuardPolicy -Command $command -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
+    }
+
+    Invoke-TestCase 'rtk push-location to an outside directory does not escalate a commit in main to Allow' {
+        $command = "rtk push-location `"$($fixture.Unrelated)`" && git commit -m x"
+        $decision = Invoke-AgentGuardPolicy -Command $command -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
+    }
+
+    # popd/pop-location take no directory argument, so there is nothing to escalate to - it pops
+    # whatever the (guard-tracked) stack already holds. With an empty stack the commit still runs
+    # against the unchanged Cwd, main, so the correct expectation is the same Deny a bare `popd`
+    # already gets today (confirmed by direct probe): both the bare and the wrapped spelling stay
+    # in main and deny the commit. This test pins that the wrapper does not change that outcome.
+    Invoke-TestCase 'rtk popd does not escalate a commit in main to Allow' {
+        $command = 'rtk popd && git commit -m x'
+        $decision = Invoke-AgentGuardPolicy -Command $command -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
+    }
+
+    Invoke-TestCase 'rtk pop-location does not escalate a commit in main to Allow' {
+        $command = 'rtk pop-location && git commit -m x'
         $decision = Invoke-AgentGuardPolicy -Command $command -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
         Assert-Equal 'Deny' $decision.Action 'Action'
         Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -744,6 +744,117 @@ try {
         Assert-Equal 'Warn' $decision.Action 'Action'
     }
 
+    Write-Host 'Wrapper prefix (rtk)' -ForegroundColor Cyan
+
+    # Parity: a wrapped command must get exactly the same decision as its bare form, across every
+    # tier the guard recognizes. Driven from pairs so the two forms can never drift apart.
+    $wrapperParityPairs = @(
+        @{ Bare = 'git worktree prune'; Wrapped = 'rtk git worktree prune' },
+        @{ Bare = 'git branch newtopic'; Wrapped = 'rtk git branch newtopic' },
+        @{ Bare = 'git worktree repair'; Wrapped = 'rtk git worktree repair' },
+        @{ Bare = 'git branch -D topic'; Wrapped = 'rtk git branch -D topic' },
+        @{ Bare = 'git commit -m x'; Wrapped = 'rtk git commit -m x' },
+        @{ Bare = 'git commit --amend'; Wrapped = 'rtk git commit --amend' }
+    )
+    foreach ($pair in $wrapperParityPairs) {
+        Invoke-TestCase "Wrapped command matches its bare form: $($pair.Wrapped)" {
+            $bareDecision = Invoke-AgentGuardPolicy -Command $pair.Bare -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+            $wrappedDecision = Invoke-AgentGuardPolicy -Command $pair.Wrapped -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+            Assert-Equal $bareDecision.Action $wrappedDecision.Action 'Action'
+            Assert-Equal $bareDecision.Rule $wrappedDecision.Rule 'Rule'
+        }
+    }
+
+    # Every spelling below must still deny a commit exactly the way the bare command does. This
+    # covers rtk 0.43.0's global options (-v/-vv/-vvv/--verbose/--ultra-compact/--skip-env), the
+    # proxy/run pass-through subcommands, a repeated wrapper, a leading NAME=value assignment, and
+    # a full path to the rtk executable.
+    $wrapperSpellings = @(
+        'rtk', 'rtk.exe', 'C:\tools\rtk.exe', 'rtk -v', 'rtk -vvv', 'rtk --ultra-compact',
+        'rtk --skip-env', 'rtk --ultra-compact --skip-env', 'rtk proxy', 'rtk --ultra-compact proxy',
+        'rtk rtk', 'SKIP_COVERAGE_HOOK=1 rtk'
+    )
+    foreach ($prefix in $wrapperSpellings) {
+        Invoke-TestCase "Wrapper spelling still denies a commit: $prefix git commit -m x" {
+            $decision = Invoke-AgentGuardPolicy -Command "$prefix git commit -m x" `
+                -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+            Assert-Equal 'Deny' $decision.Action 'Action'
+            Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
+        }
+    }
+
+    Invoke-TestCase 'Commit still dominates through a chain of wrapped segments' {
+        $decision = Invoke-AgentGuardPolicy -Command 'rtk git add . && rtk git commit -m x' `
+            -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
+    }
+
+    # Documented remaining bypasses, pinned as tests so a future change to either is deliberate,
+    # not accidental. The tokenizer keeps a quoted string as one token, so a subcommand that takes
+    # a raw command string hides the git word inside a single token. A hypothetical rtk option
+    # that takes the next token as its value has the same effect: the git word is no longer the
+    # segment's leading word. Neither case is modelled today.
+    Invoke-TestCase 'Documented bypass: rtk run with a quoted command stays Allow' {
+        $decision = Invoke-AgentGuardPolicy -Command 'rtk run "git commit -m x"' `
+            -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Allow' $decision.Action 'Action'
+    }
+
+    Invoke-TestCase 'Documented bypass: a value-taking rtk option stays Allow' {
+        $decision = Invoke-AgentGuardPolicy -Command 'rtk --out foo git commit -m x' `
+            -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Allow' $decision.Action 'Action'
+    }
+
+    # The one escalation guard: rtk cannot move the calling shell's own working directory, so the
+    # guard must not act as if it did. Without this, the commit below would look like it targeted
+    # the unrelated directory rtk was told to cd into, when the real shell never left main.
+    Invoke-TestCase 'rtk cd to an outside directory does not escalate a commit in main to Allow' {
+        $command = "rtk cd `"$($fixture.Unrelated)`" && git commit -m x"
+        $decision = Invoke-AgentGuardPolicy -Command $command -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
+    }
+
+    # The rm/dotnet safety rules read the same parsed segments as git, so they see through the
+    # wrapper as a side effect of the fix, with no rule change of their own.
+    Invoke-TestCase 'Wrapped force-push still denies' {
+        $decision = Invoke-AgentGuardPolicy -Command 'rtk git push --force' -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'force-push' $decision.Rule 'Rule'
+    }
+
+    Invoke-TestCase 'Wrapped git reset --hard still denies' {
+        $decision = Invoke-AgentGuardPolicy -Command 'rtk git reset --hard' -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'git-reset-hard' $decision.Rule 'Rule'
+    }
+
+    Invoke-TestCase 'Wrapped rm -rf still denies' {
+        $decision = Invoke-AgentGuardPolicy -Command 'rtk rm -rf C:/somewhere' -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'dangerous-rm' $decision.Rule 'Rule'
+    }
+
+    Invoke-TestCase 'Wrapped dotnet run still warns' {
+        $decision = Invoke-AgentGuardPolicy -Command 'rtk dotnet run' -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Warn' $decision.Action 'Action'
+        Assert-Equal 'dotnet-run' $decision.Rule 'Rule'
+    }
+
+    # Not over-broad: a non-wrapper leading word is left untouched. These stay documented accepted
+    # limitations, not something this change fixes.
+    Invoke-TestCase 'sh -c wrapping a commit stays an accepted limitation, not newly caught' {
+        $decision = Invoke-AgentGuardPolicy -Command 'sh -c "git commit -m x"' -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Allow' $decision.Action 'Action'
+    }
+
+    Invoke-TestCase 'pwsh -File running a script is untouched by the wrapper rule' {
+        $decision = Invoke-AgentGuardPolicy -Command 'pwsh -File custom.ps1' -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Allow' $decision.Action 'Action'
+    }
+
     Write-Host 'Tier reclassification: adapter matrix' -ForegroundColor Cyan
 
     Invoke-TestCase 'Claude: a Tier 1a decision emits permissionDecision ask' {
@@ -1201,6 +1312,14 @@ try {
         '{"command":"cd f&&git commit -m test"},"cwd":"' +
         ($script:RealMainCheckout -replace '\\', '\\') + '"}'
         $result = Invoke-BashShim -StdIn $escaped -ShimArguments @('Claude')
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+        $json = $result.StdOut | ConvertFrom-Json
+        Assert-Equal 'deny' $json.hookSpecificOutput.permissionDecision 'permissionDecision'
+        Assert-Match 'BLOCKED: agent Git mutations' $json.hookSpecificOutput.permissionDecisionReason 'reason'
+    }
+
+    Invoke-TestCase 'Bash shim forwards an rtk-wrapped commit and produces the deny JSON' {
+        $result = Invoke-BashShim -StdIn (New-ClaudePayload 'rtk git commit -m x' $script:RealMainCheckout) -ShimArguments @('Claude')
         Assert-Equal 0 $result.ExitCode 'ExitCode'
         $json = $result.StdOut | ConvertFrom-Json
         Assert-Equal 'deny' $json.hookSpecificOutput.permissionDecision 'permissionDecision'

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -766,13 +766,13 @@ try {
     }
 
     # Every spelling below must still deny a commit exactly the way the bare command does. This
-    # covers rtk 0.43.0's global options (-v/-vv/-vvv/--verbose/--ultra-compact/--skip-env), the
-    # proxy/run pass-through subcommands, a repeated wrapper, a leading NAME=value assignment, and
-    # a full path to the rtk executable.
+    # covers rtk 0.43.0's global options (-v/-vv/-vvv/--verbose/--ultra-compact/--skip-env), all
+    # five pass-through subcommands (proxy/run/err/summary/test), a repeated wrapper, a leading
+    # NAME=value assignment, and a full path to the rtk executable.
     $wrapperSpellings = @(
         'rtk', 'rtk.exe', 'C:\tools\rtk.exe', 'rtk -v', 'rtk -vvv', 'rtk --ultra-compact',
         'rtk --skip-env', 'rtk --ultra-compact --skip-env', 'rtk proxy', 'rtk --ultra-compact proxy',
-        'rtk rtk', 'SKIP_COVERAGE_HOOK=1 rtk'
+        'rtk rtk', 'SKIP_COVERAGE_HOOK=1 rtk', 'rtk err', 'rtk summary', 'rtk test'
     )
     foreach ($prefix in $wrapperSpellings) {
         Invoke-TestCase "Wrapper spelling still denies a commit: $prefix git commit -m x" {
@@ -790,11 +790,14 @@ try {
         Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
     }
 
-    # Documented remaining bypasses, pinned as tests so a future change to either is deliberate,
-    # not accidental. The tokenizer keeps a quoted string as one token, so a subcommand that takes
-    # a raw command string hides the git word inside a single token. A hypothetical rtk option
-    # that takes the next token as its value has the same effect: the git word is no longer the
-    # segment's leading word. Neither case is modelled today.
+    # Documented remaining bypasses, pinned as tests so a future change to any of them is
+    # deliberate, not accidental. The tokenizer keeps a quoted string as one token, so a
+    # subcommand that takes a raw command string hides the git word inside a single token. A
+    # hypothetical rtk option that takes the next token as its value has the same effect: the git
+    # word is no longer the segment's leading word. A NAME=value assignment placed after the
+    # wrapper is never stripped, because the NAME=value strip in Get-AgentCommandSegment runs once,
+    # before the wrapper strip, and is not repeated afterward. None of these three cases is
+    # modelled today.
     Invoke-TestCase 'Documented bypass: rtk run with a quoted command stays Allow' {
         $decision = Invoke-AgentGuardPolicy -Command 'rtk run "git commit -m x"' `
             -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
@@ -803,6 +806,12 @@ try {
 
     Invoke-TestCase 'Documented bypass: a value-taking rtk option stays Allow' {
         $decision = Invoke-AgentGuardPolicy -Command 'rtk --out foo git commit -m x' `
+            -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+        Assert-Equal 'Allow' $decision.Action 'Action'
+    }
+
+    Invoke-TestCase 'Documented bypass: a NAME=value assignment after the wrapper stays Allow' {
+        $decision = Invoke-AgentGuardPolicy -Command 'rtk FOO=1 git commit -m x' `
             -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
         Assert-Equal 'Allow' $decision.Action 'Action'
     }
@@ -850,8 +859,8 @@ try {
         Assert-Equal 'Allow' $decision.Action 'Action'
     }
 
-    Invoke-TestCase 'pwsh -File running a script is untouched by the wrapper rule' {
-        $decision = Invoke-AgentGuardPolicy -Command 'pwsh -File custom.ps1' -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
+    Invoke-TestCase 'pwsh running a git word after its options is untouched by the wrapper rule' {
+        $decision = Invoke-AgentGuardPolicy -Command 'pwsh -Command git commit -m x' -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main
         Assert-Equal 'Allow' $decision.Action 'Action'
     }
 


### PR DESCRIPTION
Closes backlog 039.

## Problem

The agent Git guard decides from a command segment's leading word whether the
segment is a git invocation. A `PreToolUse` hook registered in the user-level
settings runs `rtk hook claude`, which rewrites `git ...` into `rtk git ...` and
returns `allow`. The leading word becomes `rtk`, the guard finds no git
invocation, and every location rule is skipped — including the `git commit`
hard denial.

Measured against the policy core with `Cwd` = main checkout, before this change:

| Command | Action | Rule |
|---|---|---|
| `git commit -m x` | Deny | `agent-main-git-mutation` |
| `rtk git commit -m x` | **Allow** | `none` |
| `git worktree repair` | Ask | `agent-main-git-mutation` |
| `rtk git worktree repair` | **Allow** | `none` |

## Fix

`Remove-AgentWrapperPrefix` in `scripts/agents/agent-worktree-guard.common.ps1`
strips a narrow, hard-coded wrapper prefix before the segment is classified. It
matches on the leading token's leaf, so `rtk` and `C:\tools\rtk.exe` both match.
It then skips leading `-*` options by pattern, strips one pass-through
subcommand, and repeats while the new leading word is still a wrapper.

Stripping a prefix only exposes more segments to classification. It never
removes a git invocation, so it cannot escalate what the guard permits. The one
exception is handled: `rtk` cannot change the calling shell's working directory,
so the function refuses to strip when the remaining tokens start with `cd`,
`chdir`, `set-location`, `pushd`, `push-location`, `popd`, or `pop-location`.
Without that refusal, `rtk cd C:/outside && git commit -m x` would move the
guard's tracked working directory to a place the shell never entered.

After the change every wrapped form matches its bare form exactly.

## Beyond the plan

The plan listed `proxy` and `run` as rtk's pass-through subcommands. `rtk --help`
on 0.43.0 shows three more that take a raw command — `err`, `summary`, `test`
(`Usage: rtk.exe err [OPTIONS] [COMMAND]...`). So `rtk err git commit -m x` still
bypassed the guard. All three were added. Adding a name to that list can only
expose more segments, never permit more.

## Documented remaining bypasses, pinned as tests

These are unchanged behaviour, pinned so a future change to them is deliberate:

- `rtk run "git commit -m x"` — the tokenizer keeps a quoted string as one token
- `rtk --out foo git commit -m x` — a hypothetical option that eats the next
  token as its value; rtk has none today
- `rtk FOO=1 git commit -m x` — the `NAME=value` strip runs once, before the
  wrapper strip

## Tests

`tests/AgentWorktreeGuard.Tests.ps1` grows from 301 to 339 cases, all green.
`tests/AgentPreCommitHook.Tests.ps1` stays at 11, green. Both already run in
`.github/workflows/ci.yml`.

New coverage: a bare/wrapped parity table, twelve wrapper spellings, the three
documented bypasses, the directory-command refusal for all four push and pop
spellings, the safety rules through the wrapper (`force-push`, `git-reset-hard`,
`dangerous-rm`, `dotnet-run`), a managed-worktree case, and a Bash shim case.

## Not done here

No settings file is touched. A `permissions.allow` entry cannot suppress a hook
`ask`, so removing allow rules would not help and would make ordinary worktree
Git work prompt.

The plan's step 3 — confirming a permission prompt renders on screen — cannot run
from a session rooted in the main checkout, because the hook resolves its scripts
from the session's project directory. Manual steps are in the review thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
