### PR TITLE
docs: backlog housekeeping (031 hold, worktree convention, 050 follow-ups)

### DIFF
--- a/.claude/backlog/031-cli-winget-distribution.md
+++ b/.claude/backlog/031-cli-winget-distribution.md
@@ -6,6 +6,7 @@
 - **Type**: Feature
 - **Interfaces**: CLI
 - **Depends on**: 030-cli-native-windows-distribution
+- **Status**: On hold — see Notes/dependencies
 
 ## Summary
 
@@ -39,6 +40,9 @@ As a Windows user, I want to run `winget install AHKFlow.CLI` so that I can inst
 
 ## Notes / dependencies
 
+- On hold until the API is complete and the frontend design has been updated with the Claude design
+  files. Packaging and publishing a CLI installer against a client shape that is still changing risks
+  shipping a distribution for a UI/API surface that gets reworked shortly after.
 - Submission targets the existing v0.1.1 GitHub Release; no rebuild.
 - Manifests use `InstallerType: zip` + `NestedInstallerType: portable` so Winget handles PATH registration via its symlink directory.
 - License pulled from existing root `LICENSE` (MIT, Copyright 2026 Bart Segers).

--- a/.claude/backlog/050-known-shortcut-marker-review-followups.md
+++ b/.claude/backlog/050-known-shortcut-marker-review-followups.md
@@ -1,0 +1,54 @@
+# 050 - Known-shortcut marker review follow-ups
+
+## Metadata
+
+- **Epic**: Known shortcuts
+- **Type**: Chore
+- **Interfaces**: UI
+
+## Summary
+
+The whole-branch review of the known-shortcut list marker (backlog 038, PR #249) raised five Minor
+findings. None blocked the merge, so they were deferred rather than folded into the fix commit.
+Two are real accessibility defects, one is an unchecked layout risk, and two are notes that may
+need no work at all.
+
+## Acceptance criteria
+
+- [ ] An expanded mobile row announces the notice once, not twice — the collapsed-row
+      `<span role="img" aria-label="@notice">` stays in the DOM when the row expands, and the panel
+      then repeats the same sentence as text
+      (`Components/Hotkeys/HotkeyMobileList.razor:68` and `:93`). Likely fix: `aria-hidden="true"`
+      on the span while `expanded` is true
+- [ ] The desktop marker stops repeating its own accessible name — `aria-label` and
+      `MudTooltip.Text` carry the same string, so a keyboard user hears the sentence as the
+      element's name and again as the tooltip (`Pages/Hotkeys.razor:117`). Decide whether
+      `tabindex="0"` on a non-interactive `role="img"` element is wanted, and record the decision
+      either way
+- [ ] The mobile trigger cell is checked at about 400px wide with a marker present, and any
+      squeeze on the description is fixed — `.trigger-cell` is `width: 30%; white-space: nowrap`
+      (`Components/Hotkeys/HotkeyMobileList.razor.css:33`), so the added icon widens the column.
+      Nothing has looked at this yet; the marker went to bUnit only
+- [ ] A desktop edit or bulk delete refreshes the mobile branch too, or the gap is recorded as
+      accepted — `CommitEditAsync` and the desktop `BulkDeleteAsync` call `_grid.ReloadServerData()`
+      rather than `ReloadAllAsync()` (`Pages/Hotkeys.razor:534`), so `_mobileNotices` joins the
+      pre-existing `_mobileItems` staleness. Only observable if the viewport crosses 959.95px
+      without a reload
+- [ ] The tooltip-per-row cost is measured or accepted — one `MudTooltip` popover is registered per
+      marked desktop row (`Pages/Hotkeys.razor:113-121`), and `RowsPerPage` comes from user
+      preferences, so a large page can register many on WebAssembly
+
+## Out of scope
+
+- Any change to how a notice is resolved. `Helpers/KnownShortcutNotices.cs` is settled and covered
+  by tests
+- Any change to which rows carry a marker, or to the marker's icon, colour, or wording
+
+## Notes / dependencies
+
+- Source: whole-branch review of `feature/wt-038-known-shortcut-indicator` at `ce3585d2`, 2026-08-02.
+  The two Important findings from the same review were fixed on that branch in `6e4f8451`
+- Line numbers were recorded at `ce3585d2`. The fix commit added lines in `OnInitializedAsync`, so
+  references below that point have shifted slightly
+- The last two criteria may close as "no change needed". Record the reasoning rather than deleting
+  the line

--- a/docs/development/testing-workflow.md
+++ b/docs/development/testing-workflow.md
@@ -4,6 +4,10 @@ Use the fastest test slice that still covers the code you changed. The pre-push 
 
 This file is the single source for which tests to run and when. Other docs link here rather than restating commands.
 
+## Housekeeping worktree
+
+For small, unrelated doc or config tweaks — backlog notes, minor rule edits, one-off cleanups — that don't warrant their own branch, keep one long-lived worktree open, e.g. `chore/wt-backlog-housekeeping`. Commit each change to it immediately, as its own commit, so it shows up in git history right away — don't leave it staged or uncommitted. Don't open a PR after every commit. Once the branch holds a few of these, or one grows in importance, open the PR and start a fresh housekeeping worktree for the next round.
+
 ## Canonical pre-PR gate
 
 Four steps, in order. Nothing else counts as the gate.


### PR DESCRIPTION
## Summary
- Note backlog 031 on hold until API+frontend redesign lands
- Add housekeeping worktree convention doc
- Backlog 050 known-shortcut marker review follow-ups

## Test plan
- Docs-only change, no build/test surface affected