### PR TITLE
docs: file backlog 048 and 049

### DIFF
--- a/.claude/backlog/048-worktree-setup-rewrites-lose-json-comments.md
+++ b/.claude/backlog/048-worktree-setup-rewrites-lose-json-comments.md
@@ -1,0 +1,49 @@
+# 048 - Worktree setup must not strip comments from the JSON files it rewrites
+
+## Metadata
+
+- **Epic**: Developer experience
+- **Type**: Fix
+- **Interfaces**: UI
+
+## Summary
+
+`setup-worktree-local-dev.ps1` rewrites several local configuration files so a worktree runs on its own ports. It parses each file as JSON and writes it back out. That round trip deletes every comment, adds a UTF-8 BOM, and reformats arrays. The port change is correct. The collateral damage is not.
+
+## User story
+
+As a developer working in an agent worktree, I want the setup script to change only the ports and names it needs to change, so that my `git diff` shows the isolation and nothing else.
+
+## Evidence
+
+Observed in the `fix/wt-no-auth-frontend-profile` worktree on 2026-08-01. `git diff` reported 37 changed lines across the five rewritten files. Only 5 of those lines were actual port or name rewrites.
+
+Three separate kinds of damage:
+
+- **Comments deleted.** `.vscode/launch.json` lost every comment, including ones that explain non-obvious configuration. Two examples, both gone: `// internalConsole is required for serverReadyAction: VS Code only scans the Debug Console for the pattern below (never an external/integrated terminal).` and `// Keep the UI debugger on an isolated Chrome profile. Reusing the default profile can hand startup off to an existing Chrome process and reintroduce cold-start crashes.`
+- **UTF-8 BOM added.** Three files gained a BOM on their first line: `.vscode/launch.json`, `src/Backend/AHKFlowApp.API/Properties/launchSettings.json`, and `src/Frontend/AHKFlowApp.UI.Blazor/wwwroot/appsettings.json`.
+- **Arrays reformatted.** Single-line arrays became multi-line. For example `"Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ]` in `src/Backend/AHKFlowApp.API/appsettings.json`.
+
+These files are meant to stay uncommitted forever, so nothing is lost in git today. Two reasons it still matters:
+
+1. The noise hides real mistakes. A worktree-local port value was committed by accident on `fix/wt-no-auth-frontend-profile` and had to be caught in review. A diff that showed only the 5 intended lines would have made that obvious.
+2. If anyone does commit `.vscode/launch.json`, the deleted comments are gone for every contributor. The `serverReadyAction` comment records why a setting cannot be changed.
+
+## Acceptance criteria
+
+- [ ] Running `setup-worktree-local-dev.ps1` in a fresh worktree leaves every comment in `.vscode/launch.json` intact
+- [ ] No rewritten file gains a UTF-8 BOM that it did not already have
+- [ ] Array formatting is unchanged in files the script rewrites
+- [ ] `git diff` in a fresh worktree shows only the port, database, and project-name changes
+- [ ] A regression test covers a rewrite of a JSON file that contains comments and a single-line array
+
+## Out of scope
+
+- Changing which files the script rewrites, or which values it writes
+- Changing the port allocation scheme
+
+## Notes / dependencies
+
+- `scripts/setup-worktree-local-dev.ps1` is the file to change. The JSON helpers live in `scripts/worktree-json.common.ps1`.
+- `.vscode/launch.json` is JSON with comments (JSONC). A plain JSON parser cannot preserve it. A targeted text edit, or a JSONC-aware writer, would.
+- Existing PowerShell tests for this script: `tests/WorktreeLocalDevSetup.Tests.ps1`. CI runs it from the explicit list in `.github/workflows/ci.yml`.

--- a/.claude/backlog/049-nginx-emits-dead-blazor-environment-header.md
+++ b/.claude/backlog/049-nginx-emits-dead-blazor-environment-header.md
@@ -1,0 +1,50 @@
+# 049 - Decide what to do with the dead Blazor-Environment header in nginx
+
+## Metadata
+
+- **Epic**: Developer experience
+- **Type**: Chore
+- **Interfaces**: UI
+
+## Summary
+
+`src/Frontend/AHKFlowApp.UI.Blazor/nginx/default.conf` still sends a `Blazor-Environment` header. In .NET 10 a standalone Blazor WebAssembly app does not read that header, so the setting does nothing. Decide whether to delete it or keep it with an accurate comment.
+
+## User story
+
+As a developer reading the nginx configuration, I want it to be clear whether the `Blazor-Environment` header does anything, so that I do not copy a setting that has no effect.
+
+## Evidence
+
+In .NET 10 the WebAssembly environment is fixed at build time by the `WasmApplicationEnvironmentName` MSBuild property. It is baked into `_framework/dotnet.js`. The `Blazor-Environment` HTTP header is no longer read. This was confirmed on the `fix/wt-no-auth-frontend-profile` branch, which corrected every document that claimed otherwise.
+
+The nginx file emits the header at two places, `default.conf:10` and `:34`:
+
+```
+add_header Blazor-Environment "Local" always;
+```
+
+Nothing breaks today. The homelab container path works because `src/Frontend/AHKFlowApp.UI.Blazor/Dockerfile:25-26` copies `appsettings.Local.json` over `appsettings.json` before publish, so the configuration is baked into the image rather than selected by a header.
+
+Two reviewers disagreed about whether this needs action:
+
+- One judged the existing comment honest enough. It already says the header is *"kept as an explicit signal and for future use if standalone WASM honours it"*, which does not claim the header works.
+- The other wanted the lines deleted, or a comment added stating plainly that .NET 10 ignores the header, on the grounds that a future reader will grep for `Blazor-Environment` and be misled.
+
+That disagreement is why this is a decision to make rather than a defect to fix.
+
+## Acceptance criteria
+
+- [ ] A decision is recorded: delete the two `add_header` lines, or keep them with a comment that states .NET 10 does not read the header
+- [ ] The chosen change is applied at both `default.conf:10` and `:34`
+- [ ] If the lines are deleted, the container path is verified to still serve the correct configuration
+
+## Out of scope
+
+- Any change to how the WebAssembly environment is selected. That is settled: `WasmApplicationEnvironmentName` at build time.
+- Any change to `Dockerfile` or to `appsettings.Local.json`.
+
+## Notes / dependencies
+
+- Related work: `docs/development/configuration-strategy.md` and `docs/environments.md` were corrected on the no-auth frontend branch. This nginx file was deliberately left out of that diff to keep it focused.
+- Microsoft's guidance on the .NET 10 behaviour: [Blazor environments](https://learn.microsoft.com/aspnet/core/blazor/fundamentals/environments?view=aspnetcore-10.0).


### PR DESCRIPTION
## Why

Two issues surfaced while working on `fix/wt-no-auth-frontend-profile`. Neither belonged in that diff, so they are filed here instead.

## 048 — worktree setup strips JSON comments

`setup-worktree-local-dev.ps1` rewrites five local configuration files so a worktree runs on its own ports. It parses each as JSON and writes it back, which deletes every comment, adds a UTF-8 BOM, and reformats arrays.

In a real worktree that produced 37 changed lines, of which only 5 were actual port rewrites. `.vscode/launch.json` lost comments that explain non-obvious configuration, including why `internalConsole` is required for `serverReadyAction` and why the UI debugger needs an isolated Chrome profile.

Nothing is lost in git today, because these files are meant to stay uncommitted. It still matters for two reasons. The noise hides real mistakes — a worktree-local port value was committed by accident on the no-auth branch and had to be caught in review. And if anyone does commit `.vscode/launch.json`, that documentation is gone for everyone.

`.vscode/launch.json` is JSONC, so a plain JSON parser cannot preserve it.

## 049 — nginx emits a dead `Blazor-Environment` header

`nginx/default.conf` still sends `Blazor-Environment` at two places. In .NET 10 a standalone Blazor WebAssembly app does not read that header, so it does nothing.

Filed as a decision rather than a defect, because two reviewers disagreed: one judged the existing comment honest enough, the other wanted the lines deleted or the comment made explicit. Both positions are recorded in the item so it does not get re-litigated.

Nothing breaks today — the container path works because the Dockerfile copies `appsettings.Local.json` over `appsettings.json` before publish.

## Verification

Documentation only, nothing compiled. Exemption 1 in **Verification After Implementation** applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
