### PR TITLE
fix: e2e suite always tests a freshly published blazor app

### DIFF
--- a/.claude/backlog/046-e2e-publish-serves-stale-build.md
+++ b/.claude/backlog/046-e2e-publish-serves-stale-build.md
@@ -30,10 +30,10 @@ A test that cannot fail is worse than no test. This one hides regressions and wa
 
 ## Acceptance criteria
 
-- [ ] An E2E run after a source change always exercises that change, with no manual publish step
-- [ ] The publish destination holds exactly one copy of the app, so stale hashed assets cannot be served
+- [x] An E2E run after a source change always exercises that change, with no manual publish step
+- [x] The publish destination holds exactly one copy of the app, so stale hashed assets cannot be served
 - [ ] Deliberately breaking a component that an E2E test asserts on makes that test fail on a normal `test-fast.ps1 -Mode E2E` run
-- [ ] `docs/development/testing-workflow.md` describes whatever the resulting procedure is
+- [x] `docs/development/testing-workflow.md` describes whatever the resulting procedure is
 
 ## Out of scope
 

--- a/.claude/backlog/046-e2e-publish-serves-stale-build.md
+++ b/.claude/backlog/046-e2e-publish-serves-stale-build.md
@@ -32,7 +32,7 @@ A test that cannot fail is worse than no test. This one hides regressions and wa
 
 - [x] An E2E run after a source change always exercises that change, with no manual publish step
 - [x] The publish destination holds exactly one copy of the app, so stale hashed assets cannot be served
-- [ ] Deliberately breaking a component that an E2E test asserts on makes that test fail on a normal `test-fast.ps1 -Mode E2E` run
+- [x] Deliberately breaking a component that an E2E test asserts on makes that test fail on a normal `test-fast.ps1 -Mode E2E` run
 - [x] `docs/development/testing-workflow.md` describes whatever the resulting procedure is
 
 ## Out of scope

--- a/.claude/backlog/done/041-hotkey-window-context.md
+++ b/.claude/backlog/done/041-hotkey-window-context.md
@@ -28,33 +28,33 @@ Example of the intended output:
 
 ## Acceptance criteria
 
-- [ ] `Hotkey` gains `ContextMatchType` and `ContextValue`, matching the `Hotstring` columns and their validation rules
-- [ ] Both are optional, and both must be set or both left empty
-- [ ] The generator wraps context-limited hotkeys in `#HotIf WinActive(...)` and closes the group with a bare `#HotIf`
-- [ ] Hotkeys with no context still emit unwrapped, and a group left open never captures them
-- [ ] The hotkey edit dialog offers the same three match types the hotstring dialog offers
-- [ ] The hotkeys list shows which hotkeys are limited, and to what
-- [ ] An EF Core migration adds the columns, and existing hotkeys keep firing everywhere
+- [x] `Hotkey` gains `ContextMatchType` and `ContextValue`, matching the `Hotstring` columns and their validation rules
+- [x] Both are optional, and both must be set or both left empty
+- [x] The generator wraps context-limited hotkeys in `#HotIf WinActive(...)` and closes the group with a bare `#HotIf`
+- [x] Hotkeys with no context still emit unwrapped, and a group left open never captures them
+- [x] The hotkey edit dialog offers the same three match types the hotstring dialog offers
+- [x] The hotkeys list shows which hotkeys are limited, and to what
+- [x] An EF Core migration adds the columns, and existing hotkeys keep firing everywhere
 
 ### Uniqueness
 
 Context changes what counts as a duplicate. Today one key plus modifier combination may exist once per owner, whatever the context.
 
-- [ ] Uniqueness covers owner, key, all four modifiers, and the context pair together
-- [ ] The same key and modifier combination is allowed in two different contexts
-- [ ] The same key and modifier combination in the same context is still a conflict
-- [ ] Two hotkeys with no context are still a conflict, so an owner keeps one global row per combination
-- [ ] The migration replaces the `IX_Hotkey_Owner_Modifiers` unique index with one that includes both context columns
-- [ ] The new index sets `.HasFilter(null)`, the same way `IX_Hotstring_Owner_Trigger_Context` does, so SQL Server treats two all-null context rows as duplicates
-- [ ] The conflict message names the context, so an owner can tell a global clash from a per-application one
+- [x] Uniqueness covers owner, key, all four modifiers, and the context pair together
+- [x] The same key and modifier combination is allowed in two different contexts
+- [x] The same key and modifier combination in the same context is still a conflict
+- [x] Two hotkeys with no context are still a conflict, so an owner keeps one global row per combination
+- [x] The migration replaces the `IX_Hotkey_Owner_Modifiers` unique index with one that includes both context columns
+- [x] The new index sets `.HasFilter(null)`, the same way `IX_Hotstring_Owner_Trigger_Context` does, so SQL Server treats two all-null context rows as duplicates
+- [x] The conflict message names the context, so an owner can tell a global clash from a per-application one
 
 ### History
 
 `HotkeySnapshot` carries every editable field, and restore and revert rebuild the hotkey from it. A snapshot that skips context would turn a limited hotkey back into a global one.
 
-- [ ] `HotkeySnapshot` carries `ContextMatchType` and `ContextValue`
-- [ ] Both are optional and default to null, so a snapshot written before this change restores as a global hotkey — the same pattern `HotstringSnapshot` already uses
-- [ ] Restore and revert put the captured context back, and a restored hotkey that clashes with a live one still returns a conflict
+- [x] `HotkeySnapshot` carries `ContextMatchType` and `ContextValue`
+- [x] Both are optional and default to null, so a snapshot written before this change restores as a global hotkey — the same pattern `HotstringSnapshot` already uses
+- [x] Restore and revert put the captured context back, and a restored hotkey that clashes with a live one still returns a conflict
 
 ## Out of scope
 

--- a/docs/development/testing-workflow.md
+++ b/docs/development/testing-workflow.md
@@ -64,7 +64,7 @@ pwsh .\scripts\test-fast.ps1 -Mode E2E
 
 E2E mode runs `AHKFlowApp.E2E.Tests`. Use it for browser flows, Playwright-covered UI behavior, mobile viewport behavior, service-worker/PWA behavior, and changes to the E2E fixture or published Blazor output. The script starts the same disposable shared SQL Server container used by Integration mode, and the E2E API fixture uses an isolated per-assembly database on that server.
 
-The first E2E run after frontend source changes publishes the Blazor app before Playwright starts. Unchanged reruns reuse the cached publish output through the E2E project target, so the publish step is skipped while the browser tests still run normally. E2E flow classes share one API/Spa/browser stack, and each test resets mutable database rows before it starts.
+A normal E2E run builds the project and its references. Every E2E run clears and republishes the Blazor output before Playwright starts. `-NoBuild` republishes existing build output, so use it only after a successful build for the same configuration. E2E flow classes share one API/Spa/browser stack, and each test resets mutable database rows before it starts.
 
 ### Writing a flow test
 

--- a/docs/development/testing-workflow.md
+++ b/docs/development/testing-workflow.md
@@ -64,7 +64,7 @@ pwsh .\scripts\test-fast.ps1 -Mode E2E
 
 E2E mode runs `AHKFlowApp.E2E.Tests`. Use it for browser flows, Playwright-covered UI behavior, mobile viewport behavior, service-worker/PWA behavior, and changes to the E2E fixture or published Blazor output. The script starts the same disposable shared SQL Server container used by Integration mode, and the E2E API fixture uses an isolated per-assembly database on that server.
 
-A normal E2E run builds the project and its references. Every E2E run clears and republishes the Blazor output before Playwright starts. `-NoBuild` republishes existing build output, so use it only after a successful build for the same configuration. E2E flow classes share one API/Spa/browser stack, and each test resets mutable database rows before it starts.
+A normal E2E run builds the project and its references. Every E2E run clears the Blazor publish folder, then publishes the app again before Playwright starts. That publish compiles and links the current source, so the browser always loads the code in your working tree. `-NoBuild` skips the solution build, but the Blazor publish still runs, so the app under test stays current. E2E flow classes share one API/Spa/browser stack, and each test resets mutable database rows before it starts.
 
 ### Writing a flow test
 

--- a/scripts/measure-tests.ps1
+++ b/scripts/measure-tests.ps1
@@ -31,10 +31,6 @@ $sharedSqlTestProjects = @(
     'AHKFlowApp.E2E.Tests',
     'AHKFlowApp.Infrastructure.Tests'
 )
-$e2eTestProjectName = 'AHKFlowApp.E2E.Tests'
-$e2eFrontendProjectName = 'AHKFlowApp.UI.Blazor'
-$e2eFrontendProjectPath = Join-Path $repoRoot 'src\Frontend\AHKFlowApp.UI.Blazor\AHKFlowApp.UI.Blazor.csproj'
-
 function Resolve-TestProjectPath {
     param(
         [Parameter(Mandatory = $true)]
@@ -269,14 +265,6 @@ try {
         if (-not $artifact) {
             $warnings += "Missing build artifact for $projectName. Run: dotnet build $projectPath --configuration $Configuration"
             continue
-        }
-
-        if ($projectName -eq $e2eTestProjectName) {
-            $frontendArtifact = Get-BuildArtifact -ProjectPath $e2eFrontendProjectPath -ProjectName $e2eFrontendProjectName
-            if (-not $frontendArtifact) {
-                $warnings += "Missing frontend build artifact required by $projectName. Its publish target runs with --no-build; run: dotnet build $e2eFrontendProjectPath --configuration $Configuration"
-                continue
-            }
         }
 
         Write-Host "Measuring $projectName..." -ForegroundColor Cyan

--- a/tests/AHKFlowApp.CLI.Tests/Launcher/E2EPublishTargetTests.cs
+++ b/tests/AHKFlowApp.CLI.Tests/Launcher/E2EPublishTargetTests.cs
@@ -7,21 +7,32 @@ namespace AHKFlowApp.CLI.Tests.Launcher;
 public sealed class E2EPublishTargetTests
 {
     [Fact]
-    public void PublishBlazorForE2E_Target_IsIncrementalAndUsesBuiltFrontendOutput()
+    public void PublishBlazorForE2E_Target_AlwaysRunsAndCleansBeforePublish()
     {
         // Arrange
         var document = XDocument.Load(FindE2ETestProjectPath());
 
         // Act
         XElement target = FindElement(document, "Target", "Name", "PublishBlazorForE2E");
+        List<XElement> tasks = [.. target.Elements()];
+        XElement removeDir = target.Elements("RemoveDir").Single();
         XElement exec = target.Elements("Exec").Single();
-        XElement touch = target.Elements("Touch").Single();
         string command = exec.Attribute("Command")?.Value ?? string.Empty;
 
         // Assert
         target.Attribute("BeforeTargets")?.Value.Should().Be("VSTest");
-        target.Attribute("Inputs")?.Value.Should().Be("@(BlazorE2EPublishInput)");
-        target.Attribute("Outputs")?.Value.Should().Be("$(BlazorE2EPublishStamp);$(BlazorE2EPublishIndex)");
+        target.Attribute("Inputs").Should()
+            .BeNull("an up-to-date check lets MSBuild skip the publish and serve a stale app");
+        target.Attribute("Outputs").Should()
+            .BeNull("an up-to-date check lets MSBuild skip the publish and serve a stale app");
+        target.Elements("Touch").Should()
+            .BeEmpty("the stamp and index.html proxy outputs no longer exist");
+
+        removeDir.Attribute("Directories")?.Value.Should().Be("$(BlazorE2EPublishDir)");
+        removeDir.Attribute("Condition")?.Value.Should().Be("'$(BlazorE2EPublishDir)' != ''");
+        tasks.IndexOf(removeDir).Should().BeLessThan(
+            tasks.IndexOf(exec),
+            "cleaning after the publish would delete the app it just copied");
 
         command.Should().Contain("dotnet publish");
         command.Should().Contain("\"$(BlazorE2EProject)\"");
@@ -29,28 +40,29 @@ public sealed class E2EPublishTargetTests
         command.Should().Contain("--no-build");
         command.Should().Contain("--no-restore");
         command.Should().Contain("-o \"$(BlazorE2EPublishDir)\"");
-
-        touch.Attribute("Files")?.Value.Should().Be("$(BlazorE2EPublishStamp);$(BlazorE2EPublishIndex)");
-        touch.Attribute("AlwaysCreate")?.Value.Should().Be("true");
     }
 
     [Fact]
-    public void PublishBlazorForE2E_Inputs_TrackFrontendSourcesAndExcludeGeneratedOutput()
+    public void PublishBlazorForE2E_ObsoleteIncrementalMachinery_IsAbsent()
     {
         // Arrange
         var document = XDocument.Load(FindE2ETestProjectPath());
 
         // Act
-        XElement item = document.Root!
-            .Elements("ItemGroup")
-            .Elements("BlazorE2EPublishInput")
-            .Single();
-        string exclude = item.Attribute("Exclude")?.Value ?? string.Empty;
+        List<string> itemNames =
+        [
+            .. document.Root!.Elements("ItemGroup").Elements().Select(element => element.Name.LocalName)
+        ];
+        List<string> propertyNames =
+        [
+            .. document.Root!.Elements("PropertyGroup").Elements().Select(element => element.Name.LocalName)
+        ];
 
         // Assert
-        item.Attribute("Include")?.Value.Should().Be("$(BlazorE2EProjectDir)**/*");
-        exclude.Should().Contain("$(BlazorE2EProjectDir)bin/**/*");
-        exclude.Should().Contain("$(BlazorE2EProjectDir)obj/**/*");
+        itemNames.Should().NotContain("BlazorE2EPublishInput");
+        propertyNames.Should().NotContain("BlazorE2EPublishStamp");
+        propertyNames.Should().NotContain("BlazorE2EPublishIndex");
+        propertyNames.Should().NotContain("BlazorE2EProjectDir");
     }
 
     private static XElement FindElement(

--- a/tests/AHKFlowApp.CLI.Tests/Launcher/E2EPublishTargetTests.cs
+++ b/tests/AHKFlowApp.CLI.Tests/Launcher/E2EPublishTargetTests.cs
@@ -37,7 +37,9 @@ public sealed class E2EPublishTargetTests
         command.Should().Contain("dotnet publish");
         command.Should().Contain("\"$(BlazorE2EProject)\"");
         command.Should().Contain("-c $(Configuration)");
-        command.Should().Contain("--no-build");
+        command.Should().NotContain(
+            "--no-build",
+            "--no-build reuses a stale trimmed assembly, so the published app can miss the latest source");
         command.Should().Contain("--no-restore");
         command.Should().Contain("-o \"$(BlazorE2EPublishDir)\"");
     }

--- a/tests/AHKFlowApp.E2E.Tests/AHKFlowApp.E2E.Tests.csproj
+++ b/tests/AHKFlowApp.E2E.Tests/AHKFlowApp.E2E.Tests.csproj
@@ -34,6 +34,6 @@
   </ItemGroup>
   <Target Name="PublishBlazorForE2E" BeforeTargets="VSTest">
     <RemoveDir Directories="$(BlazorE2EPublishDir)" Condition="'$(BlazorE2EPublishDir)' != ''" />
-    <Exec Command="dotnet publish &quot;$(BlazorE2EProject)&quot; -c $(Configuration) --no-build --no-restore --disable-build-servers -p:UseSharedCompilation=false -o &quot;$(BlazorE2EPublishDir)&quot;" />
+    <Exec Command="dotnet publish &quot;$(BlazorE2EProject)&quot; -c $(Configuration) --no-restore --disable-build-servers -p:UseSharedCompilation=false -o &quot;$(BlazorE2EPublishDir)&quot;" />
   </Target>
 </Project>

--- a/tests/AHKFlowApp.E2E.Tests/AHKFlowApp.E2E.Tests.csproj
+++ b/tests/AHKFlowApp.E2E.Tests/AHKFlowApp.E2E.Tests.csproj
@@ -6,10 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <BlazorE2EProject>../../src/Frontend/AHKFlowApp.UI.Blazor/AHKFlowApp.UI.Blazor.csproj</BlazorE2EProject>
-    <BlazorE2EProjectDir>../../src/Frontend/AHKFlowApp.UI.Blazor/</BlazorE2EProjectDir>
     <BlazorE2EPublishDir>../../src/Frontend/AHKFlowApp.UI.Blazor/bin/$(Configuration)/$(TargetFramework)/publish</BlazorE2EPublishDir>
-    <BlazorE2EPublishStamp>$(BaseIntermediateOutputPath)e2e-blazor-publish.$(Configuration).stamp</BlazorE2EPublishStamp>
-    <BlazorE2EPublishIndex>$(BlazorE2EPublishDir)/wwwroot/index.html</BlazorE2EPublishIndex>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector">
@@ -35,15 +32,8 @@
     <ProjectReference Include="..\..\src\Frontend\AHKFlowApp.UI.Blazor\AHKFlowApp.UI.Blazor.csproj" />
     <ProjectReference Include="..\AHKFlowApp.TestUtilities\AHKFlowApp.TestUtilities.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <BlazorE2EPublishInput Include="$(BlazorE2EProjectDir)**/*" Exclude="$(BlazorE2EProjectDir)bin/**/*;$(BlazorE2EProjectDir)obj/**/*" />
-  </ItemGroup>
-  <Target
-    Name="PublishBlazorForE2E"
-    BeforeTargets="VSTest"
-    Inputs="@(BlazorE2EPublishInput)"
-    Outputs="$(BlazorE2EPublishStamp);$(BlazorE2EPublishIndex)">
+  <Target Name="PublishBlazorForE2E" BeforeTargets="VSTest">
+    <RemoveDir Directories="$(BlazorE2EPublishDir)" Condition="'$(BlazorE2EPublishDir)' != ''" />
     <Exec Command="dotnet publish &quot;$(BlazorE2EProject)&quot; -c $(Configuration) --no-build --no-restore --disable-build-servers -p:UseSharedCompilation=false -o &quot;$(BlazorE2EPublishDir)&quot;" />
-    <Touch Files="$(BlazorE2EPublishStamp);$(BlazorE2EPublishIndex)" AlwaysCreate="true" />
   </Target>
 </Project>

--- a/tests/AHKFlowApp.E2E.Tests/Fixtures/StackFixture.cs
+++ b/tests/AHKFlowApp.E2E.Tests/Fixtures/StackFixture.cs
@@ -45,25 +45,32 @@ public sealed class StackFixture : IAsyncLifetime
         nameof(InitializeAsync),
         InitializeCoreAsync);
 
+    public string PublishedWwwroot { get; } = ResolvePublishedWwwroot();
+
+    public static string ResolveConfiguration() =>
+        new DirectoryInfo(AppContext.BaseDirectory).Parent?.Name ?? "Release";
+
+    public static string ResolvePublishedWwwroot()
+    {
+        var testOutputDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        string targetFramework = testOutputDirectory.Name;
+
+        return Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "..",
+            "src", "Frontend", "AHKFlowApp.UI.Blazor", "bin", ResolveConfiguration(), targetFramework, "publish", "wwwroot"));
+    }
+
     private async Task InitializeCoreAsync()
     {
         await Api.StartAsync();
 
-        var testOutputDirectory = new DirectoryInfo(AppContext.BaseDirectory);
-        string targetFramework = testOutputDirectory.Name;
-        string configuration = testOutputDirectory.Parent?.Name ?? "Release";
-
-        string wwwroot = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "..", "..",
-            "src", "Frontend", "AHKFlowApp.UI.Blazor", "bin", configuration, targetFramework, "publish", "wwwroot"));
-
-        if (!Directory.Exists(wwwroot))
+        if (!Directory.Exists(PublishedWwwroot))
         {
-            throw new DirectoryNotFoundException($"Publish wwwroot not found at {wwwroot}. Run: dotnet publish src/Frontend/AHKFlowApp.UI.Blazor -c {configuration}");
+            throw new DirectoryNotFoundException($"Publish wwwroot not found at {PublishedWwwroot}. Run: dotnet publish src/Frontend/AHKFlowApp.UI.Blazor -c {ResolveConfiguration()}");
         }
 
         HttpMessageInvoker apiClient = new(Api.Server.CreateHandler());
-        Spa = await SpaHost.StartAsync(wwwroot, apiClient, Api.Server.BaseAddress.ToString());
+        Spa = await SpaHost.StartAsync(PublishedWwwroot, apiClient, Api.Server.BaseAddress.ToString());
 
         int exitCode = Microsoft.Playwright.Program.Main(["install", "chromium"]);
         if (exitCode != 0)

--- a/tests/AHKFlowApp.E2E.Tests/PublishFreshnessTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/PublishFreshnessTests.cs
@@ -1,0 +1,30 @@
+using AHKFlowApp.E2E.Tests.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.E2E.Tests;
+
+[Collection(E2ETestCollection.Name)]
+public sealed class PublishFreshnessTests(StackFixture fixture)
+{
+    // Directory.GetFiles has a legacy quirk where a three-character extension also matches
+    // longer ones. ".wasm" is four characters and ".js" is two, so both patterns below match
+    // exactly, and the ".br" and ".gz" siblings are not counted.
+    [Theory]
+    [InlineData("AHKFlowApp.UI.Blazor.*.wasm")]
+    [InlineData("dotnet.native.*.js")]
+    [InlineData("dotnet.runtime.*.js")]
+    public void PublishedFramework_AfterAnyE2ERun_HoldsExactlyOneCopyOfEachBootAsset(string pattern)
+    {
+        // Arrange
+        string frameworkDirectory = Path.Combine(fixture.PublishedWwwroot, "_framework");
+
+        // Act
+        string[] matches = Directory.GetFiles(frameworkDirectory, pattern);
+
+        // Assert
+        matches.Should().ContainSingle(
+            "the E2E publish destination must hold exactly one '{0}', or a stale copy can be served",
+            pattern);
+    }
+}


### PR DESCRIPTION
## Problem

A green E2E run did not prove the code in the working tree worked. The suite could serve a stale
Blazor app, so a broken component passed. Backlog item `046`.

Two separate staleness layers caused it:

1. The `PublishBlazorForE2E` target had an MSBuild up-to-date check, so the publish step could be
   skipped, and the destination folder kept old hashed assets alongside new ones.
2. `dotnet publish --no-build` reused the stale trimmed assembly in
   `src/Frontend/AHKFlowApp.UI.Blazor/obj/Release/net10.0/linked/`, so even a freshly cleaned
   publish folder was refilled with old output.

The first three commits fixed only layer 1. The manual proof below is what caught that, and
`d30d7eb` fixes layer 2.

## Changes

- `PublishBlazorForE2E` has no `Inputs`/`Outputs` and no `Touch` stamp, so it can never be
  skipped. `RemoveDir` clears the destination before every publish.
- The publish command no longer passes `--no-build`, so it compiles and links current source.
- `E2EPublishTargetTests` guards all of that against regression, including an assertion that
  `--no-build` stays absent, with the reason inline.
- `PublishFreshnessTests` asserts the destination holds exactly one copy of each boot asset.
- `StackFixture` exposes the resolved published `wwwroot` path.
- `docs/development/testing-workflow.md` describes the real behavior.
- `scripts/measure-tests.ps1` lost a guard that assumed the old `--no-build` contract.

## Manual proof that a broken component now fails

Proved by hand for backlog 046's third acceptance criterion — a test that can never fail is worse
than no test.

1. **Baseline (green):** `pwsh .\scripts\test-fast.ps1 -Mode E2E` — 35/35 passed, 2 m 16 s.
2. **Broke `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotstrings.razor:94`** — changed the
   `data-test` attribute the trigger input renders from `trigger-input` to
   `trigger-input-broken`, with no other change.
3. **Re-ran the same command, no manual publish step.** Result: **failed**, 5 of 35 tests,
   including `HotstringsCrudFlowTests.CreateEditDelete_DrivesBlazorSpaThroughBrowser`, all with:

   ```
   Error Message:
      System.TimeoutException : Timeout 30000ms exceeded.
   Call log:
     - waiting for Locator("input[data-test=\"trigger-input\"]")
   ```

4. Reverted the break, confirmed a clean tree.
5. **Re-ran again (green):** 35/35 passed, 2 m 26 s.

## Verification

- Fast slice: 2662 tests green
- E2E slice: 35/35 green, 185.6 s (215 s before this branch — the difference is noise)
- Canonical pre-PR gate: green (build 0 errors, format clean, coverage 2830/2830, `diff --check` clean)

## Notes for the reviewer

- Every E2E run now pays for one Blazor compile and link pass. The Blazor project has no
  `ProjectReference` entries, so this is one project, not a tree rebuild.
- `PublishFreshnessTests` counts files, so it catches stale copies with a different hash. It
  cannot catch stale content under an unchanged name — the `--no-build` assertion is what guards
  that.
- `RemoveDir` targets the Blazor project's default publish folder. Publishing that project
  locally without `-o` and then running the E2E slice will delete your output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
