### PR TITLE
feat: known-shortcut marker on the hotkeys list

### DIFF
--- a/.claude/backlog/done/038-known-shortcut-indicator-on-hotkeys-list.md
+++ b/.claude/backlog/done/038-known-shortcut-indicator-on-hotkeys-list.md
@@ -16,10 +16,10 @@ As an owner, I want my hotkeys list to show which hotkeys match a known shortcut
 
 ## Acceptance criteria
 
-- [ ] A row whose combination matches a known shortcut carries a visible marker
-- [ ] The marker names what uses the combination, on hover or on tap
-- [ ] The desktop `MudDataGrid` branch and the mobile list branch both show it
-- [ ] The list reads the catalog through `IKnownShortcutCatalog`, so it costs no extra fetch
+- [x] A row whose combination matches a known shortcut carries a visible marker
+- [x] The marker names what uses the combination, on hover or on tap
+- [x] The desktop `MudDataGrid` branch and the mobile list branch both show it
+- [x] The list reads the catalog through `IKnownShortcutCatalog`, so it costs no extra fetch
 
 ## Out of scope
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/HotkeyMobileList.razor
@@ -45,6 +45,7 @@
                 @foreach (HotkeyEditModel item in Items)
                 {
                     bool expanded = item.Id is { } id && !_selectMode && _expandedId == id;
+                    string? notice = Notice(item);
                     <tr class="mobile-row" @onclick="() => OnRowClick(item)">
                         @if (_selectMode)
                         {
@@ -55,7 +56,20 @@
                                        @onchange="e => OnRowCheckboxChanged(item, IsChecked(e))" />
                             </td>
                         }
-                        <td class="trigger-cell"><code>@HotkeyActionDisplay.ComboLabel(item)</code></td>
+                        <td class="trigger-cell">
+                            <code>@HotkeyActionDisplay.ComboLabel(item)</code>
+                            @if (notice is not null)
+                            {
+                                @* No tooltip here: a tap-to-open tooltip would fight the row's own
+                                   tap-to-expand handler, and the text has its own line in the
+                                   panel. So a plain wrapper carries the name and the test hook,
+                                   and the icon stays decoration. No tabindex — there is nothing
+                                   to reveal on focus. *@
+                                <span role="img" aria-label="@notice" data-test="known-shortcut-marker">
+                                    <MudIcon Icon="@Icons.Material.Filled.Warning" Color="Color.Warning" Size="Size.Small" />
+                                </span>
+                            }
+                        </td>
                         <td class="replacement-cell">@item.Description</td>
                         <td class="chevron-cell">@(expanded ? "▾" : "▸")</td>
                     </tr>
@@ -72,6 +86,12 @@
                                     {
                                         <MudText Typo="Typo.body2" UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "context-row" })">
                                             <strong>Context:</strong> @item.ContextSummary
+                                        </MudText>
+                                    }
+                                    @if (notice is not null)
+                                    {
+                                        <MudText Typo="Typo.body2" UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "known-shortcut-row" })">
+                                            <strong>Known shortcut:</strong> @notice
                                         </MudText>
                                     }
                                     <MudText Typo="Typo.body2"><strong>Profiles:</strong>
@@ -123,6 +143,13 @@
     /// <summary>Suppresses the empty state while a load is in flight - an empty list mid-load is
     /// not yet known to be empty, and "No hotkeys yet" during a fetch reads as a result.</summary>
     [Parameter] public bool Loading { get; set; }
+
+    /// <summary>
+    /// Known-shortcut notices, keyed by the combination label a row prints. A row whose
+    /// combination is absent carries no marker.
+    /// </summary>
+    [Parameter] public IReadOnlyDictionary<string, string> ShortcutNotices { get; set; } =
+        new Dictionary<string, string>();
 
     private Guid? _expandedId;
     private bool _selectMode;
@@ -182,4 +209,7 @@
         _selectMode = false;
         _selectedIds.Clear();
     }
+
+    private string? Notice(HotkeyEditModel item) =>
+        ShortcutNotices.TryGetValue(HotkeyActionDisplay.ComboLabel(item), out string? notice) ? notice : null;
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/KnownShortcutNotices.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/KnownShortcutNotices.cs
@@ -69,16 +69,12 @@ internal static class KnownShortcutNotices
                     notices[label] = KnownShortcutWarning.TextFor(match, label);
             }
         }
-        catch (OperationCanceledException)
-        {
-            // The page moved on. Whatever was resolved so far is handed back; a newer load
-            // replaces it.
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // Caught broadly on purpose, the same way the edit dialog does. The marker is
             // advisory, and a list page must never fail to render because a notice could not be
-            // worked out.
+            // worked out. Cancellation is excluded: it propagates to the caller, exactly like
+            // the list fetch that already runs before this method is called.
             logger.LogWarning(ex, "Known-shortcut markers could not be built.");
         }
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/KnownShortcutNotices.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Helpers/KnownShortcutNotices.cs
@@ -1,0 +1,87 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Services;
+using AHKFlowApp.UI.Blazor.Validation;
+
+namespace AHKFlowApp.UI.Blazor.Helpers;
+
+/// <summary>
+/// Known-shortcut notices for a page of hotkey rows, keyed by the combination label the row
+/// renders. A combination that matches nothing is absent, so a <c>TryGetValue</c> miss is the
+/// "no marker" answer.
+/// </summary>
+/// <remarks>
+/// Two key forms are in play and they must not be swapped. The display label is built from the
+/// raw key, and it is both the dictionary key and the label the notice names. The canonical key
+/// goes to <see cref="KnownShortcutWarning.Match"/> and nowhere else. A row keyed "Esc" with Ctrl
+/// held displays "Ctrl+Esc" and canonicalizes to "Escape". Store the notice under "Ctrl+Escape"
+/// and the cell — which looks up "Ctrl+Esc", the string it is about to print — misses every time.
+/// </remarks>
+internal static class KnownShortcutNotices
+{
+    public static async Task<IReadOnlyDictionary<string, string>> BuildAsync(
+        IEnumerable<HotkeyEditModel> items,
+        IHotkeyKeyCatalog keys,
+        IKnownShortcutCatalog knownShortcuts,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        Dictionary<string, string> notices = [];
+
+        // One row per distinct label. Twenty rows sharing five combinations cost five
+        // canonicalize calls, not twenty.
+        List<HotkeyEditModel> distinct =
+        [
+            .. items
+                .GroupBy(item => HotkeyActionDisplay.ComboLabel(item), StringComparer.Ordinal)
+                .Select(group => group.First())
+        ];
+
+        if (distinct.Count == 0)
+            return notices;
+
+        try
+        {
+            // Session-cached: only the first read in a session reaches the network.
+            KnownShortcutCatalogDto? catalog = await knownShortcuts.GetAsync(ct);
+
+            if (catalog is null)
+            {
+                // The fetch failed. No marker anywhere, and a trace in the browser console. The
+                // cache does not remember the failure, so the next load tries again. This is the
+                // rule the edit dialog already follows.
+                logger.LogWarning("Known-shortcut list could not be read; showing no markers.");
+                return notices;
+            }
+
+            foreach (HotkeyEditModel item in distinct)
+            {
+                string label = HotkeyActionDisplay.ComboLabel(item);
+
+                // A key registry that has not loaded hands the key back unchanged, so an alias
+                // such as "Esc" misses the "Escape" row. The marker is advice, so a miss is the
+                // safe outcome.
+                string canonical = await keys.CanonicalizeAsync(item.Key, ct);
+
+                KnownShortcutDto? match = KnownShortcutWarning.Match(
+                    catalog, canonical, item.Ctrl, item.Alt, item.Shift, item.Win);
+
+                if (match is not null)
+                    notices[label] = KnownShortcutWarning.TextFor(match, label);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The page moved on. Whatever was resolved so far is handed back; a newer load
+            // replaces it.
+        }
+        catch (Exception ex)
+        {
+            // Caught broadly on purpose, the same way the edit dialog does. The marker is
+            // advisory, and a list page must never fail to render because a notice could not be
+            // worked out.
+            logger.LogWarning(ex, "Known-shortcut markers could not be built.");
+        }
+
+        return notices;
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
@@ -244,6 +244,7 @@
         }
 
         <HotkeyMobileList Items="_mobileItems"
+                         ShortcutNotices="_mobileNotices"
                          Profiles="_profiles"
                          Categories="_categories"
                          HasActiveFilters="HasActiveFilters"
@@ -303,6 +304,9 @@
     // silences or restores a use, and a surviving dictionary would keep showing a warning the
     // owner just turned off.
     private IReadOnlyDictionary<string, string> _gridNotices = new Dictionary<string, string>();
+
+    // The mobile branch's own copy. See the note on _gridNotices for why these are two fields.
+    private IReadOnlyDictionary<string, string> _mobileNotices = new Dictionary<string, string>();
 
     private IReadOnlyList<HotkeyEditModel> _mobileItems = [];
     private int _mobilePage = 1;
@@ -641,12 +645,18 @@
         {
             _loadError = ApiErrorMessageFactory.Build(result.Status, result.Problem);
             _mobileItems = [];
+            _mobileNotices = new Dictionary<string, string>();
             _mobileTotalPages = 0;
             return;
         }
 
         _mobileItems = [.. result.Value!.Items.Select(HotkeyEditModel.FromDto)];
         _mobileTotalPages = (int)Math.Ceiling((double)result.Value.TotalCount / _mobilePageSize);
+
+        // This path is awaited from an event handler or from OnInitializedAsync, so the render
+        // that follows already picks the notices up. No extra StateHasChanged is needed.
+        _mobileNotices = await KnownShortcutNotices.BuildAsync(
+            _mobileItems, KeyCatalog, KnownShortcuts, Logger, _cts.Token);
     }
 
     private async Task OnMobilePageChangedAsync(int page)

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
@@ -102,7 +102,26 @@
                     }
                     else
                     {
-                        <code>@HotkeyActionDisplay.ComboLabel(context.Item)</code>
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                            <code>@HotkeyActionDisplay.ComboLabel(context.Item)</code>
+                            @if (GridNotice(context.Item) is { } notice)
+                            {
+                                @* The attributes go on MudTooltip, never on MudIcon. MudIcon
+                                   hard-codes aria-hidden="true" on every branch, so a screen
+                                   reader ignores anything named there. MudTooltip puts
+                                   UserAttributes on its own root div, and that root is what
+                                   handles focusin — tabindex="0" makes the plain div focusable,
+                                   so a keyboard user can reveal the text. *@
+                                <MudTooltip Text="@notice"
+                                            UserAttributes="@(new Dictionary<string, object?> {
+                                                ["data-test"] = "known-shortcut-marker",
+                                                ["role"] = "img",
+                                                ["aria-label"] = notice,
+                                                ["tabindex"] = "0" })">
+                                    <MudIcon Icon="@Icons.Material.Filled.Warning" Color="Color.Warning" Size="Size.Small" />
+                                </MudTooltip>
+                            }
+                        </MudStack>
                     }
                 </CellTemplate>
             </PropertyColumn>
@@ -256,6 +275,8 @@
     [Inject] private IDialogService DialogService { get; set; } = default!;
     [Inject] private IUserPreferencesService Preferences { get; set; } = default!;
     [Inject] private IHotkeyKeyCatalog KeyCatalog { get; set; } = default!;
+    [Inject] private IKnownShortcutCatalog KnownShortcuts { get; set; } = default!;
+    [Inject] private ILogger<Hotkeys> Logger { get; set; } = default!;
 
     private MudDataGrid<HotkeyEditModel>? _grid;
     private HotkeyEditModel? _editingItem;
@@ -274,6 +295,14 @@
     private bool _hasColumnFilters;
     private int _rowsPerPage = UserPreferences.Default.RowsPerPage;
     private readonly CancellationTokenSource _cts = new();
+
+    // Notices for the desktop grid, keyed by the combination label the cell prints. Mobile gets
+    // its own field in the block below: both branches are in the DOM at once and load through
+    // separate paths, so one shared field would let a desktop load erase the mobile markers.
+    // Rebuilt on every load, never accumulated — the catalog is invalidated when an owner
+    // silences or restores a use, and a surviving dictionary would keep showing a warning the
+    // owner just turned off.
+    private IReadOnlyDictionary<string, string> _gridNotices = new Dictionary<string, string>();
 
     private IReadOnlyList<HotkeyEditModel> _mobileItems = [];
     private int _mobilePage = 1;
@@ -354,11 +383,16 @@
         if (!result.IsSuccess)
         {
             _loadError = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+            _gridNotices = new Dictionary<string, string>();
             await InvokeAsync(StateHasChanged);
             return new GridData<HotkeyEditModel> { Items = [], TotalItems = 0 };
         }
 
         List<HotkeyEditModel> items = [.. result.Value!.Items.Select(MapItem)];
+
+        // Built inside the await the grid is already in, so the cells have their notices by the
+        // time this returns and no extra StateHasChanged is needed.
+        _gridNotices = await KnownShortcutNotices.BuildAsync(items, KeyCatalog, KnownShortcuts, Logger, ct);
 
         ClearEditingIfMissing(items);
 
@@ -411,6 +445,11 @@
 
     private bool IsEditing(HotkeyEditModel item) =>
         _editingItem is { Id: Guid editingId } && item.Id == editingId;
+
+    // The lookup key is the label the cell is about to print, so nothing new has to be threaded
+    // into the cell. A miss means "no marker".
+    private string? GridNotice(HotkeyEditModel item) =>
+        _gridNotices.TryGetValue(HotkeyActionDisplay.ComboLabel(item), out string? notice) ? notice : null;
 
     private string GetRowClass(HotkeyEditModel item, int _)
         => IsEditing(item) ? "edit-row" : string.Empty;

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Hotkeys.razor
@@ -330,16 +330,19 @@
 
         if (_isAuthenticated)
         {
-            // Three independent fetches, so they go out together rather than costing three
+            // Four independent fetches, so they go out together rather than costing four
             // serial round trips before the list can start loading. The key registry is warmed
             // here because IsValidKey answers optimistically until it arrives, which would
-            // route a legacy row to inline edit by mistake.
+            // route a legacy row to inline edit by mistake. The known-shortcut catalog is
+            // warmed here too, so the first BuildAsync call finds it already cached instead of
+            // paying its own round trip after the list has already come back.
             Task<ApiResult<IReadOnlyList<ProfileDto>>> profilesTask = ProfilesApi.ListAsync(_cts.Token);
             Task<ApiResult<PagedList<CategoryDto>>> catTask =
                 CategoriesApi.ListAsync(new CategoryListRequest(PageSize: 200), _cts.Token);
             Task keysTask = KeyCatalog.ForRoleAsync("HotkeyKey", _cts.Token).AsTask();
+            Task shortcutsTask = KnownShortcuts.GetAsync(_cts.Token).AsTask();
 
-            await Task.WhenAll(profilesTask, catTask, keysTask);
+            await Task.WhenAll(profilesTask, catTask, keysTask, shortcutsTask);
 
             ApiResult<IReadOnlyList<ProfileDto>> profilesResult = await profilesTask;
             if (profilesResult.IsSuccess)

--- a/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
@@ -218,6 +218,32 @@ public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifet
             .ToHaveCountAsync(0);
     }
 
+    [Fact]
+    public async Task AHotkeyOnAKnownShortcut_IsMarkedOnTheList()
+    {
+        await using IBrowserContext context = await fixture.Browser.NewContextAsync();
+        IPage page = await context.NewPageAsync();
+
+        // Win+L is a seeded Protected row: Windows locks the computer with it.
+        await OpenCreateDialogAsync(page);
+        await CommitKeyAsync(page, "l");
+        await page.CheckAsync(".hotkey-edit-dialog input[data-test=\"win-checkbox\"]");
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"description-input\"]", "E2E lock marker");
+        await page.FillAsync(".hotkey-edit-dialog [data-test=\"text-input\"]", "my notes");
+        await page.ClickAsync(".hotkey-edit-dialog button.commit-edit");
+        await page.WaitForSelectorAsync("text=Hotkey created.");
+
+        // Scoped to the desktop branch: the mobile branch renders too and is hidden by CSS only.
+        ILocator marker = page.Locator(".desktop-branch tr", new() { HasTextString = "E2E lock marker" })
+            .Locator("[data-test=\"known-shortcut-marker\"]");
+
+        await Assertions.Expect(marker).ToHaveCountAsync(1);
+
+        // The name a screen reader reads is the whole notice, the same sentence the dialog shows.
+        string? label = await marker.GetAttributeAsync("aria-label");
+        Assert.Contains("Windows uses Win+L to lock the computer.", label, StringComparison.Ordinal);
+    }
+
     // The table holds a row per use, over a hundred of them, and pages at 25. Every row this file
     // acts on is addressed through the search box, never by paging to it.
     private async Task OpenKnownShortcutsAsync(IPage page, string? search = null)

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/HotkeyMobileListTests.cs
@@ -1,6 +1,7 @@
 using AHKFlowApp.UI.Blazor.Components.Hotkeys;
 using AHKFlowApp.UI.Blazor.DTOs;
 using AHKFlowApp.UI.Blazor.Validation;
+using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
@@ -235,5 +236,68 @@ public sealed class HotkeyMobileListTests : BunitContext, IAsyncLifetime
 
         cut.Markup.Should().NotContain("No hotkeys yet.");
         cut.Markup.Should().NotContain("No hotkeys match these filters.");
+    }
+
+    private const string Notice =
+        "Windows uses Ctrl+Shift+K to open the console. Your hotkey may override this shortcut.";
+
+    private static IReadOnlyDictionary<string, string> NoticeFor(string label) =>
+        new Dictionary<string, string> { [label] = Notice };
+
+    [Fact]
+    public void CollapsedRow_WithAKnownShortcut_ShowsTheMarkerWithItsName()
+    {
+        IRenderedComponent<HotkeyMobileList> cut = Render<HotkeyMobileList>(p => p
+            .Add(c => c.Items, [Item("Open palette", "K", ctrl: true, shift: true)])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[])
+            .Add(c => c.ShortcutNotices, NoticeFor("Ctrl+Shift+K")));
+
+        // No tooltip here, so the wrapper carries the accessible name. MudIcon hard-codes
+        // aria-hidden="true", so naming the icon itself would reach no screen reader.
+        IElement marker = cut.Find("td.trigger-cell [data-test=\"known-shortcut-marker\"]");
+        marker.GetAttribute("role").Should().Be("img");
+        marker.GetAttribute("aria-label").Should().Be(Notice);
+    }
+
+    [Fact]
+    public void CollapsedRow_WithoutAKnownShortcut_ShowsNoMarker()
+    {
+        IRenderedComponent<HotkeyMobileList> cut = Render<HotkeyMobileList>(p => p
+            .Add(c => c.Items, [Item("Open palette", "K", ctrl: true, shift: true)])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[])
+            .Add(c => c.ShortcutNotices, NoticeFor("Win+E")));
+
+        cut.FindAll("[data-test=\"known-shortcut-marker\"]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExpandedRow_WithAKnownShortcut_ShowsTheNoticeLine()
+    {
+        IRenderedComponent<HotkeyMobileList> cut = Render<HotkeyMobileList>(p => p
+            .Add(c => c.Items, [Item("Open palette", "K", ctrl: true, shift: true)])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[])
+            .Add(c => c.ShortcutNotices, NoticeFor("Ctrl+Shift+K")));
+
+        await cut.InvokeAsync(() => cut.Find("tr.mobile-row").Click());
+
+        cut.WaitForAssertion(() =>
+            cut.Find("[data-test=\"known-shortcut-row\"]").TextContent.Should().Contain(Notice));
+    }
+
+    [Fact]
+    public async Task ExpandedRow_WithoutAKnownShortcut_HidesTheNoticeLine()
+    {
+        IRenderedComponent<HotkeyMobileList> cut = Render<HotkeyMobileList>(p => p
+            .Add(c => c.Items, [Item()])
+            .Add(c => c.Profiles, (IReadOnlyList<ProfileDto>)[])
+            .Add(c => c.Categories, (IReadOnlyList<CategoryDto>)[]));
+
+        await cut.InvokeAsync(() => cut.Find("tr.mobile-row").Click());
+
+        cut.WaitForAssertion(() => cut.Find("tr.mobile-row-expanded").Should().NotBeNull());
+        cut.FindAll("[data-test=\"known-shortcut-row\"]").Should().BeEmpty();
     }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/KnownShortcutNoticesTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Helpers/KnownShortcutNoticesTests.cs
@@ -1,0 +1,136 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Helpers;
+using AHKFlowApp.UI.Blazor.Services;
+using AHKFlowApp.UI.Blazor.Validation;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Helpers;
+
+public sealed class KnownShortcutNoticesTests
+{
+    private readonly IHotkeyKeyCatalog _keys = Substitute.For<IHotkeyKeyCatalog>();
+    private readonly IKnownShortcutCatalog _knownShortcuts = Substitute.For<IKnownShortcutCatalog>();
+
+    // The Windows use of Win+E, in the shape the client DTOs carry it.
+    private static KnownShortcutCatalogDto WinEOnly() =>
+        new([
+            new KnownShortcutDto("windows.file-explorer", "e", false, false, false, true,
+                [new ShortcutUseDto("Windows", ShortcutProtection.Normal, ShortcutScope.Global, "open File Explorer")],
+                null),
+        ]);
+
+    // Ctrl+Escape, so the alias test has a row its raw key ("Esc") does not spell.
+    private static KnownShortcutCatalogDto CtrlEscapeOnly() =>
+        new([
+            new KnownShortcutDto("windows.start-menu", "Escape", true, false, false, false,
+                [new ShortcutUseDto("Windows", ShortcutProtection.Normal, ShortcutScope.Global, "open the Start menu")],
+                null),
+        ]);
+
+    private static HotkeyEditModel Row(string key, bool ctrl = false, bool win = false) =>
+        new() { Id = Guid.NewGuid(), Description = "Row", Key = key, Ctrl = ctrl, Win = win };
+
+    // The registry hands most keys back unchanged. Tests that need an alias override this.
+    private void StubCanonicalizeAsIs() =>
+        _keys.CanonicalizeAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(call => ValueTask.FromResult(call.Arg<string?>() ?? ""));
+
+    private void StubCatalog(KnownShortcutCatalogDto? catalog) =>
+        _knownShortcuts.GetAsync(Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(catalog));
+
+    private Task<IReadOnlyDictionary<string, string>> BuildAsync(params HotkeyEditModel[] items) =>
+        KnownShortcutNotices.BuildAsync(items, _keys, _knownShortcuts, NullLogger.Instance, CancellationToken.None);
+
+    [Fact]
+    public async Task BuildAsync_MatchingRow_KeysTheNoticeByTheComboLabel()
+    {
+        StubCanonicalizeAsIs();
+        StubCatalog(WinEOnly());
+
+        IReadOnlyDictionary<string, string> notices = await BuildAsync(Row("e", win: true));
+
+        notices.Should().ContainKey("Win+E");
+        notices["Win+E"].Should().Be(
+            "Windows uses Win+E to open File Explorer. Your hotkey may override this shortcut.");
+    }
+
+    [Fact]
+    public async Task BuildAsync_RowMatchingNothing_IsAbsent()
+    {
+        StubCanonicalizeAsIs();
+        StubCatalog(WinEOnly());
+
+        IReadOnlyDictionary<string, string> notices = await BuildAsync(Row("F13", win: true));
+
+        notices.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BuildAsync_BlankKey_IsAbsent()
+    {
+        StubCanonicalizeAsIs();
+        StubCatalog(WinEOnly());
+
+        IReadOnlyDictionary<string, string> notices = await BuildAsync(Row("", win: true));
+
+        notices.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BuildAsync_WhenTheCatalogFetchFails_ReturnsEmpty()
+    {
+        StubCanonicalizeAsIs();
+        StubCatalog(null);
+
+        IReadOnlyDictionary<string, string> notices = await BuildAsync(Row("e", win: true));
+
+        notices.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BuildAsync_TwoRowsSharingOneCombination_CanonicalizesOnce()
+    {
+        StubCanonicalizeAsIs();
+        StubCatalog(WinEOnly());
+
+        IReadOnlyDictionary<string, string> notices =
+            await BuildAsync(Row("e", win: true), Row("e", win: true));
+
+        notices.Should().ContainKey("Win+E");
+        await _keys.Received(1).CanonicalizeAsync("e", Arg.Any<CancellationToken>());
+    }
+
+    // The one mistake this helper can quietly make. The cell looks up the string it is about to
+    // print, which is built from the raw key. Storing the notice under the canonical label
+    // ("Ctrl+Escape") would match the catalog and still show no marker.
+    [Fact]
+    public async Task BuildAsync_AliasKey_KeysTheNoticeByTheRawLabel()
+    {
+        _keys.CanonicalizeAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(call => ValueTask.FromResult(call.Arg<string?>() == "Esc" ? "Escape" : call.Arg<string?>() ?? ""));
+        StubCatalog(CtrlEscapeOnly());
+
+        IReadOnlyDictionary<string, string> notices = await BuildAsync(Row("Esc", ctrl: true));
+
+        notices.Should().ContainKey("Ctrl+Esc");
+        notices.Should().NotContainKey("Ctrl+Escape");
+    }
+
+    // The notice names the keys the owner typed, not the registry's spelling of them — the same
+    // rule the edit dialog follows.
+    [Fact]
+    public async Task BuildAsync_AliasKey_NamesTheRawLabelInTheNotice()
+    {
+        _keys.CanonicalizeAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(call => ValueTask.FromResult(call.Arg<string?>() == "Esc" ? "Escape" : call.Arg<string?>() ?? ""));
+        StubCatalog(CtrlEscapeOnly());
+
+        IReadOnlyDictionary<string, string> notices = await BuildAsync(Row("Esc", ctrl: true));
+
+        notices["Ctrl+Esc"].Should().Contain("Ctrl+Esc").And.NotContain("Ctrl+Escape");
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
@@ -184,6 +184,17 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
     // Both branches render at once — the scoped CSS only hides one — so every marker assertion
     // is scoped to the branch it is about.
     private const string DesktopMarker = ".desktop-branch [data-test=\"known-shortcut-marker\"]";
+    private const string MobileMarker = ".mobile-branch [data-test=\"known-shortcut-marker\"]";
+
+    [Fact]
+    public void Mobile_RowMatchingAKnownShortcut_ShowsTheMarker()
+    {
+        StubKnownShortcuts(WinNCatalog());
+
+        IRenderedComponent<Hotkeys> cut = RenderPageWith(OneRunHotkey());
+
+        cut.WaitForAssertion(() => cut.FindAll(MobileMarker).Should().ContainSingle());
+    }
 
     [Fact]
     public void Grid_RowMatchingAKnownShortcut_ShowsTheMarker()

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/HotkeysPageTests.cs
@@ -4,6 +4,7 @@ using AHKFlowApp.UI.Blazor.DTOs;
 using AHKFlowApp.UI.Blazor.Pages;
 using AHKFlowApp.UI.Blazor.Services;
 using AHKFlowApp.UI.Blazor.Validation;
+using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Authorization;
@@ -28,6 +29,7 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
     private readonly IProfilesApiClient _profilesApi = Substitute.For<IProfilesApiClient>();
     private readonly ICategoriesApiClient _categoriesApi = Substitute.For<ICategoriesApiClient>();
     private readonly IHotkeyKeyCatalog _catalog = Substitute.For<IHotkeyKeyCatalog>();
+    private readonly IKnownShortcutCatalog _knownShortcuts = Substitute.For<IKnownShortcutCatalog>();
 
     private IRenderedComponent<MudDialogProvider>? _dialogProvider;
 
@@ -52,12 +54,10 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
         StubKeyCatalog(keysValid: true);
         Services.AddSingleton(_catalog);
 
-        // The edit dialog injects this. An empty catalog means no shortcut warning, which is what
-        // these page tests want — they are about the grid and the dialog opening, not the notice.
-        IKnownShortcutCatalog knownShortcuts = Substitute.For<IKnownShortcutCatalog>();
-        knownShortcuts.GetAsync(Arg.Any<CancellationToken>())
-            .Returns(ValueTask.FromResult<KnownShortcutCatalogDto?>(new KnownShortcutCatalogDto([])));
-        Services.AddSingleton(knownShortcuts);
+        // The edit dialog and the list both inject this. The default is an empty catalog: most
+        // page tests are about the grid and the dialog opening, not the notice.
+        StubKnownShortcuts(new KnownShortcutCatalogDto([]));
+        Services.AddSingleton(_knownShortcuts);
 
         Services.AddMudServices();
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -125,7 +125,21 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
         _catalog.GroupOf(Arg.Any<string>())
             .Returns(call => CatalogKeys.FirstOrDefault(k => k.Canonical == call.Arg<string>())?.Group);
         _catalog.IsValidKey(Arg.Any<string>()).Returns(keysValid);
+        _catalog.CanonicalizeAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(call => ValueTask.FromResult(call.Arg<string?>() ?? ""));
     }
+
+    private void StubKnownShortcuts(KnownShortcutCatalogDto catalog) =>
+        _knownShortcuts.GetAsync(Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<KnownShortcutCatalogDto?>(catalog));
+
+    /// <summary>The Windows use of Win+N, so a row bound to Win+N carries a marker.</summary>
+    private static KnownShortcutCatalogDto WinNCatalog() =>
+        new([
+            new KnownShortcutDto("windows.notepad", "n", false, false, false, true,
+                [new ShortcutUseDto("Windows", ShortcutProtection.Normal, ShortcutScope.Global, "open Notepad")],
+                null),
+        ]);
 
     private static ProfileDto MakeProfile(string name = "Work") =>
         new(Guid.NewGuid(), name, false, "header text", "footer text", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
@@ -166,6 +180,53 @@ public sealed class HotkeysPageTests : BunitContext, IAsyncLifetime
     // selection from the dropdown does, without depending on popover/JS behaviour.
     private static Task SetKeyAsync(IRenderedComponent<Hotkeys> cut, string? key) =>
         cut.InvokeAsync(() => cut.FindComponent<KeyPicker>().Instance.ValueChanged.InvokeAsync(key));
+
+    // Both branches render at once — the scoped CSS only hides one — so every marker assertion
+    // is scoped to the branch it is about.
+    private const string DesktopMarker = ".desktop-branch [data-test=\"known-shortcut-marker\"]";
+
+    [Fact]
+    public void Grid_RowMatchingAKnownShortcut_ShowsTheMarker()
+    {
+        StubKnownShortcuts(WinNCatalog());
+
+        IRenderedComponent<Hotkeys> cut = RenderPageWith(OneRunHotkey());
+
+        cut.WaitForAssertion(() => cut.FindAll(DesktopMarker).Should().ContainSingle());
+
+        IElement marker = cut.Find(DesktopMarker);
+        marker.GetAttribute("role").Should().Be("img");
+        marker.GetAttribute("tabindex").Should().Be("0");
+        marker.GetAttribute("aria-label").Should().Be(
+            "Windows uses Win+N to open Notepad. Your hotkey may override this shortcut.");
+    }
+
+    [Fact]
+    public void Grid_RowMatchingNothing_ShowsNoMarker()
+    {
+        StubKnownShortcuts(WinNCatalog());
+
+        // F1 with Win held is not the Win+N row, so nothing marks it.
+        IRenderedComponent<Hotkeys> cut = RenderPageWith(OneHotkeyOfKind(HotkeyActionKind.Run));
+
+        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
+        cut.FindAll(DesktopMarker).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Grid_RowInInlineEdit_ShowsNoMarker()
+    {
+        StubKnownShortcuts(WinNCatalog());
+
+        IRenderedComponent<Hotkeys> cut = RenderPageWith(OneRunHotkey());
+        cut.WaitForAssertion(() => cut.FindAll(DesktopMarker).Should().ContainSingle());
+
+        // The inline row renders the full ShortcutWarning alert, so an icon would say the same
+        // thing twice.
+        await cut.InvokeAsync(() => cut.Find(".desktop-branch button.start-edit").Click());
+
+        cut.WaitForAssertion(() => cut.FindAll(DesktopMarker).Should().BeEmpty());
+    }
 
     [Fact]
     public void Page_OnLoad_ShowsRowsFromApi()


### PR DESCRIPTION
Closes backlog item 038.

A hotkey row whose key-and-modifier combination matches a Known shortcut now shows a
small amber warning icon. It appears on both the desktop grid and the mobile list. The
marker is advice only — it never blocks a save, exactly like the warning in the edit
dialog.

## What changed

- **New helper.** `Helpers/KnownShortcutNotices.cs` resolves `combination label -> notice
  text` for a page of rows. It reads the two session caches the edit dialog already reads,
  so the list costs no extra fetch. A combination that matches nothing is absent from the
  dictionary, so a lookup miss is the "no marker" answer.
- **Desktop grid.** `Pages/Hotkeys.razor` builds `_gridNotices` in `LoadServerData` and
  renders a `MudTooltip`-wrapped `MudIcon` in the Hotkey column's read-only cell. A row in
  inline edit gets no icon — it already renders the full `ShortcutWarning` alert.
- **Mobile list.** `HotkeyMobileList.razor` takes a `ShortcutNotices` parameter, shows the
  icon on the collapsed row, and adds a "Known shortcut:" line to the expanded panel. The
  page builds `_mobileNotices` in `LoadMobileAsync`.

The two branches hold separate dictionaries on purpose. Both are in the DOM at the same
time and load through separate paths, so one shared field would let a desktop load erase
the mobile markers.

## The one trap this design has

Two key forms are in play and they must not be swapped. The display label is built from the
raw key, and it is both the dictionary key and the label the notice names. The canonical
key goes to `KnownShortcutWarning.Match` and nowhere else. A row keyed "Esc" with Ctrl held
displays "Ctrl+Esc" and canonicalizes to "Escape". Store the notice under "Ctrl+Escape" and
the cell — which looks up the string it is about to print — misses every time. Two unit
tests pin this down.

## Accessibility

`MudIcon` hard-codes `aria-hidden="true"`, so naming the icon itself would reach no screen
reader. On desktop the name and the test hook go on the `MudTooltip` root, which is also
what handles focus, so a keyboard user can reveal the text. On mobile a plain wrapper
carries the name — a tap-to-open tooltip would fight the row's own tap-to-expand handler,
and the text has its own line in the panel anyway.

## Testing

| Surface | Artifact |
|---|---|
| Helper, pure logic | `KnownShortcutNoticesTests` — 7 tests, including both alias cases |
| Desktop grid cell | `HotkeysPageTests` — marker shown, not shown, and gone during inline edit |
| Mobile list component | `HotkeyMobileListTests` — 4 tests |
| Page feeds the mobile branch | `HotkeysPageTests` — scoped to `.mobile-branch` |
| Blazor UI flow | `ShortcutWarningFlowTests` — Win+L marked on the list, in a real browser |

Gate on the final commit: `dotnet format --verify-no-changes` clean, Fast slice 2705
passed, E2E slice 36 passed, `git diff --check main...HEAD` clean.

## Known follow-ups, deliberately not fixed here

- The mobile trigger cell was never checked visually at about 400px wide. It is a `nowrap`
  cell and the icon widens it.
- An expanded mobile row announces the notice twice — once from the collapsed-row icon,
  once from the panel line.
- The desktop marker has `tabindex="0"` on a `role="img"` element, and the tooltip repeats
  the same sentence as the accessible name.
- A desktop edit or delete reloads the grid only, so `_mobileNotices` joins the existing
  `_mobileItems` staleness. Pre-existing behaviour, one more field in the same class.
- One `MudTooltip` popover per marked desktop row. Worth watching if rows-per-page is set
  high.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
