### PR TITLE
feat: mobile layout for the known shortcuts page

### DIFF
--- a/.claude/backlog/done/040-known-shortcuts-mobile-layout.md
+++ b/.claude/backlog/done/040-known-shortcuts-mobile-layout.md
@@ -16,10 +16,10 @@ As an owner on a phone, I want the known shortcuts list to read like the other l
 
 ## Acceptance criteria
 
-- [ ] The page renders a `.desktop-branch` and a `.mobile-branch`, gated in `Pages/KnownShortcuts.razor.css` at `959.95px`, matching `Pages/Hotkeys.razor` and `Pages/Hotstrings.razor`
-- [ ] The mobile branch shows the combination, what uses it, and what it does, plus the row's one action
-- [ ] Search still filters both branches
-- [ ] An E2E flow test at a phone viewport silences a use and brings it back
+- [x] The page renders a `.desktop-branch` and a `.mobile-branch`, gated in `Pages/KnownShortcuts.razor.css` at `959.95px`, matching `Pages/Hotkeys.razor` and `Pages/Hotstrings.razor`
+- [x] The mobile branch shows the combination, what uses it, and what it does, plus the row's one action
+- [x] Search still filters both branches
+- [x] An E2E flow test at a phone viewport silences a use and brings it back
 
 ## Out of scope
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/KnownShortcuts/KnownShortcutMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/KnownShortcuts/KnownShortcutMobileList.razor
@@ -1,0 +1,80 @@
+@using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Helpers
+@using MudBlazor
+
+@* Flat rows, not tap-to-expand. A use has three short fields, so hiding two of them behind a tap
+   would cost a tap and buy nothing. The hotkeys mobile list expands because a hotkey has six more
+   fields worth reading. *@
+@if (LoadError is not null)
+{
+    <MudAlert Severity="Severity.Error" Class="ma-2">@LoadError</MudAlert>
+}
+else
+{
+    @* A blank panel during a fetch reads as "nothing here" just as wrongly as the empty message
+       would. Same bar the hotstrings mobile branch shows (Pages/Hotstrings.razor:261). *@
+    @if (Loading)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" Class="mb-2"
+                           UserAttributes="@LoadingAttributes" />
+    }
+
+    @if (Items.Count > 0)
+    {
+        <div class="mobile-list">
+            @* One row per use, never per combination: a browser combination holds a Chrome use and
+               an Edge use, and each is silenced on its own. The combination label repeats. *@
+            @foreach (KnownShortcutUseRow row in Items)
+            {
+                <div class="mobile-row">
+                    @* Three grid columns: the combination takes what is left, the chip and the
+                       button take what they need. A flex row with a spacer let a long combination
+                       push the button off a 375px screen instead of wrapping. *@
+                    <div class="row-head">
+                        <code data-test="known-shortcut-row"
+                              data-shortcut-id="@row.ShortcutId"
+                              data-used-by="@row.Use.UsedBy">@row.ComboLabel</code>
+                        <KnownShortcutSourceChip Use="row.Use" />
+                        <KnownShortcutUseActions Row="row" Busy="Busy"
+                                                 OnIgnore="OnIgnore" OnRestore="OnRestore"
+                                                 OnDelete="OnDelete" />
+                    </div>
+                    @* The separator is real text, not CSS content. Generated content is dropped
+                       from the accessibility tree and from a copied selection, so the two values
+                       would run together for the readers least able to guess where one ends. *@
+                    <div class="row-what">
+                        <span class="used-by">@row.Use.UsedBy</span><span class="separator">: </span><span class="does">@row.Use.Does</span>
+                    </div>
+                    <div class="scope">@ShortcutScopeDisplay.Label(row.Use.Scope)</div>
+                </div>
+            }
+        </div>
+    }
+    else if (!Loading)
+    {
+        <MudText Class="pa-4 text-center" Typo="Typo.body2">No known shortcuts.</MudText>
+    }
+}
+
+@code {
+    [Parameter] public IReadOnlyList<KnownShortcutUseRow> Items { get; set; } = [];
+
+    /// <summary>True while a write is in flight. Every action button reads it.</summary>
+    [Parameter] public bool Busy { get; set; }
+
+    /// <summary>Holds the empty state back while a read is out — an empty list mid-load is not
+    /// yet known to be empty.</summary>
+    [Parameter] public bool Loading { get; set; }
+
+    /// <summary>Replaces the list when the read failed, matching the desktop table.</summary>
+    [Parameter] public string? LoadError { get; set; }
+
+    [Parameter] public EventCallback<KnownShortcutUseRow> OnIgnore { get; set; }
+    [Parameter] public EventCallback<KnownShortcutUseRow> OnRestore { get; set; }
+    [Parameter] public EventCallback<KnownShortcutUseRow> OnDelete { get; set; }
+
+    private static readonly Dictionary<string, object?> LoadingAttributes = new()
+    {
+        ["data-test"] = "known-shortcut-loading",
+    };
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/KnownShortcuts/KnownShortcutMobileList.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/KnownShortcuts/KnownShortcutMobileList.razor.css
@@ -1,0 +1,43 @@
+.mobile-row {
+    border-top: 1px solid var(--mud-palette-divider);
+    padding: 10px 12px;
+}
+
+/* Three columns: the combination takes what is left, the chip and the button take what they need.
+   minmax(0, 1fr) rather than 1fr — a bare 1fr floors at the content's minimum width, which is what
+   pushes a long combination past the right edge instead of wrapping it. */
+.mobile-row .row-head {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 8px;
+}
+
+.mobile-row .row-head code {
+    font-size: 0.9rem;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+/* Owner text is up to 60 and 200 characters and need not contain a space. */
+.mobile-row .row-what {
+    margin-top: 4px;
+    font-size: 0.9rem;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.mobile-row .used-by {
+    font-weight: 500;
+}
+
+.mobile-row .separator {
+    color: var(--mud-palette-text-secondary);
+}
+
+.mobile-row .scope {
+    margin-top: 2px;
+    font-size: 0.75rem;
+    color: var(--mud-palette-text-secondary);
+    overflow-wrap: anywhere;
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/KnownShortcuts/KnownShortcutSourceChip.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/KnownShortcuts/KnownShortcutSourceChip.razor
@@ -1,0 +1,28 @@
+@using AHKFlowApp.UI.Blazor.DTOs
+@using MudBlazor
+
+@* Lives in its own component so the desktop table and the mobile list cannot drift apart. A
+   silenced use reads "Silenced" whatever it came from: that state is what the reader acts on,
+   and it is the state the bell beside it agrees with. *@
+@if (Use.IsIgnored)
+{
+    <MudChip T="string" Size="Size.Small" Color="Color.Default"
+             UserAttributes="@ChipAttributes">Silenced</MudChip>
+}
+else
+{
+    <MudChip T="string" Size="Size.Small"
+             Color="@(Use.Origin == ShortcutRecordOrigin.Owner ? Color.Primary : Color.Default)"
+             UserAttributes="@ChipAttributes">
+        @(Use.Origin == ShortcutRecordOrigin.Owner ? "Yours" : "Built in")
+    </MudChip>
+}
+
+@code {
+    [Parameter, EditorRequired] public ManagedShortcutUseDto Use { get; set; } = default!;
+
+    private static readonly Dictionary<string, object?> ChipAttributes = new()
+    {
+        ["data-test"] = "known-shortcut-source-chip",
+    };
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/KnownShortcuts/KnownShortcutUseActions.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/KnownShortcuts/KnownShortcutUseActions.razor
@@ -1,0 +1,55 @@
+@using AHKFlowApp.UI.Blazor.DTOs
+@using MudBlazor
+
+@* Every action is disabled while one is running. Two overlapping writes each end with their own
+   reload, and the older answer could land last.
+
+   The bell shows the state of the row, matching its chip: crossed out on a silenced use, ringing
+   on one that still warns. It used to show the action instead, which put a ringing bell next to
+   the word "Silenced". The tooltip carries what the click does.
+
+   Lives in its own component so the desktop table and the mobile list cannot drift apart. *@
+@if (Row.Use.Origin == ShortcutRecordOrigin.Owner)
+{
+    <MudIconButton Class="delete-use" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
+                   OnClick="() => OnDelete.InvokeAsync(Row)" Disabled="@Busy"
+                   UserAttributes="@Attributes("Delete this record", $"Delete the record that {Row.Use.UsedBy} uses {Row.ComboLabel}")" />
+}
+else if (Row.Use.IsIgnored)
+{
+    <MudIconButton Class="restore-use" Icon="@Icons.Material.Filled.NotificationsOff"
+                   OnClick="() => OnRestore.InvokeAsync(Row)" Disabled="@Busy"
+                   UserAttributes="@Attributes("Warn about this again", $"Warn again that {Row.Use.UsedBy} uses {Row.ComboLabel}")" />
+}
+else
+{
+    <MudIconButton Class="ignore-use" Icon="@Icons.Material.Filled.NotificationsActive"
+                   OnClick="() => OnIgnore.InvokeAsync(Row)" Disabled="@Busy"
+                   UserAttributes="@Attributes("Stop warning about this", $"Stop warning that {Row.Use.UsedBy} uses {Row.ComboLabel}")" />
+}
+
+@code {
+    [Parameter, EditorRequired] public KnownShortcutUseRow Row { get; set; } = default!;
+
+    /// <summary>True while a write is in flight anywhere on the page.</summary>
+    [Parameter] public bool Busy { get; set; }
+
+    [Parameter] public EventCallback<KnownShortcutUseRow> OnIgnore { get; set; }
+    [Parameter] public EventCallback<KnownShortcutUseRow> OnRestore { get; set; }
+    [Parameter] public EventCallback<KnownShortcutUseRow> OnDelete { get; set; }
+
+    // The button carries the pair that names its use, so a selector can tell the Chrome row from
+    // the Edge row on the same combination.
+    //
+    // Both text attributes ride along as plain attributes: MudIconButton has no Title and no
+    // AriaLabel parameter, so they reach the rendered button through MudComponentBase's
+    // UserAttributes. The title is the short hover tooltip. The aria-label names the use in full,
+    // because the button shows an icon and no text, so "this" would be all a screen reader heard.
+    private Dictionary<string, object?> Attributes(string title, string ariaLabel) => new()
+    {
+        ["data-shortcut-id"] = Row.ShortcutId,
+        ["data-used-by"] = Row.Use.UsedBy,
+        ["title"] = title,
+        ["aria-label"] = ariaLabel,
+    };
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/KnownShortcuts/KnownShortcutUseRow.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/KnownShortcuts/KnownShortcutUseRow.cs
@@ -1,0 +1,10 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+
+namespace AHKFlowApp.UI.Blazor.Components.KnownShortcuts;
+
+/// <summary>
+/// One use, flattened out of its combination so a list stays one row per item. A browser
+/// combination holds a Chrome use and an Edge use, and each is silenced on its own, so the
+/// combination label repeats across rows.
+/// </summary>
+public sealed record KnownShortcutUseRow(string ShortcutId, string ComboLabel, ManagedShortcutUseDto Use);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/ShortcutScopeDisplay.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/ShortcutScopeDisplay.cs
@@ -1,0 +1,10 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+
+namespace AHKFlowApp.UI.Blazor.Helpers;
+
+/// <summary>Where a known shortcut applies, in the words the pages show.</summary>
+public static class ShortcutScopeDisplay
+{
+    public static string Label(ShortcutScope scope) =>
+        scope == ShortcutScope.Global ? "Anywhere" : "Only in front";
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
@@ -1,6 +1,7 @@
 ﻿@page "/known-shortcuts"
 @using AHKFlowApp.UI.Blazor.DTOs
 @using AHKFlowApp.UI.Blazor.Helpers
+@using AHKFlowApp.UI.Blazor.Components.KnownShortcuts
 @using AHKFlowApp.UI.Blazor.Services
 @using MudBlazor
 @using Microsoft.AspNetCore.Components.Authorization
@@ -85,7 +86,7 @@
         </MudPaper>
     }
 
-    <MudTable T="UseRow" Items="_rows" Filter="MatchesSearch" Dense="true" Hover="true" Loading="_loading">
+    <MudTable T="KnownShortcutUseRow" Items="_rows" Filter="MatchesSearch" Dense="true" Hover="true" Loading="_loading">
         <HeaderContent>
             <MudTh>Combination</MudTh>
             <MudTh>Used by</MudTh>
@@ -104,7 +105,7 @@
             </MudTd>
             <MudTd DataLabel="Used by">@context.Use.UsedBy</MudTd>
             <MudTd DataLabel="What it does">@context.Use.Does</MudTd>
-            <MudTd DataLabel="Where it applies">@ScopeLabel(context.Use.Scope)</MudTd>
+            <MudTd DataLabel="Where it applies">@ShortcutScopeDisplay.Label(context.Use.Scope)</MudTd>
             <MudTd DataLabel="Source">
                 @if (context.Use.IsIgnored)
                 {
@@ -168,9 +169,6 @@
     [Inject] private ISnackbar Snackbar { get; set; } = default!;
     [Inject] private IDialogService DialogService { get; set; } = default!;
 
-    /// <summary>One use, flattened out of its combination so MudTable stays one row per item.</summary>
-    private sealed record UseRow(string ShortcutId, string ComboLabel, ManagedShortcutUseDto Use);
-
     private sealed class DraftModel
     {
         public string Key { get; set; } = "";
@@ -186,7 +184,7 @@
             new(Key, Ctrl, Alt, Shift, Win, UsedBy, Scope, Does);
     }
 
-    private List<UseRow> _rows = [];
+    private List<KnownShortcutUseRow> _rows = [];
     private DraftModel _draft = new();
     private string? _search;
     private string? _loadError;
@@ -241,7 +239,7 @@
         _rows =
         [
             .. catalog.Shortcuts
-                .SelectMany(s => s.Uses.Select(u => new UseRow(
+                .SelectMany(s => s.Uses.Select(u => new KnownShortcutUseRow(
                     s.Id,
                     HotkeyActionDisplay.ComboLabel(s.Key, s.Ctrl, s.Alt, s.Shift, s.Win),
                     u)))
@@ -249,7 +247,7 @@
                 .ThenBy(r => r.Use.UsedBy, StringComparer.OrdinalIgnoreCase)
         ];
 
-    private bool MatchesSearch(UseRow row)
+    private bool MatchesSearch(KnownShortcutUseRow row)
     {
         if (string.IsNullOrWhiteSpace(_search))
             return true;
@@ -270,13 +268,10 @@
     private static string Squeeze(string value) =>
         value.Replace(" ", "", StringComparison.Ordinal).Replace("+", "", StringComparison.Ordinal);
 
-    private static string ScopeLabel(ShortcutScope scope) =>
-        scope == ShortcutScope.Global ? "Anywhere" : "Only in front";
-
     // Every action button carries the pair that names its use, so a selector can tell the Chrome
     // row from the Edge row on the same combination. Tooltip text rides along as a plain title
     // attribute: MudIconButton has no Title parameter.
-    private static Dictionary<string, object?> UseAttributes(UseRow row, string title) => new()
+    private static Dictionary<string, object?> UseAttributes(KnownShortcutUseRow row, string title) => new()
     {
         ["data-shortcut-id"] = row.ShortcutId,
         ["data-used-by"] = row.Use.UsedBy,
@@ -320,7 +315,7 @@
         Catalog.Invalidate();
     }
 
-    private async Task DeleteAsync(UseRow row)
+    private async Task DeleteAsync(KnownShortcutUseRow row)
     {
         if (row.Use.OwnerRecordId is not Guid recordId)
             return;
@@ -338,10 +333,10 @@
         await RunMutationAsync(() => Api.DeleteAsync(recordId, _cts.Token), "Record deleted.");
     }
 
-    private Task IgnoreAsync(UseRow row) => RunMutationAsync(
+    private Task IgnoreAsync(KnownShortcutUseRow row) => RunMutationAsync(
         () => Api.IgnoreAsync(row.ShortcutId, row.Use.UsedBy, _cts.Token), "Warning silenced.");
 
-    private Task RestoreAsync(UseRow row) => RunMutationAsync(
+    private Task RestoreAsync(KnownShortcutUseRow row) => RunMutationAsync(
         () => Api.RestoreAsync(row.ShortcutId, row.Use.UsedBy, _cts.Token), "Warning turned back on.");
 
     // One write at a time. Every action button is disabled while _busy, so two writes cannot

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
@@ -28,7 +28,8 @@
                    Disabled="@(!_isAuthenticated || _loading || _busy)">
             Reload
         </MudButton>
-        <MudTextField T="string" @bind-Value="_search" Immediate="true" Clearable="true"
+        <MudTextField T="string" @bind-Value="_search" @bind-Value:after="OnSearchChanged"
+                      Immediate="true" Clearable="true"
                       Placeholder="Search" Adornment="Adornment.Start"
                       AdornmentIcon="@Icons.Material.Filled.Search"
                       UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "known-shortcut-search" })" />
@@ -86,6 +87,7 @@
         </MudPaper>
     }
 
+    <div class="desktop-branch">
     <MudTable T="KnownShortcutUseRow" Items="_rows" Filter="MatchesSearch" Dense="true" Hover="true" Loading="_loading">
         <HeaderContent>
             <MudTh>Combination</MudTh>
@@ -129,6 +131,19 @@
             <MudTablePager PageSizeOptions="@(new[] { 25, 50, 100 })" />
         </PagerContent>
     </MudTable>
+    </div>
+
+    <div class="mobile-branch">
+        <KnownShortcutMobileList Items="MobilePageRows" Busy="_busy" Loading="_loading"
+                                 LoadError="@_loadError"
+                                 OnIgnore="IgnoreAsync" OnRestore="RestoreAsync"
+                                 OnDelete="DeleteAsync" />
+        @if (MobileTotalPages > 1)
+        {
+            <MudPagination Class="mt-2" Count="MobileTotalPages" Selected="_mobilePage"
+                           SelectedChanged="OnMobilePageChanged" />
+        }
+    </div>
 </MudPaper>
 
 @code {
@@ -162,6 +177,24 @@
     private bool _adding;
     private bool _loading;
     private bool _saving;
+
+    // The desktop table pages itself at 25. The card list has no pager of its own, so the page
+    // slices the filtered rows for it. Searching resets to the first page, or a term that matches
+    // three rows would show an empty page four.
+    private const int MobilePageSize = 20;
+    private int _mobilePage = 1;
+
+    private List<KnownShortcutUseRow> FilteredRows => [.. _rows.Where(MatchesSearch)];
+
+    private int MobileTotalPages =>
+        (int)Math.Ceiling((double)FilteredRows.Count / MobilePageSize);
+
+    private IReadOnlyList<KnownShortcutUseRow> MobilePageRows =>
+        [.. FilteredRows.Skip((_mobilePage - 1) * MobilePageSize).Take(MobilePageSize)];
+
+    private void OnMobilePageChanged(int page) => _mobilePage = page;
+
+    private void OnSearchChanged() => _mobilePage = 1;
 
     // True while a write is in flight. Every action button reads it, so a second write cannot
     // start before the first one has reloaded the list. Reload watches _loading for the same
@@ -204,7 +237,8 @@
 
     private Task ReloadAsync() => LoadAsync();
 
-    private void Flatten(ManagedKnownShortcutCatalogDto catalog) =>
+    private void Flatten(ManagedKnownShortcutCatalogDto catalog)
+    {
         _rows =
         [
             .. catalog.Shortcuts
@@ -215,6 +249,11 @@
                 .OrderBy(r => r.ComboLabel, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(r => r.Use.UsedBy, StringComparer.OrdinalIgnoreCase)
         ];
+
+        // A shorter list can leave the reader on a page that no longer exists.
+        if (_mobilePage > MobileTotalPages)
+            _mobilePage = 1;
+    }
 
     private bool MatchesSearch(KnownShortcutUseRow row)
     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
@@ -110,30 +110,9 @@
                 <KnownShortcutSourceChip Use="context.Use" />
             </MudTd>
             <MudTd DataLabel="Actions">
-                @* Every action is disabled while one is running. Two overlapping writes each end
-                   with their own reload, and the older answer could land last. *@
-                @if (context.Use.Origin == ShortcutRecordOrigin.Owner)
-                {
-                    <MudIconButton Class="delete-use" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
-                                   OnClick="() => DeleteAsync(context)" Disabled="@_busy"
-                                   UserAttributes='@UseAttributes(context, "Delete this record")' />
-                }
-                @* The bell shows the state of the row, matching its chip: crossed out on a
-                   silenced use, ringing on one that still warns. It used to show the action
-                   instead, which put a ringing bell next to the word "Silenced". The tooltip
-                   carries what the click does. *@
-                else if (context.Use.IsIgnored)
-                {
-                    <MudIconButton Class="restore-use" Icon="@Icons.Material.Filled.NotificationsOff"
-                                   OnClick="() => RestoreAsync(context)" Disabled="@_busy"
-                                   UserAttributes='@UseAttributes(context, "Warn about this again")' />
-                }
-                else
-                {
-                    <MudIconButton Class="ignore-use" Icon="@Icons.Material.Filled.NotificationsActive"
-                                   OnClick="() => IgnoreAsync(context)" Disabled="@_busy"
-                                   UserAttributes='@UseAttributes(context, "Stop warning about this")' />
-                }
+                <KnownShortcutUseActions Row="context" Busy="_busy"
+                                         OnIgnore="IgnoreAsync" OnRestore="RestoreAsync"
+                                         OnDelete="DeleteAsync" />
             </MudTd>
         </RowTemplate>
         <NoRecordsContent>
@@ -257,16 +236,6 @@
 
     private static string Squeeze(string value) =>
         value.Replace(" ", "", StringComparison.Ordinal).Replace("+", "", StringComparison.Ordinal);
-
-    // Every action button carries the pair that names its use, so a selector can tell the Chrome
-    // row from the Edge row on the same combination. Tooltip text rides along as a plain title
-    // attribute: MudIconButton has no Title parameter.
-    private static Dictionary<string, object?> UseAttributes(KnownShortcutUseRow row, string title) => new()
-    {
-        ["data-shortcut-id"] = row.ShortcutId,
-        ["data-used-by"] = row.Use.UsedBy,
-        ["title"] = title,
-    };
 
     private void StartAdd()
     {

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor
@@ -107,17 +107,7 @@
             <MudTd DataLabel="What it does">@context.Use.Does</MudTd>
             <MudTd DataLabel="Where it applies">@ShortcutScopeDisplay.Label(context.Use.Scope)</MudTd>
             <MudTd DataLabel="Source">
-                @if (context.Use.IsIgnored)
-                {
-                    <MudChip T="string" Size="Size.Small" Color="Color.Default">Silenced</MudChip>
-                }
-                else
-                {
-                    <MudChip T="string" Size="Size.Small"
-                             Color="@(context.Use.Origin == ShortcutRecordOrigin.Owner ? Color.Primary : Color.Default)">
-                        @(context.Use.Origin == ShortcutRecordOrigin.Owner ? "Yours" : "Built in")
-                    </MudChip>
-                }
+                <KnownShortcutSourceChip Use="context.Use" />
             </MudTd>
             <MudTd DataLabel="Actions">
                 @* Every action is disabled while one is running. Two overlapping writes each end

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor.css
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/KnownShortcuts.razor.css
@@ -1,0 +1,17 @@
+.desktop-branch {
+    display: block;
+}
+
+.mobile-branch {
+    display: none;
+}
+
+@media (max-width: 959.95px) {
+    .desktop-branch {
+        display: none;
+    }
+
+    .mobile-branch {
+        display: block;
+    }
+}

--- a/tests/AHKFlowApp.E2E.Tests/KnownShortcutsMobileFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/KnownShortcutsMobileFlowTests.cs
@@ -1,0 +1,137 @@
+using AHKFlowApp.E2E.Tests.Fixtures;
+using AHKFlowApp.Infrastructure.Persistence;
+using AHKFlowApp.TestUtilities.Builders;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace AHKFlowApp.E2E.Tests;
+
+[Collection(E2ETestCollection.Name)]
+public sealed class KnownShortcutsMobileFlowTests(StackFixture fixture) : IAsyncLifetime
+{
+    private static readonly BrowserNewContextOptions PhoneViewport = new()
+    {
+        ViewportSize = new ViewportSize { Width = 375, Height = 812 },
+    };
+
+    private static readonly BrowserNewContextOptions TabletViewport = new()
+    {
+        ViewportSize = new ViewportSize { Width = 768, Height = 1024 },
+    };
+
+    private sealed class OverflowMetrics
+    {
+        public int BodyOverflow { get; init; }
+
+        public int DocumentOverflow { get; init; }
+    }
+
+    // Names the Windows use of Win+E in the mobile branch. A combination can hold several uses,
+    // and each has its own button. {0} is the action class.
+    private const string MobileWindowsFileExplorerUse =
+        ".mobile-branch button{0}[data-shortcut-id=\"windows.file-explorer\"][data-used-by=\"Windows\"]";
+
+    public Task InitializeAsync() => fixture.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task PhoneViewport_SilencesAUse_AndBringsItBack()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/known-shortcuts");
+        await page.WaitForSelectorAsync("button.reload-known-shortcuts");
+
+        // The catalog runs past a hundred uses and the card list pages at 20, so reach the row
+        // through the search box rather than paging to it.
+        await page.FillAsync("input[data-test=\"known-shortcut-search\"]", "Win+E");
+
+        await page.ClickAsync(string.Format(MobileWindowsFileExplorerUse, ".ignore-use"));
+        await page.WaitForSelectorAsync(string.Format(MobileWindowsFileExplorerUse, ".restore-use"));
+
+        await page.ClickAsync(string.Format(MobileWindowsFileExplorerUse, ".restore-use"));
+        await page.WaitForSelectorAsync(string.Format(MobileWindowsFileExplorerUse, ".ignore-use"));
+    }
+
+    [Fact]
+    public async Task PhoneViewport_ShowsWhatUsesTheKeysAndWhatItDoes()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/known-shortcuts");
+        await page.WaitForSelectorAsync("button.reload-known-shortcuts");
+        await page.FillAsync("input[data-test=\"known-shortcut-search\"]", "Win+E");
+
+        // Addressed by the pair that names the use, not by position. "Win+E" also matches Win+Enter
+        // once the search squeezes out spaces and plus signs, so the first row is not this row.
+        ILocator row = page.Locator(
+            ".mobile-branch .mobile-row:has(code[data-shortcut-id=\"windows.file-explorer\"][data-used-by=\"Windows\"])");
+
+        await Assertions.Expect(row.Locator(".used-by")).ToHaveTextAsync("Windows");
+        await Assertions.Expect(row.Locator(".does")).ToHaveTextAsync("open File Explorer");
+    }
+
+    [Fact]
+    public async Task PhoneViewport_LongOwnerText_DoesNotCreatePageHorizontalOverflow()
+    {
+        // The phone is the point of this page, so the phone is where overflow is proved. The row
+        // is seeded at the real limits and with no spaces to break on: 60 characters of UsedBy,
+        // 200 of Does, and every modifier on a long key name.
+        await SeedLongOwnerRecordAsync(fixture);
+
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(PhoneViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/known-shortcuts");
+        await page.WaitForSelectorAsync("button.reload-known-shortcuts");
+        await page.FillAsync("input[data-test=\"known-shortcut-search\"]", LongUsedBy);
+        await page.WaitForSelectorAsync(".mobile-branch .mobile-row");
+
+        OverflowMetrics metrics = await page.EvaluateAsync<OverflowMetrics>(
+            "() => ({ BodyOverflow: document.body.scrollWidth - window.innerWidth, DocumentOverflow: document.documentElement.scrollWidth - window.innerWidth })");
+
+        Assert.True(metrics.BodyOverflow <= 0, $"Body overflowed by {metrics.BodyOverflow}px.");
+        Assert.True(metrics.DocumentOverflow <= 0, $"Document overflowed by {metrics.DocumentOverflow}px.");
+    }
+
+    [Fact]
+    public async Task TabletViewport_DoesNotCreatePageHorizontalOverflow()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync(TabletViewport);
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/known-shortcuts");
+        await page.WaitForSelectorAsync(".mobile-branch .mobile-row");
+
+        OverflowMetrics metrics = await page.EvaluateAsync<OverflowMetrics>(
+            "() => ({ BodyOverflow: document.body.scrollWidth - window.innerWidth, DocumentOverflow: document.documentElement.scrollWidth - window.innerWidth })");
+
+        Assert.True(metrics.BodyOverflow <= 0, $"Body overflowed by {metrics.BodyOverflow}px.");
+        Assert.True(metrics.DocumentOverflow <= 0, $"Document overflowed by {metrics.DocumentOverflow}px.");
+    }
+
+    // Exactly the column limits, and no spaces, so nothing can wrap on a word boundary:
+    // HasMaxLength(60) and HasMaxLength(200) in CustomKnownShortcutConfiguration.cs:15-16.
+    private static readonly string LongUsedBy = new('W', 60);
+
+    private static readonly string LongDoes = new('d', 200);
+
+    private static async Task SeedLongOwnerRecordAsync(StackFixture fixture)
+    {
+        await using AsyncServiceScope scope = fixture.Api.Services.CreateAsyncScope();
+        AppDbContext db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        db.CustomKnownShortcuts.Add(new CustomKnownShortcutBuilder()
+            .ForOwner(TestAuthHandler.TestOwnerOid)
+            .WithCombination("NumpadEnter", ctrl: true, alt: true, shift: true, win: true)
+            .UsedBy(LongUsedBy)
+            .Does(LongDoes)
+            .Build());
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
@@ -112,9 +112,11 @@ public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifet
     }
 
     // Addresses the Windows use of Win+E by id and use label, not by row text. A combination can
-    // hold several uses, and each has its own buttons.
+    // hold several uses, and each has its own buttons. The page renders a desktop branch and a
+    // mobile branch, both carrying this pair, so the branch is named here once. {0} is the action
+    // class. This file runs at the default desktop viewport, so it always means the desktop one.
     private const string WindowsFileExplorerUse =
-        "[data-shortcut-id=\"windows.file-explorer\"][data-used-by=\"Windows\"]";
+        ".desktop-branch button{0}[data-shortcut-id=\"windows.file-explorer\"][data-used-by=\"Windows\"]";
 
     [Fact]
     public async Task IgnoringTheWindowsUse_SilencesTheWarning_AndRestoringBringsItBack()
@@ -124,8 +126,8 @@ public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifet
 
         // Silence the Windows use of Win+E.
         await OpenKnownShortcutsAsync(page, "Win+E");
-        await page.ClickAsync($"button.ignore-use{WindowsFileExplorerUse}");
-        await page.WaitForSelectorAsync($"button.restore-use{WindowsFileExplorerUse}");
+        await page.ClickAsync(string.Format(WindowsFileExplorerUse, ".ignore-use"));
+        await page.WaitForSelectorAsync(string.Format(WindowsFileExplorerUse, ".restore-use"));
 
         // The dialog no longer warns. Arm the wait before the dialog opens: the catalog request
         // fires as it loads, and a fixed delay would let a slow response assert on an empty page.
@@ -151,8 +153,8 @@ public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifet
 
         // Bring it back.
         await OpenKnownShortcutsAsync(page, "Win+E");
-        await page.ClickAsync($"button.restore-use{WindowsFileExplorerUse}");
-        await page.WaitForSelectorAsync($"button.ignore-use{WindowsFileExplorerUse}");
+        await page.ClickAsync(string.Format(WindowsFileExplorerUse, ".restore-use"));
+        await page.WaitForSelectorAsync(string.Format(WindowsFileExplorerUse, ".ignore-use"));
 
         await OpenCreateDialogAsync(page);
         await CommitKeyAsync(page, "e");
@@ -182,7 +184,7 @@ public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifet
         // The table paginates 103 built-in rows plus this one, so search for the new row rather
         // than hunting for it across pages.
         await page.FillAsync("input[data-test=\"known-shortcut-search\"]", "My notes tool");
-        await page.WaitForSelectorAsync("text=My notes tool");
+        await page.WaitForSelectorAsync(".desktop-branch >> text=My notes tool");
 
         await OpenCreateDialogAsync(page);
         await CommitKeyAsync(page, "F7");

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/KnownShortcuts/KnownShortcutMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/KnownShortcuts/KnownShortcutMobileListTests.cs
@@ -1,0 +1,142 @@
+using AHKFlowApp.UI.Blazor.Components.KnownShortcuts;
+using AHKFlowApp.UI.Blazor.DTOs;
+using Bunit;
+using FluentAssertions;
+using MudBlazor.Services;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Components.KnownShortcuts;
+
+public sealed class KnownShortcutMobileListTests : BunitContext, IAsyncLifetime
+{
+    public KnownShortcutMobileListTests()
+    {
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+
+    async Task IAsyncLifetime.DisposeAsync() => await DisposeAsync();
+
+    /// <summary>Types the rows as the parameter expects, so no call site needs an inline cast.</summary>
+    private static IReadOnlyList<KnownShortcutUseRow> Items(params KnownShortcutUseRow[] rows) => rows;
+
+    private static KnownShortcutUseRow Row(
+        string usedBy = "Chrome",
+        string does = "open a new window",
+        ShortcutScope scope = ShortcutScope.Foreground,
+        ShortcutRecordOrigin origin = ShortcutRecordOrigin.BuiltIn,
+        bool ignored = false) =>
+        new("browser.new-window", "Ctrl+N",
+            new ManagedShortcutUseDto(usedBy, ShortcutProtection.Normal, scope, does,
+                origin, OwnerRecordId: null, IsIgnored: ignored));
+
+    [Fact]
+    public void EachRow_ShowsTheCombinationWhatUsesItAndWhatItDoes()
+    {
+        IRenderedComponent<KnownShortcutMobileList> cut = Render<KnownShortcutMobileList>(p => p
+            .Add(c => c.Items, Items(Row())));
+
+        cut.Find("[data-test=\"known-shortcut-row\"]").TextContent.Should().Be("Ctrl+N");
+        cut.Find(".used-by").TextContent.Should().Be("Chrome");
+        cut.Find(".does").TextContent.Should().Be("open a new window");
+    }
+
+    [Theory]
+    [InlineData(ShortcutScope.Global, "Anywhere")]
+    [InlineData(ShortcutScope.Foreground, "Only in front")]
+    public void EachRow_SaysWhereItApplies(ShortcutScope scope, string expected)
+    {
+        IRenderedComponent<KnownShortcutMobileList> cut = Render<KnownShortcutMobileList>(p => p
+            .Add(c => c.Items, Items(Row(scope: scope))));
+
+        cut.Find(".scope").TextContent.Should().Be(expected);
+    }
+
+    [Fact]
+    public void OneCombinationWithTwoUses_RendersTwoRows()
+    {
+        // A browser combination holds a Chrome use and an Edge use. Each is silenced on its own,
+        // so each needs its own row and its own button.
+        IRenderedComponent<KnownShortcutMobileList> cut = Render<KnownShortcutMobileList>(p => p
+            .Add(c => c.Items, Items(Row("Chrome"), Row("Edge"))));
+
+        cut.FindAll("[data-test=\"known-shortcut-row\"]").Should().HaveCount(2);
+        cut.FindAll("button.ignore-use").Should().HaveCount(2);
+    }
+
+    [Theory]
+    // The list forwards all three events, not just the one. A missed wire-up on restore or delete
+    // would leave a button that looks live and does nothing.
+    [InlineData(ShortcutRecordOrigin.BuiltIn, false, "ignore-use")]
+    [InlineData(ShortcutRecordOrigin.BuiltIn, true, "restore-use")]
+    [InlineData(ShortcutRecordOrigin.Owner, false, "delete-use")]
+    public void ClickingAnAction_RaisesThatEventWithThatRow(
+        ShortcutRecordOrigin origin, bool ignored, string cssClass)
+    {
+        KnownShortcutUseRow row = Row(origin: origin, ignored: ignored);
+        KnownShortcutUseRow? ignoredRow = null;
+        KnownShortcutUseRow? restoredRow = null;
+        KnownShortcutUseRow? deletedRow = null;
+
+        IRenderedComponent<KnownShortcutMobileList> cut = Render<KnownShortcutMobileList>(p => p
+            .Add(c => c.Items, Items(row))
+            .Add(c => c.OnIgnore, r => ignoredRow = (KnownShortcutUseRow?)r)
+            .Add(c => c.OnRestore, r => restoredRow = (KnownShortcutUseRow?)r)
+            .Add(c => c.OnDelete, r => deletedRow = (KnownShortcutUseRow?)r));
+
+        cut.Find($"button.{cssClass}").Click();
+
+        KnownShortcutUseRow? raised = cssClass switch
+        {
+            "ignore-use" => ignoredRow,
+            "restore-use" => restoredRow,
+            _ => deletedRow,
+        };
+        raised.Should().Be(row);
+    }
+
+    [Fact]
+    public void NoRows_SaysSo()
+    {
+        IRenderedComponent<KnownShortcutMobileList> cut = Render<KnownShortcutMobileList>(p => p
+            .Add(c => c.Items, Items()));
+
+        cut.Markup.Should().Contain("No known shortcuts.");
+    }
+
+    [Fact]
+    public void WhileLoading_ShowsProgress_AndHoldsTheEmptyStateBack()
+    {
+        // An empty list mid-load is not yet known to be empty, and "No known shortcuts." during a
+        // fetch reads as a result. Holding the message back is not enough on its own: that left a
+        // blank panel that reads as "nothing here" just as wrongly.
+        IRenderedComponent<KnownShortcutMobileList> cut = Render<KnownShortcutMobileList>(p => p
+            .Add(c => c.Items, Items())
+            .Add(c => c.Loading, true));
+
+        cut.Markup.Should().NotContain("No known shortcuts.");
+        cut.FindAll("[data-test=\"known-shortcut-loading\"]").Should().ContainSingle();
+    }
+
+    [Fact]
+    public void WhenNotLoading_ThereIsNoProgressBar()
+    {
+        IRenderedComponent<KnownShortcutMobileList> cut = Render<KnownShortcutMobileList>(p => p
+            .Add(c => c.Items, Items(Row())));
+
+        cut.FindAll("[data-test=\"known-shortcut-loading\"]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ALoadError_ReplacesTheList()
+    {
+        IRenderedComponent<KnownShortcutMobileList> cut = Render<KnownShortcutMobileList>(p => p
+            .Add(c => c.Items, Items())
+            .Add(c => c.LoadError, "The server did not answer."));
+
+        cut.Markup.Should().Contain("The server did not answer.");
+        cut.Markup.Should().NotContain("No known shortcuts.");
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/KnownShortcuts/KnownShortcutSourceChipTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/KnownShortcuts/KnownShortcutSourceChipTests.cs
@@ -1,0 +1,40 @@
+using AHKFlowApp.UI.Blazor.Components.KnownShortcuts;
+using AHKFlowApp.UI.Blazor.DTOs;
+using Bunit;
+using FluentAssertions;
+using MudBlazor.Services;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Components.KnownShortcuts;
+
+public sealed class KnownShortcutSourceChipTests : BunitContext, IAsyncLifetime
+{
+    public KnownShortcutSourceChipTests()
+    {
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+
+    async Task IAsyncLifetime.DisposeAsync() => await DisposeAsync();
+
+    private static ManagedShortcutUseDto Use(ShortcutRecordOrigin origin, bool ignored) =>
+        new("Chrome", ShortcutProtection.Normal, ShortcutScope.Foreground, "open a new window",
+            origin, OwnerRecordId: null, IsIgnored: ignored);
+
+    [Theory]
+    // A silenced use reads "Silenced" whatever it came from — that state is what matters.
+    [InlineData(ShortcutRecordOrigin.BuiltIn, true, "Silenced")]
+    [InlineData(ShortcutRecordOrigin.Owner, true, "Silenced")]
+    [InlineData(ShortcutRecordOrigin.Owner, false, "Yours")]
+    [InlineData(ShortcutRecordOrigin.BuiltIn, false, "Built in")]
+    public void Chip_SaysWhereTheRowCameFrom(ShortcutRecordOrigin origin, bool ignored, string expected)
+    {
+        IRenderedComponent<KnownShortcutSourceChip> cut =
+            Render<KnownShortcutSourceChip>(p => p.Add(c => c.Use, Use(origin, ignored)));
+
+        cut.Find("[data-test=\"known-shortcut-source-chip\"]").TextContent.Trim()
+            .Should().Be(expected);
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/KnownShortcuts/KnownShortcutUseActionsTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/KnownShortcuts/KnownShortcutUseActionsTests.cs
@@ -1,0 +1,118 @@
+using AHKFlowApp.UI.Blazor.Components.KnownShortcuts;
+using AHKFlowApp.UI.Blazor.DTOs;
+using Bunit;
+using FluentAssertions;
+using MudBlazor.Services;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Components.KnownShortcuts;
+
+public sealed class KnownShortcutUseActionsTests : BunitContext, IAsyncLifetime
+{
+    public KnownShortcutUseActionsTests()
+    {
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+
+    async Task IAsyncLifetime.DisposeAsync() => await DisposeAsync();
+
+    private static KnownShortcutUseRow Row(
+        ShortcutRecordOrigin origin = ShortcutRecordOrigin.BuiltIn,
+        bool ignored = false,
+        Guid? recordId = null) =>
+        new("browser.new-window", "Ctrl+N",
+            new ManagedShortcutUseDto("Chrome", ShortcutProtection.Normal, ShortcutScope.Foreground,
+                "open a new window", origin, recordId, ignored));
+
+    [Theory]
+    [InlineData(ShortcutRecordOrigin.Owner, false, "delete-use")]
+    [InlineData(ShortcutRecordOrigin.BuiltIn, true, "restore-use")]
+    [InlineData(ShortcutRecordOrigin.BuiltIn, false, "ignore-use")]
+    public void OneButtonPerRow_ChosenByOriginAndState(
+        ShortcutRecordOrigin origin, bool ignored, string expectedClass)
+    {
+        IRenderedComponent<KnownShortcutUseActions> cut = Render<KnownShortcutUseActions>(p => p
+            .Add(c => c.Row, Row(origin, ignored, origin == ShortcutRecordOrigin.Owner ? Guid.NewGuid() : null)));
+
+        cut.FindAll("button").Should().ContainSingle();
+        cut.Find("button").ClassList.Should().Contain(expectedClass);
+    }
+
+    [Fact]
+    public void TheButton_CarriesThePairThatNamesItsUse()
+    {
+        IRenderedComponent<KnownShortcutUseActions> cut =
+            Render<KnownShortcutUseActions>(p => p.Add(c => c.Row, Row()));
+
+        cut.Find("button.ignore-use").GetAttribute("data-shortcut-id").Should().Be("browser.new-window");
+        cut.Find("button.ignore-use").GetAttribute("data-used-by").Should().Be("Chrome");
+    }
+
+    [Theory]
+    // The button shows an icon and no text, so the accessible name is all a screen reader gets.
+    // "Stop warning about this" does not say what "this" is.
+    [InlineData(ShortcutRecordOrigin.BuiltIn, false, "ignore-use", "Stop warning that Chrome uses Ctrl+N")]
+    [InlineData(ShortcutRecordOrigin.BuiltIn, true, "restore-use", "Warn again that Chrome uses Ctrl+N")]
+    [InlineData(ShortcutRecordOrigin.Owner, false, "delete-use", "Delete the record that Chrome uses Ctrl+N")]
+    public void TheButton_IsNamedForItsUse(
+        ShortcutRecordOrigin origin, bool ignored, string cssClass, string expectedLabel)
+    {
+        IRenderedComponent<KnownShortcutUseActions> cut = Render<KnownShortcutUseActions>(p => p
+            .Add(c => c.Row, Row(origin, ignored, origin == ShortcutRecordOrigin.Owner ? Guid.NewGuid() : null)));
+
+        cut.Find($"button.{cssClass}").GetAttribute("aria-label").Should().Be(expectedLabel);
+    }
+
+    [Fact]
+    public void TheButton_KeepsAShortHoverTooltip()
+    {
+        IRenderedComponent<KnownShortcutUseActions> cut =
+            Render<KnownShortcutUseActions>(p => p.Add(c => c.Row, Row()));
+
+        cut.Find("button.ignore-use").GetAttribute("title").Should().Be("Stop warning about this");
+    }
+
+    [Theory]
+    [InlineData(ShortcutRecordOrigin.BuiltIn, false, "ignore-use")]
+    [InlineData(ShortcutRecordOrigin.BuiltIn, true, "restore-use")]
+    [InlineData(ShortcutRecordOrigin.Owner, false, "delete-use")]
+    public void ClickingTheButton_RaisesTheMatchingEvent(
+        ShortcutRecordOrigin origin, bool ignored, string cssClass)
+    {
+        KnownShortcutUseRow row = Row(origin, ignored, origin == ShortcutRecordOrigin.Owner ? Guid.NewGuid() : null);
+        KnownShortcutUseRow? ignoredRow = null;
+        KnownShortcutUseRow? restoredRow = null;
+        KnownShortcutUseRow? deletedRow = null;
+
+        IRenderedComponent<KnownShortcutUseActions> cut = Render<KnownShortcutUseActions>(p => p
+            .Add(c => c.Row, row)
+            .Add(c => c.OnIgnore, r => ignoredRow = (KnownShortcutUseRow?)r)
+            .Add(c => c.OnRestore, r => restoredRow = (KnownShortcutUseRow?)r)
+            .Add(c => c.OnDelete, r => deletedRow = (KnownShortcutUseRow?)r));
+
+        cut.Find($"button.{cssClass}").Click();
+
+        KnownShortcutUseRow? raised = cssClass switch
+        {
+            "ignore-use" => ignoredRow,
+            "restore-use" => restoredRow,
+            _ => deletedRow,
+        };
+        raised.Should().Be(row);
+    }
+
+    [Fact]
+    public void WhileBusy_TheButtonIsDisabled()
+    {
+        // Two overlapping writes each end with their own reload, and the older answer could land
+        // last. One at a time is what keeps the list honest.
+        IRenderedComponent<KnownShortcutUseActions> cut = Render<KnownShortcutUseActions>(p => p
+            .Add(c => c.Row, Row())
+            .Add(c => c.Busy, true));
+
+        cut.Find("button.ignore-use").HasAttribute("disabled").Should().BeTrue();
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
@@ -96,8 +96,12 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         Services.AddSingleton(dialogService);
     }
 
-    private static IElement Button(IRenderedComponent<KnownShortcuts> page, string css, string shortcutId, string usedBy) =>
-        page.Find($"button.{css}[data-shortcut-id=\"{shortcutId}\"][data-used-by=\"{usedBy}\"]");
+    // Both branches render this button with the same class and the same pair, so every lookup has
+    // to say which branch it means. CSS hides one; bunit sees both.
+    private static IElement Button(
+        IRenderedComponent<KnownShortcuts> page, string css, string shortcutId, string usedBy,
+        string branch = ".desktop-branch") =>
+        page.Find($"{branch} button.{css}[data-shortcut-id=\"{shortcutId}\"][data-used-by=\"{usedBy}\"]");
 
     [Fact]
     public void Page_RendersOneRowPerUse()
@@ -106,10 +110,10 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
 
-        page.FindAll("[data-test=\"known-shortcut-row\"]").Should().HaveCount(2);
-        page.FindAll("[data-test=\"known-shortcut-row\"]").Should()
+        page.FindAll(".desktop-branch [data-test=\"known-shortcut-row\"]").Should().HaveCount(2);
+        page.FindAll(".desktop-branch [data-test=\"known-shortcut-row\"]").Should()
             .OnlyContain(r => r.TextContent == "Ctrl+N");
-        page.FindAll("button.ignore-use").Should().HaveCount(2);
+        page.FindAll(".desktop-branch button.ignore-use").Should().HaveCount(2);
     }
 
     [Fact]
@@ -133,7 +137,7 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
             .Returns(ApiResult.Ok());
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
-        page.FindAll("button.ignore-use").Should().BeEmpty();
+        page.FindAll(".desktop-branch button.ignore-use").Should().BeEmpty();
         Button(page, "restore-use", "windows.file-explorer", "Windows").Click();
 
         _api.Received(1).RestoreAsync("windows.file-explorer", "Windows", Arg.Any<CancellationToken>());
@@ -148,7 +152,7 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         _api.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(ApiResult.Ok());
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
-        page.Find("button.delete-use").Click();
+        page.Find(".desktop-branch button.delete-use").Click();
 
         page.WaitForAssertion(() =>
             _api.Received(1).DeleteAsync(recordId, Arg.Any<CancellationToken>()));
@@ -163,9 +167,9 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
 
-        page.FindAll("button.ignore-use").Should().ContainSingle()
+        page.FindAll(".desktop-branch button.ignore-use").Should().ContainSingle()
             .Which.GetAttribute("data-shortcut-id").Should().Be("windows.file-explorer");
-        page.FindAll("button.delete-use").Should().ContainSingle()
+        page.FindAll(".desktop-branch button.delete-use").Should().ContainSingle()
             .Which.GetAttribute("data-shortcut-id").Should().Be("owner.1");
     }
 
@@ -176,9 +180,9 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
 
-        page.FindAll("[data-test=\"known-shortcut-row\"]").Should().HaveCount(2);
-        page.FindAll("button.ignore-use").Should().ContainSingle();
-        page.FindAll("button.delete-use").Should().ContainSingle();
+        page.FindAll(".desktop-branch [data-test=\"known-shortcut-row\"]").Should().HaveCount(2);
+        page.FindAll(".desktop-branch button.ignore-use").Should().ContainSingle();
+        page.FindAll(".desktop-branch button.delete-use").Should().ContainSingle();
     }
 
     [Fact]
@@ -223,7 +227,7 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         Button(page, "ignore-use", "windows.file-explorer", "Windows").Click();
 
         _api.Received(2).ListManagedAsync(Arg.Any<CancellationToken>());
-        page.FindAll("button.restore-use").Should().ContainSingle();
+        page.FindAll(".desktop-branch button.restore-use").Should().ContainSingle();
     }
 
     [Fact]
@@ -243,7 +247,7 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         _api.Received(1).CreateAsync(
             Arg.Is<CreateCustomKnownShortcutDto>(d => d.UsedBy == "My notes tool" && d.Does == "open my notes"),
             Arg.Any<CancellationToken>());
-        page.FindAll("[data-test=\"known-shortcut-row\"]").Should().ContainSingle();
+        page.FindAll(".desktop-branch [data-test=\"known-shortcut-row\"]").Should().ContainSingle();
     }
 
     [Fact]
@@ -270,7 +274,7 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
 
-        page.FindAll("[data-test=\"known-shortcut-row\"]").Should().BeEmpty();
+        page.FindAll(".desktop-branch [data-test=\"known-shortcut-row\"]").Should().BeEmpty();
         page.FindAll("div.mud-alert").Should().NotBeEmpty();
     }
 
@@ -285,7 +289,7 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         IRenderedComponent<KnownShortcuts> page = RenderPage();
         page.Find("[data-test=\"known-shortcut-search\"]").Input(term);
 
-        page.FindAll("[data-test=\"known-shortcut-row\"]").Should()
+        page.FindAll(".desktop-branch [data-test=\"known-shortcut-row\"]").Should()
             .HaveCount(2, "Ctrl+N carries a Chrome use and an Edge use");
     }
 
@@ -297,7 +301,7 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         IRenderedComponent<KnownShortcuts> page = RenderPage();
         page.Find("[data-test=\"known-shortcut-search\"]").Input("new window");
 
-        page.FindAll("[data-test=\"known-shortcut-row\"]").Should().HaveCount(2);
+        page.FindAll(".desktop-branch [data-test=\"known-shortcut-row\"]").Should().HaveCount(2);
     }
 
     [Fact]
@@ -311,9 +315,9 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
 
-        page.Find("button.ignore-use").InnerHtml
+        page.Find(".desktop-branch button.ignore-use").InnerHtml
             .Should().Contain(IconPath(Icons.Material.Filled.NotificationsActive));
-        page.Find("button.restore-use").InnerHtml
+        page.Find(".desktop-branch button.restore-use").InnerHtml
             .Should().Contain(IconPath(Icons.Material.Filled.NotificationsOff));
     }
 
@@ -349,10 +353,10 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         _api.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(ApiResult.Ok());
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
-        page.Find("button.delete-use").Click();
+        page.Find(".desktop-branch button.delete-use").Click();
 
         _api.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
-        page.FindAll("[data-test=\"known-shortcut-row\"]").Should().ContainSingle();
+        page.FindAll(".desktop-branch [data-test=\"known-shortcut-row\"]").Should().ContainSingle();
     }
 
     [Fact]
@@ -364,7 +368,7 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         _api.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(ApiResult.Ok());
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
-        page.Find("button.delete-use").Click();
+        page.Find(".desktop-branch button.delete-use").Click();
 
         page.WaitForAssertion(() =>
             _api.Received(1).DeleteAsync(recordId, Arg.Any<CancellationToken>()));
@@ -380,9 +384,9 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
             .Returns(pending.Task);
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
-        page.Find("button.ignore-use").Click();
+        page.Find(".desktop-branch button.ignore-use").Click();
 
-        page.Find("button.ignore-use").HasAttribute("disabled").Should().BeTrue();
+        page.Find(".desktop-branch button.ignore-use").HasAttribute("disabled").Should().BeTrue();
         page.Find("button.reload-known-shortcuts").HasAttribute("disabled").Should().BeTrue();
 
         pending.SetResult(ApiResult.Ok());
@@ -419,7 +423,7 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
             .Returns(ApiResult.Failure(ApiResultStatus.NetworkError, null));
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
-        page.Find("button.ignore-use").Click();
+        page.Find(".desktop-branch button.ignore-use").Click();
 
         page.WaitForAssertion(() => _catalog.Received(1).Invalidate());
         _api.Received(2).ListManagedAsync(Arg.Any<CancellationToken>());
@@ -497,18 +501,91 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         switch (mutation)
         {
             case "ignore":
-                page.Find("button.ignore-use").Click();
+                page.Find(".desktop-branch button.ignore-use").Click();
                 break;
             case "restore":
-                page.Find("button.restore-use").Click();
+                page.Find(".desktop-branch button.restore-use").Click();
                 break;
             case "delete":
-                page.Find("button.delete-use").Click();
+                page.Find(".desktop-branch button.delete-use").Click();
                 break;
             default:
                 page.Find("button.add-known-shortcut").Click();
                 page.Find("button.commit-edit").Click();
                 break;
         }
+    }
+
+    [Fact]
+    public void ThePage_RendersBothBranches()
+    {
+        StubList(BrowserShortcut());
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+
+        page.FindAll(".desktop-branch [data-test=\"known-shortcut-row\"]").Should().HaveCount(2);
+        page.FindAll(".mobile-branch [data-test=\"known-shortcut-row\"]").Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void OneSearchTerm_FiltersBothBranches()
+    {
+        StubList(BrowserShortcut(), Shortcut("windows.file-explorer", "e", BuiltInUse()));
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        page.Find("[data-test=\"known-shortcut-search\"]").Input("File Explorer");
+
+        page.FindAll(".desktop-branch [data-test=\"known-shortcut-row\"]").Should().ContainSingle();
+        page.FindAll(".mobile-branch [data-test=\"known-shortcut-row\"]").Should().ContainSingle();
+    }
+
+    [Fact]
+    public void TheMobileBranch_ActsOnTheUseItNames()
+    {
+        StubList(BrowserShortcut());
+        _api.IgnoreAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ApiResult.Ok());
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+        Button(page, "ignore-use", "browser.new-window", "Edge", ".mobile-branch").Click();
+
+        _api.Received(1).IgnoreAsync("browser.new-window", "Edge", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void TheMobileBranch_PagesTwentyRowsAtATime()
+    {
+        // The catalog runs past a hundred rows. An unpaged card list would render every one.
+        StubList([.. Enumerable.Range(0, 25).Select(i =>
+            Shortcut($"built-in.{i}", "e", BuiltInUse(usedBy: $"Program {i:00}")))]);
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+
+        page.FindAll(".mobile-branch [data-test=\"known-shortcut-row\"]").Should().HaveCount(20);
+    }
+
+    [Fact]
+    public void ANewSearchTerm_ReturnsTheMobileBranchToPageOne()
+    {
+        // Searching from page 2 used to leave the page number alone, so a term matching three rows
+        // showed an empty page 2. Starting this test on page 1 would pass without the reset.
+        StubList([.. Enumerable.Range(0, 25).Select(i =>
+            Shortcut($"built-in.{i}", "e", BuiltInUse(usedBy: $"Program {i:00}")))]);
+
+        IRenderedComponent<KnownShortcuts> page = RenderPage();
+
+        // Page 2 holds the last five rows, Program 20 to Program 24. The page button is found by
+        // its own number rather than an aria-label, so the test does not depend on wording
+        // MudPagination could change between versions.
+        page.FindAll(".mobile-branch .mud-pagination button")
+            .Single(b => b.TextContent.Trim() == "2")
+            .Click();
+        page.FindAll(".mobile-branch [data-test=\"known-shortcut-row\"]").Should().HaveCount(5);
+
+        page.Find("[data-test=\"known-shortcut-search\"]").Input("Program 0");
+
+        // Program 00 to Program 09 match, and all ten fit on page 1. Still on page 2, this would
+        // find nothing.
+        page.FindAll(".mobile-branch [data-test=\"known-shortcut-row\"]").Should().HaveCount(10);
     }
 }


### PR DESCRIPTION
## What

Gives `/known-shortcuts` a phone layout. The page rendered one six-column `MudTable` at every
screen size, so on a phone the Actions column was the one most likely to be pushed out of reach.

Closes backlog item 040.

## How

The page keeps **one** `MudPaper` and one data load. Toolbar, sign-in alert, and add form stay
shared and unbranched — only the list splits:

- `.desktop-branch` — the existing `MudTable`, unchanged
- `.mobile-branch` — a new flat card list, paged at 20

Gated at `959.95px` in a new `Pages/KnownShortcuts.razor.css`, matching `Hotkeys.razor.css:23`.

Hotkeys duplicates its whole toolbar because its two branches fetch different data. This page
loads the whole catalog once and filters client-side, so duplicating the toolbar would only put a
second `button.commit-edit` in the DOM. One search field feeds both branches.

### New `Components/KnownShortcuts/`

| File | Why |
|---|---|
| `KnownShortcutUseRow.cs` | Row record, lifted off the page so components can name it |
| `KnownShortcutSourceChip.razor` | Silenced / Yours / Built in |
| `KnownShortcutUseActions.razor` | The row's one action button, and the rule that picks it |
| `KnownShortcutMobileList.razor` | The card list |

The chip and the action button are shared by both branches for the reason
`HotstringKindChip.razor` already states in its own comment: so the desktop grid and the mobile
list cannot drift apart. They render the same elements with the same classes, so the desktop table
looks unchanged.

Rows are flat, not tap-to-expand. A use has three short fields, so hiding two behind a tap would
cost a tap and buy nothing.

### Accessibility

The action button is icon-only, so `title="Stop warning about this"` was the whole accessible name
and it did not say what "this" was. Each button now carries a contextual `aria-label` —
"Stop warning that Windows uses Win+E" — with the short `title` kept as the hover tooltip.

`MudIconButton` in MudBlazor 9.3.0 has no `Title` or `AriaLabel` parameter, so both ride on
`MudComponentBase.UserAttributes`, the way `Hotkeys.razor:188` already does it.

### Overflow

`UsedBy` holds up to 60 characters and `Does` up to 200, the owner types both, and neither is
guaranteed to contain a space. The row header is a three-column grid, `minmax(0, 1fr) auto auto`,
with `min-width: 0` and `overflow-wrap: anywhere`. A bare `1fr` floors at the content's minimum
width, which is what would push the button off a 375px screen.

## Testing

3,394 tests pass. Line coverage 94.5%, branch 81.6%, all per-assembly thresholds met.

- `KnownShortcutSourceChipTests` — 4 cases
- `KnownShortcutUseActionsTests` — 12 cases, including the accessible name per action
- `KnownShortcutMobileListTests` — 11 cases, including all three action events and the loading bar
- `KnownShortcutsPageTests` — 5 new cases: both branches render, one term filters both, the mobile
  branch acts on the use it names, paging at 20, and a new search term returning to page 1 **from
  page 2**
- `KnownShortcutsMobileFlowTests` — 4 E2E: silence and restore at 375×812, the three fields, and
  horizontal overflow at 375×812 with a seeded owner record at the 60/200-character limits and no
  spaces to break on. Tablet overflow test kept as secondary coverage.

Both branches reuse `ignore-use` / `restore-use` / `delete-use` and `data-test="known-shortcut-row"`,
so all 26 branch-sensitive selectors in `KnownShortcutsPageTests` and the ones in
`ShortcutWarningFlowTests` are now scoped to `.desktop-branch`. Same call `HotkeysPageTests.cs:553`
already made.

## Two bugs found while building this

**`LoadError="_loadError"` bound the literal string.** Blazor treats an unprefixed attribute value
as a literal for `string` parameters, so the mobile branch rendered a permanent error alert and
zero rows. Fixed to `@_loadError`. Caught by the new page tests.

**The E2E text assertion needed the id/use pair, not `.First`.** Searching `Win+E` also matches
`Win+Enter` once the search squeezes out spaces and plus signs, so the first row was `open Narrator`.

## Notes for reviewers

Add stays a toolbar button rather than a `MudFab` — a deliberate exception to the mobile convention
in `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md`. Hotkeys and hotstrings pair their FAB with a
full-screen dialog, so where the user taps does not matter. This page opens an inline form *above*
the list, and a FAB tapped far down the page would open a form the user cannot see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
