### PR TITLE
fix: refuse bash writes into main from a worktree session

### DIFF
--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -44,9 +44,20 @@ CANDIDATE_PATTERN='(^|[^A-Za-z0-9_.-])(git(\.exe)?|rm|dotnet)([^A-Za-z0-9_.-]|$)
 # A false positive only costs one jq call; a false negative would silently disable the guard.
 RAW_CANDIDATE_PATTERN='(git(\.exe)?|rm|dotnet)([^A-Za-z0-9_.-]|$)'
 
+# Worktree write isolation. This clause only matters when the SESSION is inside a worktree, and
+# a worktree cwd always contains the "worktrees" path segment. A main-checkout session never
+# matches, so its cost stays exactly what it was: one Bash exit, no PowerShell start.
+#
+# Same conservative-superset discipline as CANDIDATE_PATTERN above: a false positive costs one
+# PowerShell start, a false negative silently disables the guard. The command text itself may
+# contain "worktrees", which costs one wasted start in a main session. That is the accepted
+# direction of error.
+WORKTREE_SESSION_PATTERN='worktrees'
+WRITE_CANDIDATE_PATTERN='(>|(^|[^A-Za-z0-9_.-])(cp|mv|tee|truncate|install|ln|touch|mkdir|rmdir|dd|sed|unlink|shred|Set-Content|Add-Content|Clear-Content|Out-File|New-Item|Remove-Item|Copy-Item|Move-Item|Rename-Item)([^A-Za-z0-9_.-]|$))'
+
 shopt -s nocasematch
 
-if [[ ! "$INPUT" =~ $RAW_CANDIDATE_PATTERN ]]; then
+if [[ ! "$INPUT" =~ $RAW_CANDIDATE_PATTERN ]] && [[ ! "$INPUT" =~ $WORKTREE_SESSION_PATTERN ]]; then
   exit 0
 fi
 
@@ -64,7 +75,12 @@ if [[ $PARSED -eq 1 ]]; then
   # Match only the extracted command, never the raw payload: a cwd containing "segocom-github"
   # must not drag a noncandidate command onto the slow path.
   if [[ ! "$COMMAND" =~ $CANDIDATE_PATTERN ]]; then
-    exit 0
+    # Not a git/rm/dotnet candidate. It may still be a write from a worktree session, which is
+    # decided from the payload's cwd, not from the command text.
+    CWD=$(printf '%s' "$INPUT" | jq -er '.cwd // empty' 2>/dev/null) || CWD=""
+    if [[ ! "$CWD" =~ $WORKTREE_SESSION_PATTERN ]] || [[ ! "$COMMAND" =~ $WRITE_CANDIDATE_PATTERN ]]; then
+      exit 0
+    fi
   fi
 
   if [[ "$ADAPTER" == "Auto" ]]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,9 +273,10 @@ an open branch produces a diff full of unrelated commits after the first rebase.
 worktree creation cannot pass a base ref, so stacked work must call the script directly; see the
 `worktrees` skill.
 
-The AHKFlowApp main checkout is human-owned. Agents may inspect, edit, build, test, and format
-there. The guard gates a Git command only when it could change the human's HEAD, index, or
-working tree in main. Most of these mutations need a managed linked worktree. Run from main
+The AHKFlowApp main checkout is human-owned. A session running **in main** may inspect, edit,
+build, test, and format there. A session running in a managed worktree may read main, but a shell
+command that writes, moves, or deletes a path under main is refused. The guard gates a Git command
+only when it could change the human's HEAD, index, or working tree in main. Most of these mutations need a managed linked worktree. Run from main
 instead, and most now get an in-session approval prompt. A short list of operations — such as
 `git worktree prune` or deleting an already-merged branch — always run from main, no prompt.
 `git commit` is the one exception. It always needs a worktree, or a session-wide

--- a/backlog/054-worktree-isolation-guard-misses-bash-file-writes.md
+++ b/backlog/054-worktree-isolation-guard-misses-bash-file-writes.md
@@ -52,9 +52,12 @@ The message therefore names a file that cannot exist, and sends the next agent l
       worktree-isolated session, the same way Edit and Write already are
 - [ ] Reads stay allowed. AGENTS.md says agents may inspect, build, test, and format in main, and
       building writes to `obj/` and `bin/` — so the rule must target source paths, not every write
-- [ ] The refusal names the real reason and a real next step. When no worktree copy of the path can
-      exist, it must not tell the agent to edit one
+- [ ] The **Bash** refusal this repo owns names the real reason and a real next step. When no
+      worktree copy of the path can exist, it must not tell the agent to edit one
 - [ ] A test covers both probes above — the symlinked path and a plain main-checkout path
+
+The Edit tool's refusal message is Claude Code's own text, not this repo's. It moved to
+`backlog/058-native-edit-refusal-names-missing-worktree-copy.md`, so this item stays closable.
 
 ## Out of scope
 

--- a/backlog/058-native-edit-refusal-names-missing-worktree-copy.md
+++ b/backlog/058-native-edit-refusal-names-missing-worktree-copy.md
@@ -1,0 +1,68 @@
+# 058 - Native Edit refusal names a worktree copy that cannot exist
+
+## Metadata
+
+- **Epic**: Agent tooling
+- **Type**: Bug
+- **Interfaces**: UI | API | CLI (none — agent tooling only)
+
+## Summary
+
+Claude Code's own worktree isolation refuses an `Edit` or `Write` aimed at the main checkout. The
+refusal reads:
+
+> This session is isolated in the worktree ... Edit the worktree copy of this file instead of the
+> shared-checkout path.
+
+For `docs/superpowers/` there is no worktree copy to edit. `.gitignore:469` excludes
+`docs/superpowers`, so `git worktree add` never checks it out.
+`scripts/worktree-plans.common.ps1:59` links the main checkout's folder in with `mklink /D` instead.
+The message names a file that cannot exist, and sends the next agent looking for it.
+
+## Why this is its own item
+
+Split out of `backlog/054-worktree-isolation-guard-misses-bash-file-writes.md`, which carried it as
+a second, smaller defect.
+
+054 closes a real hole this repository owns: a Bash write from a worktree reaching the main
+checkout. This one is different in kind. The text belongs to the Claude Code harness, not to this
+repository — the string `isolated in the worktree` appears nowhere in the checkout. Keeping both in
+one item would have made 054 unclosable, because AGENTS.md requires every acceptance box ticked
+before an item moves to `backlog/done/`.
+
+This item is also Claude-only. Codex and Copilot have no equivalent isolation, so they never show
+this message.
+
+## First step: is it fixable here at all?
+
+This is a real question, not a foregone conclusion. Answer it before designing anything.
+
+A `PreToolUse` hook matching `Edit|Write` can return a deny decision with its own message. If that
+hook fires **before** the harness's own isolation check, this repository can emit a correct message
+and the item is fixable locally. If the harness checks first, its message wins and no hook can
+replace it.
+
+Probe: register a temporary `PreToolUse` hook on `Edit|Write` that denies with a recognizable
+string, then attempt an `Edit` on a main-checkout path from a worktree session. Whichever message
+appears answers the question.
+
+## Acceptance criteria
+
+- [ ] The hook-versus-harness precedence question above is answered, with the observed message
+      recorded
+- [ ] If a hook can win: a refusal message that names the real reason and a real next step, and that
+      never tells the agent to edit a worktree copy which cannot exist for `docs/superpowers`
+- [ ] If a hook cannot win: an upstream report filed with Anthropic, linked from this item, and the
+      limitation recorded in `docs/agents/cross-agent-git-guardrails.md`
+
+## Out of scope
+
+- The Bash write hole. That is 054.
+- Any change to where plans are written. `.claude/CLAUDE.md` deliberately keeps plan writes and plan
+  commits in the main checkout. This item fixes wording, not policy.
+
+## Notes / dependencies
+
+- Depends on 054 only for context, not for code. They can land in either order.
+- Design for 054: `docs/superpowers/specs/2026-08-06-worktree-guard-bash-writes-design.md`, section
+  "Backlog scope"

--- a/backlog/done/054-worktree-isolation-guard-misses-bash-file-writes.md
+++ b/backlog/done/054-worktree-isolation-guard-misses-bash-file-writes.md
@@ -48,13 +48,13 @@ The message therefore names a file that cannot exist, and sends the next agent l
 
 ## Acceptance criteria
 
-- [ ] A Bash command that writes, moves, or deletes a file under the main checkout is refused from a
+- [x] A Bash command that writes, moves, or deletes a file under the main checkout is refused from a
       worktree-isolated session, the same way Edit and Write already are
-- [ ] Reads stay allowed. AGENTS.md says agents may inspect, build, test, and format in main, and
+- [x] Reads stay allowed. AGENTS.md says agents may inspect, build, test, and format in main, and
       building writes to `obj/` and `bin/` — so the rule must target source paths, not every write
-- [ ] The **Bash** refusal this repo owns names the real reason and a real next step. When no
+- [x] The **Bash** refusal this repo owns names the real reason and a real next step. When no
       worktree copy of the path can exist, it must not tell the agent to edit one
-- [ ] A test covers both probes above — the symlinked path and a plain main-checkout path
+- [x] A test covers both probes above — the symlinked path and a plain main-checkout path
 
 The Edit tool's refusal message is Claude Code's own text, not this repo's. It moved to
 `backlog/058-native-edit-refusal-names-missing-worktree-copy.md`, so this item stays closable.

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -146,9 +146,22 @@ A **sibling** worktree is refused. It is another agent's checkout, so writing in
 same isolation the rule exists to protect.
 
 Write targets are found from unquoted redirects, from a per-command destination table, and from
-nested `sh -c` / `pwsh -Command` arguments to a depth of 2. A target the guard cannot expand — one
-carrying a variable or a leading `~` — is denied, because the guard cannot tell where it lands.
-Only the leading literal prefix must expand, so `rm -rf ./obj/*` stays allowed.
+nested `sh -c` / `pwsh -Command` arguments to a depth of 2. `cp`, `mv`, `install`, and `ln` are
+read for `-t` and `--target-directory` as well, because that option moves the destination off the
+last argument.
+
+A target the guard cannot expand is denied, because the guard cannot tell where it lands. That
+covers a leading `~`, and a variable, a percent expansion, a command substitution, or a backtick
+**anywhere** in the path. A leading literal prefix does not rescue it: `./scripts/$DEST` reaches
+main when `DEST` is `../../../../README.md`. A glob is different — a glob cannot match `..` or a
+rooted path, so the literal prefix before it decides, and `rm -rf ./obj/*` stays allowed.
+
+The same rule applies to nesting past the depth limit. An inner command the guard never scanned
+is not an inner command that writes nothing, so a third level of `sh -c` is denied outright.
+
+A directory change the guard cannot expand — `cd "$MAIN_ROOT"` — makes every later **relative**
+write in the same chain untargetable, so those are denied too. Later absolute writes still
+classify exactly, and a later resolved `cd` restores tracking.
 
 `AHKFLOW_ALLOW_MAIN=1` downgrades this to a warned allow, as it does for the location rules.
 

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -5,8 +5,10 @@ changing state under them — especially the branch they are standing on. Local 
 and GitHub Copilot agent sessions gate every Git command the same way. The test: could it change
 the human's HEAD, index, or working tree in the main checkout? A command that cannot is allowed
 even from main. Most commands that can need a managed linked worktree, or an in-session approval
-prompt. See "Location tiers" below for the full breakdown. Agents may still **read, edit, build,
-test, and format** in main — this is a Git-mutation guard, not a filesystem sandbox.
+prompt. See "Location tiers" below for the full breakdown. A session running **in main** may still
+**read, edit, build, test, and format** there — this is a Git-mutation guard, not a filesystem
+sandbox. A session running in a managed worktree is different: it may read main, but a shell
+command that writes there is refused. See "Worktree write isolation" below.
 
 ## What "managed" means
 
@@ -126,6 +128,30 @@ destructive-command safety-rule match (force-push, `reset --hard`, `clean -f`, `
 dangerous `rm -rf`), and an unparseable `ambiguous-git-command`. Neither was ever gated by
 location logic.
 
+### Worktree write isolation
+
+Separate from the Git tiers. When the session's working directory is a **managed worktree**, a
+shell command that writes, moves, or deletes a path resolving under the main checkout is denied,
+with rule `agent-worktree-main-write`.
+
+Allowed anyway:
+
+- Anything inside the session's own worktree.
+- Anything outside the protected checkout.
+- Build output and third-party content, matched on any path component: `bin`, `obj`, `TestResults`,
+  `.vs`, `node_modules`.
+- `<main>\.claude\worktrees\worktree-removal.log`, by exact path.
+
+A **sibling** worktree is refused. It is another agent's checkout, so writing into it breaks the
+same isolation the rule exists to protect.
+
+Write targets are found from unquoted redirects, from a per-command destination table, and from
+nested `sh -c` / `pwsh -Command` arguments to a depth of 2. A target the guard cannot expand — one
+carrying a variable or a leading `~` — is denied, because the guard cannot tell where it lands.
+Only the leading literal prefix must expand, so `rm -rf ./obj/*` stays allowed.
+
+`AHKFLOW_ALLOW_MAIN=1` downgrades this to a warned allow, as it does for the location rules.
+
 **Adapter matrix for `Ask`.** Each adapter renders `Ask` differently:
 
 - **Claude** sets `hookSpecificOutput.permissionDecision = "ask"` and exits 0, which escalates to
@@ -159,11 +185,21 @@ Warm p50 over 20 runs after 5 warmups, Windows 11 / PowerShell 7:
 | Shim, read-only Git candidate | ~725 ms |
 | Shim, mutating Git candidate | ~975 ms |
 | Codex direct PowerShell, mutating Git candidate | ~630 ms |
+| Shim, worktree session, noncandidate read (exits in Bash after two `jq` calls) | ~267 ms |
+| Shim, worktree session, write candidate | ~1256 ms |
+
+The two worktree-session rows were measured later, on a different day. A main-checkout noncandidate
+re-measured at ~72 ms in that same run, against the ~54 ms above, so read the two sets as separate
+baselines rather than comparing them directly.
 
 The floor is process startup: ~260 ms for `pwsh` itself, plus ~200–340 ms more when Git Bash is
 the one spawning it. Only *candidate* commands pay this. Making the Git paths faster would mean
 either duplicating policy into Bash (rejected — it would drift from the PowerShell core) or
 starting PowerShell for every command (rejected — it would cost the ~54 ms common case ~500 ms).
+
+A worktree session pays more than a main-checkout session even for a read. Its `cwd` contains the
+`worktrees` segment, so the raw prefilter cannot exit early and the shim runs `jq` twice before
+deciding. A main-checkout session never matches that pattern and keeps its original cost.
 
 ## Setup and trust
 
@@ -254,9 +290,20 @@ An agent running the same command would need a prompt or override.
   Git after such a `cd` is unaffected. Pass an explicit `git -C <path>` to be classified normally.
 - `commit --no-verify` and `--git-dir`/`--work-tree` targeting cannot be safely inferred, so a
   mutating invocation using `--git-dir`/`--work-tree` is denied outright (unless `AHKFLOW_ALLOW_MAIN=1`).
-- File edits in main are not guarded by this mechanism at all. An `Edit`/`Write` tool call can
-  change the human's files under them the same way a Git mutation can, but this guard only covers
-  Git commands. Closing that gap is separate work, not part of this change.
+- Shell **writes** into main are guarded, in one direction only: a session whose working directory
+  is a managed worktree cannot write, move, or delete a path resolving under the main checkout. A
+  main-checkout session is unaffected and may still edit, build, test, and format there. `Edit` and
+  `Write` tool calls are not covered by this repository at all — Claude Code's own worktree
+  isolation covers them for Claude sessions, and Codex and Copilot have no equivalent.
+- The write scan reads a denylist of write commands, not an allowlist of safe ones. A writer
+  outside that list — `del`, `python -c`, a compiled tool — is not detected. Same trade-off the
+  Git mutation rule already makes.
+- `pwsh -File script.ps1` is still unread. The guard classifies the command line the hook reports,
+  never a file that command line points at.
+- Claude Code's own `Edit`/`Write` refusal tells the agent to edit "the worktree copy of this
+  file". For `docs/superpowers` no worktree copy can exist, because `.gitignore` excludes the path
+  and `scripts/worktree-plans.common.ps1` links it in instead. That text belongs to the harness and
+  cannot be changed here. Tracked in `backlog/058-native-edit-refusal-names-missing-worktree-copy.md`.
 
 ## Version-skew and authoritative main
 

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1363,6 +1363,64 @@ function Get-AgentSegmentWriteTarget {
     return $targets.ToArray()
 }
 
+# Interpreters whose quoted argument is itself a command line. `-File` and `/k`-style script
+# paths are deliberately absent: those point at a file, and the guard never reads files.
+$script:AgentGuardInterpreterSpecs = @(
+    @{ Leaf = 'sh'; Flags = @('-c') },
+    @{ Leaf = 'bash'; Flags = @('-c') },
+    @{ Leaf = 'zsh'; Flags = @('-c') },
+    @{ Leaf = 'pwsh'; Flags = @('-command', '-c') },
+    @{ Leaf = 'powershell'; Flags = @('-command', '-c') },
+    @{ Leaf = 'cmd'; Flags = @('/c', '/k') }
+)
+
+$script:AgentGuardMaxInterpreterDepth = 2
+
+<#
+.SYNOPSIS
+Every write target in a command string, following nested interpreter arguments.
+
+.DESCRIPTION
+Recursion is scoped to the write-target scan alone. Git classification still treats a quoted
+nested command as opaque, which stays a documented accepted limitation of this guard.
+#>
+function Get-AgentCommandWriteTarget {
+    [CmdletBinding()]
+    param([string] $Command, [int] $Depth = 0)
+
+    $parsed = Get-AgentCommandSegment -Command $Command
+    if ($parsed.Ambiguous) { return @() }
+
+    $targets = New-Object System.Collections.Generic.List[string]
+
+    foreach ($segment in $parsed.Segments) {
+        foreach ($target in (Get-AgentSegmentWriteTarget -Tokens $segment.Tokens -Masks $segment.Masks)) {
+            [void] $targets.Add($target)
+        }
+
+        if ($Depth -ge $script:AgentGuardMaxInterpreterDepth) { continue }
+
+        $tokens = @($segment.Tokens)
+        if ($tokens.Count -lt 3) { continue }
+
+        $leaf = Get-AgentCommandLeafName -Word $tokens[0]
+        $spec = $script:AgentGuardInterpreterSpecs | Where-Object { $_.Leaf -eq $leaf } | Select-Object -First 1
+        if ($null -eq $spec) { continue }
+
+        for ($i = 1; $i -lt $tokens.Count - 1; $i++) {
+            if ($spec.Flags -notcontains ([string] $tokens[$i]).ToLowerInvariant()) { continue }
+
+            $inner = [string] $tokens[$i + 1]
+            foreach ($target in (Get-AgentCommandWriteTarget -Command $inner -Depth ($Depth + 1))) {
+                [void] $targets.Add($target)
+            }
+            break
+        }
+    }
+
+    return $targets.ToArray()
+}
+
 $script:AgentGuardAllowedStates = @('NotRepository', 'OutsideProtectedRepository', 'ManagedWorktree')
 
 <#

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1421,6 +1421,114 @@ function Get-AgentCommandWriteTarget {
     return $targets.ToArray()
 }
 
+# Characters that make a path component impossible to expand from the command text alone.
+$script:AgentGuardUnexpandablePattern = '[\$%`]'
+
+<#
+.SYNOPSIS
+Replaces every reparse point in a path with its target, walking from the root down.
+
+.DESCRIPTION
+Windows PowerShell 5.1 has no ResolveLinkTarget, so this uses (Get-Item -Force).Target, which
+both supported hosts provide. 5.1 types that property as string[] and pwsh 7 as string, so the
+array form is normalized. The iteration cap stops a symlink cycle from hanging the hook.
+#>
+function Resolve-AgentSymlinkPath {
+    [CmdletBinding()]
+    param([string] $Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) { return $Path }
+
+    $result = $Path
+    for ($pass = 0; $pass -lt 16; $pass++) {
+        $changed = $false
+
+        $parts = $result -split '[\\/]'
+        if ($parts.Count -eq 0) { break }
+
+        $accumulated = $parts[0]
+        for ($i = 1; $i -lt $parts.Count; $i++) {
+            if ([string]::IsNullOrEmpty($parts[$i])) { continue }
+            $accumulated = Join-Path $accumulated $parts[$i]
+
+            if (-not (Test-Path -LiteralPath $accumulated)) { continue }
+
+            $item = Get-Item -LiteralPath $accumulated -Force -ErrorAction SilentlyContinue
+            if ($null -eq $item) { continue }
+            if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0) { continue }
+
+            $target = $item.Target
+            if ($target -is [array]) { $target = $target[0] }
+            if ([string]::IsNullOrWhiteSpace($target)) { continue }
+
+            $remainder = @($parts[($i + 1)..($parts.Count - 1)]) | Where-Object { $_ }
+            $result = $target
+            foreach ($piece in $remainder) { $result = Join-Path $result $piece }
+            $changed = $true
+            break
+        }
+
+        if (-not $changed) { break }
+    }
+
+    return $result
+}
+
+<#
+.SYNOPSIS
+Turns one raw write target into an absolute path, or marks it unresolved.
+
+.DESCRIPTION
+Only the longest leading literal prefix has to be expandable. A trailing glob cannot change
+which repository the path falls in, so `./obj/*` classifies on `./obj`. A target whose FIRST
+component is unexpandable - `$MAIN_ROOT/x.tmp` - has no literal prefix and is unresolved.
+
+Mirrors the precedent at Get-AgentCommandSegment, where a cd target matching [\$%] marks the
+following git mutation untargetable rather than guessing where it lands.
+#>
+function Get-AgentWriteTargetResolution {
+    [CmdletBinding()]
+    param([string] $Target, [string] $BaseDirectory)
+
+    if ([string]::IsNullOrWhiteSpace($Target)) {
+        return [pscustomobject]@{ Path = ''; Unresolved = $true }
+    }
+
+    $trimmed = $Target.Trim().Trim('"', "'")
+    if ($trimmed.StartsWith('~')) {
+        return [pscustomobject]@{ Path = ''; Unresolved = $true }
+    }
+
+    $parts = @($trimmed -split '[\\/]')
+    $literal = New-Object System.Collections.Generic.List[string]
+    foreach ($part in $parts) {
+        if ($part -match $script:AgentGuardUnexpandablePattern -or $part -match '[\*\?]') { break }
+        [void] $literal.Add($part)
+    }
+
+    if ($literal.Count -eq 0) {
+        return [pscustomobject]@{ Path = ''; Unresolved = $true }
+    }
+
+    $candidate = $literal -join '\'
+    if (-not [System.IO.Path]::IsPathRooted($candidate)) {
+        if ([string]::IsNullOrWhiteSpace($BaseDirectory)) {
+            return [pscustomobject]@{ Path = ''; Unresolved = $true }
+        }
+        $candidate = Join-Path $BaseDirectory $candidate
+    }
+
+    # GetFullPath collapses '..' segments; it does not touch the filesystem.
+    try { $candidate = [System.IO.Path]::GetFullPath($candidate) }
+    catch { return [pscustomobject]@{ Path = ''; Unresolved = $true } }
+
+    $resolved = Resolve-AgentSymlinkPath -Path $candidate
+    return [pscustomobject]@{
+        Path       = (ConvertTo-AgentGuardNormalizedPath $resolved)
+        Unresolved = $false
+    }
+}
+
 $script:AgentGuardAllowedStates = @('NotRepository', 'OutsideProtectedRepository', 'ManagedWorktree')
 
 <#

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -21,7 +21,9 @@ $script:AgentGuardProtectedCommonDirCache = @{}
 # Characters a backslash may escape inside double quotes (POSIX), and outside quotes. Compared
 # with IndexOf, not -contains: -contains on a string tests the whole string, never a character.
 $script:AgentGuardDoubleQuoteEscapables = '$`"\'
-$script:AgentGuardUnquotedEscapables = '$`"\;&|()' + "'"
+# '>' and '<' are here so `printf x\>y` reads as a literal '>', not a redirect. Neither character
+# is legal in a Windows path, so no path the guard has to classify is affected.
+$script:AgentGuardUnquotedEscapables = '$`"\;&|()<>' + "'"
 
 # Commands that move the shell's working directory, so a later `git` in the same chain does not
 # run where the hook payload said it would. pushd/popd are tracked separately because they form a
@@ -368,9 +370,13 @@ unless it precedes $, `, ", \, or newline), which keeps quoted Windows paths suc
 "C:\some;path" intact. Outside quotes a backslash only escapes a metacharacter or whitespace,
 so an unquoted C:\Dev\repo survives too.
 
-Returns { Segments = @(string[]); Ambiguous = bool }. Ambiguous means the string ended inside an
-unterminated quote or escape, which makes every segment boundary in it untrustworthy.
-This is intentionally not a complete shell parser.
+Returns { Segments = @([pscustomobject]@{ Tokens = string[]; Masks = string[] }); Ambiguous = bool }.
+Each mask runs parallel to its token, one character per token character: 'u' where the character
+was unquoted, 'q' where it came from quotes or an escape. That is what lets a later scan tell a
+real redirect from a literal '>' the tokenizer already stripped the quotes from.
+
+Ambiguous means the string ended inside an unterminated quote or escape, which makes every
+segment boundary in it untrustworthy. This is intentionally not a complete shell parser.
 #>
 function Split-AgentCommandSegment {
     [CmdletBinding()]
@@ -378,7 +384,9 @@ function Split-AgentCommandSegment {
 
     $segments = New-Object System.Collections.Generic.List[object]
     $tokens = New-Object System.Collections.Generic.List[string]
+    $masks = New-Object System.Collections.Generic.List[string]
     $current = New-Object System.Text.StringBuilder
+    $currentMask = New-Object System.Text.StringBuilder
     $hasCurrent = $false
     $state = 'None'
     $returnState = 'None'
@@ -388,6 +396,7 @@ function Split-AgentCommandSegment {
 
         if ($state -eq 'Escaped') {
             [void] $current.Append($ch)
+            [void] $currentMask.Append('q')
             $hasCurrent = $true
             $state = $returnState
             continue
@@ -395,7 +404,9 @@ function Split-AgentCommandSegment {
 
         if ($state -eq 'SingleQuoted') {
             if ($ch -eq "'") { $state = 'None' }
-            else { [void] $current.Append($ch); $hasCurrent = $true }
+            else {
+                [void] $current.Append($ch); [void] $currentMask.Append('q'); $hasCurrent = $true
+            }
             continue
         }
 
@@ -406,7 +417,9 @@ function Split-AgentCommandSegment {
                 $state = 'Escaped'
             }
             elseif ($ch -eq '"') { $state = 'None' }
-            else { [void] $current.Append($ch); $hasCurrent = $true }
+            else {
+                [void] $current.Append($ch); [void] $currentMask.Append('q'); $hasCurrent = $true
+            }
             continue
         }
 
@@ -424,17 +437,31 @@ function Split-AgentCommandSegment {
 
         if ($ch -eq "`n" -or $ch -eq "`r" -or $ch -eq ';' -or $ch -eq '&' -or $ch -eq '|' -or
             $ch -eq '`' -or $ch -eq '(' -or $ch -eq ')') {
-            if ($hasCurrent) { [void] $tokens.Add($current.ToString()); [void] $current.Clear(); $hasCurrent = $false }
-            if ($tokens.Count -gt 0) { [void] $segments.Add($tokens.ToArray()); $tokens.Clear() }
+            if ($hasCurrent) {
+                [void] $tokens.Add($current.ToString())
+                [void] $masks.Add($currentMask.ToString())
+                [void] $current.Clear(); [void] $currentMask.Clear(); $hasCurrent = $false
+            }
+            if ($tokens.Count -gt 0) {
+                [void] $segments.Add([pscustomobject]@{
+                        Tokens = $tokens.ToArray(); Masks = $masks.ToArray()
+                    })
+                $tokens.Clear(); $masks.Clear()
+            }
             continue
         }
 
         if ([char]::IsWhiteSpace($ch)) {
-            if ($hasCurrent) { [void] $tokens.Add($current.ToString()); [void] $current.Clear(); $hasCurrent = $false }
+            if ($hasCurrent) {
+                [void] $tokens.Add($current.ToString())
+                [void] $masks.Add($currentMask.ToString())
+                [void] $current.Clear(); [void] $currentMask.Clear(); $hasCurrent = $false
+            }
             continue
         }
 
         [void] $current.Append($ch)
+        [void] $currentMask.Append('u')
         $hasCurrent = $true
     }
 
@@ -442,8 +469,15 @@ function Split-AgentCommandSegment {
         return [pscustomobject]@{ Segments = @(); Ambiguous = $true }
     }
 
-    if ($hasCurrent) { [void] $tokens.Add($current.ToString()) }
-    if ($tokens.Count -gt 0) { [void] $segments.Add($tokens.ToArray()) }
+    if ($hasCurrent) {
+        [void] $tokens.Add($current.ToString())
+        [void] $masks.Add($currentMask.ToString())
+    }
+    if ($tokens.Count -gt 0) {
+        [void] $segments.Add([pscustomobject]@{
+                Tokens = $tokens.ToArray(); Masks = $masks.ToArray()
+            })
+    }
 
     return [pscustomobject]@{
         Segments  = $segments.ToArray()
@@ -490,11 +524,27 @@ function Remove-AgentWrapperPrefix {
     [CmdletBinding()]
     param([string[]] $Tokens)
 
+    return (Remove-AgentWrapperPrefixDetailed -Tokens $Tokens).Tokens
+}
+
+<#
+.SYNOPSIS
+Same as Remove-AgentWrapperPrefix, but also reports how many leading tokens were removed.
+
+.DESCRIPTION
+The mask array runs parallel to the token array, so it must be sliced by the same count. The
+original function returns only the surviving tokens, which is not enough to slice the masks.
+#>
+function Remove-AgentWrapperPrefixDetailed {
+    [CmdletBinding()]
+    param([string[]] $Tokens)
+
     $current = @($Tokens)
+    $removed = 0
 
     while ($current.Count -gt 0) {
         $leaf = (([string] $current[0]).ToLowerInvariant() -split '[\\/]')[-1]
-        if ($script:AgentGuardTransparentWrappers -notcontains $leaf) { return $current }
+        if ($script:AgentGuardTransparentWrappers -notcontains $leaf) { break }
 
         $index = 1
         while ($index -lt $current.Count -and ([string] $current[$index]) -like '-*') { $index++ }
@@ -504,20 +554,23 @@ function Remove-AgentWrapperPrefix {
             if ($script:AgentGuardWrapperPassThroughSubcommands -contains $subcommand) { $index++ }
         }
 
-        if ($index -ge $current.Count) { return @() }
+        if ($index -ge $current.Count) {
+            return [pscustomobject]@{ Tokens = @(); Removed = ($removed + $current.Count) }
+        }
 
         $remainder = @($current[$index..($current.Count - 1)])
         $remainderName = ([string] $remainder[0]).ToLowerInvariant()
         if ($script:AgentGuardChangeDirectoryCommands -contains $remainderName -or
             $script:AgentGuardPushDirectoryCommands -contains $remainderName -or
             $script:AgentGuardPopDirectoryCommands -contains $remainderName) {
-            return $current
+            break
         }
 
         $current = $remainder
+        $removed += $index
     }
 
-    return $current
+    return [pscustomobject]@{ Tokens = $current; Removed = $removed }
 }
 
 <#
@@ -526,7 +579,8 @@ Classifies each top-level segment as a git invocation, a directory change, or so
 
 .DESCRIPTION
 Returns { Segments = @(objects); Ambiguous = bool }. Each segment carries Kind
-(Git | ChangeDirectory | Other), Tokens (leading NAME=value assignments removed), and - for
+(Git | ChangeDirectory | Other), Tokens (leading NAME=value assignments removed), Masks (quote
+provenance, one character per token character, parallel to Tokens), and - for
 ChangeDirectory - Directory plus Unresolved. Unresolved marks a target the guard cannot expand
 literally (`cd -`, `cd $HOME`, bare `cd`), so a following mutation is treated as untargetable
 rather than silently classified against a stale directory.
@@ -546,18 +600,24 @@ function Get-AgentCommandSegment {
 
     $classified = New-Object System.Collections.Generic.List[object]
 
-    foreach ($tokens in $split.Segments) {
+    foreach ($entry in $split.Segments) {
+        $tokens = @($entry.Tokens)
+        $entryMasks = @($entry.Masks)
+
         # Drop NAME=value prefixes so `AHKFLOW_ALLOW_MAIN=1 git commit` still reads as git.
         $start = 0
         while ($start -lt $tokens.Count -and $tokens[$start] -match $script:AgentGuardEnvAssignmentPattern) { $start++ }
         if ($start -ge $tokens.Count) { continue }
 
         $effective = @($tokens[$start..($tokens.Count - 1)])
+        $effectiveMasks = @($entryMasks[$start..($entryMasks.Count - 1)])
 
         # Strip a transparent wrapper (rtk) after the NAME=value prefix, not before: order
         # matters so `SKIP_COVERAGE_HOOK=1 rtk git push` loses the assignment first, then rtk.
-        $effective = @(Remove-AgentWrapperPrefix -Tokens $effective)
+        $stripped = Remove-AgentWrapperPrefixDetailed -Tokens $effective
+        $effective = @($stripped.Tokens)
         if ($effective.Count -eq 0) { continue }
+        $effectiveMasks = @($effectiveMasks | Select-Object -Skip $stripped.Removed)
 
         $name = ([string] $effective[0]).ToLowerInvariant()
         $leaf = ($name -split '[\\/]')[-1]
@@ -565,9 +625,11 @@ function Get-AgentCommandSegment {
         if ($leaf -eq 'git' -or $leaf -eq 'git.exe') {
             # @() around the slice: a bare `git` has no tail, and 1..0 counts backwards.
             $tail = if ($effective.Count -gt 1) { @($effective[1..($effective.Count - 1)]) } else { @() }
+            $tailMasks = if ($effectiveMasks.Count -gt 1) { @($effectiveMasks[1..($effectiveMasks.Count - 1)]) } else { @() }
             [void] $classified.Add([pscustomobject]@{
                     Kind       = 'Git'
                     Tokens     = $tail
+                    Masks      = $tailMasks
                     Directory  = ''
                     Unresolved = $false
                 })
@@ -578,6 +640,7 @@ function Get-AgentCommandSegment {
             [void] $classified.Add([pscustomobject]@{
                     Kind       = 'PopDirectory'
                     Tokens     = $effective
+                    Masks      = $effectiveMasks
                     Directory  = ''
                     Unresolved = $false
                 })
@@ -596,6 +659,7 @@ function Get-AgentCommandSegment {
             [void] $classified.Add([pscustomobject]@{
                     Kind       = if ($isPush) { 'PushDirectory' } else { 'ChangeDirectory' }
                     Tokens     = $effective
+                    Masks      = $effectiveMasks
                     Directory  = $directory
                     Unresolved = $unresolved
                 })
@@ -605,6 +669,7 @@ function Get-AgentCommandSegment {
         [void] $classified.Add([pscustomobject]@{
                 Kind       = 'Other'
                 Tokens     = $effective
+                Masks      = $effectiveMasks
                 Directory  = ''
                 Unresolved = $false
             })

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1201,6 +1201,168 @@ function Test-AgentWorktreeManifest {
     return $true
 }
 
+# ── Write-target grammar ────────────────────────────────────────────────────────────────────
+# The tokenizer yields segments, not write targets. These tables and functions turn a segment
+# into the list of paths it would write, move, or delete. Over-reporting a target is safe: it
+# only ever produces a denial for a path that already resolves under the main checkout.
+# Under-reporting silently disables the rule, so keep every list a superset.
+
+$script:AgentGuardWriteEveryPositional = @(
+    'rm', 'unlink', 'shred', 'truncate', 'touch', 'mkdir', 'rmdir', 'tee'
+)
+$script:AgentGuardWriteLastPositional = @('cp', 'mv', 'install', 'ln')
+
+# Cmdlet name -> the parameter naming its write target. Positional fallbacks are handled below.
+$script:AgentGuardWriteCmdlets = @{
+    'set-content'   = @('Path', 'LiteralPath')
+    'add-content'   = @('Path', 'LiteralPath')
+    'clear-content' = @('Path', 'LiteralPath')
+    'out-file'      = @('FilePath', 'LiteralPath', 'Path')
+    'new-item'      = @('Path')
+    'remove-item'   = @('Path', 'LiteralPath')
+}
+$script:AgentGuardWriteDestinationCmdlets = @('copy-item', 'move-item', 'rename-item')
+
+<#
+.SYNOPSIS
+Index of the first unquoted '>' in a token, or -1 when the token carries no redirect.
+#>
+function Find-AgentUnquotedRedirectIndex {
+    param([string] $Token, [string] $Mask)
+
+    for ($i = 0; $i -lt $Token.Length; $i++) {
+        if ($Token[$i] -ne '>') { continue }
+        if ($i -lt $Mask.Length -and $Mask[$i] -eq 'u') { return $i }
+    }
+    return -1
+}
+
+<#
+.SYNOPSIS
+Lowercased leaf of a command word, with any .exe/.cmd/.bat suffix removed.
+#>
+function Get-AgentCommandLeafName {
+    param([string] $Word)
+
+    $leaf = (([string] $Word).ToLowerInvariant() -split '[\\/]')[-1]
+    return ($leaf -replace '\.(exe|cmd|bat|ps1)$', '')
+}
+
+<#
+.SYNOPSIS
+Value of the first matching -Name parameter, or $null.
+
+.DESCRIPTION
+Accepts both `-Path value` and PowerShell's `-Path:value` colon form.
+#>
+function Get-AgentNamedParameterValue {
+    param([string[]] $Arguments, [string[]] $Names)
+
+    $list = @($Arguments)
+    for ($i = 0; $i -lt $list.Count; $i++) {
+        $argument = [string] $list[$i]
+        foreach ($name in $Names) {
+            if ($argument -ieq "-$name") {
+                if (($i + 1) -lt $list.Count) { return [string] $list[$i + 1] }
+                return $null
+            }
+            if ($argument -ilike "-${name}:*") {
+                return $argument.Substring($name.Length + 2)
+            }
+        }
+    }
+    return $null
+}
+
+<#
+.SYNOPSIS
+Every path one command segment would write, move, or delete.
+
+.DESCRIPTION
+Two independent sources are scanned. Redirects are read from the token/mask pair, so only an
+unquoted '>' counts. Destination arguments are read from the leading command word using the
+tables above. A segment can produce both, for example `cp a b > log.txt`.
+#>
+function Get-AgentSegmentWriteTarget {
+    [CmdletBinding()]
+    param([string[]] $Tokens, [string[]] $Masks)
+
+    $targets = New-Object System.Collections.Generic.List[string]
+    $tokens = @($Tokens)
+    $masks = @($Masks)
+    if ($tokens.Count -eq 0) { return @() }
+
+    # --- Redirects -------------------------------------------------------------------------
+    $consumedByRedirect = @{}
+    for ($i = 0; $i -lt $tokens.Count; $i++) {
+        $token = [string] $tokens[$i]
+        $mask = if ($i -lt $masks.Count) { [string] $masks[$i] } else { '' }
+
+        $gt = Find-AgentUnquotedRedirectIndex -Token $token -Mask $mask
+        if ($gt -lt 0) { continue }
+
+        $end = $gt
+        while ($end -lt $token.Length -and $token[$end] -eq '>') { $end++ }
+        $rest = $token.Substring($end)
+
+        if (-not [string]::IsNullOrWhiteSpace($rest)) {
+            [void] $targets.Add($rest)
+        }
+        elseif (($i + 1) -lt $tokens.Count) {
+            [void] $targets.Add([string] $tokens[$i + 1])
+            $consumedByRedirect[$i + 1] = $true
+        }
+    }
+
+    # --- Destination arguments -------------------------------------------------------------
+    $leaf = Get-AgentCommandLeafName -Word $tokens[0]
+
+    # A token consumed as a redirect target is not also a positional argument of the command.
+    $arguments = @()
+    for ($i = 1; $i -lt $tokens.Count; $i++) {
+        if ($consumedByRedirect.ContainsKey($i)) { continue }
+        $token = [string] $tokens[$i]
+        $mask = if ($i -lt $masks.Count) { [string] $masks[$i] } else { '' }
+        if ((Find-AgentUnquotedRedirectIndex -Token $token -Mask $mask) -ge 0) { continue }
+        $arguments += $token
+    }
+    $positionals = @(Get-AgentGitPositionals -Arguments $arguments)
+
+    if ($script:AgentGuardWriteEveryPositional -contains $leaf) {
+        foreach ($positional in $positionals) { [void] $targets.Add($positional) }
+    }
+    elseif ($script:AgentGuardWriteLastPositional -contains $leaf) {
+        if ($positionals.Count -ge 1) { [void] $targets.Add($positionals[$positionals.Count - 1]) }
+    }
+    elseif ($leaf -eq 'sed') {
+        $inPlace = @($arguments | Where-Object { $_ -ceq '-i' -or $_ -clike '-i*' -or $_ -ceq '--in-place' }).Count -gt 0
+        if ($inPlace) {
+            # With -e or -f the script is an option value, so every positional is a file.
+            # Without them the first positional IS the script, so skip it.
+            $hasScriptOption = @($arguments | Where-Object { $_ -ceq '-e' -or $_ -ceq '-f' }).Count -gt 0
+            $files = if ($hasScriptOption) { $positionals } else { @($positionals | Select-Object -Skip 1) }
+            foreach ($file in $files) { [void] $targets.Add($file) }
+        }
+    }
+    elseif ($leaf -eq 'dd') {
+        foreach ($argument in $arguments) {
+            if ($argument -ilike 'of=*') { [void] $targets.Add($argument.Substring(3)) }
+        }
+    }
+    elseif ($script:AgentGuardWriteCmdlets.ContainsKey($leaf)) {
+        $named = Get-AgentNamedParameterValue -Arguments $arguments -Names $script:AgentGuardWriteCmdlets[$leaf]
+        if ($null -ne $named) { [void] $targets.Add($named) }
+        elseif ($positionals.Count -ge 1) { [void] $targets.Add($positionals[0]) }
+    }
+    elseif ($script:AgentGuardWriteDestinationCmdlets -contains $leaf) {
+        $named = Get-AgentNamedParameterValue -Arguments $arguments -Names @('Destination', 'NewName')
+        if ($null -ne $named) { [void] $targets.Add($named) }
+        elseif ($positionals.Count -ge 2) { [void] $targets.Add($positionals[1]) }
+    }
+
+    return $targets.ToArray()
+}
+
 $script:AgentGuardAllowedStates = @('NotRepository', 'OutsideProtectedRepository', 'ManagedWorktree')
 
 <#

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1050,6 +1050,60 @@ function Test-AgentGitTier2Allowed {
 
 <#
 .SYNOPSIS
+The nearest existing ancestor of a directory, or '' when none exists.
+
+.DESCRIPTION
+A target that does not exist yet (e.g. `git init newsub`) is classified by its nearest existing
+ancestor: git would walk up to that enclosing repository too.
+#>
+function Get-AgentGuardProbeDirectory {
+    param([string] $Path)
+
+    $probeDir = $Path
+    while (-not [string]::IsNullOrWhiteSpace($probeDir) -and -not (Test-Path -LiteralPath $probeDir)) {
+        $parent = Split-Path -Parent $probeDir
+        if ($parent -eq $probeDir) { break }
+        $probeDir = $parent
+    }
+    if ([string]::IsNullOrWhiteSpace($probeDir) -or -not (Test-Path -LiteralPath $probeDir)) { return '' }
+    return $probeDir
+}
+
+# Working directory -> that directory's git top level. One hook process can classify several
+# chained commands, so the probe is cached rather than re-spawning git per link.
+$script:AgentGuardTopLevelCache = @{}
+
+<#
+.SYNOPSIS
+The git top level containing a session's working directory, falling back to that directory.
+
+.DESCRIPTION
+The fallback only applies when git cannot answer - the directory is gone, or it is not in a
+repository at all. Callers use the result as the session's own worktree, so it must be the
+worktree ROOT and not the subdirectory the session happens to have started in.
+#>
+function Get-AgentSessionWorktreeRoot {
+    [CmdletBinding()]
+    param([string] $Cwd)
+
+    if ($script:AgentGuardTopLevelCache.ContainsKey($Cwd)) { return $script:AgentGuardTopLevelCache[$Cwd] }
+
+    $result = ConvertTo-AgentGuardNormalizedPath $Cwd
+    $probeDir = Get-AgentGuardProbeDirectory -Path $Cwd
+    if (-not [string]::IsNullOrWhiteSpace($probeDir)) {
+        $topLevel = Invoke-AgentGuardGitProbe @(
+            '-C', $probeDir, 'rev-parse', '--path-format=absolute', '--show-toplevel')
+        if (-not [string]::IsNullOrWhiteSpace($topLevel)) {
+            $result = ConvertTo-AgentGuardNormalizedPath $topLevel
+        }
+    }
+
+    $script:AgentGuardTopLevelCache[$Cwd] = $result
+    return $result
+}
+
+<#
+.SYNOPSIS
 Classifies a directory relative to the protected AHKFlowApp checkout.
 
 .DESCRIPTION
@@ -1067,15 +1121,8 @@ function Get-ManagedWorktreeState {
         return 'NotRepository'
     }
 
-    # A target that does not exist yet (e.g. `git init newsub`) is classified by its nearest
-    # existing ancestor: git would walk up to that enclosing repository too.
-    $probeDir = $Cwd
-    while (-not [string]::IsNullOrWhiteSpace($probeDir) -and -not (Test-Path -LiteralPath $probeDir)) {
-        $parent = Split-Path -Parent $probeDir
-        if ($parent -eq $probeDir) { break }
-        $probeDir = $parent
-    }
-    if ([string]::IsNullOrWhiteSpace($probeDir) -or -not (Test-Path -LiteralPath $probeDir)) {
+    $probeDir = Get-AgentGuardProbeDirectory -Path $Cwd
+    if ([string]::IsNullOrWhiteSpace($probeDir)) {
         return 'NotRepository'
     }
 
@@ -1276,6 +1323,39 @@ function Get-AgentNamedParameterValue {
 
 <#
 .SYNOPSIS
+The directory named by -t / --target-directory, or $null when the arguments carry neither.
+
+.DESCRIPTION
+cp, mv, install, and ln all accept this option, and it changes which argument is the
+destination. Three spellings are read: `-t DIR`, `--target-directory DIR`, and
+`--target-directory=DIR`. Short options cluster, so `-rt DIR` and `-vtDIR` are read too. The `t`
+test is case-sensitive: `-T` is --no-target-directory, a different option that names nothing.
+#>
+function Get-AgentTargetDirectoryOption {
+    param([string[]] $Arguments)
+
+    $list = @($Arguments)
+    for ($i = 0; $i -lt $list.Count; $i++) {
+        $argument = [string] $list[$i]
+
+        if ($argument -ilike '--target-directory=*') {
+            return $argument.Substring('--target-directory='.Length)
+        }
+
+        $takesNext = $argument -ieq '--target-directory' -or $argument -cmatch '^-[a-zA-Z]*t$'
+        if ($takesNext) {
+            if (($i + 1) -lt $list.Count) { return [string] $list[$i + 1] }
+            return $null
+        }
+
+        # A cluster with the value attached, e.g. `cp -vtDIR src`.
+        if ($argument -cmatch '^-[a-zA-Z]*t(.+)$') { return $Matches[1] }
+    }
+    return $null
+}
+
+<#
+.SYNOPSIS
 Every path one command segment would write, move, or delete.
 
 .DESCRIPTION
@@ -1332,7 +1412,11 @@ function Get-AgentSegmentWriteTarget {
         foreach ($positional in $positionals) { [void] $targets.Add($positional) }
     }
     elseif ($script:AgentGuardWriteLastPositional -contains $leaf) {
-        if ($positionals.Count -ge 1) { [void] $targets.Add($positionals[$positionals.Count - 1]) }
+        # -t/--target-directory moves the destination off the last positional: with it, every
+        # positional is a SOURCE and the named directory is the only thing written.
+        $targetDirectory = Get-AgentTargetDirectoryOption -Arguments $arguments
+        if ($null -ne $targetDirectory) { [void] $targets.Add($targetDirectory) }
+        elseif ($positionals.Count -ge 1) { [void] $targets.Add($positionals[$positionals.Count - 1]) }
     }
     elseif ($leaf -eq 'sed') {
         $inPlace = @($arguments | Where-Object { $_ -ceq '-i' -or $_ -clike '-i*' -or $_ -ceq '--in-place' }).Count -gt 0
@@ -1381,6 +1465,11 @@ $script:AgentGuardMaxInterpreterDepth = 2
 Every write target in a command string, following nested interpreter arguments.
 
 .DESCRIPTION
+Returns { Targets = @(string[]); Unresolved = bool }. Unresolved means some inner command was
+never scanned, so the target list is incomplete and the caller must fail closed rather than read
+an empty list as "writes nothing". Two things set it: an inner command the tokenizer could not
+split safely, and nesting deeper than AgentGuardMaxInterpreterDepth.
+
 Recursion is scoped to the write-target scan alone. Git classification still treats a quoted
 nested command as opaque, which stays a documented accepted limitation of this guard.
 #>
@@ -1388,17 +1477,19 @@ function Get-AgentCommandWriteTarget {
     [CmdletBinding()]
     param([string] $Command, [int] $Depth = 0)
 
-    $parsed = Get-AgentCommandSegment -Command $Command
-    if ($parsed.Ambiguous) { return @() }
-
     $targets = New-Object System.Collections.Generic.List[string]
+
+    $parsed = Get-AgentCommandSegment -Command $Command
+    if ($parsed.Ambiguous) {
+        return [pscustomobject]@{ Targets = $targets.ToArray(); Unresolved = $true }
+    }
+
+    $unresolved = $false
 
     foreach ($segment in $parsed.Segments) {
         foreach ($target in (Get-AgentSegmentWriteTarget -Tokens $segment.Tokens -Masks $segment.Masks)) {
             [void] $targets.Add($target)
         }
-
-        if ($Depth -ge $script:AgentGuardMaxInterpreterDepth) { continue }
 
         $tokens = @($segment.Tokens)
         if ($tokens.Count -lt 3) { continue }
@@ -1410,15 +1501,22 @@ function Get-AgentCommandWriteTarget {
         for ($i = 1; $i -lt $tokens.Count - 1; $i++) {
             if ($spec.Flags -notcontains ([string] $tokens[$i]).ToLowerInvariant()) { continue }
 
-            $inner = [string] $tokens[$i + 1]
-            foreach ($target in (Get-AgentCommandWriteTarget -Command $inner -Depth ($Depth + 1))) {
-                [void] $targets.Add($target)
+            # The depth test lives here, not at the top of the loop: a segment that is not an
+            # interpreter carrying an inner command was already scanned in full above, so it must
+            # not be reported as unresolved just because the recursion budget ran out.
+            if ($Depth -ge $script:AgentGuardMaxInterpreterDepth) {
+                $unresolved = $true
+                break
             }
+
+            $inner = Get-AgentCommandWriteTarget -Command ([string] $tokens[$i + 1]) -Depth ($Depth + 1)
+            foreach ($target in $inner.Targets) { [void] $targets.Add($target) }
+            if ($inner.Unresolved) { $unresolved = $true }
             break
         }
     }
 
-    return $targets.ToArray()
+    return [pscustomobject]@{ Targets = $targets.ToArray(); Unresolved = $unresolved }
 }
 
 # Characters that make a path component impossible to expand from the command text alone.
@@ -1479,9 +1577,12 @@ function Resolve-AgentSymlinkPath {
 Turns one raw write target into an absolute path, or marks it unresolved.
 
 .DESCRIPTION
-Only the longest leading literal prefix has to be expandable. A trailing glob cannot change
-which repository the path falls in, so `./obj/*` classifies on `./obj`. A target whose FIRST
-component is unexpandable - `$MAIN_ROOT/x.tmp` - has no literal prefix and is unresolved.
+A glob is classified on the literal prefix before it: a glob cannot match `..` or an absolute
+path, so it cannot change which repository the path falls in, and `./obj/*` classifies on
+`./obj`. A variable, a percent expansion, or a command substitution can expand to anything,
+including `../..` or a rooted path, so ONE anywhere in the target makes the whole target
+unresolved. A leading literal prefix proves nothing about it: `./scripts/$DEST` reaches main
+when DEST is `../../../../README.md`.
 
 Mirrors the precedent at Get-AgentCommandSegment, where a cd target matching [\$%] marks the
 following git mutation untargetable rather than guessing where it lands.
@@ -1499,10 +1600,14 @@ function Get-AgentWriteTargetResolution {
         return [pscustomobject]@{ Path = ''; Unresolved = $true }
     }
 
+    if ($trimmed -match $script:AgentGuardUnexpandablePattern) {
+        return [pscustomobject]@{ Path = ''; Unresolved = $true }
+    }
+
     $parts = @($trimmed -split '[\\/]')
     $literal = New-Object System.Collections.Generic.List[string]
     foreach ($part in $parts) {
-        if ($part -match $script:AgentGuardUnexpandablePattern -or $part -match '[\*\?]') { break }
+        if ($part -match '[\*\?]') { break }
         [void] $literal.Add($part)
     }
 
@@ -1618,9 +1723,13 @@ function Get-AgentWorktreeWriteDecision {
     if ([string]::IsNullOrWhiteSpace($protectedCommonDir)) { return New-AgentGuardDecision -Action Allow }
     $mainCheckout = ConvertTo-AgentGuardNormalizedPath (Split-Path -Parent (
             ConvertTo-AgentGuardNormalizedPath $protectedCommonDir))
-    $worktreeRoot = ConvertTo-AgentGuardNormalizedPath $Cwd
+    # The session's own worktree is its git top level, not the directory it happens to sit in. A
+    # session started in <worktree>\src would otherwise treat src as the whole worktree and refuse
+    # a write to the worktree's own root, which is inside main and so fails the outside-main test.
+    $worktreeRoot = Get-AgentSessionWorktreeRoot -Cwd $Cwd
 
     $effectiveCwd = $Cwd
+    $unresolvedDirectory = $false
     $directoryStack = New-Object System.Collections.Generic.List[string]
     $blockingPath = ''
     $unresolvedBlock = $false
@@ -1630,19 +1739,32 @@ function Get-AgentWorktreeWriteDecision {
             if ($directoryStack.Count -gt 0) {
                 $effectiveCwd = $directoryStack[$directoryStack.Count - 1]
                 $directoryStack.RemoveAt($directoryStack.Count - 1)
+                $unresolvedDirectory = $false
             }
             continue
         }
 
         if ($segment.Kind -eq 'ChangeDirectory' -or $segment.Kind -eq 'PushDirectory') {
-            if ($segment.Unresolved) { continue }
+            # A cd the guard cannot expand leaves the shell somewhere unknown, so every later
+            # RELATIVE write is untargetable. Dropping the move and keeping the old directory
+            # classified `cd "$MAIN_ROOT"; printf x > x.tmp` against the worktree and allowed a
+            # write that landed in main. Mirrors Get-AgentGitLocationDecision.
+            if ($segment.Unresolved) {
+                $unresolvedDirectory = $true
+                continue
+            }
             $candidate = if ([System.IO.Path]::IsPathRooted($segment.Directory)) { $segment.Directory }
             elseif (-not [string]::IsNullOrWhiteSpace($effectiveCwd)) { Join-Path $effectiveCwd $segment.Directory }
             else { '' }
-            if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+            if ([string]::IsNullOrWhiteSpace($candidate)) {
+                $unresolvedDirectory = $true
+                continue
+            }
+            # A cd to a path that does not exist fails, leaving the shell where it already was.
             if (-not (Test-Path -LiteralPath $candidate -PathType Container)) { continue }
             if ($segment.Kind -eq 'PushDirectory') { [void] $directoryStack.Add($effectiveCwd) }
             $effectiveCwd = $candidate
+            $unresolvedDirectory = $false
             continue
         }
 
@@ -1656,14 +1778,22 @@ function Get-AgentWorktreeWriteDecision {
             if ($null -ne $spec) {
                 for ($i = 1; $i -lt $tokens.Count - 1; $i++) {
                     if ($spec.Flags -notcontains ([string] $tokens[$i]).ToLowerInvariant()) { continue }
-                    $targets += @(Get-AgentCommandWriteTarget -Command ([string] $tokens[$i + 1]) -Depth 1)
+                    $nested = Get-AgentCommandWriteTarget -Command ([string] $tokens[$i + 1]) -Depth 1
+                    $targets += @($nested.Targets)
+                    # An inner command that was never scanned is not an inner command that writes
+                    # nothing. Fail closed on it.
+                    if ($nested.Unresolved) { $unresolvedBlock = $true }
                     break
                 }
             }
         }
 
         foreach ($target in $targets) {
-            $resolution = Get-AgentWriteTargetResolution -Target $target -BaseDirectory $effectiveCwd
+            # A relative target after an unexpandable cd cannot be placed. Passing no base
+            # directory is what makes Get-AgentWriteTargetResolution report that; an absolute
+            # target ignores the base and still classifies exactly.
+            $baseDirectory = if ($unresolvedDirectory) { '' } else { $effectiveCwd }
+            $resolution = Get-AgentWriteTargetResolution -Target $target -BaseDirectory $baseDirectory
             if ($resolution.Unresolved) {
                 if (-not $unresolvedBlock -and $blockingPath -eq '') { $unresolvedBlock = $true }
                 continue

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1529,6 +1529,183 @@ function Get-AgentWriteTargetResolution {
     }
 }
 
+# Path components that are build output or third-party content, never source the human owns.
+$script:AgentGuardThrowawayComponents = @('bin', 'obj', 'testresults', '.vs', 'node_modules')
+
+$script:AgentGuardWriteDenialMessage = @'
+BLOCKED: this session is isolated in a worktree, so it cannot write into the main checkout at {0}
+Read from here. Write from the main checkout.
+To override, a human must set AHKFLOW_ALLOW_MAIN=1 in the shell environment before starting the
+agent session.
+'@
+
+$script:AgentGuardPlansDenialMessage = @'
+BLOCKED: this session is isolated in a worktree, so it cannot write into the main checkout at {0}
+docs/superpowers is a symlink to the main checkout. There is no worktree copy of it, so do not
+look for one. Plan and spec writes belong in the main checkout by design.
+Read the plan from here. Write and commit it from the main checkout.
+'@
+
+$script:AgentGuardUnresolvedWriteMessage = @'
+BLOCKED: this session is isolated in a worktree, and the guard cannot expand this write target, so
+it cannot tell whether the write lands in the main checkout.
+Write the path out literally instead of using a variable, or run the command from the main checkout.
+'@
+
+<#
+.SYNOPSIS
+True when a resolved path is one the session may write despite sitting under the main checkout.
+#>
+function Test-AgentWriteTargetAllowed {
+    [CmdletBinding()]
+    param([string] $ResolvedPath, [string] $MainCheckout, [string] $WorktreeRoot)
+
+    $path = $ResolvedPath.TrimEnd('\', '/')
+    $main = $MainCheckout.TrimEnd('\', '/')
+    $worktree = $WorktreeRoot.TrimEnd('\', '/')
+
+    # The session's own worktree, and anything inside it.
+    if ($path -ieq $worktree -or $path.StartsWith($worktree + '\', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $true
+    }
+
+    # Anything outside the protected checkout entirely.
+    if (-not ($path -ieq $main -or $path.StartsWith($main + '\', [System.StringComparison]::OrdinalIgnoreCase))) {
+        return $true
+    }
+
+    # The removal log, by exact path. Its parent directory stays refused, so a sibling worktree
+    # is not writable just because the log lives beside it.
+    $removalLog = Join-Path $main '.claude\worktrees\worktree-removal.log'
+    if ($path -ieq (ConvertTo-AgentGuardNormalizedPath $removalLog)) { return $true }
+
+    # Build output and third-party content.
+    $relative = $path.Substring($main.Length).Trim('\', '/')
+    foreach ($component in ($relative -split '[\\/]')) {
+        if ($script:AgentGuardThrowawayComponents -contains $component.ToLowerInvariant()) { return $true }
+    }
+
+    return $false
+}
+
+<#
+.SYNOPSIS
+Refuses a shell write into the main checkout from a session isolated in a managed worktree.
+
+.DESCRIPTION
+Only fires when the session's own working directory is a managed worktree. A main-checkout
+session is unaffected, which keeps the AGENTS.md rule that agents may edit, build, test, and
+format in main. Segments are walked in order so an earlier cd moves where a later write lands,
+matching Get-AgentGitLocationDecision.
+#>
+function Get-AgentWorktreeWriteDecision {
+    [CmdletBinding()]
+    param(
+        [string] $Command,
+        [string] $Cwd,
+        [string] $ProtectedRepoRoot,
+        [bool] $AllowMain = $false
+    )
+
+    $sessionState = Get-ManagedWorktreeState -Cwd $Cwd -ProtectedRepoRoot $ProtectedRepoRoot
+    if ($sessionState -ne 'ManagedWorktree') { return New-AgentGuardDecision -Action Allow }
+
+    $parsed = Get-AgentCommandSegment -Command $Command
+    if ($parsed.Ambiguous) { return New-AgentGuardDecision -Action Allow }
+
+    $protectedCommonDir = Invoke-AgentGuardGitProbe @(
+        '-C', $ProtectedRepoRoot, 'rev-parse', '--path-format=absolute', '--git-common-dir')
+    if ([string]::IsNullOrWhiteSpace($protectedCommonDir)) { return New-AgentGuardDecision -Action Allow }
+    $mainCheckout = ConvertTo-AgentGuardNormalizedPath (Split-Path -Parent (
+            ConvertTo-AgentGuardNormalizedPath $protectedCommonDir))
+    $worktreeRoot = ConvertTo-AgentGuardNormalizedPath $Cwd
+
+    $effectiveCwd = $Cwd
+    $directoryStack = New-Object System.Collections.Generic.List[string]
+    $blockingPath = ''
+    $unresolvedBlock = $false
+
+    foreach ($segment in $parsed.Segments) {
+        if ($segment.Kind -eq 'PopDirectory') {
+            if ($directoryStack.Count -gt 0) {
+                $effectiveCwd = $directoryStack[$directoryStack.Count - 1]
+                $directoryStack.RemoveAt($directoryStack.Count - 1)
+            }
+            continue
+        }
+
+        if ($segment.Kind -eq 'ChangeDirectory' -or $segment.Kind -eq 'PushDirectory') {
+            if ($segment.Unresolved) { continue }
+            $candidate = if ([System.IO.Path]::IsPathRooted($segment.Directory)) { $segment.Directory }
+            elseif (-not [string]::IsNullOrWhiteSpace($effectiveCwd)) { Join-Path $effectiveCwd $segment.Directory }
+            else { '' }
+            if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+            if (-not (Test-Path -LiteralPath $candidate -PathType Container)) { continue }
+            if ($segment.Kind -eq 'PushDirectory') { [void] $directoryStack.Add($effectiveCwd) }
+            $effectiveCwd = $candidate
+            continue
+        }
+
+        $targets = @(Get-AgentSegmentWriteTarget -Tokens $segment.Tokens -Masks $segment.Masks)
+
+        # Nested interpreters: re-scan the quoted argument the tokenizer kept whole.
+        $tokens = @($segment.Tokens)
+        if ($tokens.Count -ge 3) {
+            $leaf = Get-AgentCommandLeafName -Word $tokens[0]
+            $spec = $script:AgentGuardInterpreterSpecs | Where-Object { $_.Leaf -eq $leaf } | Select-Object -First 1
+            if ($null -ne $spec) {
+                for ($i = 1; $i -lt $tokens.Count - 1; $i++) {
+                    if ($spec.Flags -notcontains ([string] $tokens[$i]).ToLowerInvariant()) { continue }
+                    $targets += @(Get-AgentCommandWriteTarget -Command ([string] $tokens[$i + 1]) -Depth 1)
+                    break
+                }
+            }
+        }
+
+        foreach ($target in $targets) {
+            $resolution = Get-AgentWriteTargetResolution -Target $target -BaseDirectory $effectiveCwd
+            if ($resolution.Unresolved) {
+                if (-not $unresolvedBlock -and $blockingPath -eq '') { $unresolvedBlock = $true }
+                continue
+            }
+
+            if (Test-AgentWriteTargetAllowed -ResolvedPath $resolution.Path `
+                    -MainCheckout $mainCheckout -WorktreeRoot $worktreeRoot) {
+                continue
+            }
+
+            if ($blockingPath -eq '') { $blockingPath = $resolution.Path }
+        }
+    }
+
+    if ($blockingPath -eq '' -and -not $unresolvedBlock) {
+        return New-AgentGuardDecision -Action Allow
+    }
+
+    if ($AllowMain) {
+        $overrideTarget = if ($blockingPath -ne '') { $blockingPath } else { 'an unexpandable target' }
+        return New-AgentGuardDecision -Action Warn -Rule 'agent-worktree-main-write-overridden' -Message `
+        ("WARNING: AHKFLOW_ALLOW_MAIN=1 overrode the worktree write-isolation rule for: $overrideTarget")
+    }
+
+    if ($blockingPath -eq '') {
+        return New-AgentGuardDecision -Action Deny -Rule 'agent-worktree-main-write' -Message `
+            $script:AgentGuardUnresolvedWriteMessage
+    }
+
+    $plansRoot = ConvertTo-AgentGuardNormalizedPath (Join-Path $mainCheckout 'docs\superpowers')
+    $template = if ($blockingPath -ieq $plansRoot -or
+        $blockingPath.StartsWith($plansRoot + '\', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $script:AgentGuardPlansDenialMessage
+    }
+    else {
+        $script:AgentGuardWriteDenialMessage
+    }
+
+    return New-AgentGuardDecision -Action Deny -Rule 'agent-worktree-main-write' -Message `
+    ([string]::Format($template, $blockingPath))
+}
+
 $script:AgentGuardAllowedStates = @('NotRepository', 'OutsideProtectedRepository', 'ManagedWorktree')
 
 <#
@@ -1788,6 +1965,18 @@ function Invoke-AgentGuardPolicy {
     }
 
     if ($location.Action -ne 'Allow') { return $location }
+
+    try {
+        $write = Get-AgentWorktreeWriteDecision -Command $Command -Cwd $Cwd `
+            -ProtectedRepoRoot $ProtectedRepoRoot -AllowMain $AllowMain
+    }
+    catch {
+        # Fail open, same as the location rule: keep the shell usable, but say so loudly.
+        return New-AgentGuardDecision -Action Warn -Rule 'write-guard-error' -Message `
+        ("WARNING: the agent worktree write guard could not evaluate this command: $($_.Exception.Message)")
+    }
+
+    if ($write.Action -ne 'Allow') { return $write }
 
     return $safety
 }

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1546,6 +1546,32 @@ try {
             Assert-Equal ($case.Expected -join '|') ($actual -join '|') 'Targets'
         }
     }
+
+    Write-Host 'Nested interpreter write targets' -ForegroundColor Cyan
+
+    $nestedCases = @(
+        @{ Command = 'pwsh -Command "Set-Content -Path out.txt -Value x"'; Expected = @('out.txt') },
+        @{ Command = "sh -c 'printf x > out.txt'"; Expected = @('out.txt') },
+        @{ Command = "bash -c 'rm out.txt'"; Expected = @('out.txt') },
+        @{ Command = 'cmd /c "del out.txt"'; Expected = @() },
+        @{ Command = 'powershell -Command "Remove-Item out.txt"'; Expected = @('out.txt') },
+        # Depth 2 is reached and still scanned.
+        @{ Command = 'sh -c "pwsh -Command ''Set-Content out.txt x''"'; Expected = @('out.txt') },
+        # A plain read inside the nested command yields nothing.
+        @{ Command = "sh -c 'cat out.txt'"; Expected = @() }
+    )
+
+    foreach ($case in $nestedCases) {
+        Invoke-TestCase "Nested: $($case.Command)" {
+            $actual = @(Get-AgentCommandWriteTarget -Command $case.Command)
+            Assert-Equal ($case.Expected -join '|') ($actual -join '|') 'Targets'
+        }
+    }
+
+    Invoke-TestCase 'Nested: pwsh -File is deliberately not followed' {
+        $actual = @(Get-AgentCommandWriteTarget -Command 'pwsh -File build.ps1')
+        Assert-Equal '' ($actual -join '|') 'Targets'
+    }
 }
 finally {
     Remove-GuardFixture -Fixture $fixture

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1653,6 +1653,116 @@ try {
         Assert-True (-not $resolution.Unresolved) 'Must resolve on the literal prefix'
         Assert-Equal (Join-Path $fixture.Managed 'obj') $resolution.Path 'Path'
     }
+
+    Write-Host 'Worktree write isolation' -ForegroundColor Cyan
+
+    $writeDecisionCases = @(
+        # The two probes recorded in backlog 054.
+        @{ Name    = 'probe 1, symlinked plans path'
+            Command = 'printf probe > docs/superpowers/.guard-probe.tmp'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'probe 2, plain main checkout root'
+            Command = 'printf probe > <MAIN>/.guard-probe2.tmp'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        # Reads stay allowed.
+        @{ Name    = 'read through the symlink'
+            Command = 'cat docs/superpowers/seed-plan.md'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        @{ Name    = 'read a main checkout file'
+            Command = 'cat <MAIN>/seed.txt'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        # Writes inside the session's own worktree stay allowed.
+        @{ Name    = 'write inside the worktree'
+            Command = 'printf x > src.tmp'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        # Build output in main stays allowed.
+        @{ Name    = 'build output in main'
+            Command = 'printf x > <MAIN>/obj/build.tmp'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        @{ Name    = 'nested build output in main'
+            Command = 'printf x > <MAIN>/src/Api/bin/Debug/app.dll'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        # A sibling worktree is another agent's checkout.
+        @{ Name    = 'sibling worktree is refused'
+            Command = 'printf x > <MANAGED2>/src.tmp'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        # The removal log is the one allowed path under the worktree parent.
+        @{ Name    = 'removal log is allowed'
+            Command = 'printf x >> <MAIN>/.claude/worktrees/worktree-removal.log'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        # A main-checkout session is unaffected.
+        @{ Name    = 'main session writes main'
+            Command = 'printf x > <MAIN>/x.tmp'; Cwd = 'Main'; Action = 'Allow'
+        },
+        # Grammar shapes, end to end.
+        @{ Name    = 'attached redirect'
+            Command = 'printf x><MAIN>/x.tmp'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'nested interpreter'
+            Command = 'pwsh -Command "Set-Content <MAIN>/x.tmp y"'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'destination argument'
+            Command = 'cp a.txt <MAIN>/a.txt'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'quoted literal redirect is not a redirect'
+            Command = "printf 'a><MAIN>/x.tmp'"; Cwd = 'Managed'; Action = 'Allow'
+        },
+        @{ Name    = 'unresolved target fails closed'
+            Command = 'printf x > "$MAIN_ROOT/x.tmp"'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        # `rm -rf` is not used here: the older dangerous-rm safety rule denies it on its own, so
+        # the case would pass for the wrong reason. The write rule is exercised in isolation
+        # below with the exact `rm -rf ./obj/*` command instead.
+        @{ Name    = 'glob inside the worktree stays allowed'
+            Command = 'rm -f ./obj/*'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        # A cd earlier in the chain moves where the write lands.
+        @{ Name    = 'cd into main then write'
+            Command = 'cd <MAIN>; printf x > x.tmp'; Cwd = 'Managed'; Action = 'Deny'
+        }
+    )
+
+    foreach ($case in $writeDecisionCases) {
+        Invoke-TestCase "Write isolation: $($case.Name)" {
+            $command = $case.Command.
+            Replace('<MAIN>', $fixture.Main.Replace('\', '/')).
+            Replace('<MANAGED2>', $fixture.Managed2.Replace('\', '/'))
+            $cwd = if ($case.Cwd -eq 'Main') { $fixture.Main } else { $fixture.Managed }
+            $decision = Invoke-AgentGuardPolicy -Command $command `
+                -Cwd $cwd -ProtectedRepoRoot $fixture.Main -AllowMain $false
+            Assert-Equal $case.Action $decision.Action 'Action'
+        }
+    }
+
+    Invoke-TestCase 'Write isolation: rm -rf on a worktree glob is not a write-rule denial' {
+        $decision = Get-AgentWorktreeWriteDecision -Command 'rm -rf ./obj/*' `
+            -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main -AllowMain $false
+        Assert-Equal 'Allow' $decision.Action 'Action'
+    }
+
+    Invoke-TestCase 'Write isolation: the plans refusal does not name a worktree copy' {
+        $decision = Invoke-AgentGuardPolicy -Command 'printf probe > docs/superpowers/x.tmp' `
+            -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main -AllowMain $false
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'agent-worktree-main-write' $decision.Rule 'Rule'
+        Assert-Match 'no worktree copy' $decision.Message 'Message'
+        Assert-True ($decision.Message -notmatch 'Edit the worktree copy') 'Must not send the agent looking for a copy'
+    }
+
+    Invoke-TestCase 'Write isolation: AHKFLOW_ALLOW_MAIN=1 downgrades to a warning' {
+        $command = 'printf probe > ' + $fixture.Main.Replace('\', '/') + '/x.tmp'
+        $decision = Invoke-AgentGuardPolicy -Command $command `
+            -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main -AllowMain $true
+        Assert-Equal 'Warn' $decision.Action 'Action'
+    }
+
+    Invoke-TestCase 'Write isolation: a git mutation decision still wins over a write decision' {
+        $command = 'git commit -m x'
+        $decision = Invoke-AgentGuardPolicy -Command $command `
+            -Cwd $fixture.Main -ProtectedRepoRoot $fixture.Main -AllowMain $false
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
+    }
 }
 finally {
     Remove-GuardFixture -Fixture $fixture

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1464,6 +1464,46 @@ try {
         Assert-Match 'invoke-agent-worktree-guard\.ps1' $guards[0].powershell 'powershell command'
         Assert-Match '-Adapter Copilot' $guards[0].powershell 'powershell adapter'
     }
+
+    Write-Host 'Token quote masks' -ForegroundColor Cyan
+
+    $maskCases = @(
+        @{ Command = 'printf x > out.txt'; Token = 2; ExpectedToken = '>'; ExpectedMask = 'u' },
+        @{ Command = "printf 'a>b'"; Token = 1; ExpectedToken = 'a>b'; ExpectedMask = 'qqq' },
+        @{ Command = 'printf "a>b"'; Token = 1; ExpectedToken = 'a>b'; ExpectedMask = 'qqq' },
+        @{ Command = 'printf x>out.txt'; Token = 1; ExpectedToken = 'x>out.txt'; ExpectedMask = 'uuuuuuuuu' }
+    )
+
+    foreach ($case in $maskCases) {
+        Invoke-TestCase "Mask: $($case.Command)" {
+            $parsed = Get-AgentCommandSegment -Command $case.Command
+            $segment = $parsed.Segments[0]
+            Assert-Equal $case.ExpectedToken $segment.Tokens[$case.Token] 'Token'
+            Assert-Equal $case.ExpectedMask $segment.Masks[$case.Token] 'Mask'
+        }
+    }
+
+    Invoke-TestCase 'Mask: an escaped redirect character is quoted, not a redirect' {
+        $parsed = Get-AgentCommandSegment -Command 'printf x\>y'
+        $segment = $parsed.Segments[0]
+        Assert-Equal 'x>y' $segment.Tokens[1] 'Token'
+        Assert-Equal 'uqu' $segment.Masks[1] 'Mask'
+    }
+
+    Invoke-TestCase 'Mask: masks stay aligned after an rtk wrapper is stripped' {
+        $parsed = Get-AgentCommandSegment -Command 'rtk proxy printf x>out.txt'
+        $segment = $parsed.Segments[0]
+        Assert-Equal 'printf' $segment.Tokens[0] 'Leading token'
+        Assert-Equal 'x>out.txt' $segment.Tokens[1] 'Target token'
+        Assert-Equal 'uuuuuuuuu' $segment.Masks[1] 'Mask'
+    }
+
+    Invoke-TestCase 'Mask: masks stay aligned after a NAME=value prefix is stripped' {
+        $parsed = Get-AgentCommandSegment -Command 'FOO=1 printf x>out.txt'
+        $segment = $parsed.Segments[0]
+        Assert-Equal 'printf' $segment.Tokens[0] 'Leading token'
+        Assert-Equal 'uuuuuuuuu' $segment.Masks[1] 'Mask'
+    }
 }
 finally {
     Remove-GuardFixture -Fixture $fixture

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1504,6 +1504,48 @@ try {
         Assert-Equal 'printf' $segment.Tokens[0] 'Leading token'
         Assert-Equal 'uuuuuuuuu' $segment.Masks[1] 'Mask'
     }
+
+    Write-Host 'Write-target extraction' -ForegroundColor Cyan
+
+    $writeTargetCases = @(
+        # Redirects
+        @{ Command = 'printf x > out.txt'; Expected = @('out.txt') },
+        @{ Command = 'printf x >> out.txt'; Expected = @('out.txt') },
+        @{ Command = 'printf x>out.txt'; Expected = @('out.txt') },
+        @{ Command = 'printf x >out.txt'; Expected = @('out.txt') },
+        @{ Command = 'dotnet build 2> err.log'; Expected = @('err.log') },
+        @{ Command = "printf 'a>b'"; Expected = @() },
+        @{ Command = 'printf x\>y'; Expected = @() },
+        # Destination arguments
+        @{ Command = 'cp a.txt b.txt'; Expected = @('b.txt') },
+        @{ Command = 'mv a.txt b.txt'; Expected = @('b.txt') },
+        @{ Command = 'rm a.txt b.txt'; Expected = @('a.txt', 'b.txt') },
+        @{ Command = 'tee out.txt'; Expected = @('out.txt') },
+        @{ Command = 'touch a.txt'; Expected = @('a.txt') },
+        @{ Command = 'sed -i s/a/b/ file.txt'; Expected = @('file.txt') },
+        @{ Command = 'sed s/a/b/ file.txt'; Expected = @() },
+        @{ Command = 'dd if=a.bin of=b.bin'; Expected = @('b.bin') },
+        @{ Command = 'Set-Content -Path out.txt -Value x'; Expected = @('out.txt') },
+        @{ Command = 'Set-Content out.txt x'; Expected = @('out.txt') },
+        @{ Command = 'Out-File -FilePath out.txt'; Expected = @('out.txt') },
+        @{ Command = 'Copy-Item a.txt -Destination b.txt'; Expected = @('b.txt') },
+        @{ Command = 'Copy-Item a.txt b.txt'; Expected = @('b.txt') },
+        @{ Command = 'Remove-Item -LiteralPath out.txt'; Expected = @('out.txt') },
+        # Reads produce nothing
+        @{ Command = 'cat out.txt'; Expected = @() },
+        @{ Command = 'Get-Content out.txt'; Expected = @() }
+    )
+
+    foreach ($case in $writeTargetCases) {
+        Invoke-TestCase "Write target: $($case.Command)" {
+            $parsed = Get-AgentCommandSegment -Command $case.Command
+            $actual = @()
+            foreach ($segment in $parsed.Segments) {
+                $actual += @(Get-AgentSegmentWriteTarget -Tokens $segment.Tokens -Masks $segment.Masks)
+            }
+            Assert-Equal ($case.Expected -join '|') ($actual -join '|') 'Targets'
+        }
+    }
 }
 finally {
     Remove-GuardFixture -Fixture $fixture

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -233,6 +233,8 @@ function New-GuardFixture {
         'ahkflow-agent-guard-' + [guid]::NewGuid().ToString('N'))
     $main = Join-Path $testRoot 'repo'
     $managed = Join-Path $main '.claude\worktrees\valid'
+    # A second managed worktree, so a write into a sibling agent's checkout can be tested.
+    $managed2 = Join-Path $main '.claude\worktrees\second'
     $badManifest = Join-Path $main '.claude\worktrees\badmanifest'
     # One level deeper than the approved parent: an approved grandparent must not qualify.
     $nested = Join-Path $main '.claude\worktrees\group\nested'
@@ -251,6 +253,7 @@ function New-GuardFixture {
     Invoke-Git -C $main add seed.txt
     Invoke-Git -C $main commit -m 'test: seed temporary repository'
     Invoke-Git -C $main worktree add -b feature/wt-valid $managed
+    Invoke-Git -C $main worktree add -b feature/wt-second $managed2
     Invoke-Git -C $main worktree add -b feature/wt-badmanifest $badManifest
     Invoke-Git -C $main worktree add -b feature/wt-nested $nested
     Invoke-Git -C $main worktree add -b feature/wt-sibling $siblingPrefix
@@ -269,6 +272,41 @@ function New-GuardFixture {
         "AHKFLOW_ROOT=$managedRoot"
     ) -join "`n"
     Set-Content -LiteralPath (Join-Path $managedRoot 'scripts\.env.worktree') -Value $manifest -Encoding utf8
+
+    $managed2Root = (Resolve-Path -LiteralPath $managed2).Path
+    New-Item -ItemType Directory -Path (Join-Path $managed2Root 'scripts') -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $managed2Root 'scripts\.env.worktree') -Encoding utf8 -Value (@(
+            'AHKFLOW_API_PORT=5604',
+            'AHKFLOW_UI_PORT=5605',
+            'AHKFLOW_API_URL=http://localhost:5604',
+            'AHKFLOW_UI_URL=http://localhost:5605',
+            'AHKFLOW_DB_NAME=AHKFlowApp_second',
+            'AHKFLOW_SQL_PORT=14333',
+            'AHKFLOW_COMPOSE_PROJECT=ahkflow-second',
+            "AHKFLOW_ROOT=$managed2Root"
+        ) -join "`n")
+
+    # The symlinked docs/superpowers path is one of the two probes backlog 054 records, so its
+    # absence must fail the suite rather than quietly skip a required regression.
+    $plansSource = Join-Path $main 'docs\superpowers'
+    New-Item -ItemType Directory -Path $plansSource -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $plansSource 'seed-plan.md') -Value '# seed' -Encoding utf8
+
+    $plansLinkParent = Join-Path $managedRoot 'docs'
+    New-Item -ItemType Directory -Path $plansLinkParent -Force | Out-Null
+    Push-Location $plansLinkParent
+    try { cmd /c mklink /D 'superpowers' $plansSource > $null 2>&1 }
+    finally { Pop-Location }
+
+    $plansLink = Join-Path $plansLinkParent 'superpowers'
+    if (-not (Test-Path -LiteralPath $plansLink)) {
+        throw ('Could not create the docs\superpowers symlink the guard tests require. ' +
+            'Enable Windows Developer Mode, then re-run. See docs/development/prerequisites.md.')
+    }
+    if ((Get-Item -LiteralPath $plansLink -Force).LinkType -ne 'SymbolicLink') {
+        throw ('docs\superpowers was created as a real directory, not a symlink. ' +
+            'Enable Windows Developer Mode, then re-run. See docs/development/prerequisites.md.')
+    }
 
     # badManifest sits in an approved parent but its manifest port disagrees with its URL.
     $badRoot = (Resolve-Path -LiteralPath $badManifest).Path
@@ -307,6 +345,7 @@ function New-GuardFixture {
         TestRoot      = (Resolve-Path -LiteralPath $testRoot).Path
         Main          = (Resolve-Path -LiteralPath $main).Path
         Managed       = $managedRoot
+        Managed2      = $managed2Root
         BadManifest   = $badRoot
         Nested        = $nestedRoot
         SiblingPrefix = $siblingRoot
@@ -327,7 +366,7 @@ function Remove-GuardFixture {
     }
 
     foreach ($worktree in @(
-            $Fixture.Managed, $Fixture.BadManifest, $Fixture.Nested,
+            $Fixture.Managed, $Fixture.Managed2, $Fixture.BadManifest, $Fixture.Nested,
             $Fixture.SiblingPrefix, $Fixture.Unmanaged)) {
         Invoke-Git -C $Fixture.Main worktree remove --force $worktree
     }
@@ -1571,6 +1610,48 @@ try {
     Invoke-TestCase 'Nested: pwsh -File is deliberately not followed' {
         $actual = @(Get-AgentCommandWriteTarget -Command 'pwsh -File build.ps1')
         Assert-Equal '' ($actual -join '|') 'Targets'
+    }
+
+    Write-Host 'Write-target path resolution' -ForegroundColor Cyan
+
+    Invoke-TestCase 'Resolution: a relative target joins the base directory' {
+        $resolution = Get-AgentWriteTargetResolution -Target 'out.txt' -BaseDirectory $fixture.Managed
+        Assert-True (-not $resolution.Unresolved) 'Must resolve'
+        Assert-Equal (Join-Path $fixture.Managed 'out.txt') $resolution.Path 'Path'
+    }
+
+    Invoke-TestCase 'Resolution: an absolute target ignores the base directory' {
+        $target = Join-Path $fixture.Main 'x.tmp'
+        $resolution = Get-AgentWriteTargetResolution -Target $target -BaseDirectory $fixture.Managed
+        Assert-True (-not $resolution.Unresolved) 'Must resolve'
+        Assert-Equal $target $resolution.Path 'Path'
+    }
+
+    Invoke-TestCase 'Resolution: a symlinked directory resolves to its target' {
+        $target = 'docs/superpowers/probe.tmp'
+        $resolution = Get-AgentWriteTargetResolution -Target $target -BaseDirectory $fixture.Managed
+        Assert-True (-not $resolution.Unresolved) 'Must resolve'
+        Assert-Equal (Join-Path $fixture.Main 'docs\superpowers\probe.tmp') $resolution.Path 'Path'
+    }
+
+    Invoke-TestCase 'Resolution: a parent escape resolves out of the worktree' {
+        $resolution = Get-AgentWriteTargetResolution -Target '../../../x.tmp' -BaseDirectory $fixture.Managed
+        Assert-True (-not $resolution.Unresolved) 'Must resolve'
+        Assert-Equal (Join-Path $fixture.Main 'x.tmp') $resolution.Path 'Path'
+    }
+
+    $unresolvedCases = @('$MAIN_ROOT/x.tmp', '%USERPROFILE%\x.tmp', '~/x.tmp')
+    foreach ($case in $unresolvedCases) {
+        Invoke-TestCase "Resolution: unexpandable leading component is unresolved: $case" {
+            $resolution = Get-AgentWriteTargetResolution -Target $case -BaseDirectory $fixture.Managed
+            Assert-True $resolution.Unresolved 'Must be unresolved'
+        }
+    }
+
+    Invoke-TestCase 'Resolution: a glob after a literal prefix stays resolved' {
+        $resolution = Get-AgentWriteTargetResolution -Target './obj/*' -BaseDirectory $fixture.Managed
+        Assert-True (-not $resolution.Unresolved) 'Must resolve on the literal prefix'
+        Assert-Equal (Join-Path $fixture.Managed 'obj') $resolution.Path 'Path'
     }
 }
 finally {

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1602,14 +1602,26 @@ try {
 
     foreach ($case in $nestedCases) {
         Invoke-TestCase "Nested: $($case.Command)" {
-            $actual = @(Get-AgentCommandWriteTarget -Command $case.Command)
-            Assert-Equal ($case.Expected -join '|') ($actual -join '|') 'Targets'
+            $result = Get-AgentCommandWriteTarget -Command $case.Command
+            Assert-Equal ($case.Expected -join '|') (@($result.Targets) -join '|') 'Targets'
+            Assert-True (-not $result.Unresolved) 'Must resolve'
         }
     }
 
     Invoke-TestCase 'Nested: pwsh -File is deliberately not followed' {
-        $actual = @(Get-AgentCommandWriteTarget -Command 'pwsh -File build.ps1')
-        Assert-Equal '' ($actual -join '|') 'Targets'
+        $result = Get-AgentCommandWriteTarget -Command 'pwsh -File build.ps1'
+        Assert-Equal '' (@($result.Targets) -join '|') 'Targets'
+        Assert-True (-not $result.Unresolved) 'Must resolve'
+    }
+
+    Invoke-TestCase 'Nested: nesting past the cap reports unresolved, not an empty target list' {
+        $result = Get-AgentCommandWriteTarget -Command 'sh -c "sh -c \"sh -c ''rm out.txt''\""'
+        Assert-True $result.Unresolved 'Must be unresolved'
+    }
+
+    Invoke-TestCase 'Nested: an untokenizable inner command reports unresolved' {
+        $result = Get-AgentCommandWriteTarget -Command 'sh -c "rm ''out.txt"'
+        Assert-True $result.Unresolved 'Must be unresolved'
     }
 
     Write-Host 'Write-target path resolution' -ForegroundColor Cyan
@@ -1643,6 +1655,16 @@ try {
     $unresolvedCases = @('$MAIN_ROOT/x.tmp', '%USERPROFILE%\x.tmp', '~/x.tmp')
     foreach ($case in $unresolvedCases) {
         Invoke-TestCase "Resolution: unexpandable leading component is unresolved: $case" {
+            $resolution = Get-AgentWriteTargetResolution -Target $case -BaseDirectory $fixture.Managed
+            Assert-True $resolution.Unresolved 'Must be unresolved'
+        }
+    }
+
+    # A glob cannot match '..', so a literal prefix pins the directory. A variable or a command
+    # substitution can expand to anything, including an absolute path or a parent escape.
+    $unexpandableTailCases = @('./scripts/$DEST', 'scripts/%DEST%/x.tmp', 'scripts/$(cat p)/x.tmp', 'a/`b`/x.tmp')
+    foreach ($case in $unexpandableTailCases) {
+        Invoke-TestCase "Resolution: an unexpandable component after a literal prefix is unresolved: $case" {
             $resolution = Get-AgentWriteTargetResolution -Target $case -BaseDirectory $fixture.Managed
             Assert-True $resolution.Unresolved 'Must be unresolved'
         }
@@ -1719,6 +1741,65 @@ try {
         # A cd earlier in the chain moves where the write lands.
         @{ Name    = 'cd into main then write'
             Command = 'cd <MAIN>; printf x > x.tmp'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        # An unexpandable cd target leaves the guard blind to where a later relative write lands.
+        @{ Name    = 'unresolved cd then a relative write'
+            Command = 'cd "$MAIN_ROOT"; printf x > x.tmp'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'unresolved cd then an absolute write inside the worktree'
+            Command = 'cd "$MAIN_ROOT"; printf x > <MANAGED>/x.tmp'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        @{ Name    = 'a later resolved cd restores tracking'
+            Command = 'cd "$MAIN_ROOT"; cd <MANAGED>; printf x > x.tmp'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        # An unresolved pushd never lands on the guard's stack, because the guard cannot tell
+        # whether the real pushd succeeded. So the following popd cannot prove where the shell
+        # ended up either, and the chain stays untargetable.
+        @{ Name    = 'popd after an unresolved pushd stays untargetable'
+            Command = 'pushd "$MAIN_ROOT"; popd; printf x > x.tmp'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'popd after a resolved pushd restores tracking'
+            Command = 'pushd <MAIN>; popd; printf x > x.tmp'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        # A variable anywhere in the path can expand through '..' into main.
+        @{ Name    = 'a variable after a literal prefix fails closed'
+            Command = 'printf x > ./scripts/$DEST'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        # -t / --target-directory move the destination off the last positional.
+        @{ Name    = 'cp -t into main'
+            Command = 'cp -t <MAIN> source.txt'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'cp --target-directory= into main'
+            Command = 'cp --target-directory=<MAIN> source.txt'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'cp with a clustered -t into main'
+            Command = 'cp -rt <MAIN> source.txt'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'mv -t into main'
+            Command = 'mv -t <MAIN> source.txt'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'ln -t into main'
+            Command = 'ln -s -t <MAIN> source.txt'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'install -t into main'
+            Command = 'install -m 644 -t <MAIN> source.txt'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'cp -t inside the worktree stays allowed'
+            Command = 'cp -t ./obj a.txt'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        # Nesting deeper than the interpreter cap is never scanned, so it must fail closed.
+        @{ Name    = 'nesting past the interpreter cap'
+            Command = 'sh -c "sh -c \"sh -c ''printf x > <MAIN>/x.tmp''\""'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'nesting past the cap fails closed even when the inner command only reads'
+            Command = 'sh -c "sh -c \"sh -c ''cat <MAIN>/seed.txt''\""'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        # The session's worktree root is the git top level, not whatever directory it started in.
+        @{ Name    = 'a subdirectory session writes its own worktree root'
+            Command = 'printf x > ../README.md'; Cwd = 'ManagedSub'; Action = 'Allow'
+        },
+        @{ Name    = 'a subdirectory session still cannot write main'
+            Command = 'printf x > <MAIN>/x.tmp'; Cwd = 'ManagedSub'; Action = 'Deny'
         }
     )
 
@@ -1726,8 +1807,13 @@ try {
         Invoke-TestCase "Write isolation: $($case.Name)" {
             $command = $case.Command.
             Replace('<MAIN>', $fixture.Main.Replace('\', '/')).
-            Replace('<MANAGED2>', $fixture.Managed2.Replace('\', '/'))
-            $cwd = if ($case.Cwd -eq 'Main') { $fixture.Main } else { $fixture.Managed }
+            Replace('<MANAGED2>', $fixture.Managed2.Replace('\', '/')).
+            Replace('<MANAGED>', $fixture.Managed.Replace('\', '/'))
+            $cwd = switch ($case.Cwd) {
+                'Main' { $fixture.Main }
+                'ManagedSub' { Join-Path $fixture.Managed 'scripts' }
+                default { $fixture.Managed }
+            }
             $decision = Invoke-AgentGuardPolicy -Command $command `
                 -Cwd $cwd -ProtectedRepoRoot $fixture.Main -AllowMain $false
             Assert-Equal $case.Action $decision.Action 'Action'

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1763,6 +1763,31 @@ try {
         Assert-Equal 'Deny' $decision.Action 'Action'
         Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
     }
+
+    Write-Host 'Bash shim prefilter for worktree writes' -ForegroundColor Cyan
+
+    # These three run against the REAL repository identity, like every other shim test above: the
+    # entrypoint derives the protected repository from its own checked-in location, so a fixture
+    # path would classify as OutsideProtectedRepository and prove nothing. Nothing is executed -
+    # the shim only classifies the command text.
+    $script:RealWriteCommand = 'printf probe > ' + $script:RealMainCheckout.Replace('\', '/') + '/.guard-probe.tmp'
+
+    Invoke-TestCase 'Shim: a worktree-session redirect reaches the policy core' {
+        $result = Invoke-BashShim -StdIn (New-ClaudePayload $script:RealWriteCommand $suiteRoot)
+        Assert-Match 'agent-worktree-main-write' ($result.StdOut + $result.StdErr) 'Decision must be reported'
+    }
+
+    Invoke-TestCase 'Shim: a main-session redirect still exits in Bash' {
+        $result = Invoke-BashShim -StdIn (New-ClaudePayload $script:RealWriteCommand $script:RealMainCheckout)
+        Assert-Equal 0 $result.ExitCode 'Exit code'
+        Assert-Equal '' $result.StdOut.Trim() 'Must produce no decision payload'
+    }
+
+    Invoke-TestCase 'Shim: a worktree-session read still exits in Bash' {
+        $result = Invoke-BashShim -StdIn (New-ClaudePayload 'cat README.md' $suiteRoot)
+        Assert-Equal 0 $result.ExitCode 'Exit code'
+        Assert-Equal '' $result.StdOut.Trim() 'Must produce no decision payload'
+    }
 }
 finally {
     Remove-GuardFixture -Fixture $fixture


### PR DESCRIPTION
## What

A shell command run from a worktree-isolated agent session can no longer write, move, or delete a
path that resolves under the main checkout. Closes backlog 054.

## The two-mechanism finding

Backlog 054 recorded that `git` and the `Edit`/`Write` tools were both refused from a worktree, but
a plain Bash redirect went straight through. The reason is that those are two different mechanisms.
`Edit`/`Write` isolation belongs to Claude Code itself. Only the git half belonged to this
repository. So there was nothing here to extend for Bash — the rule is new.

## The new rule

Rule name `agent-worktree-main-write`. It fires only when the session's own working directory is a
managed worktree. A main-checkout session is unaffected and may still edit, build, test, and format
in main.

Allowed anyway:

- Anything inside the session's own worktree.
- Anything outside the protected checkout.
- Build output and third-party content, on any path component: `bin`, `obj`, `TestResults`, `.vs`,
  `node_modules`.
- `<main>\.claude\worktrees\worktree-removal.log`, by exact path.

A sibling worktree is refused. It is another agent's checkout.

`AHKFLOW_ALLOW_MAIN=1` downgrades the denial to a warned allow, as it does for the location rules.

## How a write target is found

1. The tokenizer now records quote provenance per token, one character per token character. Only an
   unquoted `>` counts as a redirect, so `printf 'a>b'` and `printf x\>y` are not writes.
2. Redirects, plus a per-command destination table: the coreutils writers, `sed -i`, `dd of=`, and
   the PowerShell content and item cmdlets.
3. Nested interpreter arguments (`sh -c`, `bash -c`, `pwsh -Command`, `cmd /c`) are re-tokenized to
   a depth of 2. `pwsh -File` is deliberately not followed — the guard never reads files.
4. The target is resolved to an absolute path with every symlink replaced, so the `docs/superpowers`
   link resolves back to the main checkout. Only the leading literal prefix must expand, so
   `rm -rf ./obj/*` stays allowed. A target the guard cannot expand is denied.

## The 058 split

The second defect in backlog 054 was Claude Code's own `Edit` refusal text, which tells the agent to
edit "the worktree copy of this file". For `docs/superpowers` no such copy can exist. That text is
the harness's, not this repository's, so it moved to backlog 058 and stays open.

## Verification

- `tests/AgentWorktreeGuard.Tests.ps1` green under both pwsh 7 and Windows PowerShell 5.1. The
  fixture gained a second managed worktree and a real `docs/superpowers` symlink; a missing symlink
  now fails the suite rather than skipping the regression.
- Both probes recorded in backlog 054 were re-run live from this worktree session and are refused.
  Reads through the symlink and writes inside the worktree still work.
- Canonical pre-PR gate green: Release build, `dotnet format --verify-no-changes`, coverage slice,
  `git diff --check main...HEAD`.
- `tests/AgentPreCommitHook.Tests.ps1` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
