### PR TITLE
fix: worktree setup edits JSON in place, keeping comments and BOM state

### DIFF
--- a/.claude/backlog/done/048-worktree-setup-rewrites-lose-json-comments.md
+++ b/.claude/backlog/done/048-worktree-setup-rewrites-lose-json-comments.md
@@ -31,11 +31,11 @@ These files are meant to stay uncommitted forever, so nothing is lost in git tod
 
 ## Acceptance criteria
 
-- [ ] Running `setup-worktree-local-dev.ps1` in a fresh worktree leaves every comment in `.vscode/launch.json` intact
-- [ ] No rewritten file gains a UTF-8 BOM that it did not already have
-- [ ] Array formatting is unchanged in files the script rewrites
-- [ ] `git diff` in a fresh worktree shows only the port, database, and project-name changes
-- [ ] A regression test covers a rewrite of a JSON file that contains comments and a single-line array
+- [x] Running `setup-worktree-local-dev.ps1` in a fresh worktree leaves every comment in `.vscode/launch.json` intact
+- [x] No rewritten file gains a UTF-8 BOM that it did not already have
+- [x] Array formatting is unchanged in files the script rewrites
+- [x] `git diff` in a fresh worktree shows only the port, database, and project-name changes
+- [x] A regression test covers a rewrite of a JSON file that contains comments and a single-line array
 
 ## Out of scope
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
           ./tests/WorktreePlansSymlink.Tests.ps1
           ./tests/WorktreeRemoveHook.Tests.ps1
           ./tests/WorktreeLocalDevSetup.Tests.ps1
+          ./tests/WorktreeJsonEdit.Tests.ps1
           ./tests/RunFrontend.Tests.ps1
           ./tests/SkillParity.Tests.ps1
           ./tests/SkillLayout.Tests.ps1

--- a/scripts/setup-worktree-local-dev.ps1
+++ b/scripts/setup-worktree-local-dev.ps1
@@ -351,6 +351,19 @@ function Invoke-WithFileLock {
     }
 }
 
+# Record one edit for Set-JsoncValues. A string path segment names an object property; an
+# integer segment names an array index.
+function Add-JsonEdit {
+    param(
+        # AllowEmptyCollection: the list starts empty, and Mandatory alone rejects that.
+        [Parameter(Mandatory)][AllowEmptyCollection()][System.Collections.ArrayList] $Edits,
+        [Parameter(Mandatory)][object[]] $Path,
+        $Value
+    )
+
+    [void] $Edits.Add(@{ Path = $Path; Value = $Value })
+}
+
 function Write-JsonFile {
     param(
         [string] $Path,
@@ -359,7 +372,7 @@ function Write-JsonFile {
 
     New-Item -ItemType Directory -Path (Split-Path -Parent $Path) -Force | Out-Null
     $json = Format-Json ($Value | ConvertTo-Json -Depth 8)
-    [System.IO.File]::WriteAllText($Path, $json + [Environment]::NewLine, [System.Text.Encoding]::UTF8)
+    [System.IO.File]::WriteAllText($Path, $json + [Environment]::NewLine, (New-Object System.Text.UTF8Encoding($false)))
 }
 
 function Update-TrackedWorktreeJsonOverride {
@@ -380,38 +393,23 @@ function Update-TrackedWorktreeJsonOverride {
 
     & git -C $Root update-index --no-skip-worktree -- $RelativePath 2>$null
 
-    # launch.json / launchSettings.json may carry comments and trailing commas (JSONC), which
-    # Windows PowerShell 5.1's ConvertFrom-Json rejects; ConvertFrom-Jsonc tolerates them.
-    $jsonObject = ConvertFrom-Jsonc (Get-Content -LiteralPath $jsonPath -Raw)
-    & $PatchJson $jsonObject
+    # Edit the text in place. Re-serializing a parsed object deletes comments, adds a BOM,
+    # and re-flows one-line arrays (backlog 048), so only the changed spans are spliced.
+    $file = Read-JsoncFile $jsonPath
 
-    $json = Format-Json ($jsonObject | ConvertTo-Json -Depth 16)
-    [System.IO.File]::WriteAllText($jsonPath, $json + [Environment]::NewLine, [System.Text.Encoding]::UTF8)
+    # launch.json / launchSettings.json may carry comments and trailing commas (JSONC), which
+    # Windows PowerShell 5.1's ConvertFrom-Json rejects; ConvertFrom-Jsonc tolerates them. The
+    # parsed object is read-only here: the scriptblock uses it to decide, and records edits.
+    $jsonObject = ConvertFrom-Jsonc $file.Text
+    $edits = New-Object System.Collections.ArrayList
+    & $PatchJson $jsonObject $edits
+
+    if ($edits.Count -gt 0) {
+        $updated = Set-JsoncValues -Json $file.Text -Edits ([hashtable[]] $edits.ToArray()) -Eol $file.Eol
+        Write-JsoncFile -Path $jsonPath -Text $updated -HasBom $file.HasBom
+    }
 
     & git -C $Root update-index --skip-worktree -- $RelativePath
-}
-
-# Set $Object.$Section.$Property = $Value on a parsed JSON object, creating the section
-# and/or property when absent. Used to override appsettings keys regardless of whether the
-# target's committed file already declares them.
-function Set-JsonSectionValue {
-    param(
-        [object] $Object,
-        [string] $Section,
-        [string] $Property,
-        [object] $Value
-    )
-
-    if (($Object.PSObject.Properties.Name) -notcontains $Section) {
-        $Object | Add-Member -NotePropertyName $Section -NotePropertyValue ([pscustomobject]@{})
-    }
-
-    $sectionObject = $Object.$Section
-    if (($sectionObject.PSObject.Properties.Name) -notcontains $Property) {
-        $sectionObject | Add-Member -NotePropertyName $Property -NotePropertyValue $Value
-    } else {
-        $sectionObject.$Property = $Value
-    }
 }
 
 function Write-VsCodeWorktreeLaunchConfig {
@@ -422,11 +420,14 @@ function Write-VsCodeWorktreeLaunchConfig {
     )
 
     Update-TrackedWorktreeJsonOverride $Root $VsCodeLaunchSettingsRelativePath {
-        param([object] $Launch)
+        param([object] $Launch, [System.Collections.ArrayList] $Edits)
 
-        foreach ($configuration in $Launch.configurations) {
+        # An edit path needs the array index, so this loop is indexed rather than foreach.
+        for ($index = 0; $index -lt $Launch.configurations.Count; $index++) {
+            $configuration = $Launch.configurations[$index]
+
             if ($configuration.name -eq 'UI: http') {
-                $configuration.url = $UiUrl
+                Add-JsonEdit -Edits $Edits -Path @('configurations', $index, 'url') -Value $UiUrl
             }
 
             # Rebase a standalone Chrome opener for the API (e.g. the Swagger browser launched
@@ -436,7 +437,7 @@ function Write-VsCodeWorktreeLaunchConfig {
                 ($configuration.type -eq 'chrome') -and
                 (($configuration.PSObject.Properties.Name) -contains 'url') -and
                 ($configuration.url -match '^(https?://[^/]+)(.*)$')) {
-                $configuration.url = $ApiUrl + $matches[2]
+                Add-JsonEdit -Edits $Edits -Path @('configurations', $index, 'url') -Value ($ApiUrl + $matches[2])
             }
 
             # Rebase a hardcoded API browser URL (e.g. http://localhost:5600/swagger). A
@@ -446,7 +447,7 @@ function Write-VsCodeWorktreeLaunchConfig {
                 $serverReadyAction = $configuration.serverReadyAction
                 if ((($serverReadyAction.PSObject.Properties.Name) -contains 'uriFormat') -and
                     ($serverReadyAction.uriFormat -match '^(https?://[^/]+)(.*)$')) {
-                    $serverReadyAction.uriFormat = $ApiUrl + $matches[2]
+                    Add-JsonEdit -Edits $Edits -Path @('configurations', $index, 'serverReadyAction', 'uriFormat') -Value ($ApiUrl + $matches[2])
                 }
             }
         }
@@ -460,14 +461,16 @@ function Write-BackendWorktreeLaunchSettings {
     )
 
     Update-TrackedWorktreeJsonOverride $Root $BackendLaunchSettingsRelativePath {
-        param([object] $LaunchSettings)
+        param([object] $LaunchSettings, [System.Collections.ArrayList] $Edits)
 
+        # Iterate the properties, not their values: an edit path needs the profile name.
         # Only "Project" profiles bind via applicationUrl; leave Docker/Executable/IISExpress alone.
-        foreach ($profile in $LaunchSettings.profiles.PSObject.Properties.Value) {
-            $names = $profile.PSObject.Properties.Name
-            if (($names -contains 'commandName') -and ($profile.commandName -eq 'Project') -and
+        foreach ($profileProperty in $LaunchSettings.profiles.PSObject.Properties) {
+            $launchProfile = $profileProperty.Value
+            $names = $launchProfile.PSObject.Properties.Name
+            if (($names -contains 'commandName') -and ($launchProfile.commandName -eq 'Project') -and
                 ($names -contains 'applicationUrl')) {
-                $profile.applicationUrl = $ApiUrl
+                Add-JsonEdit -Edits $Edits -Path @('profiles', $profileProperty.Name, 'applicationUrl') -Value $ApiUrl
             }
         }
     }
@@ -481,11 +484,11 @@ function Write-FrontendWorktreeLaunchSettings {
 
     $relativePath = $FrontendLaunchSettingsRelativePath
     Update-TrackedWorktreeJsonOverride $Root $relativePath {
-        param([object] $LaunchSettings)
+        param([object] $LaunchSettings, [System.Collections.ArrayList] $Edits)
 
-        foreach ($profile in $LaunchSettings.profiles.PSObject.Properties.Value) {
-            if ($profile.PSObject.Properties.Name -contains 'applicationUrl') {
-                $profile.applicationUrl = $UiUrl
+        foreach ($profileProperty in $LaunchSettings.profiles.PSObject.Properties) {
+            if ($profileProperty.Value.PSObject.Properties.Name -contains 'applicationUrl') {
+                Add-JsonEdit -Edits $Edits -Path @('profiles', $profileProperty.Name, 'applicationUrl') -Value $UiUrl
             }
         }
     }
@@ -499,10 +502,11 @@ function Write-BackendWorktreeAppSettings {
     )
 
     Update-TrackedWorktreeJsonOverride $Root $BackendAppSettingsRelativePath {
-        param([object] $Config)
+        param([object] $Config, [System.Collections.ArrayList] $Edits)
 
-        Set-JsonSectionValue $Config 'Cors' 'AllowedOrigins' @($UiUrl)
-        Set-JsonSectionValue $Config 'ConnectionStrings' 'DefaultConnection' $ConnectionString
+        # Set-JsoncValues creates a missing section, so no probe of $Config is needed here.
+        Add-JsonEdit -Edits $Edits -Path @('Cors', 'AllowedOrigins') -Value @($UiUrl)
+        Add-JsonEdit -Edits $Edits -Path @('ConnectionStrings', 'DefaultConnection') -Value $ConnectionString
     }
 }
 
@@ -513,9 +517,9 @@ function Write-FrontendWorktreeAppSettings {
     )
 
     Update-TrackedWorktreeJsonOverride $Root $FrontendAppSettingsRelativePath {
-        param([object] $Config)
+        param([object] $Config, [System.Collections.ArrayList] $Edits)
 
-        Set-JsonSectionValue $Config 'ApiHttpClient' 'BaseAddress' $ApiUrl
+        Add-JsonEdit -Edits $Edits -Path @('ApiHttpClient', 'BaseAddress') -Value $ApiUrl
     }
 }
 
@@ -605,16 +609,6 @@ function Resolve-WorktreeDatabaseName {
     return $name
 }
 
-function Set-NoteProperty {
-    param([object] $Object, [string] $Name, [object] $Value)
-
-    if (($Object.PSObject.Properties.Name) -notcontains $Name) {
-        $Object | Add-Member -NotePropertyName $Name -NotePropertyValue $Value
-    } else {
-        $Object.$Name = $Value
-    }
-}
-
 function Write-BackendWorktreeDockerProfile {
     param([string] $Root, [int] $SqlPort, [string] $ComposeProject)
 
@@ -623,7 +617,7 @@ function Write-BackendWorktreeDockerProfile {
     $composeIntended = Test-Path -LiteralPath (Join-Path $Root 'docker-compose.yml')
 
     Update-TrackedWorktreeJsonOverride $Root $BackendLaunchSettingsRelativePath {
-        param([object] $LaunchSettings)
+        param([object] $LaunchSettings, [System.Collections.ArrayList] $Edits)
 
         $profiles = $LaunchSettings.profiles
         $patched = 0
@@ -640,13 +634,13 @@ function Write-BackendWorktreeDockerProfile {
                 continue
             }
 
-            Set-NoteProperty $env 'COMPOSE_PROJECT_NAME' $ComposeProject
-            Set-NoteProperty $env 'AHKFLOW_SQL_PORT' ([string] $SqlPort)
+            Add-JsonEdit -Edits $Edits -Path @('profiles', $profileName, 'environmentVariables', 'COMPOSE_PROJECT_NAME') -Value $ComposeProject
+            Add-JsonEdit -Edits $Edits -Path @('profiles', $profileName, 'environmentVariables', 'AHKFLOW_SQL_PORT') -Value ([string] $SqlPort)
 
             if (($env.PSObject.Properties.Name) -contains 'ConnectionStrings__DefaultConnection') {
                 $builder = New-Object System.Data.SqlClient.SqlConnectionStringBuilder([string] $env.'ConnectionStrings__DefaultConnection')
                 $builder['Data Source'] = "localhost,$SqlPort"
-                $env.'ConnectionStrings__DefaultConnection' = $builder.ConnectionString
+                Add-JsonEdit -Edits $Edits -Path @('profiles', $profileName, 'environmentVariables', 'ConnectionStrings__DefaultConnection') -Value $builder.ConnectionString
             }
             $patched++
         }

--- a/scripts/worktree-json.common.ps1
+++ b/scripts/worktree-json.common.ps1
@@ -559,3 +559,68 @@ function Write-JsoncFile {
 
     [System.IO.File]::WriteAllText($Path, $Text, (New-Object System.Text.UTF8Encoding($HasBom)))
 }
+
+# --- Literal writers ----------------------------------------------------------
+# Written by hand rather than through ConvertTo-Json: Windows PowerShell 5.1 escapes
+# < > & ' as \u00xx and PowerShell 7 does not, so only a hand-written escaper gives
+# byte-identical output on both hosts.
+
+function ConvertTo-JsonStringLiteral {
+    param([Parameter(Mandatory)][AllowEmptyString()][string] $Value)
+
+    $sb = New-Object System.Text.StringBuilder
+    [void] $sb.Append('"')
+
+    foreach ($c in $Value.ToCharArray()) {
+        $code = [int] $c
+        if ($c -eq '"') { [void] $sb.Append('\"') }
+        elseif ($c -eq '\') { [void] $sb.Append('\\') }
+        elseif ($code -eq 8) { [void] $sb.Append('\b') }
+        elseif ($code -eq 9) { [void] $sb.Append('\t') }
+        elseif ($code -eq 10) { [void] $sb.Append('\n') }
+        elseif ($code -eq 12) { [void] $sb.Append('\f') }
+        elseif ($code -eq 13) { [void] $sb.Append('\r') }
+        elseif ($code -lt 32) { [void] $sb.Append('\u').Append($code.ToString('x4', [System.Globalization.CultureInfo]::InvariantCulture)) }
+        else { [void] $sb.Append($c) }
+    }
+
+    [void] $sb.Append('"')
+    return $sb.ToString()
+}
+
+# Leaf values only. Building a missing object is New-JsoncChainLiteral's job.
+function ConvertTo-JsonLiteral {
+    param($Value)
+
+    if ($null -eq $Value) { return 'null' }
+    if ($Value -is [string]) { return ConvertTo-JsonStringLiteral $Value }
+    if ($Value -is [bool]) { if ($Value) { return 'true' } else { return 'false' } }
+    if ($Value -is [int] -or $Value -is [long]) { return $Value.ToString([System.Globalization.CultureInfo]::InvariantCulture) }
+
+    if ($Value -is [System.Collections.IEnumerable]) {
+        $parts = @()
+        foreach ($item in $Value) { $parts += ConvertTo-JsonLiteral $item }
+        return '[' + ($parts -join ',') + ']'
+    }
+
+    throw "ConvertTo-JsonLiteral cannot write a value of type '$($Value.GetType().FullName)'."
+}
+
+# Text for a property whose value may sit under a chain of objects that do not exist yet.
+# $Indent is the indent of the line the property will be written on; each nested level adds
+# two spaces, and each closing brace sits at the indent of its own opening line.
+function New-JsoncChainLiteral {
+    param(
+        [Parameter(Mandatory)][string[]] $Names,
+        $Value,
+        [Parameter(Mandatory)][AllowEmptyString()][string] $Indent,
+        [Parameter(Mandatory)][string] $Eol
+    )
+
+    if ($Names.Count -eq 1) {
+        return (ConvertTo-JsonStringLiteral $Names[0]) + ': ' + (ConvertTo-JsonLiteral $Value)
+    }
+
+    $inner = New-JsoncChainLiteral -Names $Names[1..($Names.Count - 1)] -Value $Value -Indent ($Indent + '  ') -Eol $Eol
+    return (ConvertTo-JsonStringLiteral $Names[0]) + ': {' + $Eol + $Indent + '  ' + $inner + $Eol + $Indent + '}'
+}

--- a/scripts/worktree-json.common.ps1
+++ b/scripts/worktree-json.common.ps1
@@ -624,3 +624,176 @@ function New-JsoncChainLiteral {
     $inner = New-JsoncChainLiteral -Names $Names[1..($Names.Count - 1)] -Value $Value -Indent ($Indent + '  ') -Eol $Eol
     return (ConvertTo-JsonStringLiteral $Names[0]) + ': {' + $Eol + $Indent + '  ' + $inner + $Eol + $Indent + '}'
 }
+
+# --- Splicer ------------------------------------------------------------------
+
+function New-JsoncSplice {
+    param([int] $Start, [int] $End, [string] $Text, [int] $Rank, [string] $Path)
+
+    # Rank breaks ties when two splices sit at the same offset. Splices are applied from the
+    # highest offset down, and at equal offsets from the highest rank down, so an inserted
+    # member (rank 1) is placed before the comma that must precede it (rank 0).
+    return [pscustomobject]@{ Start = $Start; End = $End; Text = $Text; Rank = $Rank; Path = $Path }
+}
+
+# Splices for every new member going into one object. All members of an object are emitted
+# together: one at a time, each would write its own separating comma at the same offset,
+# producing ",," and no comma between the new members.
+function New-JsoncInsertion {
+    param(
+        [string] $Text,
+        [hashtable] $Object,
+        [System.Collections.ArrayList] $Members,
+        [string] $Eol
+    )
+
+    $label = (($Members | ForEach-Object { $_.Label }) -join ', ')
+
+    if ($Object.IsEmpty) {
+        # Splice over the whitespace run in front of the closing brace, never over the whole
+        # {...} span: an object that holds only comments has no members but must keep them.
+        $closeIndent = Get-JsoncLineIndent $Text $Object.Start
+        $indent = $closeIndent + '  '
+        $literals = @()
+        foreach ($member in $Members) {
+            $literals += New-JsoncChainLiteral -Names $member.Names -Value $member.Value -Indent $indent -Eol $Eol
+        }
+
+        $body = $Eol + $indent + ($literals -join (',' + $Eol + $indent)) + $Eol + $closeIndent
+        $runStart = Get-JsoncWhitespaceRunStart $Text $Object.CloseIndex
+        return @(New-JsoncSplice -Start $runStart -End $Object.CloseIndex -Text $body -Rank 0 -Path $label)
+    }
+
+    $indent = $Object.Indent
+    $last = $Object.Order[$Object.Order.Count - 1]
+    $literals = @()
+    foreach ($member in $Members) {
+        $literals += New-JsoncChainLiteral -Names $member.Names -Value $member.Value -Indent $indent -Eol $Eol
+    }
+
+    # Splice at LineEnd, not at the value's end, so a trailing comment stays attached to the
+    # member it describes instead of drifting onto the new member's line.
+    $body = $Eol + $indent + ($literals -join (',' + $Eol + $indent))
+    $splices = @(New-JsoncSplice -Start $last.LineEnd -End $last.LineEnd -Text $body -Rank 1 -Path $label)
+    if ($last.CommaIndex -lt 0) {
+        $splices += New-JsoncSplice -Start $last.Value.End -End $last.Value.End -Text ',' -Rank 0 -Path $label
+    }
+
+    return $splices
+}
+
+# Classify one edit against the tree: either a span to replace, or a set of names to insert
+# into the deepest object that does exist. Splices are not built here, because insertions
+# into the same object must be merged first.
+function Resolve-JsoncEdit {
+    param(
+        [hashtable] $Root,
+        [object[]] $Path
+    )
+
+    $label = ($Path -join '.')
+    if ($Path.Count -eq 0) { throw 'Cannot apply a JSON edit with an empty path.' }
+
+    $node = $Root
+
+    for ($i = 0; $i -lt $Path.Count; $i++) {
+        $segment = $Path[$i]
+        $isLast = ($i -eq $Path.Count - 1)
+
+        if ($segment -is [int]) {
+            if ($node.Kind -ne 'Array') {
+                throw "Cannot apply JSON edit '$label': segment $i needs an array at offset $($node.Start)."
+            }
+            if ($segment -lt 0 -or $segment -ge $node.Items.Count) {
+                throw "Cannot apply JSON edit '$label': array index $segment is out of range at offset $($node.Start)."
+            }
+
+            $node = $node.Items[$segment]
+            if ($isLast) { return @{ Kind = 'Replace'; Node = $node; Label = $label } }
+            continue
+        }
+
+        if ($node.Kind -ne 'Object') {
+            throw "Cannot apply JSON edit '$label': segment $i needs an object at offset $($node.Start)."
+        }
+
+        $name = [string] $segment
+        if ($node.Members.ContainsKey($name)) {
+            $node = $node.Members[$name].Value
+            if ($isLast) { return @{ Kind = 'Replace'; Node = $node; Label = $label } }
+            continue
+        }
+
+        # The segment is missing. Every remaining segment must name a property: the script
+        # never needs to grow an array, so a missing integer segment is a fault.
+        $remaining = @($Path[$i..($Path.Count - 1)])
+        foreach ($remainingSegment in $remaining) {
+            if ($remainingSegment -is [int]) {
+                throw "Cannot apply JSON edit '$label': cannot create array index $remainingSegment at offset $($node.Start)."
+            }
+        }
+
+        return @{ Kind = 'Insert'; Object = $node; Names = ([string[]] $remaining); Label = $label }
+    }
+
+    throw "Cannot apply JSON edit '$label': the path resolved to nothing."
+}
+
+# Return new document text with every edit applied. Nothing is written when any edit fails,
+# so a caller can never leave a file half-patched.
+function Set-JsoncValues {
+    param(
+        [Parameter(Mandatory)][string] $Json,
+        [Parameter(Mandatory)][AllowEmptyCollection()][hashtable[]] $Edits,
+        [string] $Eol
+    )
+
+    if ($Edits.Count -eq 0) { return $Json }
+    if (-not $Eol) { $Eol = Get-JsoncEol $Json }
+
+    $root = Read-JsoncTree $Json
+    $splices = New-Object System.Collections.ArrayList
+    $groups = New-Object System.Collections.ArrayList
+    $groupByObjectStart = @{}
+
+    foreach ($edit in $Edits) {
+        $resolved = Resolve-JsoncEdit -Root $root -Path ([object[]] $edit.Path)
+
+        if ($resolved.Kind -eq 'Replace') {
+            [void] $splices.Add((New-JsoncSplice -Start $resolved.Node.Start -End $resolved.Node.End `
+                -Text (ConvertTo-JsonLiteral $edit.Value) -Rank 0 -Path $resolved.Label))
+            continue
+        }
+
+        # Every insertion into the same object joins one group, keyed by that object's start
+        # offset. Emitting them separately is what produced ",," before.
+        $key = [string] $resolved.Object.Start
+        if (-not $groupByObjectStart.ContainsKey($key)) {
+            $group = @{ Object = $resolved.Object; Members = (New-Object System.Collections.ArrayList) }
+            $groupByObjectStart[$key] = $group
+            [void] $groups.Add($group)
+        }
+        [void] $groupByObjectStart[$key].Members.Add(@{ Names = $resolved.Names; Value = $edit.Value; Label = $resolved.Label })
+    }
+
+    foreach ($group in $groups) {
+        foreach ($splice in (New-JsoncInsertion -Text $Json -Object $group.Object -Members $group.Members -Eol $Eol)) {
+            [void] $splices.Add($splice)
+        }
+    }
+
+    $ascending = @($splices | Sort-Object -Property Start, End)
+    for ($i = 1; $i -lt $ascending.Count; $i++) {
+        if ($ascending[$i].Start -lt $ascending[$i - 1].End) {
+            throw "Conflicting JSON edits: '$($ascending[$i - 1].Path)' covers offsets $($ascending[$i - 1].Start)..$($ascending[$i - 1].End) and '$($ascending[$i].Path)' starts at offset $($ascending[$i].Start)."
+        }
+    }
+
+    $result = $Json
+    $descending = @($splices | Sort-Object -Property @{ Expression = 'Start'; Descending = $true }, @{ Expression = 'Rank'; Descending = $true })
+    foreach ($splice in $descending) {
+        $result = $result.Substring(0, $splice.Start) + $splice.Text + $result.Substring($splice.End)
+    }
+
+    return $result
+}

--- a/scripts/worktree-json.common.ps1
+++ b/scripts/worktree-json.common.ps1
@@ -636,6 +636,69 @@ function New-JsoncSplice {
     return [pscustomobject]@{ Start = $Start; End = $End; Text = $Text; Rank = $Rank; Path = $Path }
 }
 
+# Property text for every new member going into one object, with members that share a missing
+# ancestor merged into one section. Rendering each chain on its own writes that ancestor once
+# per edit, and ConvertFrom-Json keeps only the last of two properties with the same name, so
+# the earlier edits would vanish with no error.
+function New-JsoncMemberLiterals {
+    param(
+        [System.Collections.ArrayList] $Members,
+        [string] $Indent,
+        [string] $Eol,
+        # Start of the existing object the new members go into. Every failure below reports it,
+        # so a caller can point at the place in the file that the edit could not be applied.
+        [int] $Offset
+    )
+
+    # Group by the first name, keeping the order the edits arrived in.
+    $order = New-Object System.Collections.ArrayList
+    $byName = @{}
+    foreach ($member in $Members) {
+        $name = $member.Names[0]
+        if (-not $byName.ContainsKey($name)) {
+            $byName[$name] = New-Object System.Collections.ArrayList
+            [void] $order.Add($name)
+        }
+        [void] $byName[$name].Add($member)
+    }
+
+    $literals = @()
+    foreach ($name in $order) {
+        $group = $byName[$name]
+
+        if ($group.Count -eq 1) {
+            $member = $group[0]
+            try {
+                $literals += New-JsoncChainLiteral -Names $member.Names -Value $member.Value -Indent $Indent -Eol $Eol
+            } catch {
+                throw "Cannot apply JSON edit '$($member.Label)' at offset $Offset`: $($_.Exception.Message)"
+            }
+            continue
+        }
+
+        # More than one edit wants this name. That only works when every one of them treats it
+        # as a parent object; a name cannot be a value for one edit and an object for another.
+        $inner = New-Object System.Collections.ArrayList
+        foreach ($member in $group) {
+            if ($member.Names.Count -eq 1) {
+                throw "Conflicting JSON edits at offset $Offset`: '$($member.Label)' writes '$name' as a value, and another edit writes properties inside it."
+            }
+            [void] $inner.Add(@{
+                Names = ([string[]] $member.Names[1..($member.Names.Count - 1)])
+                Value = $member.Value
+                Label = $member.Label
+            })
+        }
+
+        $childIndent = $Indent + '  '
+        $childLiterals = New-JsoncMemberLiterals -Members $inner -Indent $childIndent -Eol $Eol -Offset $Offset
+        $literals += (ConvertTo-JsonStringLiteral $name) + ': {' + $Eol + $childIndent +
+            ($childLiterals -join (',' + $Eol + $childIndent)) + $Eol + $Indent + '}'
+    }
+
+    return $literals
+}
+
 # Splices for every new member going into one object. All members of an object are emitted
 # together: one at a time, each would write its own separating comma at the same offset,
 # producing ",," and no comma between the new members.
@@ -654,10 +717,7 @@ function New-JsoncInsertion {
         # {...} span: an object that holds only comments has no members but must keep them.
         $closeIndent = Get-JsoncLineIndent $Text $Object.Start
         $indent = $closeIndent + '  '
-        $literals = @()
-        foreach ($member in $Members) {
-            $literals += New-JsoncChainLiteral -Names $member.Names -Value $member.Value -Indent $indent -Eol $Eol
-        }
+        $literals = New-JsoncMemberLiterals -Members $Members -Indent $indent -Eol $Eol -Offset $Object.Start
 
         $body = $Eol + $indent + ($literals -join (',' + $Eol + $indent)) + $Eol + $closeIndent
         $runStart = Get-JsoncWhitespaceRunStart $Text $Object.CloseIndex
@@ -666,10 +726,7 @@ function New-JsoncInsertion {
 
     $indent = $Object.Indent
     $last = $Object.Order[$Object.Order.Count - 1]
-    $literals = @()
-    foreach ($member in $Members) {
-        $literals += New-JsoncChainLiteral -Names $member.Names -Value $member.Value -Indent $indent -Eol $Eol
-    }
+    $literals = New-JsoncMemberLiterals -Members $Members -Indent $indent -Eol $Eol -Offset $Object.Start
 
     # Splice at LineEnd, not at the value's end, so a trailing comment stays attached to the
     # member it describes instead of drifting onto the new member's line.
@@ -760,8 +817,16 @@ function Set-JsoncValues {
         $resolved = Resolve-JsoncEdit -Root $root -Path ([object[]] $edit.Path)
 
         if ($resolved.Kind -eq 'Replace') {
+            # A value the writer cannot express is reported against the edit that carried it,
+            # not as a bare type name with no clue which of the edits was at fault.
+            try {
+                $literal = ConvertTo-JsonLiteral $edit.Value
+            } catch {
+                throw "Cannot apply JSON edit '$($resolved.Label)' at offset $($resolved.Node.Start)`: $($_.Exception.Message)"
+            }
+
             [void] $splices.Add((New-JsoncSplice -Start $resolved.Node.Start -End $resolved.Node.End `
-                -Text (ConvertTo-JsonLiteral $edit.Value) -Rank 0 -Path $resolved.Label))
+                -Text $literal -Rank 0 -Path $resolved.Label))
             continue
         }
 

--- a/scripts/worktree-json.common.ps1
+++ b/scripts/worktree-json.common.ps1
@@ -163,3 +163,399 @@ function Format-Json {
 
     return $sb.ToString()
 }
+
+# --- JSONC text scanner -------------------------------------------------------
+# Everything below edits JSON as text. ConvertFrom-Json/ConvertTo-Json cannot be used for
+# writing: the round trip deletes comments, adds a BOM, and re-flows one-line arrays. The
+# scanner records the character span of every value so a writer can splice new text into
+# exactly that span and touch nothing else.
+
+# The whitespace prefix of the line that holds $Index.
+function Get-JsoncLineIndent {
+    param([Parameter(Mandatory)][string] $Text, [int] $Index)
+
+    $lineStart = $Index
+    while ($lineStart -gt 0 -and $Text[$lineStart - 1] -ne "`n") { $lineStart-- }
+
+    $i = $lineStart
+    while ($i -lt $Index -and ($Text[$i] -eq ' ' -or $Text[$i] -eq "`t")) { $i++ }
+
+    return $Text.Substring($lineStart, $i - $lineStart)
+}
+
+# The first index of the whitespace run that ends just before $Index. Insertion into an
+# object with no members splices over this run, so an interior comment is never touched.
+function Get-JsoncWhitespaceRunStart {
+    param([Parameter(Mandatory)][string] $Text, [int] $Index)
+
+    $i = $Index
+    while ($i -gt 0 -and ($Text[$i - 1] -eq ' ' -or $Text[$i - 1] -eq "`t" -or $Text[$i - 1] -eq "`r" -or $Text[$i - 1] -eq "`n")) { $i-- }
+
+    return $i
+}
+
+# The file's dominant line ending. CRLF wins when most newlines are preceded by a return.
+function Get-JsoncEol {
+    param([Parameter(Mandatory)][AllowEmptyString()][string] $Json)
+
+    $crlf = ([regex]::Matches($Json, "`r`n")).Count
+    $lf = ([regex]::Matches($Json, "`n")).Count
+    if ($crlf * 2 -gt $lf) { return "`r`n" }
+    return "`n"
+}
+
+# Decode a JSON string literal (quotes included) into its characters.
+function ConvertFrom-JsoncStringLiteral {
+    param([Parameter(Mandatory)][string] $Literal)
+
+    $sb = New-Object System.Text.StringBuilder
+    $i = 1
+    $end = $Literal.Length - 1
+
+    while ($i -lt $end) {
+        $c = $Literal[$i]
+        if ($c -ne '\') { [void] $sb.Append($c); $i++; continue }
+
+        $i++
+        if ($i -ge $end) { throw "Unterminated escape in string literal $Literal." }
+        $escape = $Literal[$i]
+
+        switch -CaseSensitive ($escape) {
+            '"' { [void] $sb.Append('"'); $i++ }
+            '\' { [void] $sb.Append('\'); $i++ }
+            '/' { [void] $sb.Append('/'); $i++ }
+            'b' { [void] $sb.Append([char] 8); $i++ }
+            'f' { [void] $sb.Append([char] 12); $i++ }
+            'n' { [void] $sb.Append([char] 10); $i++ }
+            'r' { [void] $sb.Append([char] 13); $i++ }
+            't' { [void] $sb.Append([char] 9); $i++ }
+            'u' {
+                [void] $sb.Append([char] [Convert]::ToInt32($Literal.Substring($i + 1, 4), 16))
+                $i += 5
+            }
+            default { throw "Unsupported escape '\$escape' in string literal $Literal." }
+        }
+    }
+
+    return $sb.ToString()
+}
+
+# Index of the next character that is not whitespace and not a comment.
+function Get-JsoncNextNonTrivia {
+    param([hashtable] $State, [int] $Index)
+
+    $text = $State.Text
+    $i = $Index
+
+    while ($i -lt $State.Length) {
+        $c = $text[$i]
+        if ($c -eq ' ' -or $c -eq "`t" -or $c -eq "`r" -or $c -eq "`n") { $i++; continue }
+
+        if ($c -eq '/' -and $i + 1 -lt $State.Length) {
+            $next = $text[$i + 1]
+            if ($next -eq '/') {
+                $i += 2
+                while ($i -lt $State.Length -and $text[$i] -ne "`n") { $i++ }
+                continue
+            }
+            if ($next -eq '*') {
+                $j = $i + 2
+                while ($j + 1 -lt $State.Length -and -not ($text[$j] -eq '*' -and $text[$j + 1] -eq '/')) { $j++ }
+                if ($j + 1 -ge $State.Length) { throw "Unterminated block comment at offset $i." }
+                $i = $j + 2
+                continue
+            }
+        }
+
+        break
+    }
+
+    return $i
+}
+
+# Named Move-, not Skip-: Skip is not an approved PowerShell verb.
+function Move-JsoncPastTrivia {
+    param([hashtable] $State)
+
+    $State.Pos = Get-JsoncNextNonTrivia $State $State.Pos
+}
+
+# Index one past the closing quote of the string literal that starts at $Start. Escape
+# sequences are validated here, where the walk already happens.
+function Get-JsoncStringEnd {
+    param([hashtable] $State, [int] $Start)
+
+    $text = $State.Text
+    $i = $Start + 1
+
+    while ($i -lt $State.Length) {
+        $c = $text[$i]
+
+        if ($c -eq '"') { return $i + 1 }
+
+        if ($c -eq '\') {
+            if ($i + 1 -ge $State.Length) { throw "Unterminated escape at offset $i." }
+            $escape = $text[$i + 1]
+
+            if ('"\/bfnrt'.IndexOf($escape) -ge 0) { $i += 2; continue }
+
+            if ($escape -eq 'u') {
+                if ($i + 5 -ge $State.Length) { throw "Truncated \u escape at offset $i." }
+                $hex = $text.Substring($i + 2, 4)
+                if ($hex -notmatch '^[0-9a-fA-F]{4}$') { throw "Invalid \u escape at offset $i." }
+                $i += 6
+                continue
+            }
+
+            throw "Invalid escape '\$escape' at offset $i."
+        }
+
+        $i++
+    }
+
+    throw "Unterminated string starting at offset $Start."
+}
+
+function Read-JsoncScalar {
+    param([hashtable] $State)
+
+    $text = $State.Text
+    $start = $State.Pos
+
+    if ($text[$start] -eq '"') {
+        $State.Pos = Get-JsoncStringEnd $State $start
+        return @{ Kind = 'Scalar'; Start = $start; End = $State.Pos }
+    }
+
+    while ($State.Pos -lt $State.Length) {
+        $c = $text[$State.Pos]
+        if ($c -eq ',' -or $c -eq '}' -or $c -eq ']' -or $c -eq ' ' -or $c -eq "`t" -or $c -eq "`r" -or $c -eq "`n") { break }
+        if ($c -eq '/' -and $State.Pos + 1 -lt $State.Length -and ($text[$State.Pos + 1] -eq '/' -or $text[$State.Pos + 1] -eq '*')) { break }
+        $State.Pos++
+    }
+
+    if ($State.Pos -eq $start) { throw "Expected a JSON value at offset $start." }
+
+    # A run of non-delimiter characters is not automatically a value: only the three
+    # literals and JSON number syntax are legal here.
+    $token = $text.Substring($start, $State.Pos - $start)
+    if ($token -cne 'true' -and $token -cne 'false' -and $token -cne 'null' -and
+        $token -notmatch '^-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][-+]?[0-9]+)?$') {
+        throw "Invalid JSON value '$token' at offset $start."
+    }
+
+    return @{ Kind = 'Scalar'; Start = $start; End = $State.Pos }
+}
+
+# What follows a member's value on the value's own line: the separating comma, and any
+# comment that starts on that line. LineEnd is one past the last such token. Splicing a new
+# member at LineEnd keeps a trailing comment attached to the member it describes.
+function Read-JsoncMemberTrailing {
+    param([hashtable] $State, [int] $ValueEnd)
+
+    $text = $State.Text
+    $i = $ValueEnd
+    $commaIndex = -1
+    $lineEnd = $ValueEnd
+
+    while ($i -lt $State.Length) {
+        $c = $text[$i]
+
+        if ($c -eq ' ' -or $c -eq "`t") { $i++; continue }
+        if ($c -eq "`r" -or $c -eq "`n") { break }
+
+        if ($c -eq ',' -and $commaIndex -eq -1) {
+            $commaIndex = $i
+            $i++
+            $lineEnd = $i
+            continue
+        }
+
+        if ($c -eq '/' -and $i + 1 -lt $State.Length -and $text[$i + 1] -eq '/') {
+            $i += 2
+            while ($i -lt $State.Length -and $text[$i] -ne "`n" -and $text[$i] -ne "`r") { $i++ }
+            $lineEnd = $i
+            break
+        }
+
+        if ($c -eq '/' -and $i + 1 -lt $State.Length -and $text[$i + 1] -eq '*') {
+            $j = $i + 2
+            while ($j + 1 -lt $State.Length -and -not ($text[$j] -eq '*' -and $text[$j + 1] -eq '/')) { $j++ }
+            if ($j + 1 -ge $State.Length) { throw "Unterminated block comment at offset $i." }
+            $i = $j + 2
+            $lineEnd = $i
+            continue
+        }
+
+        break
+    }
+
+    # A comma written on the next line is still this member's separator.
+    if ($commaIndex -eq -1) {
+        $next = Get-JsoncNextNonTrivia $State $lineEnd
+        if ($next -lt $State.Length -and $text[$next] -eq ',') {
+            $commaIndex = $next
+            $lineEnd = $next + 1
+        }
+    }
+
+    return @{ CommaIndex = $commaIndex; LineEnd = $lineEnd }
+}
+
+function Read-JsoncObject {
+    param([hashtable] $State)
+
+    $text = $State.Text
+    $start = $State.Pos
+    $State.Pos++   # past '{'
+
+    $members = @{}
+    $order = New-Object System.Collections.ArrayList
+
+    while ($true) {
+        Move-JsoncPastTrivia $State
+        if ($State.Pos -ge $State.Length) { throw "Unterminated object starting at offset $start." }
+        if ($text[$State.Pos] -eq '}') { break }
+
+        if ($text[$State.Pos] -ne '"') {
+            throw "Expected a property name in the object starting at offset $start, found '$($text[$State.Pos])' at offset $($State.Pos)."
+        }
+
+        $nameStart = $State.Pos
+        $nameEnd = Get-JsoncStringEnd $State $nameStart
+        $name = ConvertFrom-JsoncStringLiteral $text.Substring($nameStart, $nameEnd - $nameStart)
+        $State.Pos = $nameEnd
+
+        Move-JsoncPastTrivia $State
+        if ($State.Pos -ge $State.Length -or $text[$State.Pos] -ne ':') {
+            throw "Expected ':' after property '$name' at offset $($State.Pos)."
+        }
+        $State.Pos++
+
+        $value = Read-JsoncValue $State
+        $trailing = Read-JsoncMemberTrailing $State $value.End
+
+        $member = @{
+            Name = $name
+            NameStart = $nameStart
+            Value = $value
+            CommaIndex = $trailing.CommaIndex
+            LineEnd = $trailing.LineEnd
+        }
+        $members[$name] = $member
+        [void] $order.Add($member)
+
+        if ($trailing.CommaIndex -ge 0) {
+            $State.Pos = $trailing.CommaIndex + 1
+            continue
+        }
+
+        $State.Pos = $trailing.LineEnd
+        Move-JsoncPastTrivia $State
+        if ($State.Pos -ge $State.Length) { throw "Unterminated object starting at offset $start." }
+        if ($text[$State.Pos] -ne '}') {
+            throw "Expected ',' or '}' in the object starting at offset $start, found '$($text[$State.Pos])' at offset $($State.Pos)."
+        }
+        break
+    }
+
+    Move-JsoncPastTrivia $State
+    if ($State.Pos -ge $State.Length -or $text[$State.Pos] -ne '}') {
+        throw "Unterminated object starting at offset $start."
+    }
+
+    $closeIndex = $State.Pos
+    $State.Pos++
+
+    $indent = if ($order.Count -gt 0) { Get-JsoncLineIndent $text $order[0].NameStart } else { '' }
+
+    return @{
+        Kind = 'Object'
+        Start = $start
+        End = $State.Pos
+        Members = $members
+        Order = $order.ToArray()
+        CloseIndex = $closeIndex
+        IsEmpty = ($order.Count -eq 0)
+        Indent = $indent
+    }
+}
+
+function Read-JsoncArray {
+    param([hashtable] $State)
+
+    $text = $State.Text
+    $start = $State.Pos
+    $State.Pos++   # past '['
+    $items = New-Object System.Collections.ArrayList
+
+    while ($true) {
+        Move-JsoncPastTrivia $State
+        if ($State.Pos -ge $State.Length) { throw "Unterminated array starting at offset $start." }
+        if ($text[$State.Pos] -eq ']') { $State.Pos++; break }
+
+        [void] $items.Add((Read-JsoncValue $State))
+
+        Move-JsoncPastTrivia $State
+        if ($State.Pos -ge $State.Length) { throw "Unterminated array starting at offset $start." }
+
+        $c = $text[$State.Pos]
+        if ($c -eq ',') { $State.Pos++; continue }
+        if ($c -eq ']') { $State.Pos++; break }
+        throw "Expected ',' or ']' in the array starting at offset $start, found '$c' at offset $($State.Pos)."
+    }
+
+    return @{ Kind = 'Array'; Start = $start; End = $State.Pos; Items = $items.ToArray() }
+}
+
+function Read-JsoncValue {
+    param([hashtable] $State)
+
+    Move-JsoncPastTrivia $State
+    if ($State.Pos -ge $State.Length) { throw "Unexpected end of JSON at offset $($State.Pos)." }
+
+    $c = $State.Text[$State.Pos]
+    if ($c -eq '{') { return Read-JsoncObject $State }
+    if ($c -eq '[') { return Read-JsoncArray $State }
+    return Read-JsoncScalar $State
+}
+
+# Walk JSON-with-comments once and return a node tree of character spans.
+function Read-JsoncTree {
+    param([Parameter(Mandatory)][string] $Json)
+
+    $state = @{ Text = $Json; Pos = 0; Length = $Json.Length }
+    $root = Read-JsoncValue $state
+    Move-JsoncPastTrivia $state
+    if ($state.Pos -lt $state.Length) {
+        throw "Unexpected character '$($Json[$state.Pos])' after the top-level value at offset $($state.Pos)."
+    }
+
+    return $root
+}
+
+# --- File encoding ------------------------------------------------------------
+# Encoding is observed, never assumed. A BOM is dropped before decoding so every span the
+# scanner records is relative to the first real character; Write-JsoncFile puts it back
+# through the encoding, so the two can never double up.
+
+function Read-JsoncFile {
+    param([Parameter(Mandatory)][string] $Path)
+
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+    $hasBom = ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF)
+    $offset = if ($hasBom) { 3 } else { 0 }
+    $text = (New-Object System.Text.UTF8Encoding($false)).GetString($bytes, $offset, $bytes.Length - $offset)
+
+    return @{ Text = $text; HasBom = $hasBom; Eol = (Get-JsoncEol $text) }
+}
+
+function Write-JsoncFile {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][AllowEmptyString()][string] $Text,
+        [bool] $HasBom
+    )
+
+    [System.IO.File]::WriteAllText($Path, $Text, (New-Object System.Text.UTF8Encoding($HasBom)))
+}

--- a/tests/WorktreeJsonEdit.Tests.ps1
+++ b/tests/WorktreeJsonEdit.Tests.ps1
@@ -184,4 +184,246 @@ Assert-ExactText (@(
     '}'
 ) -join "`r`n") $deepChain 'A three-name chain adds two spaces per level and honours CRLF.'
 
+# --- Set-JsoncValues ---
+
+# 1. Replacing a scalar keeps the comment above it and the comment below it.
+$doc = @(
+    '{',
+    '  // explains port',
+    '  "port": 5600,',
+    '  // explains name',
+    '  "name": "api"',
+    '}'
+) -join "`n"
+Assert-ExactText (@(
+    '{',
+    '  // explains port',
+    '  "port": 5604,',
+    '  // explains name',
+    '  "name": "api"',
+    '}'
+) -join "`n") (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('port'); Value = 5604 })) 'Comments around a replaced value must survive.'
+
+# 2. A one-line array elsewhere in the file is untouched by an unrelated edit.
+$doc = @(
+    '{',
+    '  "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],',
+    '  "AllowedHosts": "*"',
+    '}'
+) -join "`n"
+Assert-ExactText (@(
+    '{',
+    '  "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],',
+    '  "AllowedHosts": "localhost"',
+    '}'
+) -join "`n") (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('AllowedHosts'); Value = 'localhost' })) 'A one-line array must not be re-flowed.'
+
+# 3. A missing property is inserted last, at the parent's member indent.
+$doc = @('{', '  "environmentVariables": {', '    "A": "1"', '  }', '}') -join "`n"
+Assert-ExactText (@(
+    '{',
+    '  "environmentVariables": {',
+    '    "A": "1",',
+    '    "B": "2"',
+    '  }',
+    '}'
+) -join "`n") (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('environmentVariables', 'B'); Value = '2' })) 'An inserted property lands last at the parent indent.'
+
+# 4. A missing property in an empty object.
+$doc = @('{', '  "Cors": {}', '}') -join "`n"
+Assert-ExactText (@(
+    '{',
+    '  "Cors": {',
+    '    "AllowedOrigins": ["http://localhost:5605"]',
+    '  }',
+    '}'
+) -join "`n") (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('Cors', 'AllowedOrigins'); Value = @('http://localhost:5605') })) 'An empty object must be opened up correctly.'
+
+# 5. A missing intermediate section is created.
+$doc = @('{', '  "AllowedHosts": "*"', '}') -join "`n"
+Assert-ExactText (@(
+    '{',
+    '  "AllowedHosts": "*",',
+    '  "Cors": {',
+    '    "AllowedOrigins": ["http://localhost:5605"]',
+    '  }',
+    '}'
+) -join "`n") (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('Cors', 'AllowedOrigins'); Value = @('http://localhost:5605') })) 'A missing section must be created with its nested property.'
+
+# 6. An array-index path.
+$doc = @(
+    '{',
+    '  "configurations": [',
+    '    { "name": "a", "url": "http://localhost:5600" },',
+    '    { "name": "b" },',
+    '    { "name": "c", "url": "http://localhost:5600/swagger" }',
+    '  ]',
+    '}'
+) -join "`n"
+Assert-ExactText (@(
+    '{',
+    '  "configurations": [',
+    '    { "name": "a", "url": "http://localhost:5600" },',
+    '    { "name": "b" },',
+    '    { "name": "c", "url": "http://localhost:5604/swagger" }',
+    '  ]',
+    '}'
+) -join "`n") (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('configurations', 2, 'url'); Value = 'http://localhost:5604/swagger' })) 'An array index must select the right element.'
+
+# 7. Escaping in a written value.
+$doc = @('{', '  "v": "x"', '}') -join "`n"
+Assert-ExactText (@('{', '  "v": "a\"b\\c\td"', '}') -join "`n") `
+    (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('v'); Value = ('a"b\c' + [char] 9 + 'd') })) 'A written value must be escaped.'
+
+# 8. A trailing comma in the input survives.
+$doc = @('{', '  "a": 1,', '  "b": 2,', '}') -join "`n"
+Assert-ExactText (@('{', '  "a": 3,', '  "b": 2,', '}') -join "`n") `
+    (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('a'); Value = 3 })) 'A trailing comma must survive an edit.'
+
+# 9. Line endings are preserved in both directions.
+$crlf = @('{', '  "a": 1', '}') -join "`r`n"
+Assert-ExactText (@('{', '  "a": 1,', '  "b": 2', '}') -join "`r`n") `
+    (Set-JsoncValues -Json $crlf -Edits @(@{ Path = @('b'); Value = 2 })) 'A CRLF file must keep CRLF.'
+$lf = @('{', '  "a": 1', '}') -join "`n"
+Assert-ExactText (@('{', '  "a": 1,', '  "b": 2', '}') -join "`n") `
+    (Set-JsoncValues -Json $lf -Edits @(@{ Path = @('b'); Value = 2 })) 'An LF file must keep LF.'
+
+# 10. Applying the same edits twice is byte-identical.
+$doc = @('{', '  "environmentVariables": {', '    "A": "1"', '  }', '}') -join "`n"
+$edits = @(
+    @{ Path = @('environmentVariables', 'A'); Value = '9' },
+    @{ Path = @('environmentVariables', 'B'); Value = '2' }
+)
+$once = Set-JsoncValues -Json $doc -Edits $edits
+$twice = Set-JsoncValues -Json $once -Edits $edits
+Assert-ExactText $once $twice 'Re-applying the same edits must change nothing.'
+
+# 11. An out-of-range array index throws, naming the path and the offset.
+$doc = @('{', '  "configurations": [ { "url": "a" } ]', '}') -join "`n"
+Assert-Throws { Set-JsoncValues -Json $doc -Edits @(@{ Path = @('configurations', 5, 'url'); Value = 'b' }) } `
+    'configurations\.5\.url.*offset' 'An out-of-range index must name the path and the offset.'
+
+# 12. Inserting after a member that carries a trailing // comment.
+$doc = @('{', '  "a": 1 // explains a', '}') -join "`n"
+Assert-ExactText (@('{', '  "a": 1, // explains a', '  "b": 2', '}') -join "`n") `
+    (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('b'); Value = 2 })) 'The comma must land before a trailing line comment.'
+
+# 13. Inserting after a member that carries a trailing block comment.
+$doc = @('{', '  "a": 1 /* note */', '}') -join "`n"
+Assert-ExactText (@('{', '  "a": 1, /* note */', '  "b": 2', '}') -join "`n") `
+    (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('b'); Value = 2 })) 'The comma must land before a trailing block comment.'
+
+# 14. Inserting after a member whose block comment closes lines later.
+$doc = @('{', '  "a": 1 /* note', '     more note */', '}') -join "`n"
+Assert-ExactText (@('{', '  "a": 1, /* note', '     more note */', '  "b": 2', '}') -join "`n") `
+    (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('b'); Value = 2 })) 'A multi-line trailing comment must stay whole.'
+
+# 15. Inserting after a member that already has a trailing comma writes no second comma.
+$doc = @('{', '  "a": 1,', '}') -join "`n"
+Assert-ExactText (@('{', '  "a": 1,', '  "b": 2', '}') -join "`n") `
+    (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('b'); Value = 2 })) 'An existing trailing comma is reused as the separator.'
+
+# 16. Overlapping edits are rejected before anything is written.
+$doc = @('{', '  "a": { "b": 1 }', '}') -join "`n"
+Assert-Throws { Set-JsoncValues -Json $doc -Edits @(
+        @{ Path = @('a'); Value = 'x' },
+        @{ Path = @('a', 'b'); Value = 2 }
+    ) } 'Conflicting JSON edits' 'Two edits whose spans overlap must throw.'
+
+# 17. Two missing sections under the same parent produce one comma each and stay valid JSON.
+$doc = @('{', '  "AllowedHosts": "*"', '}') -join "`n"
+$actual = Set-JsoncValues -Json $doc -Edits @(
+    @{ Path = @('Cors', 'AllowedOrigins'); Value = @('http://localhost:5605') },
+    @{ Path = @('ConnectionStrings', 'DefaultConnection'); Value = 'Server=localhost' }
+)
+Assert-ExactText (@(
+    '{',
+    '  "AllowedHosts": "*",',
+    '  "Cors": {',
+    '    "AllowedOrigins": ["http://localhost:5605"]',
+    '  },',
+    '  "ConnectionStrings": {',
+    '    "DefaultConnection": "Server=localhost"',
+    '  }',
+    '}'
+) -join "`n") $actual 'Two missing sections under one parent must be written as two members.'
+Assert-True ([bool] ($actual | ConvertFrom-Json)) 'Two missing sections must still produce parseable JSON.'
+
+# 18. Two missing keys in the same non-empty object, alongside a replacement in it.
+$doc = @(
+    '{',
+    '  "environmentVariables": {',
+    '    "ASPNETCORE_ENVIRONMENT": "Development",',
+    '    "AHKFLOW_START_DOCKER_SQL": "true"',
+    '  }',
+    '}'
+) -join "`n"
+$actual = Set-JsoncValues -Json $doc -Edits @(
+    @{ Path = @('environmentVariables', 'ASPNETCORE_ENVIRONMENT'); Value = 'Staging' },
+    @{ Path = @('environmentVariables', 'COMPOSE_PROJECT_NAME'); Value = 'ahkflowapp-wt' },
+    @{ Path = @('environmentVariables', 'AHKFLOW_SQL_PORT'); Value = '14330' }
+)
+Assert-ExactText (@(
+    '{',
+    '  "environmentVariables": {',
+    '    "ASPNETCORE_ENVIRONMENT": "Staging",',
+    '    "AHKFLOW_START_DOCKER_SQL": "true",',
+    '    "COMPOSE_PROJECT_NAME": "ahkflowapp-wt",',
+    '    "AHKFLOW_SQL_PORT": "14330"',
+    '  }',
+    '}'
+) -join "`n") $actual 'Two inserted keys must be separated by one comma each.'
+Assert-True ([bool] ($actual | ConvertFrom-Json)) 'Two inserted keys must still produce parseable JSON.'
+
+# 19. Two missing keys in an empty object.
+$doc = @('{', '  "environmentVariables": {}', '}') -join "`n"
+Assert-ExactText (@(
+    '{',
+    '  "environmentVariables": {',
+    '    "A": "1",',
+    '    "B": "2"',
+    '  }',
+    '}'
+) -join "`n") (Set-JsoncValues -Json $doc -Edits @(
+    @{ Path = @('environmentVariables', 'A'); Value = '1' },
+    @{ Path = @('environmentVariables', 'B'); Value = '2' }
+)) 'Two inserted keys in an empty object must be separated by a comma.'
+
+# 20. An object holding only comments keeps them when a member is inserted.
+$doc = @(
+    '{',
+    '  "Cors": {',
+    '    // keep this explanation',
+    '  }',
+    '}'
+) -join "`n"
+Assert-ExactText (@(
+    '{',
+    '  "Cors": {',
+    '    // keep this explanation',
+    '    "AllowedOrigins": ["http://localhost:5605"]',
+    '  }',
+    '}'
+) -join "`n") (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('Cors', 'AllowedOrigins'); Value = @('http://localhost:5605') })) 'A comment-only object must keep its comment.'
+
+# 21. A comment-only object written on one line keeps its comment too.
+$doc = @('{', '  "Cors": { /* why */ }', '}') -join "`n"
+Assert-ExactText (@(
+    '{',
+    '  "Cors": { /* why */',
+    '    "AllowedOrigins": []',
+    '  }',
+    '}'
+) -join "`n") (Set-JsoncValues -Json $doc -Edits @(@{ Path = @('Cors', 'AllowedOrigins'); Value = @() })) 'A one-line comment-only object must keep its comment.'
+
+# 22. Grouped insertions are idempotent too.
+$doc = @('{', '  "AllowedHosts": "*"', '}') -join "`n"
+$groupEdits = @(
+    @{ Path = @('Cors', 'AllowedOrigins'); Value = @('http://localhost:5605') },
+    @{ Path = @('ConnectionStrings', 'DefaultConnection'); Value = 'Server=localhost' }
+)
+$once = Set-JsoncValues -Json $doc -Edits $groupEdits
+$twice = Set-JsoncValues -Json $once -Edits $groupEdits
+Assert-ExactText $once $twice 'Re-applying grouped insertions must change nothing.'
+
 Write-Host 'Worktree JSON edit tests passed.'

--- a/tests/WorktreeJsonEdit.Tests.ps1
+++ b/tests/WorktreeJsonEdit.Tests.ps1
@@ -151,4 +151,37 @@ Assert-True (-not ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq
 Remove-Item -LiteralPath (Split-Path -Parent $noBomPath) -Recurse -Force -ErrorAction SilentlyContinue
 Remove-Item -LiteralPath (Split-Path -Parent $bomPath) -Recurse -Force -ErrorAction SilentlyContinue
 
+# --- Literal writers ---
+
+Assert-ExactText '"api"' (ConvertTo-JsonLiteral 'api') 'A string becomes a quoted literal.'
+Assert-ExactText '"a\"b\\c\td"' (ConvertTo-JsonLiteral ('a"b\c' + [char] 9 + 'd')) 'Quote, backslash, and tab must be escaped.'
+Assert-ExactText (('"' + [char]92 + 'u0001"')) (ConvertTo-JsonLiteral ([string] [char] 1)) "A control character becomes a backslash-u escape."
+Assert-ExactText ('"caf' + [char] 233 + '"') (ConvertTo-JsonLiteral ('caf' + [char] 233)) 'Non-ASCII is written literally.'
+Assert-ExactText 'true' (ConvertTo-JsonLiteral $true) 'A true boolean becomes true.'
+Assert-ExactText 'false' (ConvertTo-JsonLiteral $false) 'A false boolean becomes false.'
+Assert-ExactText '5602' (ConvertTo-JsonLiteral 5602) 'An integer becomes invariant digits.'
+Assert-ExactText '["a","b"]' (ConvertTo-JsonLiteral @('a', 'b')) 'A string array stays on one line.'
+Assert-ExactText '[]' (ConvertTo-JsonLiteral @()) 'An empty array becomes [].'
+Assert-Throws { ConvertTo-JsonLiteral ([pscustomobject]@{ a = 1 }) } 'cannot write' 'An unsupported type must throw.'
+
+Assert-ExactText '"BaseAddress": "http://localhost:5602"' `
+    (New-JsoncChainLiteral -Names @('BaseAddress') -Value 'http://localhost:5602' -Indent '  ' -Eol "`n") `
+    'A single name produces one property.'
+
+$chain = New-JsoncChainLiteral -Names @('Cors', 'AllowedOrigins') -Value @('http://localhost:5605') -Indent '  ' -Eol "`n"
+Assert-ExactText (@(
+    '"Cors": {',
+    '    "AllowedOrigins": ["http://localhost:5605"]',
+    '  }'
+) -join "`n") $chain 'A two-name chain nests one object level and closes at the parent indent.'
+
+$deepChain = New-JsoncChainLiteral -Names @('a', 'b', 'c') -Value 1 -Indent '' -Eol "`r`n"
+Assert-ExactText (@(
+    '"a": {',
+    '  "b": {',
+    '    "c": 1',
+    '  }',
+    '}'
+) -join "`r`n") $deepChain 'A three-name chain adds two spaces per level and honours CRLF.'
+
 Write-Host 'Worktree JSON edit tests passed.'

--- a/tests/WorktreeJsonEdit.Tests.ps1
+++ b/tests/WorktreeJsonEdit.Tests.ps1
@@ -1,0 +1,154 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+. (Join-Path $repoRoot 'scripts\worktree-json.common.ps1')
+
+function Assert-ExactText {
+    param([string] $Expected, [string] $Actual, [string] $Message)
+    if (-not [string]::Equals($Expected, $Actual, [System.StringComparison]::Ordinal)) {
+        throw "$Message`n--- expected ---`n$Expected`n--- actual ---`n$Actual`n---"
+    }
+}
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { throw $Message }
+}
+
+function Assert-Throws {
+    param([scriptblock] $Action, [string] $Pattern, [string] $Message)
+    try {
+        & $Action
+    } catch {
+        if ("$_" -notmatch $Pattern) { throw "$Message (message '$_' does not match '$Pattern')" }
+        return
+    }
+    throw "$Message (no exception was thrown)"
+}
+
+function New-TempJsonPath {
+    $dir = Join-Path ([System.IO.Path]::GetTempPath()) ('wtjson-' + [guid]::NewGuid().ToString('N').Substring(0, 8))
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    return (Join-Path $dir 'sample.json')
+}
+
+# --- Scanner: spans, comments, trailing commas ---
+
+$sample = @(
+    '{',
+    '  // leading comment',
+    '  "port": 5600,',
+    '  "name": "api"',
+    '}'
+) -join "`n"
+
+$tree = Read-JsoncTree $sample
+Assert-True ($tree.Kind -eq 'Object') 'Root must be an object node.'
+Assert-True (-not $tree.IsEmpty) 'Root object must not be reported as empty.'
+Assert-ExactText '  ' $tree.Indent 'Root members are indented two spaces.'
+Assert-True ($tree.Order.Count -eq 2) 'Root must have two members.'
+
+$portMember = $tree.Members['port']
+Assert-ExactText '5600' $sample.Substring($portMember.Value.Start, $portMember.Value.End - $portMember.Value.Start) 'The port span must cover exactly 5600.'
+Assert-True ($portMember.CommaIndex -gt 0) 'The port member must record its comma.'
+
+$nameMember = $tree.Members['name']
+Assert-ExactText '"api"' $sample.Substring($nameMember.Value.Start, $nameMember.Value.End - $nameMember.Value.Start) 'The name span must cover the quoted value.'
+Assert-True ($nameMember.CommaIndex -eq -1) 'The last member has no comma.'
+
+# A trailing comma before the closing brace is legal JSONC and must parse.
+$trailing = Read-JsoncTree (@('{', '  "a": 1,', '}') -join "`n")
+Assert-True ($trailing.Order.Count -eq 1) 'A trailing comma must not create a phantom member.'
+
+# --- Scanner: LineEnd keeps trailing comments attached ---
+
+$commented = @('{', '  "a": 1 // explains a', '}') -join "`n"
+$commentedTree = Read-JsoncTree $commented
+$aMember = $commentedTree.Members['a']
+Assert-ExactText '1' $commented.Substring($aMember.Value.Start, $aMember.Value.End - $aMember.Value.Start) 'The value span stops at the number.'
+Assert-ExactText '  "a": 1 // explains a' $commented.Substring(0, $aMember.LineEnd).Split("`n")[-1] 'LineEnd must sit after the trailing comment.'
+
+$blockCommented = @('{', '  "a": 1 /* note', '     more note */', '}') -join "`n"
+$blockTree = Read-JsoncTree $blockCommented
+Assert-ExactText '*/' $blockCommented.Substring($blockTree.Members['a'].LineEnd - 2, 2) 'LineEnd must sit after a multi-line block comment.'
+
+# --- Scanner: arrays and empty objects ---
+
+$arrayDoc = @('{', '  "items": [1, 2, 3],', '  "empty": {}', '}') -join "`n"
+$arrayTree = Read-JsoncTree $arrayDoc
+Assert-True ($arrayTree.Members['items'].Value.Kind -eq 'Array') 'items must be an array node.'
+Assert-True ($arrayTree.Members['items'].Value.Items.Count -eq 3) 'items must have three entries.'
+Assert-ExactText '2' $arrayDoc.Substring($arrayTree.Members['items'].Value.Items[1].Start, 1) 'The second array item span must cover 2.'
+Assert-True ($arrayTree.Members['empty'].Value.IsEmpty) 'An empty object must report IsEmpty.'
+
+# --- Scanner: malformed input throws with an offset ---
+
+Assert-Throws { Read-JsoncTree '{ "a": 1 ' } 'offset' 'An unterminated object must throw with an offset.'
+Assert-Throws { Read-JsoncTree '{ "a" 1 }' } 'offset' 'A missing colon must throw with an offset.'
+Assert-Throws { Read-JsoncTree '{ "a": nonsense }' } "Invalid JSON value 'nonsense'.*offset" 'A bare word must not be accepted as a value.'
+Assert-Throws { Read-JsoncTree '{ "a": 01 }' } "Invalid JSON value '01'.*offset" 'A leading zero must not be accepted as a number.'
+Assert-Throws { Read-JsoncTree '{ "a": True }' } "Invalid JSON value 'True'.*offset" 'JSON literals are lower case only.'
+Assert-Throws { Read-JsoncTree '{ "a": "x\qy" }' } 'Invalid escape.*offset' 'An unknown string escape must throw.'
+Assert-Throws { Read-JsoncTree '{ "a": "x\u12zz" }' } 'Invalid \\u escape.*offset' 'A malformed \u escape must throw.'
+
+foreach ($valid in @('0', '-0', '5600', '-12', '1.5', '-1.5e10', '2E+3', 'true', 'false', 'null')) {
+    $parsed = Read-JsoncTree ('{ "a": ' + $valid + ' }')
+    Assert-True ($parsed.Members.ContainsKey('a')) "The value $valid must parse."
+}
+
+# A literal tab inside a string is illegal by the JSON grammar but ConvertFrom-Json accepts
+# it, so the scanner must not be stricter than the parser this repo already ships.
+$tabbed = Read-JsoncTree ('{ "a": "x' + [char] 9 + 'y" }')
+Assert-True ($tabbed.Members.ContainsKey('a')) 'A literal control character inside a string must still parse.'
+
+# --- Line ending detection ---
+
+Assert-ExactText "`r`n" (Get-JsoncEol "{`r`n  `"a`": 1`r`n}") 'A CRLF document must report CRLF.'
+Assert-ExactText "`n" (Get-JsoncEol "{`n  `"a`": 1`n}") 'An LF document must report LF.'
+Assert-ExactText "`n" (Get-JsoncEol '{"a":1}') 'A document with no line break defaults to LF.'
+
+# --- Line indent ---
+
+$indentDoc = "{`n    `"a`": 1`n}"
+Assert-ExactText '    ' (Get-JsoncLineIndent $indentDoc $indentDoc.IndexOf('"a"')) 'Get-JsoncLineIndent returns the whitespace prefix.'
+
+# --- String literal decoding ---
+
+Assert-ExactText "a`tb" (ConvertFrom-JsoncStringLiteral '"a\tb"') 'A \t escape must decode to a tab.'
+Assert-ExactText 'a"b\c' (ConvertFrom-JsoncStringLiteral '"a\"b\\c"') 'Quote and backslash escapes must decode.'
+Assert-ExactText 'AB' (ConvertFrom-JsoncStringLiteral ('"' + [char]92 + 'u0041' + [char]92 + 'u0042"')) 'A \u escape must decode.'
+
+# --- Read-JsoncFile / Write-JsoncFile ---
+
+$noBomPath = New-TempJsonPath
+[System.IO.File]::WriteAllText($noBomPath, "{`n  `"a`": 1`n}", (New-Object System.Text.UTF8Encoding($false)))
+$noBom = Read-JsoncFile $noBomPath
+Assert-True (-not $noBom.HasBom) 'A file without a BOM must report HasBom false.'
+Assert-ExactText '{' $noBom.Text.Substring(0, 1) 'Text must start at the first real character.'
+Assert-ExactText "`n" $noBom.Eol 'The LF file must report LF.'
+
+$bomPath = New-TempJsonPath
+[System.IO.File]::WriteAllText($bomPath, "{`r`n  `"a`": 1`r`n}", (New-Object System.Text.UTF8Encoding($true)))
+$withBom = Read-JsoncFile $bomPath
+Assert-True $withBom.HasBom 'A file with a BOM must report HasBom true.'
+Assert-ExactText '{' $withBom.Text.Substring(0, 1) 'The BOM must be dropped before decoding.'
+Assert-ExactText "`r`n" $withBom.Eol 'The CRLF file must report CRLF.'
+
+Write-JsoncFile -Path $bomPath -Text $withBom.Text -HasBom $withBom.HasBom
+$bytes = [System.IO.File]::ReadAllBytes($bomPath)
+Assert-True ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) 'Writing back a BOM file must keep the BOM.'
+
+Write-JsoncFile -Path $noBomPath -Text $noBom.Text -HasBom $noBom.HasBom
+$bytes = [System.IO.File]::ReadAllBytes($noBomPath)
+Assert-True (-not ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF)) 'Writing back a BOM-free file must not add a BOM.'
+
+Remove-Item -LiteralPath (Split-Path -Parent $noBomPath) -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath (Split-Path -Parent $bomPath) -Recurse -Force -ErrorAction SilentlyContinue
+
+Write-Host 'Worktree JSON edit tests passed.'

--- a/tests/WorktreeJsonEdit.Tests.ps1
+++ b/tests/WorktreeJsonEdit.Tests.ps1
@@ -426,4 +426,99 @@ $once = Set-JsoncValues -Json $doc -Edits $groupEdits
 $twice = Set-JsoncValues -Json $once -Edits $groupEdits
 Assert-ExactText $once $twice 'Re-applying grouped insertions must change nothing.'
 
+# 23. Two edits under one missing ancestor merge into a single section.
+# Rendering each chain on its own writes the ancestor twice. ConvertFrom-Json keeps only the
+# last duplicate, so the first edit disappears without any error.
+$doc = @('{', '  "AllowedHosts": "*"', '}') -join "`n"
+$actual = Set-JsoncValues -Json $doc -Edits @(
+    @{ Path = @('parent', 'child', 'a'); Value = 1 },
+    @{ Path = @('parent', 'child', 'b'); Value = 2 }
+)
+Assert-ExactText (@(
+    '{',
+    '  "AllowedHosts": "*",',
+    '  "parent": {',
+    '    "child": {',
+    '      "a": 1,',
+    '      "b": 2',
+    '    }',
+    '  }',
+    '}'
+) -join "`n") $actual 'Two edits under one missing ancestor must merge into a single section.'
+$parsed = $actual | ConvertFrom-Json
+Assert-True ($parsed.parent.child.a -eq 1) 'The first edit under a shared missing ancestor must survive.'
+Assert-True ($parsed.parent.child.b -eq 2) 'The second edit under a shared missing ancestor must survive.'
+
+# 24. The merge only joins the segments the edits actually share.
+$doc = @('{', '  "AllowedHosts": "*"', '}') -join "`n"
+$actual = Set-JsoncValues -Json $doc -Edits @(
+    @{ Path = @('root', 'left', 'a'); Value = 1 },
+    @{ Path = @('root', 'right', 'b'); Value = 2 },
+    @{ Path = @('root', 'top'); Value = 3 }
+)
+Assert-ExactText (@(
+    '{',
+    '  "AllowedHosts": "*",',
+    '  "root": {',
+    '    "left": {',
+    '      "a": 1',
+    '    },',
+    '    "right": {',
+    '      "b": 2',
+    '    },',
+    '    "top": 3',
+    '  }',
+    '}'
+) -join "`n") $actual 'A shared ancestor must branch where the paths diverge.'
+Assert-True ([bool] ($actual | ConvertFrom-Json)) 'A branching merge must still produce parseable JSON.'
+
+# 25. Merging into an empty object works the same way.
+$doc = @('{', '  "Cors": {}', '}') -join "`n"
+Assert-ExactText (@(
+    '{',
+    '  "Cors": {',
+    '    "inner": {',
+    '      "a": 1,',
+    '      "b": 2',
+    '    }',
+    '  }',
+    '}'
+) -join "`n") (Set-JsoncValues -Json $doc -Edits @(
+    @{ Path = @('Cors', 'inner', 'a'); Value = 1 },
+    @{ Path = @('Cors', 'inner', 'b'); Value = 2 }
+)) 'A shared missing ancestor inside an empty object must merge too.'
+
+# 26. Merged insertions stay idempotent.
+$doc = @('{', '  "AllowedHosts": "*"', '}') -join "`n"
+$mergeEdits = @(
+    @{ Path = @('parent', 'child', 'a'); Value = 1 },
+    @{ Path = @('parent', 'child', 'b'); Value = 2 }
+)
+$once = Set-JsoncValues -Json $doc -Edits $mergeEdits
+$twice = Set-JsoncValues -Json $once -Edits $mergeEdits
+Assert-ExactText $once $twice 'Re-applying merged insertions must change nothing.'
+
+# 27. One name cannot be both a value and a parent object.
+$doc = @('{', '  "AllowedHosts": "*"', '}') -join "`n"
+Assert-Throws { Set-JsoncValues -Json $doc -Edits @(
+        @{ Path = @('parent'); Value = 1 },
+        @{ Path = @('parent', 'child'); Value = 2 }
+    ) } 'Conflicting JSON edits' 'A name used as both a value and a parent must throw.'
+Assert-Throws { Set-JsoncValues -Json $doc -Edits @(
+        @{ Path = @('parent', 'child'); Value = 1 },
+        @{ Path = @('parent', 'child'); Value = 2 }
+    ) } 'Conflicting JSON edits' 'Two edits writing the same missing path must throw.'
+
+# --- Unsupported values name the path and the offset ---
+
+# 28. On the replace path.
+$doc = @('{', '  "v": "x"', '}') -join "`n"
+Assert-Throws { Set-JsoncValues -Json $doc -Edits @(@{ Path = @('v'); Value = ([pscustomobject]@{ a = 1 }) }) } `
+    "JSON edit 'v'.*offset" 'An unsupported replacement value must name the path and the offset.'
+
+# 29. On the insert path, which reaches the writer through New-JsoncChainLiteral.
+$doc = @('{', '  "AllowedHosts": "*"', '}') -join "`n"
+Assert-Throws { Set-JsoncValues -Json $doc -Edits @(@{ Path = @('Cors', 'AllowedOrigins'); Value = ([pscustomobject]@{ a = 1 }) }) } `
+    "JSON edit 'Cors\.AllowedOrigins'.*offset" 'An unsupported inserted value must name the path and the offset.'
+
 Write-Host 'Worktree JSON edit tests passed.'

--- a/tests/WorktreeLocalDevSetup.Tests.ps1
+++ b/tests/WorktreeLocalDevSetup.Tests.ps1
@@ -9,6 +9,12 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
 $setupScript = Join-Path $repoRoot 'scripts\setup-worktree-local-dev.ps1'
 
+# ConvertTo-JsonStringLiteral builds expected lines; New-WorktreeConnectionString computes the
+# expected per-worktree connection string exactly as the setup script does.
+. (Join-Path $repoRoot 'scripts\worktree-database.common.ps1')
+
+$SeedConnection = 'Server=localhost,1433;Database=AHKFlowAppDb;User Id=sa;Password=Dev!LocalOnly_2026;TrustServerCertificate=True;MultipleActiveResultSets=true'
+
 function Assert-True {
     param([bool] $Condition, [string] $Message)
     if (-not $Condition) { throw $Message }
@@ -21,82 +27,344 @@ function Assert-Equal {
     }
 }
 
+function Assert-ExactText {
+    param([string] $Expected, [string] $Actual, [string] $Message)
+    if (-not [string]::Equals($Expected, $Actual, [System.StringComparison]::Ordinal)) {
+        throw "$Message`n--- expected ---`n$Expected`n--- actual ---`n$Actual`n---"
+    }
+}
+
+function Write-SeedFile {
+    param([string] $Path, [string[]] $Lines, [switch] $WithBom)
+    New-Item -ItemType Directory -Path (Split-Path -Parent $Path) -Force | Out-Null
+    [System.IO.File]::WriteAllText($Path, ($Lines -join "`n"), (New-Object System.Text.UTF8Encoding($WithBom.IsPresent)))
+}
+
+function Test-FileHasBom {
+    param([string] $Path)
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+    return ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF)
+}
+
+function Get-FileTextWithoutBom {
+    param([string] $Path)
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+    $offset = if (Test-FileHasBom $Path) { 3 } else { 0 }
+    return (New-Object System.Text.UTF8Encoding($false)).GetString($bytes, $offset, $bytes.Length - $offset)
+}
+
+# Idempotence is a claim about bytes, not about decoded text. Comparing BOM-stripped text
+# would pass even if a second run flipped the BOM.
+function Get-FileByteHash {
+    param([string] $Path)
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        return [BitConverter]::ToString($sha.ComputeHash([System.IO.File]::ReadAllBytes($Path)))
+    } finally {
+        $sha.Dispose()
+    }
+}
+
 function Invoke-TestGit {
     param([string] $RepoDir, [string[]] $GitArgs)
-    $out = & git -C $RepoDir @GitArgs 2>&1
+    # Windows PowerShell 5.1 turns native stderr into an ErrorRecord, which $ErrorActionPreference
+    # = 'Stop' then treats as terminating. git writes progress to stderr, so the exit code is the
+    # only reliable success signal on both hosts.
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $out = & git -C $RepoDir @GitArgs 2>&1
+    } finally {
+        $ErrorActionPreference = $previous
+    }
     if ($LASTEXITCODE -ne 0) {
         throw "git $($GitArgs -join ' ') failed: $out"
     }
     return $out
 }
 
-# Fresh main-checkout repo seeded with just the tracked backend appsettings the setup script reads
-# to derive the per-worktree database (Get-WorktreeDatabaseConfig). Worktrees are created as
-# siblings, matching the harness in the other Worktree*.Tests.ps1 files.
+# Each seed mirrors the shape of the real committed file closely enough to exercise its
+# writer: the launch.json comments, the one-line arrays, and the profiles that carry the
+# Docker SQL marker.
+
+function Get-SeedVsCodeLaunch {
+    return @(
+        '{',
+        '  "version": "0.2.0",',
+        '  "configurations": [',
+        '    {',
+        '      "name": "API: Docker SQL (Recommended)",',
+        '      "type": "coreclr",',
+        '      // internalConsole is required for serverReadyAction: VS Code only scans the Debug',
+        '      // Console for the pattern below (never an external/integrated terminal).',
+        '      "console": "internalConsole",',
+        '      "serverReadyAction": {',
+        '        "action": "openExternally",',
+        '        "pattern": "\\bNow listening on:",',
+        '        "uriFormat": "http://localhost:5600/swagger"',
+        '      }',
+        '    },',
+        '    {',
+        '      "name": "Open Swagger (Chrome)",',
+        '      "type": "chrome",',
+        '      "request": "launch",',
+        '      "url": "http://localhost:5600/swagger"',
+        '    },',
+        '    {',
+        '      "name": "UI: http",',
+        '      "type": "blazorwasm",',
+        '      "url": "http://localhost:5601",',
+        '      // Keep the UI debugger on an isolated Chrome profile. Reusing the default profile',
+        '      // can hand startup off to an existing Chrome process and reintroduce cold-start crashes.',
+        '      "browserConfig": {',
+        '        "userDataDir": "${workspaceFolder}/.vscode/chrome-debug-profile"',
+        '      }',
+        '    }',
+        '  ],',
+        '  "compounds": [',
+        '    {',
+        '      "name": "Full Stack: Docker SQL (Recommended)",',
+        '      "configurations": ["API: Docker SQL (Recommended)", "UI: http"],',
+        '      "stopAll": true',
+        '    }',
+        '  ]',
+        '}'
+    )
+}
+
+function Get-ExpectedVsCodeLaunch {
+    param([string] $ApiUrl, [string] $UiUrl)
+
+    $lines = Get-SeedVsCodeLaunch
+    $expected = @()
+    foreach ($line in $lines) {
+        if ($line -eq '        "uriFormat": "http://localhost:5600/swagger"') {
+            $expected += "        `"uriFormat`": `"$ApiUrl/swagger`""
+        } elseif ($line -eq '      "url": "http://localhost:5600/swagger"') {
+            $expected += "      `"url`": `"$ApiUrl/swagger`""
+        } elseif ($line -eq '      "url": "http://localhost:5601",') {
+            $expected += "      `"url`": `"$UiUrl`","
+        } else {
+            $expected += $line
+        }
+    }
+    return $expected
+}
+
+function Get-SeedBackendLaunchSettings {
+    return @(
+        '{',
+        '  "$schema": "https://json.schemastore.org/launchsettings.json",',
+        '  "profiles": {',
+        '    "Docker SQL (Recommended)": {',
+        '      "commandName": "Project",',
+        '      "environmentVariables": {',
+        '        "ASPNETCORE_ENVIRONMENT": "Development",',
+        '        "AHKFLOW_START_DOCKER_SQL": "true",',
+        '        "COMPOSE_PROJECT_NAME": "ahkflowapp",',
+        "        `"ConnectionStrings__DefaultConnection`": `"$SeedConnection`"",
+        '      },',
+        '      "applicationUrl": "http://localhost:5600"',
+        '    },',
+        '    "Docker SQL (No Auth)": {',
+        '      "commandName": "Project",',
+        '      "environmentVariables": {',
+        '        "ASPNETCORE_ENVIRONMENT": "Development",',
+        '        "AHKFLOW_START_DOCKER_SQL": "true",',
+        '        "COMPOSE_PROJECT_NAME": "ahkflowapp",',
+        "        `"ConnectionStrings__DefaultConnection`": `"$SeedConnection`",",
+        '        "Auth__UseTestProvider": "true"',
+        '      },',
+        '      "applicationUrl": "http://localhost:5600"',
+        '    },',
+        '    "LocalDB SQL": {',
+        '      "commandName": "Project",',
+        '      "environmentVariables": {',
+        '        "ASPNETCORE_ENVIRONMENT": "Development",',
+        '        "AHKFLOW_START_DOCKER_SQL": "false"',
+        '      },',
+        '      "applicationUrl": "http://localhost:5600"',
+        '    }',
+        '  }',
+        '}'
+    )
+}
+
+function Get-ExpectedBackendLaunchSettings {
+    param([string] $ApiUrl, [string] $ComposeProject, [string] $SqlPort)
+
+    $builder = New-Object System.Data.SqlClient.SqlConnectionStringBuilder($SeedConnection)
+    $builder['Data Source'] = "localhost,$SqlPort"
+    $connectionLiteral = ConvertTo-JsonStringLiteral $builder.ConnectionString
+    $portLiteral = ConvertTo-JsonStringLiteral $SqlPort
+    $projectLiteral = ConvertTo-JsonStringLiteral $ComposeProject
+
+    return @(
+        '{',
+        '  "$schema": "https://json.schemastore.org/launchsettings.json",',
+        '  "profiles": {',
+        '    "Docker SQL (Recommended)": {',
+        '      "commandName": "Project",',
+        '      "environmentVariables": {',
+        '        "ASPNETCORE_ENVIRONMENT": "Development",',
+        '        "AHKFLOW_START_DOCKER_SQL": "true",',
+        "        `"COMPOSE_PROJECT_NAME`": $projectLiteral,",
+        "        `"ConnectionStrings__DefaultConnection`": $connectionLiteral,",
+        "        `"AHKFLOW_SQL_PORT`": $portLiteral",
+        '      },',
+        "      `"applicationUrl`": `"$ApiUrl`"",
+        '    },',
+        '    "Docker SQL (No Auth)": {',
+        '      "commandName": "Project",',
+        '      "environmentVariables": {',
+        '        "ASPNETCORE_ENVIRONMENT": "Development",',
+        '        "AHKFLOW_START_DOCKER_SQL": "true",',
+        "        `"COMPOSE_PROJECT_NAME`": $projectLiteral,",
+        "        `"ConnectionStrings__DefaultConnection`": $connectionLiteral,",
+        '        "Auth__UseTestProvider": "true",',
+        "        `"AHKFLOW_SQL_PORT`": $portLiteral",
+        '      },',
+        "      `"applicationUrl`": `"$ApiUrl`"",
+        '    },',
+        '    "LocalDB SQL": {',
+        '      "commandName": "Project",',
+        '      "environmentVariables": {',
+        '        "ASPNETCORE_ENVIRONMENT": "Development",',
+        '        "AHKFLOW_START_DOCKER_SQL": "false"',
+        '      },',
+        "      `"applicationUrl`": `"$ApiUrl`"",
+        '    }',
+        '  }',
+        '}'
+    )
+}
+
+function Get-SeedBackendAppSettings {
+    return @(
+        '{',
+        '  "ConnectionStrings": {',
+        "    `"DefaultConnection`": `"$SeedConnection`"",
+        '  },',
+        '  "Serilog": {',
+        '    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ]',
+        '  },',
+        '  "AllowedHosts": "*",',
+        '  "Cors": {',
+        '    "AllowedOrigins": []',
+        '  }',
+        '}'
+    )
+}
+
+function Get-ExpectedBackendAppSettings {
+    param([string] $UiUrl, [string] $DbName)
+
+    $connectionLiteral = ConvertTo-JsonStringLiteral (New-WorktreeConnectionString -ConnectionString $SeedConnection -DbName $DbName)
+
+    return @(
+        '{',
+        '  "ConnectionStrings": {',
+        "    `"DefaultConnection`": $connectionLiteral",
+        '  },',
+        '  "Serilog": {',
+        '    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ]',
+        '  },',
+        '  "AllowedHosts": "*",',
+        '  "Cors": {',
+        "    `"AllowedOrigins`": [`"$UiUrl`"]",
+        '  }',
+        '}'
+    )
+}
+
+function Get-SeedFrontendLaunchSettings {
+    return @(
+        '{',
+        '  "$schema": "http://json.schemastore.org/launchsettings.json",',
+        '  "profiles": {',
+        '    "http": {',
+        '      "commandName": "Project",',
+        '      "applicationUrl": "http://localhost:5601",',
+        '      "environmentVariables": {',
+        '        "ASPNETCORE_ENVIRONMENT": "Development"',
+        '      }',
+        '    }',
+        '  }',
+        '}'
+    )
+}
+
+function Get-ExpectedFrontendLaunchSettings {
+    param([string] $UiUrl)
+
+    $lines = Get-SeedFrontendLaunchSettings
+    $expected = @()
+    foreach ($line in $lines) {
+        if ($line -eq '      "applicationUrl": "http://localhost:5601",') {
+            $expected += "      `"applicationUrl`": `"$UiUrl`","
+        } else {
+            $expected += $line
+        }
+    }
+    return $expected
+}
+
+function Get-SeedFrontendAppSettings {
+    return @(
+        '{',
+        '  "ApiHttpClient": {',
+        '    "BaseAddress": "http://localhost:5600"',
+        '  },',
+        '  "AzureAd": {',
+        '    "Instance": "https://login.microsoftonline.com/",',
+        '    "ValidateAuthority": true',
+        '  }',
+        '}'
+    )
+}
+
+function Get-ExpectedFrontendAppSettings {
+    param([string] $ApiUrl)
+
+    $lines = Get-SeedFrontendAppSettings
+    $expected = @()
+    foreach ($line in $lines) {
+        if ($line -eq '    "BaseAddress": "http://localhost:5600"') {
+            $expected += "    `"BaseAddress`": `"$ApiUrl`""
+        } else {
+            $expected += $line
+        }
+    }
+    return $expected
+}
+
+# Fresh main-checkout repo seeded with all five tracked files the setup script rewrites, plus
+# the backend appsettings it reads to derive the per-worktree database. Worktrees are created
+# as siblings, matching the harness in the other Worktree*.Tests.ps1 files.
 function New-TempMainCheckout {
+    param([switch] $BackendAppSettingsWithBom)
+
     $root = Join-Path ([System.IO.Path]::GetTempPath()) ('wtsetup-' + [guid]::NewGuid().ToString('N').Substring(0, 8))
     $repo = Join-Path $root 'repo'
-    $backendDir = Join-Path $repo 'src\Backend\AHKFlowApp.API'
-    New-Item -ItemType Directory -Path $backendDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $repo -Force | Out-Null
 
     & git -C $repo init *> $null
     & git -C $repo symbolic-ref HEAD refs/heads/main *> $null
     & git -C $repo config user.email 'test@example.com' *> $null
     & git -C $repo config user.name 'Worktree Setup Test' *> $null
 
-    # Mirror the real backend appsettings sections the setup script patches (Cors, ConnectionStrings)
-    # so per-worktree overrides take the in-place update path rather than creating empty sections.
-    $appsettings = @{
-        Cors = @{ AllowedOrigins = @('http://localhost:5601') }
-        ConnectionStrings = @{
-            DefaultConnection = 'Server=localhost,1433;Database=AHKFlowAppDb;User Id=sa;Password=Dev!LocalOnly_2026;TrustServerCertificate=True;MultipleActiveResultSets=true'
-        }
-    } | ConvertTo-Json -Depth 8
-    Set-Content -LiteralPath (Join-Path $backendDir 'appsettings.json') -Value $appsettings -Encoding utf8
+    # The seeds are written with LF. A global core.autocrlf=true would rewrite them to CRLF on
+    # checkout, so the byte-for-byte expectations below would depend on the developer's git config.
+    & git -C $repo config core.autocrlf false *> $null
 
-    # Mirror the real backend launchSettings: two Docker SQL profiles (marker
-    # AHKFLOW_START_DOCKER_SQL=true) that must both get per-worktree SQL isolation, and a
-    # LocalDB profile that must stay untouched.
-    $launchSettingsDir = Join-Path $backendDir 'Properties'
-    New-Item -ItemType Directory -Path $launchSettingsDir -Force | Out-Null
-    $connection = 'Server=localhost,1433;Database=AHKFlowAppDb;User Id=sa;Password=Dev!LocalOnly_2026;TrustServerCertificate=True;MultipleActiveResultSets=true'
-    $launchSettings = @{
-        profiles = @{
-            'Docker SQL (Recommended)' = @{
-                commandName = 'Project'
-                environmentVariables = @{
-                    ASPNETCORE_ENVIRONMENT = 'Development'
-                    AHKFLOW_START_DOCKER_SQL = 'true'
-                    COMPOSE_PROJECT_NAME = 'ahkflowapp'
-                    ConnectionStrings__DefaultConnection = $connection
-                }
-                applicationUrl = 'http://localhost:5600'
-            }
-            'Docker SQL (No Auth)' = @{
-                commandName = 'Project'
-                environmentVariables = @{
-                    ASPNETCORE_ENVIRONMENT = 'Development'
-                    AHKFLOW_START_DOCKER_SQL = 'true'
-                    COMPOSE_PROJECT_NAME = 'ahkflowapp'
-                    ConnectionStrings__DefaultConnection = $connection
-                    Auth__UseTestProvider = 'true'
-                }
-                applicationUrl = 'http://localhost:5600'
-            }
-            'LocalDB SQL' = @{
-                commandName = 'Project'
-                environmentVariables = @{
-                    ASPNETCORE_ENVIRONMENT = 'Development'
-                    AHKFLOW_START_DOCKER_SQL = 'false'
-                }
-                applicationUrl = 'http://localhost:5600'
-            }
-        }
-    } | ConvertTo-Json -Depth 8
-    Set-Content -LiteralPath (Join-Path $launchSettingsDir 'launchSettings.json') -Value $launchSettings -Encoding utf8
+    Write-SeedFile (Join-Path $repo 'src\Backend\AHKFlowApp.API\appsettings.json') (Get-SeedBackendAppSettings) -WithBom:$BackendAppSettingsWithBom
+    Write-SeedFile (Join-Path $repo 'src\Backend\AHKFlowApp.API\Properties\launchSettings.json') (Get-SeedBackendLaunchSettings)
+    Write-SeedFile (Join-Path $repo 'src\Frontend\AHKFlowApp.UI.Blazor\Properties\launchSettings.json') (Get-SeedFrontendLaunchSettings)
+    Write-SeedFile (Join-Path $repo 'src\Frontend\AHKFlowApp.UI.Blazor\wwwroot\appsettings.json') (Get-SeedFrontendAppSettings)
+    Write-SeedFile (Join-Path $repo '.vscode\launch.json') (Get-SeedVsCodeLaunch)
 
     # Compose file marks the repo as a Docker SQL adopter so profile patching is expected.
-    Set-Content -LiteralPath (Join-Path $repo 'docker-compose.yml') -Value "services: {}" -Encoding utf8
+    Write-SeedFile (Join-Path $repo 'docker-compose.yml') @('services: {}')
 
     Invoke-TestGit $repo @('add', '-A') | Out-Null
     Invoke-TestGit $repo @('commit', '-m', 'seed') | Out-Null
@@ -177,6 +445,75 @@ try {
 
     $localDbEnv = $launch.profiles.'LocalDB SQL'.environmentVariables
     Assert-True (($localDbEnv.PSObject.Properties.Name) -notcontains 'COMPOSE_PROJECT_NAME') 'Non-Docker profile must not be patched with a compose project.'
+
+    # --- backlog 048: the rewrite must change only the intended values ---
+
+    $manifestPath = Join-Path $wtPath 'scripts\.env.worktree'
+    $uiPort = Get-ManifestPort $manifestPath 'AHKFLOW_UI_PORT'
+    $dbName = Get-ManifestPort $manifestPath 'AHKFLOW_DB_NAME'
+    $apiUrl = "http://localhost:$apiPort"
+    $uiUrl = "http://localhost:$uiPort"
+
+    $rewritten = @(
+        @{ Path = '.vscode\launch.json'; Expected = (Get-ExpectedVsCodeLaunch -ApiUrl $apiUrl -UiUrl $uiUrl) },
+        @{ Path = 'src\Backend\AHKFlowApp.API\Properties\launchSettings.json'; Expected = (Get-ExpectedBackendLaunchSettings -ApiUrl $apiUrl -ComposeProject $composeProject -SqlPort $sqlPort) },
+        @{ Path = 'src\Backend\AHKFlowApp.API\appsettings.json'; Expected = (Get-ExpectedBackendAppSettings -UiUrl $uiUrl -DbName $dbName) },
+        @{ Path = 'src\Frontend\AHKFlowApp.UI.Blazor\Properties\launchSettings.json'; Expected = (Get-ExpectedFrontendLaunchSettings -UiUrl $uiUrl) },
+        @{ Path = 'src\Frontend\AHKFlowApp.UI.Blazor\wwwroot\appsettings.json'; Expected = (Get-ExpectedFrontendAppSettings -ApiUrl $apiUrl) }
+    )
+
+    foreach ($file in $rewritten) {
+        $fullPath = Join-Path $wtPath $file.Path
+        Assert-True (-not (Test-FileHasBom $fullPath)) "$($file.Path) must not gain a UTF-8 BOM."
+        Assert-ExactText (($file.Expected) -join "`n") (Get-FileTextWithoutBom $fullPath) "$($file.Path) must change only the intended values."
+    }
+
+    # Named separately because a missing comment fails with a clearer message than a whole-file mismatch.
+    $launchText = Get-FileTextWithoutBom (Join-Path $wtPath '.vscode\launch.json')
+    foreach ($comment in @(
+        '// internalConsole is required for serverReadyAction: VS Code only scans the Debug',
+        '// Keep the UI debugger on an isolated Chrome profile. Reusing the default profile'
+    )) {
+        Assert-True ($launchText.Contains($comment)) "launch.json must keep the comment '$comment'."
+    }
+
+    # The two generated dev configs are gitignored and written whole, but must not gain a BOM either.
+    Assert-True (-not (Test-FileHasBom $backendDev)) 'The generated backend dev config must not carry a BOM.'
+    Assert-True (-not (Test-FileHasBom $frontendDev)) 'The generated frontend dev config must not carry a BOM.'
+
+    # Running setup a second time must produce byte-identical files, BOM state included.
+    $before = @{}
+    foreach ($file in $rewritten) { $before[$file.Path] = Get-FileByteHash (Join-Path $wtPath $file.Path) }
+    & $setupScript -RepoRoot $wtPath -Quiet
+    foreach ($file in $rewritten) {
+        Assert-ExactText $before[$file.Path] (Get-FileByteHash (Join-Path $wtPath $file.Path)) "$($file.Path) must be byte-identical after a second setup run."
+    }
+} finally {
+    Remove-TempTree $repo
+}
+
+# --- backlog 048: a file that already had a BOM keeps it ---
+# Without this case, a Read-JsoncFile that strips the BOM and never puts it back would pass
+# every other assertion above.
+$repo = New-TempMainCheckout -BackendAppSettingsWithBom
+try {
+    $wtPath = Add-TestWorktree -RepoDir $repo -BranchName 'feat-bom'
+    & $setupScript -RepoRoot $wtPath -Quiet
+
+    $manifestPath = Join-Path $wtPath 'scripts\.env.worktree'
+    $uiUrl = 'http://localhost:' + (Get-ManifestPort $manifestPath 'AHKFLOW_UI_PORT')
+    $dbName = Get-ManifestPort $manifestPath 'AHKFLOW_DB_NAME'
+    $appSettingsPath = Join-Path $wtPath 'src\Backend\AHKFlowApp.API\appsettings.json'
+
+    Assert-True (Test-FileHasBom $appSettingsPath) 'A file that already had a BOM must keep it.'
+    Assert-ExactText ((Get-ExpectedBackendAppSettings -UiUrl $uiUrl -DbName $dbName) -join "`n") `
+        (Get-FileTextWithoutBom $appSettingsPath) 'The BOM file must change only the intended values.'
+
+    # A second run must not drop the BOM either, which only a byte comparison can prove.
+    $bomHashBefore = Get-FileByteHash $appSettingsPath
+    & $setupScript -RepoRoot $wtPath -Quiet
+    Assert-True (Test-FileHasBom $appSettingsPath) 'A second run must not drop an existing BOM.'
+    Assert-ExactText $bomHashBefore (Get-FileByteHash $appSettingsPath) 'The BOM file must be byte-identical after a second setup run.'
 } finally {
     Remove-TempTree $repo
 }


### PR DESCRIPTION
## What

`setup-worktree-local-dev.ps1` rewrote five local config files by parsing each one to an object and re-serializing it. That round trip deleted every comment, added a UTF-8 BOM, and re-flowed one-line arrays. Only the ports and names needed to change.

This replaces the parse-and-reserialize step with a text splicer. Each file is now edited in place: only the spans that hold a changed value are replaced, and every other byte is left alone.

Closes backlog 048.

## How

- **JSONC scanner** (`scripts/worktree-json.common.ps1`) — walks JSON-with-comments once and records the character span of every value, plus each member's trailing comma and trailing comment.
- **`Set-JsoncValues`** — takes a list of `@{ Path; Value }` edits and splices new text into those spans. It creates a missing section when needed, and rejects overlapping edits before writing anything.
- **Literal writers** — hand-written rather than `ConvertTo-Json`, because Windows PowerShell 5.1 escapes `<`, `>`, `&`, and `'` as `\u00xx` and PowerShell 7 does not. Hand-writing gives the same bytes on both hosts.
- **BOM is observed, never assumed** — `Read-JsoncFile` records whether a file had one, and `Write-JsoncFile` puts back exactly what was there.
- The six patch functions in the setup script now record edits instead of mutating a parsed object. `Set-JsonSectionValue` and `Set-NoteProperty` are deleted.

## Result

A real run in an agent worktree: 16 insertions, 14 deletions across the five files. It was 78 removals. Every changed line carries a port, a database name, a compose project name, or the inserted `AHKFLOW_SQL_PORT`. No comment is deleted, no array changes shape, no file gains a BOM.

## Tests

- `tests/WorktreeJsonEdit.Tests.ps1` (new) — the scanner, the literal writers, and 29 splicer cases: comments above and below a replaced value, one-line arrays, trailing commas, comment-only objects, CRLF and LF, idempotence, and the failure paths.
- `tests/WorktreeLocalDevSetup.Tests.ps1` — now seeds all five tracked files and asserts each rewritten file byte for byte, with a BOM-negative case per file, a BOM-positive case, and a second run that must be byte-identical.
- Both files run on PowerShell 7 and Windows PowerShell 5.1. `WorktreeJsonEdit.Tests.ps1` is registered in `ci.yml`.

## Review round

A review found two defects, both fixed in `5663f360`:

1. Edits sharing a missing ancestor (`parent.child.a` and `parent.child.b`) rendered the chain once per edit, so the file got two `parent` properties and the first edit was silently dropped by `ConvertFrom-Json`. Insertions that share an ancestor now merge into one section.
2. An unsupported value threw a bare type name with no clue which edit caused it. Both the replace path and the insert path now name the JSON path and the character offset.

No current setup writer produces the path shape in (1), so the five-file rewrite was correct throughout — but the helper is general, so the defect was real.

## Gate

Release build 0 errors / 0 warnings · `dotnet format --verify-no-changes` clean · coverage 94.4% line / 81.5% branch, all thresholds met · four PowerShell test runs pass across both hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
