### PR TITLE
feat: download a profile script from the Profiles page

### DIFF
--- a/backlog/055-download-profile-script-from-profiles-page.md
+++ b/backlog/055-download-profile-script-from-profiles-page.md
@@ -1,0 +1,58 @@
+# 055 - Download a profile script from the Profiles page
+
+## Metadata
+
+- **Epic**: Script generation & download
+- **Type**: Feature
+- **Interfaces**: UI
+
+## Summary
+
+The Profiles page (`/profiles`) already shows a profile's generated script in its **Script preview**
+panel, but offers no way to save it. To save it an owner must go to the Downloads page
+(`/downloads`), which lists the same profiles a second time. Add a per-row download button to the
+Profiles page, so the download sits with the profile.
+
+## User story
+
+As a profile owner, I want to download a profile's `.ahk` script from the Profiles page so that I do
+not have to find the same profile again on a second page.
+
+## Acceptance criteria
+
+- [ ] A download button sits in each Profiles row, between expand and edit
+- [ ] Pressing it saves the same file the Downloads page saves for that profile — same content, same
+      filename. Both pages call one shared `ProfileScriptDownloader`, so the two cannot drift
+- [ ] The button is disabled while the row is being edited, and on the unsaved new-profile row. The
+      server builds the script from saved data, so downloading mid-edit would hand back a file that
+      does not hold the unsaved change
+- [ ] A disabled button explains itself. MudBlazor sets `pointer-events: none` on disabled buttons,
+      so the reason rides on a `MudTooltip` wrapper and on the button's own `aria-label`
+- [ ] While one download runs, every row's download button is disabled, and the running row shows a
+      spinner. All rows become usable again after success, after failure, and after cancellation
+- [ ] Cancelling by leaving the page shows no snackbar
+- [ ] The Actions column keeps its shape when a row enters edit mode — the button is present in both
+      action groups
+- [ ] An end-to-end test downloads from `/profiles` and asserts the saved text is that profile's
+      script
+
+## Out of scope
+
+- Any change to the Downloads page's own behaviour. It keeps its per-row Download and its
+  **Download all (zip)**
+- Bulk download from the Profiles page, and multi-select
+- Deleting the Downloads page. Keeping both pages was chosen deliberately — it is the smaller
+  change, and it moves no bulk feature
+
+## Notes / dependencies
+
+- No backend work. `GET /api/v1/downloads/{profileId}` already exists
+  (`src/Backend/AHKFlowApp.API/Controllers/DownloadsController.cs:28-34`), and `Profiles.razor:178`
+  already injects `IDownloadsApiClient` for the preview panel
+- Design: `docs/superpowers/specs/2026-08-05-profiles-page-download-design.md`
+- Plan: `docs/superpowers/plans/2026-08-05-profiles-page-download-plan.md`
+- The extraction moves `SafeStem` out of `Downloads.razor` and changes one edge case on purpose: the
+  stem is now truncated to 64 characters **before** trailing `_` is trimmed, not after. Today's
+  order can leave a trailing `_` on a long name. See spec §5.2
+- Backlog 053 was found while writing the spec — the same MudBlazor disabled-button rule, in
+  `KnownShortcutUseActions.razor`. Separate item, not part of this work

--- a/backlog/056-disabled-button-reason-unreachable-by-keyboard-and-touch.md
+++ b/backlog/056-disabled-button-reason-unreachable-by-keyboard-and-touch.md
@@ -1,0 +1,44 @@
+# 056 - A disabled button's reason is unreachable by keyboard and touch
+
+## Metadata
+
+- **Epic**: Accessibility
+- **Type**: Defect
+- **Interfaces**: UI
+
+## Summary
+
+The app explains a disabled button by wrapping it in a `MudTooltip`. A mouse user hovers the
+wrapper and reads the reason. A screen reader user hears the reason, because it is also appended to
+the button's `aria-label`.
+
+A sighted keyboard user and a touch user get neither. The wrapper is a plain div, so it cannot take
+focus, and the disabled button inside it cannot take focus either. `MudTooltip.ShowOnFocus` is
+`true` by default, but nothing in the pair can ever receive focus. `ShowOnClick` is `false` by
+default, so a tap shows nothing.
+
+Found while reviewing the Profiles page download button (backlog 055). The same pattern is already
+used at `src/Frontend/AHKFlowApp.UI.Blazor/Shared/LoginDisplay.razor:17-19`, so this is a
+repository-wide gap, not one page's bug.
+
+## Acceptance criteria
+
+- [ ] A sighted keyboard user can read why a button is disabled, without a screen reader
+- [ ] A touch user can read the same reason
+- [ ] One shared way to do this, used by every disabled action that has a reason — no per-page
+      variation
+- [ ] A test covers the keyboard path
+
+## Out of scope
+
+- Enabling the buttons themselves. The reasons they are disabled are correct
+
+## Notes / dependencies
+
+- Related: backlog 053, which covers the `title` attribute being dead on a disabled MudBlazor
+  button. Both come from the same MudBlazor rule: `pointer-events: none` on a disabled button
+- Current examples of the pattern:
+  `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Profiles.razor:304-317` and
+  `src/Frontend/AHKFlowApp.UI.Blazor/Shared/LoginDisplay.razor:17-19`
+- Options worth weighing: visible helper text next to the control, a focusable wrapper with the
+  right role, or `ShowOnClick="true"` plus a focusable element

--- a/backlog/057-downloads-page-row-stays-disabled-when-the-file-save-fails.md
+++ b/backlog/057-downloads-page-row-stays-disabled-when-the-file-save-fails.md
@@ -1,0 +1,41 @@
+# 057 - The Downloads page leaves a row disabled when the file save fails
+
+## Metadata
+
+- **Epic**: Script generation & download
+- **Type**: Defect
+- **Interfaces**: UI
+
+## Summary
+
+`DownloadProfileAsync` in `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Downloads.razor:111-131` does not
+catch a failure from `IFileSaver.SaveAsync`. `JsFileSaver` calls into JavaScript
+(`src/Frontend/AHKFlowApp.UI.Blazor/Services/JsFileSaver.cs:11`), so a browser that refuses the
+write raises a `JSException`.
+
+The `finally` block clears `_busyProfileId`, but the event task ends faulted. Blazor's
+`ComponentBase` skips its own re-render after a faulted event task, so the row's Download button
+stays drawn as disabled. The user sees a dead button and no message. Any later render fixes it, so
+the state is stale rather than permanent.
+
+The Profiles page already handles this: `src/Frontend/AHKFlowApp.UI.Blazor/Pages/Profiles.razor:363`
+catches `JSException` and shows "Saving the file failed.". The Downloads page was left alone on
+purpose, because backlog 055 put changes to that page out of scope. The two pages now differ.
+
+## Acceptance criteria
+
+- [ ] A failed file save on the Downloads page shows an error message
+- [ ] The row's Download button works again straight after the failure
+- [ ] Both pages report a failed save with the same wording
+- [ ] A bUnit test covers the failing save on the Downloads page
+
+## Out of scope
+
+- Changing what `ProfileScriptDownloader` does. It lets the exception travel on by design, so each
+  page decides how to report it
+
+## Notes / dependencies
+
+- Found while reviewing backlog 055
+- The same fix shape as `Profiles.razor:363` — a `catch (JSException)` beside the existing
+  cancellation catch

--- a/backlog/done/055-download-profile-script-from-profiles-page.md
+++ b/backlog/done/055-download-profile-script-from-profiles-page.md
@@ -20,20 +20,20 @@ not have to find the same profile again on a second page.
 
 ## Acceptance criteria
 
-- [ ] A download button sits in each Profiles row, between expand and edit
-- [ ] Pressing it saves the same file the Downloads page saves for that profile — same content, same
+- [x] A download button sits in each Profiles row, between expand and edit
+- [x] Pressing it saves the same file the Downloads page saves for that profile — same content, same
       filename. Both pages call one shared `ProfileScriptDownloader`, so the two cannot drift
-- [ ] The button is disabled while the row is being edited, and on the unsaved new-profile row. The
+- [x] The button is disabled while the row is being edited, and on the unsaved new-profile row. The
       server builds the script from saved data, so downloading mid-edit would hand back a file that
       does not hold the unsaved change
-- [ ] A disabled button explains itself. MudBlazor sets `pointer-events: none` on disabled buttons,
+- [x] A disabled button explains itself. MudBlazor sets `pointer-events: none` on disabled buttons,
       so the reason rides on a `MudTooltip` wrapper and on the button's own `aria-label`
-- [ ] While one download runs, every row's download button is disabled, and the running row shows a
+- [x] While one download runs, every row's download button is disabled, and the running row shows a
       spinner. All rows become usable again after success, after failure, and after cancellation
-- [ ] Cancelling by leaving the page shows no snackbar
-- [ ] The Actions column keeps its shape when a row enters edit mode — the button is present in both
+- [x] Cancelling by leaving the page shows no snackbar
+- [x] The Actions column keeps its shape when a row enters edit mode — the button is present in both
       action groups
-- [ ] An end-to-end test downloads from `/profiles` and asserts the saved text is that profile's
+- [x] An end-to-end test downloads from `/profiles` and asserts the saved text is that profile's
       script
 
 ## Out of scope

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Downloads.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Downloads.razor
@@ -63,6 +63,7 @@
     [Inject] private IProfilesApiClient ProfilesApi { get; set; } = default!;
     [Inject] private IDownloadsApiClient DownloadsApi { get; set; } = default!;
     [Inject] private IFileSaver FileSaver { get; set; } = default!;
+    [Inject] private ProfileScriptDownloader Downloader { get; set; } = default!;
     [Inject] private ISnackbar Snackbar { get; set; } = default!;
     [Inject] private TimeProvider Clock { get; set; } = default!;
 
@@ -113,17 +114,15 @@
         _busyProfileId = profile.Id;
         try
         {
-            ApiResult<FileDownload> result = await DownloadsApi.GetProfileScriptAsync(profile.Id, _cts.Token);
+            DownloadOutcome outcome = await Downloader.DownloadAsync(profile.Id, profile.Name, _cts.Token);
 
-            if (!result.IsSuccess)
+            if (!outcome.Saved)
             {
-                Snackbar.Add(ApiErrorMessageFactory.Build(result.Status, result.Problem), Severity.Error);
+                Snackbar.Add(outcome.Error!, Severity.Error);
                 return;
             }
 
-            string fileName = $"{Timestamp()}_ahkflow_{SafeStem(profile.Name)}.ahk";
-            await FileSaver.SaveAsync(fileName, result.Value!.ContentType, result.Value.Content);
-            Snackbar.Add($"Downloaded {fileName}", Severity.Success);
+            Snackbar.Add($"Downloaded {outcome.FileName}", Severity.Success);
         }
         catch (OperationCanceledException) when (_cts.IsCancellationRequested) { }
         finally
@@ -157,20 +156,6 @@
     }
 
     private string Timestamp() => DownloadFileNames.Timestamp(Clock);
-
-    private static string SafeStem(string name)
-    {
-        var sb = new System.Text.StringBuilder(name.Length);
-        bool prev_ = false;
-        foreach (char c in name)
-        {
-            bool safe = char.IsAsciiLetterOrDigit(c) || c == '.' || c == '-';
-            if (safe) { sb.Append(c); prev_ = false; }
-            else if (!prev_) { sb.Append('_'); prev_ = true; }
-        }
-        string s = sb.ToString().Trim('_');
-        return s.Length == 0 ? "profile" : s.Length > 64 ? s[..64] : s;
-    }
 
     public void Dispose() { _cts.Cancel(); _cts.Dispose(); }
 }

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Profiles.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Profiles.razor
@@ -298,8 +298,18 @@
     // disabled button, so a title on the button itself would never fire — the tooltip root is a
     // plain div, which still receives the hover. The running row swaps its icon for a spinner,
     // because MudIconButton has no Loading parameter.
+    //
+    // The running row is checked first. Edit stays available during a download, and a row that
+    // entered edit mode mid-download must keep showing that the download is still running.
     private RenderFragment DownloadButton(ProfileDto profile) =>@<text>
-        @if (IsDownloadBlocked(profile))
+        @if (_downloadingProfileId == profile.Id)
+        {
+            <MudIconButton Class="download-profile-script" Disabled="true"
+                           UserAttributes="@DownloadAttributes(profile, blocked: false)">
+                <MudProgressCircular Size="Size.Small" Indeterminate="true" />
+            </MudIconButton>
+        }
+        else if (IsDownloadBlocked(profile))
         {
             <MudTooltip Text="@DownloadBlockedReason"
                         UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "download-disabled-reason" })">
@@ -307,13 +317,6 @@
                                Disabled="true"
                                UserAttributes="@DownloadAttributes(profile, blocked: true)" />
             </MudTooltip>
-        }
-        else if (_downloadingProfileId == profile.Id)
-        {
-            <MudIconButton Class="download-profile-script" Disabled="true"
-                           UserAttributes="@DownloadAttributes(profile, blocked: false)">
-                <MudProgressCircular Size="Size.Small" Indeterminate="true" />
-            </MudIconButton>
         }
         else
         {
@@ -358,6 +361,13 @@
         }
         // Leaving the page cancels the call. There is nobody left to read a message.
         catch (OperationCanceledException) when (_cts.IsCancellationRequested) { }
+        // The browser refused to write the file. Letting this travel on would leave the event
+        // task faulted, and Blazor skips its own re-render after a fault — so every row would
+        // stay drawn as disabled even though the field behind them was already cleared.
+        catch (JSException)
+        {
+            Snackbar.Add("Saving the file failed.", Severity.Error);
+        }
         finally
         {
             // Cleared on every path, so a failure or a cancellation still frees the other rows.

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Profiles.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Profiles.razor
@@ -63,6 +63,7 @@
                 <MudTd>@(context.Id == Guid.Empty ? "—" : context.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm"))</MudTd>
                 <MudTd>@(context.Id == Guid.Empty ? "—" : context.UpdatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm"))</MudTd>
                 <MudTd>
+                    @DownloadButton(context)
                     <MudIconButton Class="commit-edit" Icon="@Icons.Material.Filled.Check"
                                    Color="Color.Success" OnClick="() => CommitEditAsync(context.Id)" />
                     <MudIconButton Class="cancel-edit" Icon="@Icons.Material.Filled.Close"
@@ -78,6 +79,7 @@
                 <MudTd>
                     <MudIconButton Class="toggle-expand" Icon="@(IsExpanded(context.Id) ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
                                    OnClick="() => ToggleExpand(context.Id)" />
+                    @DownloadButton(context)
                     <MudIconButton Class="start-edit" Icon="@Icons.Material.Filled.Edit"
                                    OnClick="() => StartEdit(context)" />
                     <MudIconButton Class="delete" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
@@ -176,6 +178,7 @@
     [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
     [Inject] private IProfilesApiClient Api { get; set; } = default!;
     [Inject] private IDownloadsApiClient DownloadsApi { get; set; } = default!;
+    [Inject] private ProfileScriptDownloader Downloader { get; set; } = default!;
     [Inject] private ISnackbar Snackbar { get; set; } = default!;
     [Inject] private IDialogService DialogService { get; set; } = default!;
     [Inject] private IJSRuntime JS { get; set; } = default!;
@@ -188,6 +191,12 @@
     private bool _isAuthenticated;
     private bool _loading;
     private string? _loadError;
+
+    /// <summary>
+    /// The profile whose script is downloading, if one is. One field cannot hold two downloads,
+    /// so while it has a value every row's download button is disabled.
+    /// </summary>
+    private Guid? _downloadingProfileId;
     private readonly CancellationTokenSource _cts = new();
 
     protected override async Task OnInitializedAsync()
@@ -271,6 +280,89 @@
 
         state.Preview = null;
         state.Error = ApiErrorMessageFactory.Build(result.Status, result.Problem);
+    }
+
+    private const string DownloadBlockedReason = "Save your changes first";
+
+    /// <summary>
+    /// The server builds the script from saved data. Downloading mid-edit would hand back a file
+    /// that does not hold the unsaved change, and the new row has nothing on the server at all.
+    /// </summary>
+    private bool IsDownloadBlocked(ProfileDto profile) =>
+        profile.Id == Guid.Empty || _editing.ContainsKey(profile.Id);
+
+    // The row's download action. It renders in both action groups, so the Actions column keeps
+    // its shape when a row enters edit mode.
+    //
+    // A blocked button sits inside a MudTooltip. MudBlazor sets pointer-events: none on a
+    // disabled button, so a title on the button itself would never fire — the tooltip root is a
+    // plain div, which still receives the hover. The running row swaps its icon for a spinner,
+    // because MudIconButton has no Loading parameter.
+    private RenderFragment DownloadButton(ProfileDto profile) =>@<text>
+        @if (IsDownloadBlocked(profile))
+        {
+            <MudTooltip Text="@DownloadBlockedReason"
+                        UserAttributes="@(new Dictionary<string, object?> { ["data-test"] = "download-disabled-reason" })">
+                <MudIconButton Class="download-profile-script" Icon="@Icons.Material.Filled.Download"
+                               Disabled="true"
+                               UserAttributes="@DownloadAttributes(profile, blocked: true)" />
+            </MudTooltip>
+        }
+        else if (_downloadingProfileId == profile.Id)
+        {
+            <MudIconButton Class="download-profile-script" Disabled="true"
+                           UserAttributes="@DownloadAttributes(profile, blocked: false)">
+                <MudProgressCircular Size="Size.Small" Indeterminate="true" />
+            </MudIconButton>
+        }
+        else
+        {
+            <MudIconButton Class="download-profile-script" Icon="@Icons.Material.Filled.Download"
+                           Disabled="@(_downloadingProfileId is not null)"
+                           OnClick="() => DownloadScriptAsync(profile)"
+                           UserAttributes="@DownloadAttributes(profile, blocked: false)" />
+        }
+    </text>;
+
+    // MudIconButton has no AriaLabel parameter, so the label reaches the button as a plain
+    // attribute through MudComponentBase's UserAttributes. The button shows an icon and no text,
+    // so without it a screen reader announces only "button". A screen reader still announces a
+    // disabled button's name, so the reason it is disabled belongs here too. It cannot go on the
+    // MudTooltip wrapper: that div has no role, so its label would be ignored.
+    private static Dictionary<string, object?> DownloadAttributes(ProfileDto profile, bool blocked)
+    {
+        string name = string.IsNullOrWhiteSpace(profile.Name) ? "new profile" : profile.Name;
+        string label = $"Download the {name} script";
+        if (blocked)
+        {
+            label += $" — {char.ToLowerInvariant(DownloadBlockedReason[0])}{DownloadBlockedReason[1..]}";
+        }
+
+        return new Dictionary<string, object?> { ["aria-label"] = label };
+    }
+
+    private async Task DownloadScriptAsync(ProfileDto profile)
+    {
+        _downloadingProfileId = profile.Id;
+        try
+        {
+            DownloadOutcome outcome = await Downloader.DownloadAsync(profile.Id, profile.Name, _cts.Token);
+
+            if (!outcome.Saved)
+            {
+                Snackbar.Add(outcome.Error!, Severity.Error);
+                return;
+            }
+
+            Snackbar.Add($"Downloaded {outcome.FileName}", Severity.Success);
+        }
+        // Leaving the page cancels the call. There is nobody left to read a message.
+        catch (OperationCanceledException) when (_cts.IsCancellationRequested) { }
+        finally
+        {
+            // Cleared on every path, so a failure or a cancellation still frees the other rows.
+            _downloadingProfileId = null;
+        }
     }
 
     private async Task CopyPreviewAsync(Guid id)

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Program.cs
@@ -49,6 +49,7 @@ builder.RootComponents.Add<AHKFlowApp.UI.Blazor.App>("#app");
 builder.Services.AddMudServices();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddScoped<IFileSaver, JsFileSaver>();
+builder.Services.AddScoped<ProfileScriptDownloader>();
 builder.Services.AddScoped<LocalStorageUserPreferencesService>();
 builder.Services.AddScoped<IUserPreferencesService, HybridUserPreferencesService>();
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Services/ProfileScriptDownloader.cs
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Services/ProfileScriptDownloader.cs
@@ -1,0 +1,94 @@
+using System.Text;
+using AHKFlowApp.UI.Blazor.Helpers;
+
+namespace AHKFlowApp.UI.Blazor.Services;
+
+/// <summary>
+/// What a single download attempt ended with. Three free fields would allow contradictory values,
+/// such as a saved file that also carries an error. The private constructor and the two factories
+/// make those states impossible to build.
+/// </summary>
+internal sealed record DownloadOutcome
+{
+    private DownloadOutcome() { }
+
+    internal bool Saved { get; private init; }
+    internal string? FileName { get; private init; }
+    internal string? Error { get; private init; }
+
+    internal static DownloadOutcome Success(string fileName) =>
+        new() { Saved = true, FileName = fileName };
+
+    internal static DownloadOutcome Failure(string error) =>
+        new() { Saved = false, Error = error };
+}
+
+/// <summary>
+/// Fetches a profile's generated script, names the file, and saves it. The Profiles page and the
+/// Downloads page both call this, so the same profile can never download under two different
+/// names. It raises no snackbar, so each page keeps its own wording.
+/// </summary>
+internal sealed class ProfileScriptDownloader(
+    IDownloadsApiClient downloadsApi,
+    IFileSaver fileSaver,
+    TimeProvider clock)
+{
+    /// <summary>
+    /// Saves the profile's script as <c>{timestamp}_ahkflow_{stem}.ahk</c>.
+    /// </summary>
+    /// <remarks>
+    /// Cancellation is not caught here. Every caller must catch
+    /// <see cref="OperationCanceledException"/> and show no message. An exception from
+    /// <see cref="IFileSaver.SaveAsync"/> also travels out unchanged.
+    /// </remarks>
+    internal async Task<DownloadOutcome> DownloadAsync(
+        Guid profileId,
+        string profileName,
+        CancellationToken ct)
+    {
+        ApiResult<FileDownload> result = await downloadsApi.GetProfileScriptAsync(profileId, ct);
+
+        if (!result.IsSuccess)
+        {
+            return DownloadOutcome.Failure(ApiErrorMessageFactory.Build(result.Status, result.Problem));
+        }
+
+        string fileName = $"{DownloadFileNames.Timestamp(clock)}_ahkflow_{SafeStem(profileName)}.ahk";
+        await fileSaver.SaveAsync(fileName, result.Value!.ContentType, result.Value.Content);
+        return DownloadOutcome.Success(fileName);
+    }
+
+    /// <summary>
+    /// Turns a profile name into a file-name stem. Every run of unsafe characters becomes one
+    /// underscore; only ASCII letters, digits, <c>.</c> and <c>-</c> survive.
+    /// </summary>
+    /// <remarks>
+    /// The cut to 64 characters runs before the edge underscores are trimmed. The other order can
+    /// leave a trailing underscore: a long name may collapse to text whose 64th character is the
+    /// underscore, which the earlier trim never saw.
+    /// </remarks>
+    private static string SafeStem(string name)
+    {
+        StringBuilder sb = new(name.Length);
+        bool previousWasUnderscore = false;
+        foreach (char c in name)
+        {
+            bool safe = char.IsAsciiLetterOrDigit(c) || c == '.' || c == '-';
+            if (safe)
+            {
+                sb.Append(c);
+                previousWasUnderscore = false;
+            }
+            else if (!previousWasUnderscore)
+            {
+                sb.Append('_');
+                previousWasUnderscore = true;
+            }
+        }
+
+        string collapsed = sb.ToString();
+        string truncated = collapsed.Length > 64 ? collapsed[..64] : collapsed;
+        string trimmed = truncated.Trim('_');
+        return trimmed.Length == 0 ? "profile" : trimmed;
+    }
+}

--- a/tests/AHKFlowApp.E2E.Tests/ProfileScriptDownloadFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/ProfileScriptDownloadFlowTests.cs
@@ -1,0 +1,45 @@
+using System.Text.RegularExpressions;
+using AHKFlowApp.E2E.Tests.Fixtures;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace AHKFlowApp.E2E.Tests;
+
+[Collection(E2ETestCollection.Name)]
+public sealed class ProfileScriptDownloadFlowTests(StackFixture fixture) : IAsyncLifetime
+{
+    public Task InitializeAsync() => fixture.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task DownloadFromProfilesPage_SavesThatProfilesScript()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync();
+        IPage page = await ctx.NewPageAsync();
+
+        // A hotstring gives the generated script something to prove it came from this profile.
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/hotstrings");
+        await page.WaitForSelectorAsync("button.add-hotstring");
+        await page.ClickAsync("button.add-hotstring");
+        await page.FillAsync("input[data-test=\"trigger-input\"]", "dlflow");
+        await page.FillAsync("textarea[data-test=\"replacement-input\"]", "downloaded from profiles");
+        await page.ClickAsync("button.commit-edit");
+        await page.WaitForSelectorAsync("text=Hotstring created.");
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/profiles");
+        await page.WaitForSelectorAsync("button.download-profile-script");
+        IDownload download = await page.RunAndWaitForDownloadAsync(() =>
+            page.ClickAsync("button.download-profile-script"));
+
+        string path = await download.PathAsync()
+            ?? throw new InvalidOperationException("Download produced no file path.");
+        string script = await File.ReadAllTextAsync(path, System.Text.Encoding.UTF8);
+
+        Assert.Matches(new Regex(@"^\d{8}_\d{6}_ahkflow_.+\.ahk$"), download.SuggestedFilename);
+        Assert.Contains("#Requires AutoHotkey v2", script, StringComparison.Ordinal);
+        // The option letters belong to the hotstring's own defaults, so the assertion starts at
+        // the trigger. What matters here is that the file holds this profile's script.
+        Assert.Contains("dlflow::downloaded from profiles", script, StringComparison.Ordinal);
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/DownloadsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/DownloadsPageTests.cs
@@ -31,6 +31,9 @@ public sealed class DownloadsPageTests : BunitContext, IAsyncLifetime
         Services.AddSingleton(_downloads);
         Services.AddSingleton(_saver);
         Services.AddSingleton<TimeProvider>(_clock);
+        // The page calls the real downloader. It is sealed, so NSubstitute cannot fake it, and
+        // every dependency it needs is already a substitute here.
+        Services.AddSingleton<ProfileScriptDownloader>();
         Services.AddMudServices();
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
@@ -90,6 +93,26 @@ public sealed class DownloadsPageTests : BunitContext, IAsyncLifetime
             "20260726_140509_ahkflow_Work.ahk",
             "text/plain; charset=utf-8",
             Arg.Is<byte[]>(b => b.SequenceEqual(payload.Content)));
+    }
+
+    [Fact]
+    public Task Click_PerProfileDownload_ApiFails_SavesNothing()
+    {
+        ProfileDto work = MakeProfile("Work");
+        StubProfileList(work);
+        _downloads.GetProfileScriptAsync(work.Id, Arg.Any<CancellationToken>())
+            .Returns(ApiResult<FileDownload>.Failure(ApiResultStatus.NetworkError, null));
+
+        IRenderedComponent<Downloads> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find("button.download-profile"));
+        cut.Find("button.download-profile").Click();
+
+        // MudBlazor snackbars render through a portal, so the error message is not in the page
+        // markup here. The saver is the assertable proof that the failure path took no action.
+        cut.WaitForAssertion(() => _downloads.Received(1).GetProfileScriptAsync(
+            work.Id, Arg.Any<CancellationToken>()));
+        return _saver.DidNotReceive().SaveAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<byte[]>());
     }
 
     [Fact]

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/DownloadsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/DownloadsPageTests.cs
@@ -19,6 +19,7 @@ public sealed class DownloadsPageTests : BunitContext, IAsyncLifetime
     private readonly IProfilesApiClient _profiles = Substitute.For<IProfilesApiClient>();
     private readonly IDownloadsApiClient _downloads = Substitute.For<IDownloadsApiClient>();
     private readonly IFileSaver _saver = Substitute.For<IFileSaver>();
+    private readonly ISnackbar _snackbar = Substitute.For<ISnackbar>();
     private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 7, 26, 14, 5, 9, TimeSpan.Zero));
 
     private static readonly Task<AuthenticationState> AuthenticatedState =
@@ -35,6 +36,8 @@ public sealed class DownloadsPageTests : BunitContext, IAsyncLifetime
         // every dependency it needs is already a substitute here.
         Services.AddSingleton<ProfileScriptDownloader>();
         Services.AddMudServices();
+        // Registered after AddMudServices so this substitute wins over MudBlazor's own snackbar.
+        Services.AddSingleton(_snackbar);
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
 
@@ -107,10 +110,9 @@ public sealed class DownloadsPageTests : BunitContext, IAsyncLifetime
         cut.WaitForAssertion(() => cut.Find("button.download-profile"));
         cut.Find("button.download-profile").Click();
 
-        // MudBlazor snackbars render through a portal, so the error message is not in the page
-        // markup here. The saver is the assertable proof that the failure path took no action.
-        cut.WaitForAssertion(() => _downloads.Received(1).GetProfileScriptAsync(
-            work.Id, Arg.Any<CancellationToken>()));
+        cut.WaitForAssertion(() => _snackbar.Received(1).Add(
+            "Unable to reach the API. Check your connection and try again.", Severity.Error,
+            Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>()));
         return _saver.DidNotReceive().SaveAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<byte[]>());
     }

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/ProfilesPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/ProfilesPageTests.cs
@@ -7,9 +7,11 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
+using Microsoft.JSInterop;
 using MudBlazor;
 using MudBlazor.Services;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace AHKFlowApp.UI.Blazor.Tests.Pages;
@@ -390,7 +392,30 @@ public sealed class ProfilesPageTests : BunitContext, IAsyncLifetime
     }
 
     [Fact]
-    public async Task Download_CancelledByLeavingThePage_ShowsNoMessage()
+    public void Download_FileSaverFails_ReportsItAndFreesEveryRow()
+    {
+        ProfileDto alpha = MakeProfile("Alpha");
+        ProfileDto beta = MakeProfile("Beta");
+        StubList(alpha, beta);
+        StubScript(alpha);
+        _saver.SaveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<byte[]>())
+            .Throws(new JSException("the browser refused the download"));
+
+        IRenderedComponent<Profiles> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.FindAll(DownloadButtonSelector).Should().HaveCount(2));
+        cut.FindAll(DownloadButtonSelector)[0].Click();
+
+        cut.WaitForAssertion(() => _snackbar.Received(1).Add(
+            "Saving the file failed.", Severity.Error,
+            Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>()));
+        // A faulted event task skips Blazor's own re-render, so without the catch the rows stay
+        // rendered as disabled even though the field behind them was cleared.
+        cut.FindAll(DownloadButtonSelector)
+            .Should().OnlyContain(button => !button.HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public void Download_RowEntersEditWhileRunning_KeepsTheSpinner()
     {
         ProfileDto work = MakeProfile("Work");
         StubList(work);
@@ -400,10 +425,40 @@ public sealed class ProfilesPageTests : BunitContext, IAsyncLifetime
         IRenderedComponent<Profiles> cut = RenderPage();
         cut.WaitForAssertion(() => cut.Find(DownloadButtonSelector));
         cut.Find(DownloadButtonSelector).Click();
+        cut.Find("button.start-edit").Click();
+
+        // The download is still running, so the row must keep saying so.
+        cut.WaitForAssertion(() => cut.FindAll($"{DownloadButtonSelector} .mud-progress-circular")
+            .Should().ContainSingle());
+    }
+
+    [Fact]
+    public async Task Download_CancelledByLeavingThePage_ShowsNoMessage()
+    {
+        ProfileDto work = MakeProfile("Work");
+        StubList(work);
+        TaskCompletionSource<ApiResult<FileDownload>> pending = new();
+        CancellationToken passedToken = CancellationToken.None;
+        _downloads.GetProfileScriptAsync(work.Id, Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                passedToken = call.Arg<CancellationToken>();
+                return pending.Task;
+            });
+
+        IRenderedComponent<Profiles> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find(DownloadButtonSelector));
+        cut.Find(DownloadButtonSelector).Click();
 
         // Leaving the page disposes the component, which cancels its token source.
         await Renderer.DisposeComponents();
-        pending.SetException(new OperationCanceledException());
+
+        // The page must hand its own token to the downloader, and disposal must cancel it.
+        // Without this the test would still pass on a page that passed CancellationToken.None.
+        passedToken.CanBeCanceled.Should().BeTrue();
+        passedToken.IsCancellationRequested.Should().BeTrue();
+
+        pending.SetException(new OperationCanceledException(passedToken));
         await Task.Yield();
 
         AssertNoSnackbar();

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/ProfilesPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/ProfilesPageTests.cs
@@ -6,6 +6,7 @@ using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using MudBlazor;
 using MudBlazor.Services;
 using NSubstitute;
@@ -17,6 +18,9 @@ public sealed class ProfilesPageTests : BunitContext, IAsyncLifetime
 {
     private readonly IProfilesApiClient _api = Substitute.For<IProfilesApiClient>();
     private readonly IDownloadsApiClient _downloads = Substitute.For<IDownloadsApiClient>();
+    private readonly IFileSaver _saver = Substitute.For<IFileSaver>();
+    private readonly ISnackbar _snackbar = Substitute.For<ISnackbar>();
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 7, 26, 14, 5, 9, TimeSpan.Zero));
 
     private static readonly Task<AuthenticationState> AuthenticatedState =
         Task.FromResult(new AuthenticationState(
@@ -26,7 +30,14 @@ public sealed class ProfilesPageTests : BunitContext, IAsyncLifetime
     {
         Services.AddSingleton(_api);
         Services.AddSingleton(_downloads);
+        Services.AddSingleton(_saver);
+        Services.AddSingleton<TimeProvider>(_clock);
+        // The page calls the real downloader. It is sealed, so NSubstitute cannot fake it, and
+        // every dependency it needs is already a substitute here.
+        Services.AddSingleton<ProfileScriptDownloader>();
         Services.AddMudServices();
+        // Registered after AddMudServices so this substitute wins over MudBlazor's own snackbar.
+        Services.AddSingleton(_snackbar);
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
 
@@ -225,6 +236,177 @@ public sealed class ProfilesPageTests : BunitContext, IAsyncLifetime
         cut.WaitForAssertion(() => _api.Received(1).CreateAsync(
             Arg.Is<CreateProfileDto>(d => d.Name == "Work"),
             Arg.Any<CancellationToken>()));
+    }
+
+    private const string DownloadButtonSelector = "button.download-profile-script";
+
+    private static readonly FileDownload ScriptPayload =
+        new([0x41, 0x42], "ahkflow_Work.ahk", "text/plain; charset=utf-8");
+
+    private void StubScript(ProfileDto profile) =>
+        _downloads.GetProfileScriptAsync(profile.Id, Arg.Any<CancellationToken>())
+            .Returns(ApiResult<FileDownload>.Ok(ScriptPayload));
+
+    private void StubScriptFailure(ProfileDto profile) =>
+        _downloads.GetProfileScriptAsync(profile.Id, Arg.Any<CancellationToken>())
+            .Returns(ApiResult<FileDownload>.Failure(ApiResultStatus.NetworkError, null));
+
+    private void AssertNoSnackbar() =>
+        _snackbar.DidNotReceive().Add(
+            Arg.Any<string>(), Arg.Any<Severity>(),
+            Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>());
+
+    [Fact]
+    public void Download_Click_SavesTheScriptAndReportsIt()
+    {
+        ProfileDto work = MakeProfile("Work");
+        StubList(work);
+        StubScript(work);
+
+        IRenderedComponent<Profiles> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find(DownloadButtonSelector));
+        cut.Find(DownloadButtonSelector).Click();
+
+        // Exact name — the stamp comes from the injected clock, so it is deterministic.
+        cut.WaitForAssertion(() => _saver.Received(1).SaveAsync(
+            "20260726_140509_ahkflow_Work.ahk",
+            "text/plain; charset=utf-8",
+            Arg.Is<byte[]>(b => b.SequenceEqual(ScriptPayload.Content))));
+        _snackbar.Received(1).Add(
+            "Downloaded 20260726_140509_ahkflow_Work.ahk", Severity.Success,
+            Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public void Download_ApiFails_ShowsTheErrorAndSavesNothing()
+    {
+        ProfileDto work = MakeProfile("Work");
+        StubList(work);
+        StubScriptFailure(work);
+
+        IRenderedComponent<Profiles> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find(DownloadButtonSelector));
+        cut.Find(DownloadButtonSelector).Click();
+
+        cut.WaitForAssertion(() => _snackbar.Received(1).Add(
+            "Unable to reach the API. Check your connection and try again.", Severity.Error,
+            Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>()));
+        _saver.DidNotReceive().SaveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<byte[]>());
+    }
+
+    [Fact]
+    public void Download_RowBeingEdited_ButtonIsDisabled()
+    {
+        StubList(MakeProfile("Work"));
+
+        IRenderedComponent<Profiles> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
+        cut.Find("button.start-edit").Click();
+
+        cut.WaitForAssertion(() =>
+            cut.Find(DownloadButtonSelector).HasAttribute("disabled").Should().BeTrue());
+    }
+
+    [Fact]
+    public void Download_UnsavedNewRow_ButtonIsDisabled()
+    {
+        StubList();
+
+        IRenderedComponent<Profiles> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find("button.add-profile"));
+        cut.Find("button.add-profile").Click();
+
+        cut.WaitForAssertion(() =>
+            cut.Find(DownloadButtonSelector).HasAttribute("disabled").Should().BeTrue());
+    }
+
+    [Fact]
+    public void Download_DisabledButton_ExplainsWhy()
+    {
+        StubList(MakeProfile("Work"));
+
+        IRenderedComponent<Profiles> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find("button.start-edit"));
+        cut.Find("button.start-edit").Click();
+
+        // The wrapper carries the sighted reason, because MudBlazor sets pointer-events: none on
+        // a disabled button, so a title on the button itself would never fire.
+        cut.WaitForAssertion(() => cut.Find("[data-test=\"download-disabled-reason\"]"));
+        cut.Find(DownloadButtonSelector).GetAttribute("aria-label")
+            .Should().Be("Download the Work script — save your changes first");
+    }
+
+    [Fact]
+    public void Download_WhileOneRuns_EveryRowIsDisabled()
+    {
+        ProfileDto alpha = MakeProfile("Alpha");
+        ProfileDto beta = MakeProfile("Beta");
+        StubList(alpha, beta);
+        TaskCompletionSource<ApiResult<FileDownload>> pending = new();
+        _downloads.GetProfileScriptAsync(alpha.Id, Arg.Any<CancellationToken>()).Returns(pending.Task);
+
+        IRenderedComponent<Profiles> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.FindAll(DownloadButtonSelector).Should().HaveCount(2));
+        cut.FindAll(DownloadButtonSelector)[0].Click();
+
+        cut.WaitForAssertion(() => cut.FindAll(DownloadButtonSelector)
+            .Should().OnlyContain(button => button.HasAttribute("disabled")));
+    }
+
+    [Fact]
+    public void Download_AfterSuccess_EveryRowIsUsableAgain()
+    {
+        ProfileDto alpha = MakeProfile("Alpha");
+        ProfileDto beta = MakeProfile("Beta");
+        StubList(alpha, beta);
+        TaskCompletionSource<ApiResult<FileDownload>> pending = new();
+        _downloads.GetProfileScriptAsync(alpha.Id, Arg.Any<CancellationToken>()).Returns(pending.Task);
+
+        IRenderedComponent<Profiles> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.FindAll(DownloadButtonSelector).Should().HaveCount(2));
+        cut.FindAll(DownloadButtonSelector)[0].Click();
+        pending.SetResult(ApiResult<FileDownload>.Ok(ScriptPayload));
+
+        cut.WaitForAssertion(() => cut.FindAll(DownloadButtonSelector)
+            .Should().OnlyContain(button => !button.HasAttribute("disabled")));
+    }
+
+    [Fact]
+    public void Download_AfterFailure_EveryRowIsUsableAgain()
+    {
+        ProfileDto alpha = MakeProfile("Alpha");
+        ProfileDto beta = MakeProfile("Beta");
+        StubList(alpha, beta);
+        TaskCompletionSource<ApiResult<FileDownload>> pending = new();
+        _downloads.GetProfileScriptAsync(alpha.Id, Arg.Any<CancellationToken>()).Returns(pending.Task);
+
+        IRenderedComponent<Profiles> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.FindAll(DownloadButtonSelector).Should().HaveCount(2));
+        cut.FindAll(DownloadButtonSelector)[0].Click();
+        pending.SetResult(ApiResult<FileDownload>.Failure(ApiResultStatus.NetworkError, null));
+
+        cut.WaitForAssertion(() => cut.FindAll(DownloadButtonSelector)
+            .Should().OnlyContain(button => !button.HasAttribute("disabled")));
+    }
+
+    [Fact]
+    public async Task Download_CancelledByLeavingThePage_ShowsNoMessage()
+    {
+        ProfileDto work = MakeProfile("Work");
+        StubList(work);
+        TaskCompletionSource<ApiResult<FileDownload>> pending = new();
+        _downloads.GetProfileScriptAsync(work.Id, Arg.Any<CancellationToken>()).Returns(pending.Task);
+
+        IRenderedComponent<Profiles> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find(DownloadButtonSelector));
+        cut.Find(DownloadButtonSelector).Click();
+
+        // Leaving the page disposes the component, which cancels its token source.
+        await Renderer.DisposeComponents();
+        pending.SetException(new OperationCanceledException());
+        await Task.Yield();
+
+        AssertNoSnackbar();
     }
 
     [Fact]

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Services/ProfileScriptDownloaderTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Services/ProfileScriptDownloaderTests.cs
@@ -1,0 +1,153 @@
+using AHKFlowApp.UI.Blazor.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace AHKFlowApp.UI.Blazor.Tests.Services;
+
+/// <summary>
+/// The file-name rules are the reason this service exists, so they are pinned here rather than
+/// through a page. The rules run in one fixed order: collapse unsafe characters, truncate to 64
+/// characters, trim edge underscores, then fall back to "profile" when nothing is left.
+/// </summary>
+public sealed class ProfileScriptDownloaderTests
+{
+    private const string Stamp = "20260726_140509";
+
+    private readonly IDownloadsApiClient _downloads = Substitute.For<IDownloadsApiClient>();
+    private readonly IFileSaver _saver = Substitute.For<IFileSaver>();
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 7, 26, 14, 5, 9, TimeSpan.Zero));
+
+    private ProfileScriptDownloader CreateSut() => new(_downloads, _saver, _clock);
+
+    private static readonly Guid ProfileId = Guid.NewGuid();
+
+    private void StubScript(byte[]? content = null, string contentType = "text/plain; charset=utf-8") =>
+        _downloads.GetProfileScriptAsync(ProfileId, Arg.Any<CancellationToken>())
+            .Returns(ApiResult<FileDownload>.Ok(
+                new FileDownload(content ?? [0x41, 0x42], "ahkflow.ahk", contentType)));
+
+    private async Task<string> SavedNameForAsync(string profileName)
+    {
+        StubScript();
+        DownloadOutcome outcome = await CreateSut().DownloadAsync(ProfileId, profileName, CancellationToken.None);
+        outcome.Saved.Should().BeTrue();
+        return outcome.FileName!;
+    }
+
+    private static string StemOf(string fileName)
+    {
+        const string prefix = $"{Stamp}_ahkflow_";
+        fileName.Should().StartWith(prefix).And.EndWith(".ahk");
+        return fileName[prefix.Length..^".ahk".Length];
+    }
+
+    [Fact]
+    public async Task DownloadAsync_UnsafeCharacters_CollapseToOneUnderscore()
+    {
+        string name = await SavedNameForAsync("Work   //  Notes");
+
+        StemOf(name).Should().Be("Work_Notes");
+    }
+
+    [Fact]
+    public async Task DownloadAsync_EdgeUnsafeCharacters_AreTrimmed()
+    {
+        string name = await SavedNameForAsync("  Work  ");
+
+        StemOf(name).Should().Be("Work");
+    }
+
+    [Fact]
+    public async Task DownloadAsync_NameWithNoSafeCharacters_FallsBackToProfile()
+    {
+        string name = await SavedNameForAsync("///");
+
+        StemOf(name).Should().Be("profile");
+    }
+
+    [Fact]
+    public async Task DownloadAsync_StemLongerThan64Characters_IsTruncatedTo64()
+    {
+        string name = await SavedNameForAsync(new string('a', 80));
+
+        StemOf(name).Should().Be(new string('a', 64));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_TruncationLandsOnAnUnderscore_LeavesNoTrailingUnderscore()
+    {
+        // Collapses to 65 characters: 63 'a', then '_', then 'x'. Truncating to 64 keeps the
+        // underscore at the end, so the trim has to run after the cut, not before it.
+        string name = await SavedNameForAsync(new string('a', 63) + " x");
+
+        StemOf(name).Should().Be(new string('a', 63));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_DotsAndDashes_SurviveUnchanged()
+    {
+        string name = await SavedNameForAsync("work-v2.1");
+
+        StemOf(name).Should().Be("work-v2.1");
+    }
+
+    [Fact]
+    public async Task DownloadAsync_Success_SavesWithStampedNameAndPayload()
+    {
+        byte[] content = [0x41, 0x42, 0x43];
+        StubScript(content, "text/plain; charset=utf-8");
+
+        DownloadOutcome outcome = await CreateSut().DownloadAsync(ProfileId, "Work", CancellationToken.None);
+
+        outcome.Saved.Should().BeTrue();
+        outcome.FileName.Should().Be("20260726_140509_ahkflow_Work.ahk");
+        outcome.Error.Should().BeNull();
+        await _saver.Received(1).SaveAsync(
+            "20260726_140509_ahkflow_Work.ahk",
+            "text/plain; charset=utf-8",
+            Arg.Is<byte[]>(b => b.SequenceEqual(content)));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_ApiFailure_ReturnsFailureAndSavesNothing()
+    {
+        _downloads.GetProfileScriptAsync(ProfileId, Arg.Any<CancellationToken>())
+            .Returns(ApiResult<FileDownload>.Failure(ApiResultStatus.NetworkError, null));
+
+        DownloadOutcome outcome = await CreateSut().DownloadAsync(ProfileId, "Work", CancellationToken.None);
+
+        outcome.Saved.Should().BeFalse();
+        outcome.FileName.Should().BeNull();
+        outcome.Error.Should().Be("Unable to reach the API. Check your connection and try again.");
+        await _saver.DidNotReceive().SaveAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<byte[]>());
+    }
+
+    [Fact]
+    public async Task DownloadAsync_ApiCancelled_PropagatesAndSavesNothing()
+    {
+        _downloads.GetProfileScriptAsync(ProfileId, Arg.Any<CancellationToken>())
+            .Throws(new OperationCanceledException());
+
+        Func<Task> act = async () => _ = await CreateSut().DownloadAsync(ProfileId, "Work", CancellationToken.None);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        await _saver.DidNotReceive().SaveAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<byte[]>());
+    }
+
+    [Fact]
+    public async Task DownloadAsync_FileSaverThrows_PropagatesUnchanged()
+    {
+        StubScript();
+        InvalidOperationException boom = new("save failed");
+        _saver.SaveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<byte[]>()).Throws(boom);
+
+        Func<Task> act = async () => _ = await CreateSut().DownloadAsync(ProfileId, "Work", CancellationToken.None);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>()).Which.Should().BeSameAs(boom);
+    }
+}


### PR DESCRIPTION
## What

The Profiles page (`/profiles`) gains a per-row download button, so an owner can save a profile's
`.ahk` script without going to the Downloads page first. Closes backlog 055.

## How

- New `ProfileScriptDownloader` holds the fetch-name-save sequence. Both pages call it, so the same
  profile cannot download under two different file names.
- `SafeStem` moved out of `Downloads.razor` into that service. One deliberate behaviour change: the
  stem is truncated to 64 characters **before** edge underscores are trimmed, not after. The old
  order could leave a trailing `_` on a long name.
- `Downloads.razor` now calls the service. Its snackbar wording, its cancellation catch, and
  **Download all (zip)** are unchanged.
- `Profiles.razor` renders the button in both action groups, so the Actions column keeps its shape
  when a row enters edit mode.

## Disabled states

Disabled while the row is being edited, on the unsaved new-profile row, and while any download runs.
The reason rides on a `MudTooltip` wrapper and on the button's own `aria-label` — MudBlazor sets
`pointer-events: none` on a disabled button, so a `title` there would never fire.

## Review round

A local review found four real issues, all fixed in `6129211d`:

- a failed file save left every row drawn as disabled — a faulted event task skips Blazor's own
  re-render, so the cleared field never reached the screen. Now caught and reported.
- entering edit mode mid-download replaced the spinner with a plain disabled icon. The running row
  now outranks the edit branch.
- the Downloads failure test never asserted its error message.
- the disposal test would have passed on a page that passed `CancellationToken.None`.

Two follow-ups filed rather than widened into this PR: **056** (a disabled button's reason is
unreachable by keyboard and touch — repo-wide, joins 053) and **057** (the Downloads page has the
same failed-save defect, and that page is out of scope here).

## Testing

- Release build: 17 projects, 0 warnings
- `dotnet format --verify-no-changes`: clean
- `pwsh .\scripts\test-fast.ps1 -Mode Coverage`: 3564 passed, 0 failed (E2E 50/50)
- New: 10 unit tests, 11 bUnit tests, 1 E2E flow that downloads from `/profiles` and asserts the
  saved text is that profile's script

🤖 Generated with [Claude Code](https://claude.com/claude-code)