### PR TITLE
feat: header preset library

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -126,6 +126,10 @@ _Avoid_: script (unqualified), file, output, ahk
 The user-editable text a Profile places before and after the definitions in its Profile script. Tokens such as the profile's name or the generation time are substituted when the script is generated; unknown tokens are left as typed.
 _Avoid_: preamble, banner, boilerplate, prologue/epilogue
 
+**Header preset**:
+A ready-made block of AutoHotkey the app can append to a Profile's header template. The app ships a fixed list; an owner picks one, and from then on the text is an ordinary part of their header. Presets carry settings that apply to a whole Profile, which no Hotstring or Hotkey can express.
+_Avoid_: snippet, template, macro, boilerplate
+
 ### History
 
 **Snapshot**:

--- a/backlog/done/043-header-preset-library.md
+++ b/backlog/done/043-header-preset-library.md
@@ -10,6 +10,8 @@
 
 A profile header is an empty box with a few default lines in it. Anything beyond that has to be typed from memory, in a language most owners do not write daily. Ship a short list of ready-made header blocks that an owner can pick from a list and drop straight into the header.
 
+**Shipped as "header preset", not "snippet"** — `CONTEXT.md` lists snippet as a word to avoid.
+
 ## User story
 
 As an owner, I want to pick a common header setting from a list, so that I do not have to write AutoHotkey by hand to change how my whole profile behaves.
@@ -74,18 +76,18 @@ This is the same test that keeps clipboard hotkeys out. Applying it to some cand
 
 ## Acceptance criteria
 
-- [ ] A snippet catalog exists in the Application project as shipped constants, each entry carrying a stable id, name, one-line description, tag, and body
-- [ ] The API serves the catalog read-only, through a query and controller action, the same way the hotkey key registry is served
-- [ ] The Blazor project reads the catalog from that endpoint and holds no copy of the bodies
-- [ ] The profile header editor has a control that opens the picker, grouped by tag
-- [ ] Picking a snippet appends it to the header, wrapped in the marker comments
-- [ ] A header that does not end with a line break gets one before the opening marker, so a marker never joins the owner's last line
-- [ ] An insert that would push the header past `ProfileRules.HeaderTemplateMaxLength` is refused with a message, and the header is left unchanged
-- [ ] A snippet already present in the header is shown as unavailable
-- [ ] No snippet body repeats a directive the default header already emits
-- [ ] Every snippet body survives header rendering unchanged
-- [ ] Every snippet body is checked against the project's AutoHotkey v2 syntax reference before it ships
-- [ ] No snippet is inserted on its own. A newly created profile and a lazily seeded profile both have a header with no snippet markers in it
+- [x] A snippet catalog exists in the Application project as shipped constants, each entry carrying a stable id, name, one-line description, tag, and body
+- [x] The API serves the catalog read-only, through a query and controller action, the same way the hotkey key registry is served
+- [x] The Blazor project reads the catalog from that endpoint and holds no copy of the bodies
+- [x] The profile header editor has a control that opens the picker, grouped by tag
+- [x] Picking a snippet appends it to the header, wrapped in the marker comments
+- [x] A header that does not end with a line break gets one before the opening marker, so a marker never joins the owner's last line
+- [x] An insert that would push the header past `ProfileRules.HeaderTemplateMaxLength` is refused with a message, and the header is left unchanged
+- [x] A snippet already present in the header is shown as unavailable
+- [x] No snippet body repeats a directive the default header already emits
+- [x] Every snippet body survives header rendering unchanged
+- [x] Every snippet body is checked against the project's AutoHotkey v2 syntax reference before it ships
+- [x] No snippet is inserted on its own. A newly created profile and a lazily seeded profile both have a header with no snippet markers in it
 
 ## Out of scope
 

--- a/docs/development/ahk-v2-syntax.md
+++ b/docs/development/ahk-v2-syntax.md
@@ -64,6 +64,29 @@ Body layout, in order: paste helper (only when some hotstring needs it), `; --- 
 hotstring window-context groups, global hotstrings, `; --- Hotkeys ---`, hotkey window-context
 groups, global hotkeys, footer. Lines are joined with `\n`.
 
+## Header presets
+
+`HeaderPresetCatalog` ships blocks an owner can append to a profile header from the Profiles page.
+The text is copied in once; the app never rewrites a header afterwards. The blocks use four
+constructs the emitters do not:
+
+| Construct | Used by | Official page |
+|---|---|---|
+| `SetCapsLockState "AlwaysOff"` and its Num/Scroll siblings | lock keys, Caps Lock layer | `docs/lib/SetNumScrollCapsLockState.htm` |
+| `*Key::` / `*Key up::` with `Send "{Blind}{LCtrl DownR}"` | both keyboard layers | `docs/misc/Remap.htm` — AutoHotkey's own translation of a remap |
+| `SetTimer` plus `Suspend` | pause while an application is in front | `docs/lib/SetTimer.htm`, `docs/lib/Suspend.htm` |
+| `#Hotstring EndChars ...` | ending characters | `docs/Hotstrings.htm`, "Ending Characters" |
+
+Two rules bind every body, and `HeaderPresetCatalogTests` enforces both:
+
+- **No doubled braces.** `HeaderTokenRenderer` turns `{{` into `{`, which would silently change
+  the script.
+- **No directive the default header already sets.** Setting one twice warns or misbehaves.
+
+**A preset must not use `#HotIf`.** `AhkScriptGenerator` closes every window-context group with a
+bare `#HotIf`, so a context opened in the header does not survive. Use `Suspend` on a timer
+instead.
+
 ## Hotstring definitions
 
 The shape is:

--- a/src/Backend/AHKFlowApp.API/Controllers/ProfilesController.cs
+++ b/src/Backend/AHKFlowApp.API/Controllers/ProfilesController.cs
@@ -21,8 +21,19 @@ public sealed class ProfilesController(
     IUseCase<GetProfileQuery, Result<ProfileDto>> getProfile,
     IUseCase<CreateProfileCommand, Result<ProfileDto>> createProfile,
     IUseCase<UpdateProfileCommand, Result<ProfileDto>> updateProfile,
-    IUseCase<DeleteProfileCommand, Result> deleteProfile) : ControllerBase
+    IUseCase<DeleteProfileCommand, Result> deleteProfile,
+    IUseCase<ListHeaderPresetsQuery, Result<HeaderPresetCatalogDto>> listHeaderPresets) : ControllerBase
 {
+    /// <summary>Get the shipped header presets for the profile header picker.</summary>
+    /// <remarks>
+    /// Static reference data. Authorized because the controller is, not because it is
+    /// user-scoped. Inserting a preset is a client-side text edit saved through PUT.
+    /// </remarks>
+    [HttpGet("header-presets")]
+    [ProducesResponseType(typeof(HeaderPresetCatalogDto), StatusCodes.Status200OK)]
+    public async Task<ActionResult<HeaderPresetCatalogDto>> HeaderPresets(CancellationToken ct) =>
+        (await listHeaderPresets.ExecuteAsync(new ListHeaderPresetsQuery(), ct)).ToProblemActionResult(this);
+
     /// <summary>List the current user's profiles. Lazily seeds a default profile on first call.</summary>
     [HttpGet]
     [ProducesResponseType(typeof(IReadOnlyList<ProfileDto>), StatusCodes.Status200OK)]

--- a/src/Backend/AHKFlowApp.Application/Constants/HeaderPresetCatalog.cs
+++ b/src/Backend/AHKFlowApp.Application/Constants/HeaderPresetCatalog.cs
@@ -94,8 +94,10 @@ internal static class HeaderPresetCatalog
 
     private const string HotstringEndCharactersBody = """
         ; Choose which characters finish a hotstring.
-        ; This list replaces AutoHotkey's default list for every hotstring below it.
+        ; This list replaces AutoHotkey's default list for all hotstrings, not just the ones below it.
         ; `n is Enter, `s is Space, `t is Tab.
+        ; This list matches AutoHotkey's own default, so it changes nothing unless you edit it.
+        ; Remove characters you don't want, or add ones you do.
         #Hotstring EndChars -()[]{}:;'"/\,.?!`n`s`t
         """;
 }

--- a/src/Backend/AHKFlowApp.Application/Constants/HeaderPresetCatalog.cs
+++ b/src/Backend/AHKFlowApp.Application/Constants/HeaderPresetCatalog.cs
@@ -1,0 +1,114 @@
+namespace AHKFlowApp.Application.Constants;
+
+/// <summary>
+/// The shipped header presets. Each body is AutoHotkey v2 text that an owner may append to a
+/// Profile header; from that moment the text is theirs, and a later app version never rewrites
+/// it. Every body is checked by <c>HeaderPresetCatalogTests</c> against two rules that would
+/// otherwise break a generated script: no doubled braces, and no directive the default header
+/// already emits.
+/// </summary>
+/// <remarks>
+/// A preset exists only for whole-profile behaviour that a Hotstring or Hotkey row cannot
+/// express. Anything a row already does stays a row, where it gets editing, history, and
+/// conflict checks.
+/// </remarks>
+internal static class HeaderPresetCatalog
+{
+    public static IReadOnlyList<HeaderPreset> All { get; } =
+    [
+        new("capslock-modifier-layer",
+            "Caps Lock works as Ctrl+Alt+Shift",
+            "Hold Caps Lock to use hotkeys set up with Ctrl, Alt and Shift. This does not fire Ctrl+Alt hotkeys. Caps Lock stops switching capitals on and off.",
+            "Keyboard layer",
+            CapsLockLayerBody),
+
+        new("lock-keys-off",
+            "Keep Num Lock, Caps Lock and Scroll Lock off",
+            "Holds all three lock keys off, so pressing one by accident changes nothing.",
+            "Lock keys",
+            LockKeysOffBody),
+
+        new("pause-while-app-in-front",
+            "Pause every shortcut while one application is in front",
+            "Names one application, such as a game. While its window is in front, no hotstring or hotkey fires.",
+            "Application behaviour",
+            PauseWhileAppInFrontBody),
+
+        new("hotstring-end-characters",
+            "Choose which characters finish a hotstring",
+            "Replaces AutoHotkey's default list of characters that fire a hotstring.",
+            "Typing",
+            HotstringEndCharactersBody),
+    ];
+
+    // The layer is Ctrl+Alt+Shift, not Ctrl+Alt: AutoHotkey treats AltGr as Left Ctrl + Right
+    // Alt, so on an international layout a Ctrl+Alt layer fights the keyboard. Win is left out
+    // because releasing it opens the Start menu. Ctrl+Alt+Shift does not fire the Ctrl+Alt
+    // sample rows — an ordinary hotkey needs the exact modifier set — which is why the body
+    // says so in a comment. The down/up pair is AutoHotkey's own translation of a remap
+    // (docs/misc/Remap.htm, "each remapping is translated into a pair of hotkeys").
+    private const string CapsLockLayerBody = """
+        ; Hold Caps Lock to press Ctrl, Alt and Shift together.
+        ; Set your hotkeys to Ctrl+Alt+Shift to use this layer.
+        ; Caps Lock no longer switches capitals on or off.
+        SetCapsLockState "AlwaysOff"
+
+        *CapsLock::
+        {
+            SetKeyDelay -1
+            Send "{Blind}{LCtrl DownR}{LAlt DownR}{LShift DownR}"
+        }
+
+        *CapsLock up::
+        {
+            SetKeyDelay -1
+            Send "{Blind}{LCtrl Up}{LAlt Up}{LShift Up}"
+        }
+        """;
+
+    private const string LockKeysOffBody = """
+        ; Keep Num Lock, Caps Lock and Scroll Lock switched off at all times.
+        SetNumLockState "AlwaysOff"
+        SetCapsLockState "AlwaysOff"
+        SetScrollLockState "AlwaysOff"
+        """;
+
+    // A timer, not #HotIf. AhkScriptGenerator closes every window-context group with a bare
+    // #HotIf (AhkScriptGenerator.cs:93-96), which would clear any context this header set.
+    private const string PauseWhileAppInFrontBody = """
+        ; Pause every hotstring and hotkey while one application is in front.
+        ; Replace REPLACE-ME.exe with the application you want. Keep the ahk_exe part.
+        SetTimer PauseWhileAppInFront, 500
+
+        PauseWhileAppInFront()
+        {
+            static paused := false
+            inFront := WinActive("ahk_exe REPLACE-ME.exe") != 0
+            if (inFront != paused)
+            {
+                paused := inFront
+                Suspend inFront
+            }
+        }
+        """;
+
+    private const string HotstringEndCharactersBody = """
+        ; Choose which characters finish a hotstring.
+        ; This list replaces AutoHotkey's default list for every hotstring below it.
+        ; `n is Enter, `s is Space, `t is Tab.
+        #Hotstring EndChars -()[]{}:;'"/\,.?!`n`s`t
+        """;
+}
+
+/// <summary>One shipped header preset.</summary>
+/// <param name="Id">Stable kebab-case id, written into the marker comments.</param>
+/// <param name="Name">Picker heading.</param>
+/// <param name="Description">One line saying what the preset does.</param>
+/// <param name="Tag">Picker grouping label.</param>
+/// <param name="Body">The AutoHotkey text, without markers.</param>
+internal sealed record HeaderPreset(
+    string Id,
+    string Name,
+    string Description,
+    string Tag,
+    string Body);

--- a/src/Backend/AHKFlowApp.Application/DTOs/HeaderPresetDtos.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/HeaderPresetDtos.cs
@@ -14,4 +14,5 @@ public sealed record HeaderPresetDto(
     string Body);
 
 /// <summary>The whole shipped preset list, in catalog order.</summary>
+/// <param name="Presets">The shipped presets, in catalog order.</param>
 public sealed record HeaderPresetCatalogDto(IReadOnlyList<HeaderPresetDto> Presets);

--- a/src/Backend/AHKFlowApp.Application/DTOs/HeaderPresetDtos.cs
+++ b/src/Backend/AHKFlowApp.Application/DTOs/HeaderPresetDtos.cs
@@ -1,0 +1,17 @@
+namespace AHKFlowApp.Application.DTOs;
+
+/// <summary>One ready-made block an owner can append to a Profile header.</summary>
+/// <param name="Id">Stable kebab-case id. It appears in the marker comments the picker writes.</param>
+/// <param name="Name">Picker heading.</param>
+/// <param name="Description">One line saying what the preset does.</param>
+/// <param name="Tag">Picker grouping label.</param>
+/// <param name="Body">The AutoHotkey text, without markers.</param>
+public sealed record HeaderPresetDto(
+    string Id,
+    string Name,
+    string Description,
+    string Tag,
+    string Body);
+
+/// <summary>The whole shipped preset list, in catalog order.</summary>
+public sealed record HeaderPresetCatalogDto(IReadOnlyList<HeaderPresetDto> Presets);

--- a/src/Backend/AHKFlowApp.Application/DependencyInjection.cs
+++ b/src/Backend/AHKFlowApp.Application/DependencyInjection.cs
@@ -56,6 +56,7 @@ public static class DependencyInjection
             .AddUseCase<GetHotstringPreviewQuery, Result<HotstringPreviewDto>, GetHotstringPreviewQueryHandler>()
             .AddUseCase<ListHotkeyKeysQuery, Result<HotkeyKeyCatalogDto>, ListHotkeyKeysQueryHandler>()
             .AddUseCase<ListKnownShortcutsQuery, Result<KnownShortcutCatalogDto>, ListKnownShortcutsQueryHandler>()
+            .AddUseCase<ListHeaderPresetsQuery, Result<HeaderPresetCatalogDto>, ListHeaderPresetsQueryHandler>()
             .AddUseCase<ListManagedKnownShortcutsQuery, Result<ManagedKnownShortcutCatalogDto>, ListManagedKnownShortcutsQueryHandler>()
             .AddUseCase<CreateCustomKnownShortcutCommand, Result<ManagedKnownShortcutCatalogDto>, CreateCustomKnownShortcutCommandHandler>()
             .AddUseCase<DeleteCustomKnownShortcutCommand, Result, DeleteCustomKnownShortcutCommandHandler>()

--- a/src/Backend/AHKFlowApp.Application/Queries/Profiles/ListHeaderPresetsQuery.cs
+++ b/src/Backend/AHKFlowApp.Application/Queries/Profiles/ListHeaderPresetsQuery.cs
@@ -1,0 +1,24 @@
+using AHKFlowApp.Application.Abstractions;
+using AHKFlowApp.Application.Constants;
+using AHKFlowApp.Application.DTOs;
+using Ardalis.Result;
+
+namespace AHKFlowApp.Application.Queries.Profiles;
+
+/// <summary>Returns the shipped header presets for the profile header picker. Static reference data.</summary>
+public sealed record ListHeaderPresetsQuery();
+
+internal sealed class ListHeaderPresetsQueryHandler
+    : IUseCaseHandler<ListHeaderPresetsQuery, Result<HeaderPresetCatalogDto>>
+{
+    // Projected once: the catalog is immutable for the process lifetime.
+    private static readonly HeaderPresetCatalogDto s_catalog = Project();
+
+    public Task<Result<HeaderPresetCatalogDto>> ExecuteAsync(
+        ListHeaderPresetsQuery request, CancellationToken ct) =>
+        Task.FromResult(Result<HeaderPresetCatalogDto>.Success(s_catalog));
+
+    private static HeaderPresetCatalogDto Project() => new(
+        [.. HeaderPresetCatalog.All.Select(p =>
+            new HeaderPresetDto(p.Id, p.Name, p.Description, p.Tag, p.Body))]);
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Profiles/HeaderPresetPickerDialog.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Profiles/HeaderPresetPickerDialog.razor
@@ -1,0 +1,86 @@
+@using AHKFlowApp.UI.Blazor.DTOs
+@using AHKFlowApp.UI.Blazor.Services
+@using MudBlazor
+
+<MudDialog Class="header-preset-picker">
+    <DialogContent>
+        @if (_loading)
+        {
+            <MudProgressCircular Indeterminate="true" />
+        }
+        else if (_error is not null)
+        {
+            <MudAlert Severity="Severity.Error">@_error</MudAlert>
+        }
+        else
+        {
+            <MudText Typo="Typo.body2" Class="mb-3">
+                A preset is added to the end of your header. After that it is ordinary text you can edit.
+            </MudText>
+
+            @foreach (IGrouping<string, HeaderPresetDto> group in _groups)
+            {
+                <MudText Typo="Typo.subtitle2" Class="mt-3">@group.Key</MudText>
+                @foreach (HeaderPresetDto preset in group)
+                {
+                    <MudPaper Elevation="0" Class="pa-3 mt-2"
+                              Style="background-color: var(--mud-palette-background-grey);">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween"
+                                  Spacing="2" Wrap="Wrap.Wrap">
+                            <MudStack Spacing="0">
+                                <MudText Typo="Typo.body1">@preset.Name</MudText>
+                                <MudText Typo="Typo.caption">@preset.Description</MudText>
+                            </MudStack>
+                            @if (HeaderPresetInserter.IsPresent(Header, preset.Id))
+                            {
+                                <MudText Typo="Typo.caption">Already in the header</MudText>
+                            }
+                            else
+                            {
+                                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                                           OnClick="@(() => Pick(preset))"
+                                           UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = $"header-preset-insert-{preset.Id}" })">
+                                    Insert
+                                </MudButton>
+                            }
+                        </MudStack>
+                    </MudPaper>
+                }
+            }
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton Class="cancel-preset-picker" OnClick="Cancel">Cancel</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance Dialog { get; set; } = default!;
+    [Inject] private IProfilesApiClient Api { get; set; } = default!;
+
+    /// <summary>The header being edited. Used only to mark a preset as already there.</summary>
+    [Parameter] public string Header { get; set; } = "";
+
+    private IReadOnlyList<IGrouping<string, HeaderPresetDto>> _groups = [];
+    private bool _loading = true;
+    private string? _error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        ApiResult<HeaderPresetCatalogDto> result = await Api.GetHeaderPresetsAsync();
+        _loading = false;
+
+        if (!result.IsSuccess)
+        {
+            _error = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+            return;
+        }
+
+        // GroupBy is stable, so both tags and presets keep catalog order.
+        _groups = [.. result.Value!.Presets.GroupBy(p => p.Tag)];
+    }
+
+    private void Pick(HeaderPresetDto preset) => Dialog.Close(DialogResult.Ok(preset));
+
+    private void Cancel() => Dialog.Cancel();
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HeaderPresetDtos.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/DTOs/HeaderPresetDtos.cs
@@ -1,0 +1,12 @@
+namespace AHKFlowApp.UI.Blazor.DTOs;
+
+/// <summary>One ready-made block an owner can append to a Profile header.</summary>
+public sealed record HeaderPresetDto(
+    string Id,
+    string Name,
+    string Description,
+    string Tag,
+    string Body);
+
+/// <summary>The shipped preset list, in catalog order. Bodies always come from the API.</summary>
+public sealed record HeaderPresetCatalogDto(IReadOnlyList<HeaderPresetDto> Presets);

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Profiles.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Profiles.razor
@@ -1,4 +1,5 @@
 @page "/profiles"
+@using AHKFlowApp.UI.Blazor.Components.Profiles
 @using AHKFlowApp.UI.Blazor.DTOs
 @using AHKFlowApp.UI.Blazor.Services
 @using AHKFlowApp.UI.Blazor.Validation
@@ -93,6 +94,11 @@
                         <MudText Typo="Typo.subtitle2">Header template</MudText>
                         @if (edit is not null)
                         {
+                            <MudButton Class="header-preset-open mb-2" Variant="Variant.Outlined"
+                                       Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add"
+                                       OnClick="() => OpenPresetPickerAsync(context.Id)">
+                                Insert preset
+                            </MudButton>
                             <MudTextField @bind-Value="edit.HeaderTemplate"
                                           T="string" Lines="20" Variant="Variant.Outlined"
                                           MaxLength="8000" Style="font-family: monospace;"
@@ -282,6 +288,32 @@
         {
             Snackbar.Add("Copy to clipboard failed.", Severity.Warning);
         }
+    }
+
+    private async Task OpenPresetPickerAsync(Guid id)
+    {
+        if (!_editing.TryGetValue(id, out ProfileEditModel? edit)) return;
+
+        DialogParameters parameters = new()
+        {
+            [nameof(HeaderPresetPickerDialog.Header)] = edit.HeaderTemplate,
+        };
+
+        IDialogReference dialog = await DialogService.ShowAsync<HeaderPresetPickerDialog>(
+            "Insert preset", parameters);
+
+        DialogResult? result = await dialog.Result;
+        if (result?.Canceled != false || result.Data is not HeaderPresetDto preset) return;
+
+        HeaderPresetInsertResult insert = HeaderPresetInserter.Insert(edit.HeaderTemplate, preset);
+        if (!insert.Inserted)
+        {
+            Snackbar.Add(insert.Error!, Severity.Error);
+            return;
+        }
+
+        edit.HeaderTemplate = insert.Header;
+        Snackbar.Add("Preset added to the header.", Severity.Success);
     }
 
     private static string? ValidateName(string? value)

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/HeaderPresetInserter.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/HeaderPresetInserter.cs
@@ -1,0 +1,49 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+
+namespace AHKFlowApp.UI.Blazor.Services;
+
+/// <summary>The outcome of one insert. On a refusal <see cref="Header"/> is the text unchanged.</summary>
+public readonly record struct HeaderPresetInsertResult(bool Inserted, string Header, string? Error);
+
+/// <summary>
+/// Appends a header preset to a Profile header, wrapped in marker comments. This file owns the
+/// marker format: the picker reads it to tell an owner a preset is already there, and an owner
+/// reads it to find a block to delete by hand.
+/// </summary>
+public static class HeaderPresetInserter
+{
+    /// <summary>Mirrors ProfileRules.HeaderTemplateMaxLength on the server.</summary>
+    public const int HeaderMaxLength = 8000;
+
+    public static string OpenMarker(string id) => $"; --- AHKFlow preset: {id} ---";
+
+    public static string CloseMarker(string id) => $"; --- end {id} ---";
+
+    public static bool IsPresent(string? header, string id) =>
+        (header ?? string.Empty).Contains(OpenMarker(id), StringComparison.Ordinal);
+
+    /// <summary>
+    /// Appends the preset. A header that does not end with a line break gets one first, so a
+    /// marker never joins the owner's last line of code. The result ends with one line break,
+    /// so the next insert behaves the same way.
+    /// </summary>
+    public static HeaderPresetInsertResult Insert(string? header, HeaderPresetDto preset)
+    {
+        string current = header ?? string.Empty;
+        string block = $"{OpenMarker(preset.Id)}\n{preset.Body}\n{CloseMarker(preset.Id)}\n";
+
+        string candidate = current.Length == 0
+            ? block
+            : current + (current.EndsWith('\n') ? string.Empty : "\n") + "\n" + block;
+
+        if (candidate.Length > HeaderMaxLength)
+        {
+            int over = candidate.Length - HeaderMaxLength;
+            return new(false, current,
+                $"This preset does not fit. It would take the header {over} characters " +
+                $"past the limit of {HeaderMaxLength}.");
+        }
+
+        return new(true, candidate, null);
+    }
+}

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/IProfilesApiClient.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/IProfilesApiClient.cs
@@ -9,4 +9,5 @@ public interface IProfilesApiClient
     Task<ApiResult<ProfileDto>> CreateAsync(CreateProfileDto input, CancellationToken ct = default);
     Task<ApiResult<ProfileDto>> UpdateAsync(Guid id, UpdateProfileDto input, CancellationToken ct = default);
     Task<ApiResult> DeleteAsync(Guid id, CancellationToken ct = default);
+    Task<ApiResult<HeaderPresetCatalogDto>> GetHeaderPresetsAsync(CancellationToken ct = default);
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/ProfilesApiClient.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/ProfilesApiClient.cs
@@ -21,4 +21,7 @@ public sealed class ProfilesApiClient(HttpClient httpClient) : ApiClientBase(htt
 
     public Task<ApiResult> DeleteAsync(Guid id, CancellationToken ct = default) =>
         SendNoContentAsync(HttpMethod.Delete, $"{BasePath}/{id}", ct);
+
+    public Task<ApiResult<HeaderPresetCatalogDto>> GetHeaderPresetsAsync(CancellationToken ct = default) =>
+        SendAsync<HeaderPresetCatalogDto>(HttpMethod.Get, $"{BasePath}/header-presets", content: null, ct);
 }

--- a/tests/AHKFlowApp.API.Tests/Profiles/HeaderPresetsEndpointTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Profiles/HeaderPresetsEndpointTests.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using System.Net.Http.Json;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.TestUtilities.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.API.Tests.Profiles;
+
+[Collection("WebApi")]
+public sealed class HeaderPresetsEndpointTests(ApiTestFixture fixture)
+{
+    private readonly CustomWebApplicationFactory _factory = fixture.Factory;
+
+    [Fact]
+    public async Task GetHeaderPresets_ReturnsTheShippedList()
+    {
+        HttpClient client = _factory.CreateAuthenticatedClient();
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/profiles/header-presets");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        HeaderPresetCatalogDto? catalog =
+            await response.Content.ReadFromJsonAsync<HeaderPresetCatalogDto>();
+        catalog.Should().NotBeNull();
+        catalog!.Presets.Should().NotBeEmpty();
+        catalog.Presets.Should().AllSatisfy(p =>
+        {
+            p.Id.Should().NotBeNullOrWhiteSpace();
+            p.Body.Should().NotBeNullOrWhiteSpace();
+            p.Tag.Should().NotBeNullOrWhiteSpace();
+        });
+    }
+
+    [Fact]
+    public async Task GetHeaderPresets_WithoutAuth_IsRejected()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync("/api/v1/profiles/header-presets");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Constants/HeaderPresetCatalogTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Constants/HeaderPresetCatalogTests.cs
@@ -1,0 +1,115 @@
+using System.Text.RegularExpressions;
+using AHKFlowApp.Application.Constants;
+using AHKFlowApp.Application.Services;
+using AHKFlowApp.Domain.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Constants;
+
+/// <summary>
+/// The catalog is shipped text that lands verbatim in a user's header, so these rules are
+/// enforced here rather than by review. A preset that breaks one of them breaks the whole
+/// generated script for whoever picked it.
+/// </summary>
+public sealed class HeaderPresetCatalogTests
+{
+    // The Blazor inserter owns the marker format. This literal only guards against a body
+    // that would look like a marker to the picker's "already there" check.
+    private const string OpenMarkerPrefix = "; --- AHKFlow preset:";
+
+    private static readonly HeaderTokenRenderer.Context RenderContext = new(
+        ProfileName: "Work",
+        AppVersion: "1.2.3",
+        HotstringCount: 4,
+        HotkeyCount: 5,
+        GeneratedAt: new DateTimeOffset(2026, 8, 4, 10, 0, 0, TimeSpan.Zero));
+
+    public static TheoryData<string> PresetIds()
+    {
+        TheoryData<string> data = [];
+        foreach (HeaderPreset preset in HeaderPresetCatalog.All)
+            data.Add(preset.Id);
+        return data;
+    }
+
+    private static HeaderPreset Preset(string id) =>
+        HeaderPresetCatalog.All.Single(p => p.Id == id);
+
+    [Fact]
+    public void Catalog_IsNotEmpty()
+    {
+        HeaderPresetCatalog.All.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Ids_AreUniqueAndKebabCase()
+    {
+        string[] ids = [.. HeaderPresetCatalog.All.Select(p => p.Id)];
+
+        ids.Should().OnlyHaveUniqueItems();
+        ids.Should().AllSatisfy(id =>
+            Regex.IsMatch(id, "^[a-z0-9]+(-[a-z0-9]+)*$").Should().BeTrue($"'{id}' must be kebab-case"));
+    }
+
+    [Theory]
+    [MemberData(nameof(PresetIds))]
+    public void EveryField_IsFilledIn(string id)
+    {
+        HeaderPreset preset = Preset(id);
+
+        preset.Name.Should().NotBeNullOrWhiteSpace();
+        preset.Description.Should().NotBeNullOrWhiteSpace();
+        preset.Tag.Should().NotBeNullOrWhiteSpace();
+        preset.Body.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [MemberData(nameof(PresetIds))]
+    public void Body_HasNoDoubledBraces(string id)
+    {
+        string body = Preset(id).Body;
+
+        body.Should().NotContain("{{");
+        body.Should().NotContain("}}");
+    }
+
+    [Theory]
+    [MemberData(nameof(PresetIds))]
+    public void Body_SurvivesHeaderRenderingUnchanged(string id)
+    {
+        string body = Preset(id).Body;
+
+        new HeaderTokenRenderer().Render(body, RenderContext).Should().Be(body);
+    }
+
+    [Theory]
+    [MemberData(nameof(PresetIds))]
+    public void Body_RepeatsNoDirectiveFromTheDefaultHeader(string id)
+    {
+        HashSet<string> defaultDirectives = FirstWords(DefaultProfileTemplates.Header);
+
+        FirstWords(Preset(id).Body).Should().NotIntersectWith(defaultDirectives);
+    }
+
+    [Theory]
+    [MemberData(nameof(PresetIds))]
+    public void Body_HasNoMarkerTextAndNoOuterBlankLines(string id)
+    {
+        string body = Preset(id).Body;
+
+        body.Should().NotContain(OpenMarkerPrefix);
+        body.Should().Be(body.Trim('\n', '\r', ' '));
+    }
+
+    // The first word of every line that is neither blank nor a comment: "#Requires",
+    // "SendMode", and so on. Derived from the source, never hard-coded, so a change to the
+    // default header cannot leave this test asserting yesterday's list.
+    private static HashSet<string> FirstWords(string script) =>
+    [
+        .. script.Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0 && !line.StartsWith(';'))
+            .Select(line => line.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries)[0])
+    ];
+}

--- a/tests/AHKFlowApp.Application.Tests/Profiles/CreateProfileCommandHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Profiles/CreateProfileCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using AHKFlowApp.Application.Abstractions;
 using AHKFlowApp.Application.Commands.Profiles;
 using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Domain.Constants;
 using AHKFlowApp.Domain.Entities;
 using AHKFlowApp.Infrastructure.Persistence;
 using AHKFlowApp.TestUtilities.Builders;
@@ -83,6 +84,24 @@ public sealed class CreateProfileCommandHandlerTests(ProfileDbFixture fx)
         result.IsSuccess.Should().BeTrue();
         result.Value.HeaderTemplate.Should().Be("#Include work.ahk");
         result.Value.FooterTemplate.Should().Be("return");
+    }
+
+    [Fact]
+    public async Task Handle_NewProfile_HeaderHoldsNoPresetMarker()
+    {
+        await using AppDbContext ctx = fx.CreateContext();
+        ICurrentUser user = Substitute.For<ICurrentUser>();
+        user.Oid.Returns(_ownerOid);
+
+        var sut = new CreateProfileCommandHandler(ctx, user, _clock);
+
+        Result<ProfileDto> result = await sut.ExecuteAsync(
+            new CreateProfileCommand(new CreateProfileDto("Work")), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        ProfileDto created = result.Value;
+        created.HeaderTemplate.Should().NotContain("; --- AHKFlow preset:");
+        created.HeaderTemplate.Should().Be(DefaultProfileTemplates.Header);
     }
 
     [Fact]

--- a/tests/AHKFlowApp.Application.Tests/Profiles/ListHeaderPresetsQueryHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Profiles/ListHeaderPresetsQueryHandlerTests.cs
@@ -1,0 +1,41 @@
+using AHKFlowApp.Application.Constants;
+using AHKFlowApp.Application.DTOs;
+using AHKFlowApp.Application.Queries.Profiles;
+using Ardalis.Result;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.Application.Tests.Profiles;
+
+public sealed class ListHeaderPresetsQueryHandlerTests
+{
+    [Fact]
+    public async Task ExecuteAsync_ReturnsEveryPresetInCatalogOrder()
+    {
+        ListHeaderPresetsQueryHandler handler = new();
+
+        Result<HeaderPresetCatalogDto> result =
+            await handler.ExecuteAsync(new ListHeaderPresetsQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Presets.Select(p => p.Id)
+            .Should().Equal(HeaderPresetCatalog.All.Select(p => p.Id));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CarriesEveryFieldOfAPreset()
+    {
+        ListHeaderPresetsQueryHandler handler = new();
+        HeaderPreset expected = HeaderPresetCatalog.All[0];
+
+        Result<HeaderPresetCatalogDto> result =
+            await handler.ExecuteAsync(new ListHeaderPresetsQuery(), CancellationToken.None);
+
+        HeaderPresetDto actual = result.Value.Presets[0];
+        actual.Id.Should().Be(expected.Id);
+        actual.Name.Should().Be(expected.Name);
+        actual.Description.Should().Be(expected.Description);
+        actual.Tag.Should().Be(expected.Tag);
+        actual.Body.Should().Be(expected.Body);
+    }
+}

--- a/tests/AHKFlowApp.Application.Tests/Profiles/ListProfilesQueryHandlerTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Profiles/ListProfilesQueryHandlerTests.cs
@@ -47,6 +47,20 @@ public sealed class ListProfilesQueryHandlerTests(ProfileDbFixture fx)
     }
 
     [Fact]
+    public async Task ExecuteAsync_LazySeededProfile_HeaderHoldsNoPresetMarker()
+    {
+        await using AppDbContext ctx = fx.CreateContext();
+        ListProfilesQueryHandler sut = CreateSut(ctx);
+
+        Result<IReadOnlyList<ProfileDto>> result = await sut.ExecuteAsync(new ListProfilesQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().ContainSingle();
+        ProfileDto seeded = result.Value[0];
+        seeded.HeaderTemplate.Should().NotContain("; --- AHKFlow preset:");
+    }
+
+    [Fact]
     public async Task Returns_unauthorized_when_no_oid()
     {
         await using AppDbContext ctx = fx.CreateContext();

--- a/tests/AHKFlowApp.Application.Tests/Queries/Downloads/GenerateProfileScriptQueryTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Queries/Downloads/GenerateProfileScriptQueryTests.cs
@@ -120,4 +120,26 @@ public sealed class GenerateProfileScriptQueryTests(ScriptGeneratorDbFixture fx)
         result.IsSuccess.Should().BeFalse();
         result.Status.Should().Be(ResultStatus.Unauthorized);
     }
+
+    [Fact]
+    public async Task Handle_OnlyAllProfilesHotstrings_StillEmitsThem()
+    {
+        await using AppDbContext ctx = fx.CreateContext();
+        Profile work = new ProfileBuilder().WithOwner(_ownerOid).WithName($"Work-{Guid.NewGuid():N}")
+            .WithHeader("#Requires AutoHotkey v2.0").WithFooter("; end").Build();
+        Hotstring hsAny = new HotstringBuilder().WithOwner(_ownerOid)
+            .WithTrigger("btw").WithReplacement("by the way")
+            .WithEndingCharacterRequired(false).WithTriggerInsideWord(true)
+            .AppliesToAllProfiles().Build();
+        ctx.Profiles.Add(work);
+        ctx.Hotstrings.Add(hsAny);
+        await ctx.SaveChangesAsync();
+
+        GenerateProfileScriptQueryHandler sut = CreateSut(ctx);
+        Result<ProfileScript> result = await sut.ExecuteAsync(
+            new GenerateProfileScriptQuery(work.Id), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Content.Should().Contain(":*?T:btw::by the way");
+    }
 }

--- a/tests/AHKFlowApp.E2E.Tests/ProfileHeaderPresetFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/ProfileHeaderPresetFlowTests.cs
@@ -1,0 +1,61 @@
+using AHKFlowApp.E2E.Tests.Fixtures;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace AHKFlowApp.E2E.Tests;
+
+[Collection(E2ETestCollection.Name)]
+public sealed class ProfileHeaderPresetFlowTests(StackFixture fixture) : IAsyncLifetime
+{
+    public Task InitializeAsync() => fixture.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task InsertPreset_AppendsMarkedBlockAndThenReportsItAsPresent()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync();
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/profiles");
+        await page.WaitForSelectorAsync("button.start-edit");
+
+        // Insert a preset into the default profile's header.
+        await page.ClickAsync("button.start-edit");
+        await page.WaitForSelectorAsync("textarea[data-test=\"profile-header-input\"]");
+        await page.ClickAsync("button.header-preset-open");
+        await page.ClickAsync("button[data-test=\"header-preset-insert-lock-keys-off\"]");
+
+        await page.WaitForSelectorAsync("text=Preset added to the header.");
+        string headerAfterInsert =
+            await page.InputValueAsync("textarea[data-test=\"profile-header-input\"]");
+        Assert.Contains("; --- AHKFlow preset: lock-keys-off ---", headerAfterInsert);
+        Assert.Contains("; --- end lock-keys-off ---", headerAfterInsert);
+
+        await page.ClickAsync("button.commit-edit");
+        await page.WaitForSelectorAsync("text=Profile updated.");
+
+        // Re-open the editor: the preset is now reported as present.
+        await page.ClickAsync("button.start-edit");
+        await page.WaitForSelectorAsync("textarea[data-test=\"profile-header-input\"]");
+        await page.ClickAsync("button.header-preset-open");
+
+        await page.WaitForSelectorAsync("text=Already in the header");
+        Assert.Empty(await page.QuerySelectorAllAsync(
+            "button[data-test=\"header-preset-insert-lock-keys-off\"]"));
+
+        await page.ClickAsync("button.cancel-preset-picker");
+        await page.ClickAsync("button.cancel-edit");
+
+        // The block reaches the generated script, not only the stored header.
+        await page.ClickAsync("button.toggle-expand");
+        await page.ClickAsync("text=Script preview");
+        await page.ClickAsync("button.profile-preview-refresh");
+        await page.WaitForSelectorAsync("pre.profile-preview-script");
+
+        string script = await page.InnerTextAsync("pre.profile-preview-script");
+        Assert.Contains("; --- AHKFlow preset: lock-keys-off ---", script);
+        Assert.Contains("SetScrollLockState \"AlwaysOff\"", script);
+        Assert.Contains("; --- end lock-keys-off ---", script);
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Profiles/HeaderPresetPickerDialogTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Profiles/HeaderPresetPickerDialogTests.cs
@@ -1,0 +1,100 @@
+using AHKFlowApp.UI.Blazor.Components.Profiles;
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Services;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using NSubstitute;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Components.Profiles;
+
+public sealed class HeaderPresetPickerDialogTests : BunitContext, IAsyncLifetime
+{
+    private readonly IProfilesApiClient _api = Substitute.For<IProfilesApiClient>();
+
+    private static readonly HeaderPresetCatalogDto Catalog = new(
+    [
+        new("capslock-modifier-layer", "Caps Lock works as Ctrl+Alt+Shift",
+            "Hold Caps Lock instead of three keys.", "Keyboard layer", "; layer"),
+        new("lock-keys-off", "Keep lock keys off",
+            "Holds three keys off.", "Lock keys", "; locks"),
+    ]);
+
+    public HeaderPresetPickerDialogTests()
+    {
+        Services.AddSingleton(_api);
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+
+    async Task IAsyncLifetime.DisposeAsync() => await DisposeAsync();
+
+    private async Task<IRenderedComponent<MudDialogProvider>> OpenAsync(string header)
+    {
+        Render<MudPopoverProvider>();
+        IRenderedComponent<MudDialogProvider> provider = Render<MudDialogProvider>();
+
+        await provider.InvokeAsync(async () =>
+        {
+            IDialogService dialogService = Services.GetRequiredService<IDialogService>();
+            await dialogService.ShowAsync<HeaderPresetPickerDialog>(
+                "Insert preset",
+                new DialogParameters { [nameof(HeaderPresetPickerDialog.Header)] = header });
+        });
+
+        return provider;
+    }
+
+    [Fact]
+    public async Task Dialog_ShowsEveryPresetGroupedByTag()
+    {
+        _api.GetHeaderPresetsAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HeaderPresetCatalogDto>.Ok(Catalog));
+
+        IRenderedComponent<MudDialogProvider> provider = await OpenAsync("");
+
+        provider.WaitForAssertion(() =>
+        {
+            provider.Markup.Should().Contain("Keyboard layer");
+            provider.Markup.Should().Contain("Lock keys");
+            provider.Markup.Should().Contain("Caps Lock works as Ctrl+Alt+Shift");
+            provider.Markup.Should().Contain("Keep lock keys off");
+        });
+    }
+
+    [Fact]
+    public async Task Dialog_OffersNoInsertButtonForAPresetAlreadyInTheHeader()
+    {
+        _api.GetHeaderPresetsAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HeaderPresetCatalogDto>.Ok(Catalog));
+        string header = HeaderPresetInserter.Insert("", Catalog.Presets[1]).Header;
+
+        IRenderedComponent<MudDialogProvider> provider = await OpenAsync(header);
+
+        provider.WaitForAssertion(() =>
+        {
+            provider.Markup.Should().Contain("Already in the header");
+            provider.FindAll("button[data-test=\"header-preset-insert-lock-keys-off\"]")
+                .Should().BeEmpty();
+            provider.FindAll("button[data-test=\"header-preset-insert-capslock-modifier-layer\"]")
+                .Should().ContainSingle();
+        });
+    }
+
+    [Fact]
+    public async Task Dialog_ShowsTheApiErrorWhenTheCatalogCannotBeLoaded()
+    {
+        _api.GetHeaderPresetsAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HeaderPresetCatalogDto>.Failure(ApiResultStatus.ServerError, null));
+
+        IRenderedComponent<MudDialogProvider> provider = await OpenAsync("");
+
+        provider.WaitForAssertion(() =>
+            provider.FindAll("div.mud-alert").Should().NotBeEmpty());
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/ProfilesPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/ProfilesPageTests.cs
@@ -226,4 +226,28 @@ public sealed class ProfilesPageTests : BunitContext, IAsyncLifetime
             Arg.Is<CreateProfileDto>(d => d.Name == "Work"),
             Arg.Any<CancellationToken>()));
     }
+
+    [Fact]
+    public async Task InsertPreset_WritesIntoTheEditorAndSavesNothing()
+    {
+        ProfileDto profile = MakeProfile();
+        StubList(profile);
+        _api.GetHeaderPresetsAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult<HeaderPresetCatalogDto>.Ok(new HeaderPresetCatalogDto(
+                [new HeaderPresetDto("lock-keys-off", "Keep lock keys off", "Holds three keys off.",
+                    "Lock keys", "SetNumLockState \"AlwaysOff\"")])));
+        IRenderedComponent<MudDialogProvider> dialogProvider = Render<MudDialogProvider>();
+        IRenderedComponent<Profiles> cut = RenderPage();
+
+        cut.Find("button.start-edit").Click();
+        cut.Find("button.header-preset-open").Click();
+        dialogProvider.WaitForElement("button[data-test=\"header-preset-insert-lock-keys-off\"]");
+        await dialogProvider.InvokeAsync(() =>
+            dialogProvider.Find("button[data-test=\"header-preset-insert-lock-keys-off\"]").Click());
+
+        cut.WaitForAssertion(() =>
+            cut.Markup.Should().Contain("; --- AHKFlow preset: lock-keys-off ---"));
+        await _api.DidNotReceive().UpdateAsync(
+            Arg.Any<Guid>(), Arg.Any<UpdateProfileDto>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Services/HeaderPresetInserterTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Services/HeaderPresetInserterTests.cs
@@ -1,0 +1,94 @@
+using AHKFlowApp.UI.Blazor.DTOs;
+using AHKFlowApp.UI.Blazor.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Services;
+
+public sealed class HeaderPresetInserterTests
+{
+    private static HeaderPresetDto Preset(string body = "SetNumLockState \"AlwaysOff\"") =>
+        new("lock-keys-off", "Keep lock keys off", "Holds three keys off.", "Lock keys", body);
+
+    [Fact]
+    public void Insert_IntoEmptyHeader_WritesBlockWithNoLeadingBlankLine()
+    {
+        HeaderPresetInsertResult result = HeaderPresetInserter.Insert("", Preset());
+
+        result.Inserted.Should().BeTrue();
+        result.Header.Should().Be(
+            "; --- AHKFlow preset: lock-keys-off ---\n" +
+            "SetNumLockState \"AlwaysOff\"\n" +
+            "; --- end lock-keys-off ---\n");
+    }
+
+    [Fact]
+    public void Insert_WhenHeaderHasNoTrailingLineBreak_AddsOneFirst()
+    {
+        HeaderPresetInsertResult result = HeaderPresetInserter.Insert("SetTitleMatchMode 2", Preset());
+
+        result.Header.Should().StartWith("SetTitleMatchMode 2\n\n; --- AHKFlow preset:");
+    }
+
+    [Fact]
+    public void Insert_WhenHeaderEndsWithALineBreak_AddsOneBlankLineOnly()
+    {
+        HeaderPresetInsertResult result = HeaderPresetInserter.Insert("SetTitleMatchMode 2\n", Preset());
+
+        result.Header.Should().StartWith("SetTitleMatchMode 2\n\n; --- AHKFlow preset:");
+    }
+
+    [Fact]
+    public void Insert_WhenHeaderEndsWithWindowsLineBreak_AddsNoExtraBreak()
+    {
+        HeaderPresetInsertResult result = HeaderPresetInserter.Insert("SetTitleMatchMode 2\r\n", Preset());
+
+        result.Header.Should().StartWith("SetTitleMatchMode 2\r\n\n; --- AHKFlow preset:");
+    }
+
+    [Fact]
+    public void Insert_LeavesExactlyOneTrailingLineBreak()
+    {
+        HeaderPresetInsertResult first = HeaderPresetInserter.Insert("head", Preset());
+        HeaderPresetInsertResult second = HeaderPresetInserter.Insert(
+            first.Header, Preset() with { Id = "other-preset" });
+
+        second.Header.Should().EndWith("; --- end other-preset ---\n");
+        second.Header.Should().NotEndWith("\n\n");
+    }
+
+    [Fact]
+    public void Insert_WhenResultWouldPassTheCap_RefusesAndLeavesTheHeaderAlone()
+    {
+        string header = new('x', HeaderPresetInserter.HeaderMaxLength - 10);
+
+        HeaderPresetInsertResult result = HeaderPresetInserter.Insert(header, Preset());
+
+        result.Inserted.Should().BeFalse();
+        result.Header.Should().Be(header);
+        result.Error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void Insert_WhenResultLandsExactlyOnTheCap_Inserts()
+    {
+        HeaderPresetDto preset = Preset("ab");
+        int blockLength = HeaderPresetInserter.Insert("", preset).Header.Length;
+        // header + "\n" (missing break) + "\n" (blank line) + block
+        string header = new('x', HeaderPresetInserter.HeaderMaxLength - blockLength - 2);
+
+        HeaderPresetInsertResult result = HeaderPresetInserter.Insert(header, preset);
+
+        result.Inserted.Should().BeTrue();
+        result.Header.Length.Should().Be(HeaderPresetInserter.HeaderMaxLength);
+    }
+
+    [Fact]
+    public void IsPresent_IsTrueOnlyForAnIdAlreadyInTheHeader()
+    {
+        string header = HeaderPresetInserter.Insert("", Preset()).Header;
+
+        HeaderPresetInserter.IsPresent(header, "lock-keys-off").Should().BeTrue();
+        HeaderPresetInserter.IsPresent(header, "capslock-modifier-layer").Should().BeFalse();
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Services/ProfilesApiClientTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Services/ProfilesApiClientTests.cs
@@ -105,6 +105,21 @@ public sealed class ProfilesApiClientTests
         result.Status.Should().Be(ApiResultStatus.NetworkError);
     }
 
+    [Fact]
+    public async Task GetHeaderPresetsAsync_OnSuccess_ReturnsCatalogFromTheHeaderPresetsPath()
+    {
+        var catalog = new HeaderPresetCatalogDto(
+            [new HeaderPresetDto("lock-keys-off", "Keep lock keys off", "Holds three keys off.",
+                "Lock keys", "SetNumLockState \"AlwaysOff\"")]);
+        var handler = StubHttpMessageHandler.JsonResponse(HttpStatusCode.OK, catalog);
+
+        ApiResult<HeaderPresetCatalogDto> result = await ClientWith(handler).GetHeaderPresetsAsync();
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Presets.Should().ContainSingle().Which.Id.Should().Be("lock-keys-off");
+        handler.LastRequest!.RequestUri!.PathAndQuery.Should().Be("/api/v1/profiles/header-presets");
+    }
+
     private sealed class StubHttpMessageHandler : HttpMessageHandler
     {
         public HttpRequestMessage? LastRequest { get; private set; }


### PR DESCRIPTION
## What

Ships a fixed, read-only library of ready-made AutoHotkey blocks — **header presets** — that an owner can append to a Profile's header from a picker on the Profiles page.

Closes backlog item 043.

## Why

Some settings apply to a whole profile and no Hotstring or Hotkey row can express them: keeping the lock keys off, turning Caps Lock into a modifier layer, pausing every shortcut while one application is in front, choosing which characters finish a hotstring. Until now an owner had to know the AutoHotkey syntax and type it into the header by hand.

## How

One catalog of shipped constants in the Application project, projected to DTOs by a query and served read-only by `ProfilesController` — the same shape as the existing hotkey key registry. The Blazor app fetches it, shows a picker dialog, and appends the chosen body wrapped in marker comments into the header text box of the row being edited. The existing `PUT /api/v1/profiles/{id}` saves it.

- **No new table, no migration, no server-side mutation.**
- Inserting is a client-side text edit. Nothing is saved until the owner presses the existing commit button; cancelling the edit discards it, like any other typing.
- Markers are `; --- AHKFlow preset: <id> ---` / `; --- end <id> ---`, written only by the Blazor inserter. From the moment a preset lands in a header the text is the owner's, and no later app version rewrites it.
- The picker checks the 8000-character header cap before inserting; the server validator stays the final check.

## The four shipped presets

| Id | What it does |
|---|---|
| `capslock-modifier-layer` | Hold Caps Lock to press Ctrl, Alt and Shift together |
| `lock-keys-off` | Keep Num Lock, Caps Lock and Scroll Lock off |
| `pause-while-app-in-front` | Pause every shortcut while one named application is in front |
| `hotstring-end-characters` | Choose which characters finish a hotstring |

Preset ids are stable and appear verbatim in the marker comments, so they never change once released — changing one would orphan every header already holding it.

## Testing

- **Catalog guard tests** enforce the rules that would otherwise break a generated script: no `{{`/`}}` (which `HeaderTokenRenderer` would collapse), no directive the default header already emits, kebab-case unique ids, every field filled in. The conflict list is derived from `DefaultProfileTemplates.Header` at runtime, so a change to the default header cannot leave the test asserting a stale list.
- **Handler unit tests**, **API integration tests** (200 with data, 401 without auth), **bUnit tests** for the dialog and the page, and an **E2E flow** covering the full round trip: insert, save, reopen and see "Already in the header", then confirm the block reaches the generated script preview.
- **Regression guards** pin that a new profile and a lazily-seeded default profile never carry a preset marker. A keyboard layer changes how the whole machine behaves, so it must never arrive without being asked for.

Pre-PR gate green on the branch head: Release build (0 warnings), `dotnet format --verify-no-changes`, coverage slice (all five assemblies above threshold), `git diff --check`.

## Review notes

A whole-branch review found one real issue, fixed in `ff855f6b`: the `hotstring-end-characters` body claimed the directive applied only to hotstrings below it, which contradicts the AutoHotkey docs, and its character list matched AHK's own default so the preset did nothing unless edited. Both the comment and the missing "edit this list" guidance are corrected.

The last commit adds a regression test pinning that hotstrings marked "all profiles" reach a profile's generated script. It came out of a report during manual testing; the behaviour turned out to be correct, and the test now keeps it that way.

## Manual verification

Steps 1-7 of the manual AutoHotkey check were run by hand: inserting each preset, the "Already in the header" state, and saving. Running the generated `.ahk` under AutoHotkey v2 was not completed, so the emitted constructs are proven by assertion rather than by execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
