### PR TITLE
chore: drop dead Blazor-Environment header from nginx

### DIFF
--- a/.claude/backlog/done/049-nginx-emits-dead-blazor-environment-header.md
+++ b/.claude/backlog/done/049-nginx-emits-dead-blazor-environment-header.md
@@ -35,9 +35,19 @@ That disagreement is why this is a decision to make rather than a defect to fix.
 
 ## Acceptance criteria
 
-- [ ] A decision is recorded: delete the two `add_header` lines, or keep them with a comment that states .NET 10 does not read the header
-- [ ] The chosen change is applied at both `default.conf:10` and `:34`
-- [ ] If the lines are deleted, the container path is verified to still serve the correct configuration
+- [x] A decision is recorded: delete the two `add_header` lines, or keep them with a comment that states .NET 10 does not read the header
+- [x] The chosen change is applied at both `default.conf:10` and `:34`
+- [x] If the lines are deleted, the container path is verified to still serve the correct configuration
+
+**Decision:** both `add_header` lines were deleted. Every other place in the
+repository that mentions the header already says it is dead, so keeping it would
+have left the nginx file as the only misleading text.
+
+The .NET 10 release notes state the behaviour directly:
+[Set the environment in standalone Blazor WebAssembly apps](https://learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?view=aspnetcore-10.0#set-the-environment-in-standalone-blazor-webassembly-apps).
+The Blazor environments page linked under **Notes / dependencies** also still shows
+an nginx `add_header` recipe, but that section is version-gated to ASP.NET Core 3.1
+through 9.0 and does not render on the .NET 10 view of the page.
 
 ## Out of scope
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/nginx/default.conf
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/nginx/default.conf
@@ -4,10 +4,9 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Blazor environment marker. The local config is baked into appsettings.json
-    # at image build time (env-specific files are stripped); this header is kept
-    # as an explicit signal and for future use if standalone WASM honours it.
-    add_header Blazor-Environment "Local" always;
+    # The local config is baked into appsettings.json at image build time.
+    # See the Dockerfile: it copies appsettings.Local.json over appsettings.json
+    # and deletes the other environment files before publish.
 
     # Reverse-proxy API calls to the api container (same-origin, no CORS)
     location /api/ {
@@ -31,6 +30,5 @@ server {
     location ~* \.(js|css|wasm|dat|woff2)$ {
         expires 7d;
         add_header Cache-Control "public, max-age=604800";
-        add_header Blazor-Environment "Local" always;
     }
 }


### PR DESCRIPTION
## What

Deleted both dead `add_header Blazor-Environment "Local" always;` lines from
`src/Frontend/AHKFlowApp.UI.Blazor/nginx/default.conf`, and replaced the comment
above the first one with a comment that describes the real mechanism.

Closes backlog item 049.

## Why

In .NET 10 a standalone Blazor WebAssembly app does not read `Blazor-Environment`.
The environment is fixed at build time by `WasmApplicationEnvironmentName`.
See [Set the environment in standalone Blazor WebAssembly apps](https://learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?view=aspnetcore-10.0#set-the-environment-in-standalone-blazor-webassembly-apps).

The container gets its configuration from the Dockerfile instead. It copies
`appsettings.Local.json` over `appsettings.json` and deletes the other environment
files before publish.

## Verification

nginx accepts the edited file:

```
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
```

Live check against a freshly built image:

```
serving on http://localhost:32772
ready after 1s
PASS: /appsettings.json equals appsettings.Local.json
asset under test: /_framework/dotnet.native.puryxhmhq9.js
PASS: Cache-Control still sent on /_framework/dotnet.native.puryxhmhq9.js
PASS: no Blazor-Environment header on the asset
PASS: no Blazor-Environment header on /
----- asset response headers -----
HTTP/1.1 200 OK
Server: nginx/1.27.5
Content-Type: application/javascript
Content-Length: 145050
ETag: "6a3ecd1e-2369a"
Expires: Sun, 09 Aug 2026 15:07:50 GMT
Cache-Control: max-age=604800
Cache-Control: public, max-age=604800
Accept-Ranges: bytes
----- root response headers -----
HTTP/1.1 200 OK
Server: nginx/1.27.5
Content-Type: text/html
Content-Length: 1800
ETag: "6a6f3cef-708"
Accept-Ranges: bytes
```

Pre-PR gate: build 17 projects 0 errors 0 warnings, `dotnet format --verify-no-changes` clean,
`test-fast.ps1 -Mode Coverage` all thresholds met (line 94.5%, branch 81.7%),
`git diff --check main...HEAD` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
