### PR TITLE
docs: commit plans with git -C, not cd

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -42,6 +42,9 @@ plans repo has one place work happens. Follow this order:
 1. Create the worktree, but stay in the main checkout for now.
 2. Write and commit the spec and the plan there, under `docs/superpowers/specs/` and
    `docs/superpowers/plans/`. Commit from inside `docs/superpowers/`, never from the repo root.
+   Target that repo with `git -C docs/superpowers commit`, not `cd docs/superpowers && git commit`.
+   The agent Git guard reads the command before the shell runs the `cd`, so it still sees the main
+   checkout and blocks the commit. `-C` shows it the real target, which is a different repository.
 3. Switch fully into the worktree. Everything else — code, tests, docs, config — happens there and
    commits from there. The spec and plan stay readable at `docs/superpowers/` through the link.
 4. If a review round changes the plan, go back to the main checkout to edit and commit it. The


### PR DESCRIPTION
Records the `git -C docs/superpowers` form for plan and spec commits.

Hit today while committing the backlog 048 spec. `cd docs/superpowers && git commit` is blocked: the agent Git guard classifies the target from the command string, before the shell runs the `cd`, so it resolves the main checkout. `git -C docs/superpowers` gives it the real target, which resolves a different common dir and classifies as `OutsideProtectedRepository`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)