### PR TITLE
docs: file backlog 060 and 061

### DIFF
--- a/backlog/060-merged-cleanup-sweeps-new-empty-worktrees.md
+++ b/backlog/060-merged-cleanup-sweeps-new-empty-worktrees.md
@@ -1,0 +1,68 @@
+# 060 - Merged-worktree cleanup deletes brand-new worktrees that have no commits
+
+## Metadata
+
+- **Epic**: Agent tooling
+- **Type**: Bug
+- **Interfaces**: UI | API | CLI (none — agent tooling only)
+
+## Summary
+
+You cannot hold two fresh worktrees at once. Creating the second one deletes the first.
+
+`scripts/new-worktree.ps1:252` runs `scripts/cleanup-merged-worktrees.ps1` before it creates the
+worktree. That sweep decides which worktrees are finished from
+`git branch --merged main` (`scripts/cleanup-merged-worktrees.ps1:76`) and a lookup in the
+resulting set (`:115`).
+
+A worktree that was just created has no commits of its own. Its branch still points at the same
+commit as `main`, so `git branch --merged main` lists it. The sweep reads it as finished work and
+removes it.
+
+`-ExcludePath` (`:105`) protects only the worktree this run is creating. It does not protect any
+other empty worktree. So each new create deletes the previous unstarted one.
+
+## How it was seen
+
+Two worktrees were wanted at the same time, one for backlog 057 and one for backlog 053. Creating
+057 was fine. Creating 053 printed:
+
+> cleanup: removing merged worktree: ...\.claude\worktrees\downloads-save-failure [fix/wt-downloads-save-failure]
+
+Recreating 057 then deleted 053 the same way. Only ever one of the two survived.
+
+`git config --local ahkflow.worktreeCleanup` is `true` in this checkout, so the sweep runs without
+asking.
+
+## What it is not
+
+This is not Claude Code's worktree integration. The string `cleanup: eligible merged worktree` comes
+from `scripts/cleanup-merged-worktrees.ps1:283`, and the removal is spawned by that same script at
+`:247`. The worktrees above were created by calling `scripts/new-worktree.ps1` directly from a
+shell, with no Claude Code worktree tool involved.
+
+## Acceptance criteria
+
+- [ ] A worktree whose branch has no commits of its own is never swept, whatever the cleanup
+      setting says
+- [ ] Two freshly created worktrees can exist at the same time
+- [ ] A worktree whose branch really was merged into `main` is still swept, so the feature keeps
+      working
+- [ ] A test in `tests/WorktreeMergedCleanup.Tests.ps1` covers the empty-branch case
+
+## Out of scope
+
+- The dirty-working-tree check at `scripts/cleanup-merged-worktrees.ps1:117`. It is correct and this
+  item does not touch it
+- The opt-in setting and its ask-once flow. The bug is in which worktrees are picked, not in whether
+  the sweep is allowed to run
+- Changing the default of `ahkflow.worktreeCleanup`
+
+## Notes / dependencies
+
+- Likely fix: add a "has its own commits" test beside the merged test, for example
+  `git rev-list --count main..<branch>` returning 0 means unstarted, so skip it. An unstarted
+  worktree is not finished work
+- A second option is to sweep only branches with a merged pull request. That is a bigger change and
+  needs network access, so weigh it before choosing
+- Found while creating worktrees for backlog 057 and backlog 053

--- a/backlog/061-backlog-number-collisions.md
+++ b/backlog/061-backlog-number-collisions.md
@@ -1,0 +1,70 @@
+# 061 - Backlog numbers collide because they are picked by hand
+
+## Metadata
+
+- **Epic**: Agent tooling
+- **Type**: Bug
+- **Interfaces**: UI | API | CLI (none — agent tooling only)
+
+## Summary
+
+Two backlog items can end up with the same number. It has already happened twice.
+
+A new item's number is chosen by hand. The person or agent filing it has to list both `backlog/`
+and `backlog/done/` and take the highest number. Nothing checks the result, so a wrong guess is
+saved and committed.
+
+Existing collisions:
+
+- `051` — `backlog/done/051-hotkey-raw-body-inline-error-not-rendering.md` and
+  `backlog/done/051-hotstrings-mobile-branch-stale-after-desktop-mutation.md`
+- `058` — `backlog/058-native-edit-refusal-names-missing-worktree-copy.md` and
+  `backlog/done/058-template-key-use-warning.md`
+
+The `b` suffix items (`022b`, `024b`, `027b`) are not collisions. Those are deliberate follow-ups to
+a parent item and this work leaves them alone.
+
+## Why the number matters
+
+The number is a reference, not only a unique key. Items cite each other by bare number, and so do
+documents and commit messages. Some examples in the repo today:
+
+- `backlog/042-key-rebinds-as-first-class-rows.md:42` points at item 044
+- `backlog/056-disabled-button-reason-unreachable-by-keyboard-and-touch.md:38` points at item 053
+- `backlog/057-downloads-page-row-stays-disabled-when-the-file-save-fails.md:23` points at item 055
+- `backlog/058-native-edit-refusal-names-missing-worktree-copy.md:25` points at item 054
+
+So a duplicate number does not only break sorting. It makes an existing reference point at two
+different items, and the reader cannot tell which one was meant.
+
+This is also why the numbers should stay short. A longer unique name, such as a date and time
+suffix, would remove collisions but make every reference harder to read and say.
+
+## Acceptance criteria
+
+- [ ] A script scaffolds a new backlog item from `backlog/000-backlog-item-template.md`. It takes a
+      title, works out the next free number across `backlog/` and `backlog/done/`, and writes the
+      file
+- [ ] Nobody has to read or type a backlog number by hand to file an item
+- [ ] A check fails when two files share the same numeric prefix across `backlog/` and
+      `backlog/done/`. The failure message names both files
+- [ ] The check runs in CI, so a duplicate cannot reach `main`
+- [ ] The `b` suffix items keep passing the check
+- [ ] The two existing collisions are resolved, and every reference to the renumbered items is
+      updated in the same change
+
+## Out of scope
+
+- Moving the backlog into GitHub Issues. That is a separate decision, not this bug
+- Changing the numbering scheme itself. Numbers stay short and stay the reference
+- Changing the item template's sections
+
+## Notes / dependencies
+
+- The generator handles the common case: one person files one item and never sees a number
+- The CI check handles the case a generator cannot. Two agents working in separate worktrees can
+  each see 059 as the highest and each write 060. Only a check at merge time catches that
+- If a filing date is wanted, add it as a `- **Filed**: YYYY-MM-DD` line in the Metadata section.
+  Keep it out of the file name, so references stay short
+- Renumbering the existing collisions is the risky part. Search for the old number as a bare
+  reference before moving any file


### PR DESCRIPTION
## Summary

Files two new backlog items. Documentation only — no code changes.

### 060 — Merged-worktree cleanup deletes brand-new worktrees

`scripts/new-worktree.ps1` runs the merged-worktree sweep before it creates a worktree. A freshly
created worktree has no commits, so its branch still points at `main` and `git branch --merged main`
lists it. The sweep reads that as finished work and removes it. Result: you cannot hold two unstarted
worktrees at once — creating the second deletes the first.

### 061 — Backlog numbers collide because they are picked by hand

Item numbers are chosen by hand across `backlog/` and `backlog/done/`, and nothing checks the result.
Two collisions already exist (`051` and `058`). Numbers are used as references between items, so a
duplicate makes an existing reference point at two different files. Asks for a scaffold script plus a
CI check.

## Test plan

- Docs-only change, nothing compiled. Pre-push quick checks passed: 2917 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
