### PR TITLE
test: pin raw hotkey body inline error (backlog 051)

### DIFF
--- a/.claude/backlog/done/051-hotkey-raw-body-inline-error-not-rendering.md
+++ b/.claude/backlog/done/051-hotkey-raw-body-inline-error-not-rendering.md
@@ -20,11 +20,31 @@ itself, so I know what to fix.
 
 ## Acceptance criteria
 
-- [ ] Expanding the preview panel with an invalid Raw body shows the error text on the `Action body`
+- [x] Expanding the preview panel with an invalid Raw body shows the error text on the `Action body`
       field itself (`ErrorText`/`Error` on the `MudTextField`, `data-test="raw-body-input"`), not
       only the panel's generic "Fix the highlighted fields to see the generated code." message.
-- [ ] Clicking Save with an invalid Raw body shows a visible error — currently it shows nothing.
-- [ ] A regression test (E2E or Blazor component test) pins the fix so it cannot silently regress.
+- [x] Clicking Save with an invalid Raw body shows a visible error — currently it shows nothing.
+- [x] A regression test (E2E or Blazor component test) pins the fix so it cannot silently regress.
+
+## Outcome — not reproducible, closed with coverage
+
+The reported symptom does not happen. Both paths already put the message on the field. No
+production code needed changing; the item closes with the guard tests it was missing.
+
+What was checked, in order:
+
+1. A bUnit probe typed an invalid Raw body and failed the preview with `Input.Body`. The rendered
+   `raw-panel` markup carried `aria-invalid="true"` and the helper text held the server message. So
+   the component wiring was never broken, and a bUnit test cannot pin this behaviour either way.
+2. Because bUnit could not reproduce it, the check moved to a real browser against the real
+   validation rule. `RawBodyPreviewError_ShowsInlineOnTheBodyField` passes on first run — before any
+   change to production code. The preview path was already correct.
+3. `RawBodySaveError_ShowsInlineOnTheBodyField` covers the second criterion. It leaves the preview
+   panel collapsed, so only the Save response can produce the message it asserts.
+
+Why the original investigation saw nothing is not established. The most likely reading is that
+`aria-invalid` was polled on the wrong element — the Body input is a `textarea`, not an `input`, so
+a selector written for the other fields would match nothing and never change.
 
 ## Out of scope
 
@@ -48,3 +68,4 @@ itself, so I know what to fix.
 - 037's own E2E coverage (`tests/AHKFlowApp.E2E.Tests/HotkeysCrudFlowTests.cs`,
   `RawBodyInjectingAnotherHotkey_BlocksPreviewGeneration`) only asserts the panel-level
   blocked message for this reason — it could not honestly assert the field-level highlight.
+  That test's comment claiming the binding is broken has been corrected.

--- a/.claude/backlog/done/051-hotkey-raw-body-inline-error-not-rendering.md
+++ b/.claude/backlog/done/051-hotkey-raw-body-inline-error-not-rendering.md
@@ -41,10 +41,14 @@ What was checked, in order:
    change to production code. The preview path was already correct.
 3. `RawBodySaveError_ShowsInlineOnTheBodyField` covers the second criterion. It leaves the preview
    panel collapsed, so only the Save response can produce the message it asserts.
+4. The Save test then re-checks the message 1500 ms later. Filling the body arms a 300 ms debounce
+   whose elapsed handler calls `ClearSaveError("Body")` — the same key the Save response writes. The
+   message was measured as still present after that window, so the two do not race. Without this
+   second check the test would pass on a message that vanished a moment later.
 
-Why the original investigation saw nothing is not established. The most likely reading is that
-`aria-invalid` was polled on the wrong element — the Body input is a `textarea`, not an `input`, so
-a selector written for the other fields would match nothing and never change.
+Why the original investigation saw nothing is not established, and this item does not claim to know.
+No evidence from that session survives, so the question is left open rather than answered with a
+guess.
 
 ## Out of scope
 

--- a/tests/AHKFlowApp.E2E.Tests/HotkeysCrudFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/HotkeysCrudFlowTests.cs
@@ -217,6 +217,18 @@ public sealed class HotkeysCrudFlowTests(StackFixture fixture) : IAsyncLifetime
         await Assertions.Expect(page.Locator(".hotkey-edit-dialog textarea[data-test=\"raw-body-input\"]"))
             .ToHaveAttributeAsync("aria-invalid", "true");
 
+        // The message must still be there once the field's debounce can no longer be pending.
+        // Filling the body arms a 300 ms timer (HotkeyEditDialog.razor:173-175) whose elapsed
+        // handler calls ClearSaveError("Body") (razor:375-379) — the same key the Save response
+        // writes (razor:414). Playwright's Expect polls, so the assertions above would go green on
+        // a message that vanished a moment later. Re-checking after the window closes is what
+        // makes this test prove the user can actually read the message.
+        await page.WaitForTimeoutAsync(1500);
+        await Assertions.Expect(page.Locator(".hotkey-edit-dialog .raw-body-wrap .mud-input-helper-text"))
+            .ToContainTextAsync("Raw body braces are unbalanced.");
+        await Assertions.Expect(page.Locator(".hotkey-edit-dialog textarea[data-test=\"raw-body-input\"]"))
+            .ToHaveAttributeAsync("aria-invalid", "true");
+
         // The rejected hotkey must not have been created, and the dialog must still be open on it.
         await Assertions.Expect(page.Locator(".hotkey-edit-dialog")).ToBeVisibleAsync();
     }

--- a/tests/AHKFlowApp.E2E.Tests/HotkeysCrudFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/HotkeysCrudFlowTests.cs
@@ -114,9 +114,8 @@ public sealed class HotkeysCrudFlowTests(StackFixture fixture) : IAsyncLifetime
     // on screen — the body field debounces for 300 ms (HotkeyEditDialog.razor:175). Proving the
     // snippet rendered first means the blocked message can only come from the injected definition.
     //
-    // This does NOT assert the field-level highlight on the Body textarea itself — that binding is
-    // broken for every Raw rule today, not just this one (backlog 051, found while writing this
-    // test). Only the panel-level message is asserted, because that is the part that actually works.
+    // This asserts only the panel-level message. The field-level highlight on the Body textarea is
+    // a separate concern, covered by RawBodyPreviewError_ShowsInlineOnTheBodyField below.
     [Fact]
     public async Task RawBodyInjectingAnotherHotkey_BlocksPreviewGeneration()
     {
@@ -151,6 +150,75 @@ public sealed class HotkeysCrudFlowTests(StackFixture fixture) : IAsyncLifetime
             .ToContainTextAsync("Fix the highlighted fields to see the generated code.");
         await Assertions.Expect(page.Locator(".hotkey-edit-dialog [data-test=\"preview-snippet\"]"))
             .ToHaveCountAsync(0);
+    }
+
+    // Backlog 051: the Body field's own inline error, on the preview path. A bUnit test cannot
+    // pin this — it renders the field correctly whether or not the browser does — so the guard
+    // has to run in a real browser against the real validation rule.
+    [Fact]
+    public async Task RawBodyPreviewError_ShowsInlineOnTheBodyField()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync();
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotkeys");
+        await page.WaitForSelectorAsync("button.add-hotkey");
+
+        await page.ClickAsync("button.add-hotkey");
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog");
+
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"description-input\"]", "E2E raw inline error");
+        await CommitKeyAsync(page, ".hotkey-edit-dialog input[data-test=\"key-picker\"]", "j");
+
+        await page.ClickAsync(".hotkey-edit-dialog [data-test=\"action-kind-Raw\"]");
+        await page.ClickAsync(".hotkey-edit-dialog [data-test=\"ahk-preview\"] .mud-expand-panel-header");
+
+        await page.FillAsync(".hotkey-edit-dialog textarea[data-test=\"raw-body-input\"]", "return");
+        await Assertions.Expect(page.Locator(".hotkey-edit-dialog [data-test=\"preview-snippet\"]"))
+            .ToContainTextAsync("j::return");
+
+        await page.FillAsync(".hotkey-edit-dialog textarea[data-test=\"raw-body-input\"]", "if (1) {");
+
+        await Assertions.Expect(page.Locator(".hotkey-edit-dialog [data-test=\"preview-blocked\"]"))
+            .ToContainTextAsync("Fix the highlighted fields to see the generated code.");
+
+        await Assertions.Expect(page.Locator(".hotkey-edit-dialog textarea[data-test=\"raw-body-input\"]"))
+            .ToHaveAttributeAsync("aria-invalid", "true");
+        await Assertions.Expect(page.Locator(".hotkey-edit-dialog .raw-body-wrap .mud-input-helper-text"))
+            .ToContainTextAsync("Raw body braces are unbalanced.");
+    }
+
+    // Backlog 051, second half: Save routes a Body error into _saveFieldErrors
+    // (HotkeyEditDialog.razor:414) rather than the generic alert, so the field is the only place
+    // the user can learn why Save did nothing. The preview panel stays collapsed here on purpose —
+    // that way only the Save response can produce the message being asserted.
+    [Fact]
+    public async Task RawBodySaveError_ShowsInlineOnTheBodyField()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync();
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotkeys");
+        await page.WaitForSelectorAsync("button.add-hotkey");
+
+        await page.ClickAsync("button.add-hotkey");
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog");
+
+        await page.FillAsync(".hotkey-edit-dialog input[data-test=\"description-input\"]", "E2E raw save error");
+        await CommitKeyAsync(page, ".hotkey-edit-dialog input[data-test=\"key-picker\"]", "j");
+
+        await page.ClickAsync(".hotkey-edit-dialog [data-test=\"action-kind-Raw\"]");
+        await page.FillAsync(".hotkey-edit-dialog textarea[data-test=\"raw-body-input\"]", "if (1) {");
+
+        await page.ClickAsync(".hotkey-edit-dialog button.commit-edit");
+
+        await Assertions.Expect(page.Locator(".hotkey-edit-dialog .raw-body-wrap .mud-input-helper-text"))
+            .ToContainTextAsync("Raw body braces are unbalanced.");
+        await Assertions.Expect(page.Locator(".hotkey-edit-dialog textarea[data-test=\"raw-body-input\"]"))
+            .ToHaveAttributeAsync("aria-invalid", "true");
+
+        // The rejected hotkey must not have been created, and the dialog must still be open on it.
+        await Assertions.Expect(page.Locator(".hotkey-edit-dialog")).ToBeVisibleAsync();
     }
 
     // Fills a MudAutocomplete key picker and commits the typed value by blurring (CoerceValue).


### PR DESCRIPTION
Closes backlog 051.

## Verdict: not reproducible

051 reported that the Raw `Action body` field never shows its server validation
error — no inline highlight on the preview path, and nothing at all on Save. That
does not happen. The binding at `HotkeyEditDialog.razor:176-177` was already
correct. **No production code changed in this PR.**

The item closes with the guard tests it was missing.

## How that was established

1. A bUnit probe typed an invalid Raw body and failed the preview with
   `Input.Body`. The rendered `raw-panel` markup already carried
   `aria-invalid="true"` and the helper text held the server message. So the
   component wiring was never broken — and a bUnit test cannot pin this
   behaviour either way, since it renders the component tree directly and would
   pass whether or not a browser agrees. The probe was reverted.
2. That moved the check to a real browser against the real validation rule
   (`HotkeyRules.cs:105`). `RawBodyPreviewError_ShowsInlineOnTheBodyField` passed
   on its first run, before any change to production code.
3. `RawBodySaveError_ShowsInlineOnTheBodyField` covers the second acceptance
   criterion. It leaves the preview panel collapsed on purpose, so only the Save
   response can produce the message it asserts.
4. Review flagged that test as timing-coupled: filling the body arms a 300 ms
   debounce whose elapsed handler calls `ClearSaveError("Body")`, the same key
   the Save response writes. Playwright polls, so the assertions could have gone
   green on a message that vanished a moment later. Measured rather than assumed
   — the message and `aria-invalid` are both still present 1500 ms after Save, so
   the two do not race. That check is now a permanent assertion.

## Also in this PR

- Corrects the comment in `RawBodyInjectingAnotherHotkey_BlocksPreviewGeneration`
  that claimed the field-level binding was broken.
- Moves the backlog item to `.claude/backlog/done/` with its boxes ticked, per the
  Git Workflow rule in AGENTS.md.

## Known limit

The persistence check holds in this environment, where the API is in-process
(`StackFixture.cs:72-73`) and the Save response lands well under the 300 ms
debounce. A slower real network reverses that ordering — response after the
debounce rather than before — which these tests do not exercise.

## Gate

All four steps from `docs/development/testing-workflow.md`:

- `dotnet build AHKFlowApp.slnx --configuration Release` — 17 projects, 0 errors, 0 warnings
- `dotnet format AHKFlowApp.slnx --verify-no-changes` — clean
- `pwsh .\scripts\test-fast.ps1 -Mode Coverage` — all five assemblies pass; line 94.5%, branch 81.9%
- `git diff --check main...HEAD` — clean

Raw-body E2E tests: `Passed: 3, Failed: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
