### PR TITLE
test: guard modifier label map against key registry

### DIFF
--- a/.claude/backlog/done/045-modifier-label-drift-guard.md
+++ b/.claude/backlog/done/045-modifier-label-drift-guard.md
@@ -22,11 +22,13 @@ The frontend cannot reference that constant. `tests/AHKFlowApp.UI.Blazor.Tests` 
 
 The frontend does receive the registry at runtime, through the key catalog endpoint. So the check has to run where both sides are reachable. That means an integration test or an E2E test, not a unit test.
 
+**Correction, found while doing the work:** a unit test was possible after all. `AHKFlowApp.TestUtilities` already holds `InternalsVisibleTo` from the Application project and already reads `HotkeyKeys.All`. `tests/AHKFlowApp.UI.Blazor.Tests` already references `TestUtilities`. So the registry reaches a frontend unit test through a seam that already existed, and the guard needed no new project reference.
+
 ## Acceptance criteria
 
-- [ ] A test fails when the key registry gains a modifier the frontend label map does not cover
-- [ ] The failure message names the missing key, so the fix is obvious
-- [ ] The test lives where both the registry and the frontend map are reachable
+- [x] A test fails when the key registry gains a modifier the frontend label map does not cover
+- [x] The failure message names the missing key, so the fix is obvious
+- [x] The test lives where both the registry and the frontend map are reachable
 
 ## Out of scope
 

--- a/tests/AHKFlowApp.TestUtilities/Fixtures/HotkeyKeyFixtures.cs
+++ b/tests/AHKFlowApp.TestUtilities/Fixtures/HotkeyKeyFixtures.cs
@@ -1,0 +1,21 @@
+using AHKFlowApp.Application.Constants;
+
+namespace AHKFlowApp.TestUtilities.Fixtures;
+
+/// <summary>
+/// Registry-derived key lists, exposed publicly so test projects that cannot see the internal
+/// <c>HotkeyKeys</c> registry can still assert against it.
+/// </summary>
+public static class HotkeyKeyFixtures
+{
+    /// <summary>
+    /// Every canonical modifier key in the registry. Read by the frontend drift guard, so a
+    /// modifier added to the registry cannot silently miss its notice label.
+    /// </summary>
+    public static IReadOnlyList<string> ModifierCanonicals { get; } =
+    [
+        .. HotkeyKeys.All
+            .Where(e => e.Group == HotkeyKeys.GroupModifiers)
+            .Select(e => e.Canonical),
+    ];
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/KnownShortcutWarningTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/KnownShortcutWarningTests.cs
@@ -1,3 +1,4 @@
+using AHKFlowApp.TestUtilities.Fixtures;
 using AHKFlowApp.UI.Blazor.DTOs;
 using AHKFlowApp.UI.Blazor.Helpers;
 using FluentAssertions;
@@ -307,5 +308,31 @@ public sealed class KnownShortcutWarningTests
         // The list failing to load must not hide the modifier rule, which needs no catalog.
         KnownShortcutWarning.DestinationTextFor(null, "Ctrl", "CapsLock")
             .Should().Contain("Shortcuts that use Ctrl may also respond");
+    }
+
+    public static TheoryData<string> RegistryModifiers()
+    {
+        TheoryData<string> data = [];
+        foreach (string canonical in HotkeyKeyFixtures.ModifierCanonicals)
+            data.Add(canonical);
+
+        return data;
+    }
+
+    // Guards the hard-coded modifier label map against the key registry it mirrors. A modifier
+    // added to HotkeyKeys with no label entry produces no notice at all, and nothing else catches
+    // it. One case per key, so the failing test name already names the missing modifier.
+    [Theory]
+    [MemberData(nameof(RegistryModifiers))]
+    public void DestinationTextFor_EveryRegistryModifier_WarnsAboutTheModifier(string canonical)
+    {
+        // A null catalog isolates the modifier branch: Match returns null, so any text produced
+        // here came from the label map.
+        string? text = KnownShortcutWarning.DestinationTextFor(catalog: null, canonical, "Ctrl+F1");
+
+        text.Should().NotBeNull(
+            $"'{canonical}' is a modifier in HotkeyKeys but has no entry in "
+            + "KnownShortcutWarning.s_modifierLabels — add it there");
+        text.Should().Contain("may also respond");
     }
 }


### PR DESCRIPTION
## What

Guards `KnownShortcutWarning.s_modifierLabels` against the key registry it mirrors.

The frontend hard-codes 11 modifier names. The real list lives in `HotkeyKeys.s_modifierKeys` in the backend. Nothing checked that the two agree, so adding a modifier to the registry would quietly stop the remap destination notice from warning about it.

Closes backlog 045.

## How

`AHKFlowApp.TestUtilities` already has `InternalsVisibleTo` from the Application project and already reads `HotkeyKeys.All`. `tests/AHKFlowApp.UI.Blazor.Tests` already references `TestUtilities`. So the registry reaches a frontend unit test through a seam that already existed. No new project reference, and no new `InternalsVisibleTo`.

- `tests/AHKFlowApp.TestUtilities/Fixtures/HotkeyKeyFixtures.cs` — new. Public `ModifierCanonicals` over the internal registry.
- `KnownShortcutWarningTests.DestinationTextFor_EveryRegistryModifier_WarnsAboutTheModifier` — one test case per registry modifier, so a failing case names the missing key.

The test is black box. It never reads the private map. Passing `catalog: null` isolates the modifier branch, because `Match` returns null without a catalog.

The backlog item assumed no test project could see both sides, and concluded this needed an integration or E2E test. That assumption was wrong for `TestUtilities`. The item carries a correction note.

## Verification

Fast slice green: Domain 44, TestUtilities 8, UI.Blazor 784, Application 1672, CLI 182.

Drift proof — temporarily added `"LMeta"` to `s_modifierKeys`, then ran the guard:

```
DestinationTextFor_EveryRegistryModifier_WarnsAboutTheModifier(canonical: "LMeta") [FAIL]
Expected text not to be <null> because 'LMeta' is a modifier in HotkeyKeys but has no
entry in KnownShortcutWarning.s_modifierLabels — add it there.

Failed!  - Failed: 1, Passed: 11, Skipped: 0, Total: 12
```

Exactly one failure, named with the missing key. Registry edit reverted, suite green again. `dotnet format --verify-no-changes` clean.

## Out of scope

The reverse direction — a stale label with no registry key. It would need the private map exposed, and it cannot cause a missing warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
