### PR TITLE
fix: report a failed file save on the downloads page

### DIFF
--- a/backlog/done/057-downloads-page-row-stays-disabled-when-the-file-save-fails.md
+++ b/backlog/done/057-downloads-page-row-stays-disabled-when-the-file-save-fails.md
@@ -24,10 +24,13 @@ purpose, because backlog 055 put changes to that page out of scope. The two page
 
 ## Acceptance criteria
 
-- [ ] A failed file save on the Downloads page shows an error message
-- [ ] The row's Download button works again straight after the failure
-- [ ] Both pages report a failed save with the same wording
-- [ ] A bUnit test covers the failing save on the Downloads page
+- [x] A failed file save on the Downloads page shows an error message
+- [x] The row's Download button works again straight after the failure
+- [x] Both pages report a failed save with the same wording
+- [x] A bUnit test covers the failing save on the Downloads page
+
+The "Download all" (zip) button had the same bug, in `DownloadAllAsync`. Fixed it too, and covered
+it with the same test shapes.
 
 ## Out of scope
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Downloads.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Pages/Downloads.razor
@@ -4,6 +4,7 @@
 @using AHKFlowApp.UI.Blazor.Services
 @using MudBlazor
 @using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.JSInterop
 @implements IDisposable
 
 <PageTitle>Downloads</PageTitle>
@@ -125,6 +126,11 @@
             Snackbar.Add($"Downloaded {outcome.FileName}", Severity.Success);
         }
         catch (OperationCanceledException) when (_cts.IsCancellationRequested) { }
+        // Catch this error so Blazor can render the cleared busy state.
+        catch (JSException)
+        {
+            Snackbar.Add("Saving the file failed.", Severity.Error);
+        }
         finally
         {
             _busyProfileId = null;
@@ -149,6 +155,11 @@
             Snackbar.Add($"Downloaded {fileName}", Severity.Success);
         }
         catch (OperationCanceledException) when (_cts.IsCancellationRequested) { }
+        // Catch this error so Blazor can render the cleared busy state.
+        catch (JSException)
+        {
+            Snackbar.Add("Saving the file failed.", Severity.Error);
+        }
         finally
         {
             _zipLoading = false;

--- a/tests/AHKFlowApp.E2E.Tests/DownloadsSaveFailureFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/DownloadsSaveFailureFlowTests.cs
@@ -1,0 +1,48 @@
+using AHKFlowApp.E2E.Tests.Fixtures;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace AHKFlowApp.E2E.Tests;
+
+[Collection(E2ETestCollection.Name)]
+public sealed class DownloadsSaveFailureFlowTests(StackFixture fixture) : IAsyncLifetime
+{
+    // Trailing "undefined;" stops Playwright from auto-invoking the assignment's completion
+    // value (the arrow function itself) — EvaluateAsync calls a function-valued result.
+    private const string BreakSaveBlob =
+        "window.ahkFlowDownloads.saveBlob = () => { throw new Error('the browser refused the download'); }; undefined;";
+
+    public Task InitializeAsync() => fixture.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task ProfileDownload_WhenTheSaveFails_ReportsItAndFreesTheButton()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync();
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/downloads");
+        await page.WaitForSelectorAsync("button.download-profile");
+        await page.EvaluateAsync(BreakSaveBlob);
+        await page.ClickAsync("button.download-profile");
+
+        await page.WaitForSelectorAsync("text=Saving the file failed.");
+        await page.WaitForSelectorAsync("button.download-profile:not([disabled])");
+    }
+
+    [Fact]
+    public async Task DownloadAll_WhenTheSaveFails_ReportsItAndFreesTheButton()
+    {
+        await using IBrowserContext ctx = await fixture.Browser.NewContextAsync();
+        IPage page = await ctx.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/downloads");
+        await page.WaitForSelectorAsync("button.download-profile");
+        await page.EvaluateAsync(BreakSaveBlob);
+        await page.ClickAsync("button.download-all");
+
+        await page.WaitForSelectorAsync("text=Saving the file failed.");
+        await page.WaitForSelectorAsync("button.download-all:not([disabled])");
+    }
+}

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/DownloadsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/DownloadsPageTests.cs
@@ -7,9 +7,11 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
+using Microsoft.JSInterop;
 using MudBlazor;
 using MudBlazor.Services;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace AHKFlowApp.UI.Blazor.Tests.Pages;
@@ -115,6 +117,47 @@ public sealed class DownloadsPageTests : BunitContext, IAsyncLifetime
             Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>()));
         return _saver.DidNotReceive().SaveAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<byte[]>());
+    }
+
+    [Fact]
+    public void Click_PerProfileDownload_FileSaverFails_ReportsItAndFreesTheRow()
+    {
+        ProfileDto work = MakeProfile("Work");
+        StubProfileList(work);
+        FileDownload payload = new([0x41, 0x42], "ahkflow_Work.ahk", "text/plain; charset=utf-8");
+        _downloads.GetProfileScriptAsync(work.Id, Arg.Any<CancellationToken>())
+            .Returns(ApiResult<FileDownload>.Ok(payload));
+        _saver.SaveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<byte[]>())
+            .Throws(new JSException("the browser refused the download"));
+
+        IRenderedComponent<Downloads> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find("button.download-profile"));
+        cut.Find("button.download-profile").Click();
+
+        cut.WaitForAssertion(() => _snackbar.Received(1).Add(
+            "Saving the file failed.", Severity.Error,
+            Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>()));
+        cut.Find("button.download-profile").GetAttribute("disabled").Should().BeNull();
+    }
+
+    [Fact]
+    public void Click_DownloadAll_FileSaverFails_ReportsItAndFreesTheButton()
+    {
+        StubProfileList(MakeProfile("Work"));
+        FileDownload zip = new([0x50, 0x4B, 0x05, 0x06], "ahkflow_scripts.zip", "application/zip");
+        _downloads.GetAllProfileScriptsZipAsync(Arg.Any<CancellationToken>())
+            .Returns(ApiResult<FileDownload>.Ok(zip));
+        _saver.SaveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<byte[]>())
+            .Throws(new JSException("the browser refused the download"));
+
+        IRenderedComponent<Downloads> cut = RenderPage();
+        cut.WaitForAssertion(() => cut.Find("button.download-all"));
+        cut.Find("button.download-all").Click();
+
+        cut.WaitForAssertion(() => _snackbar.Received(1).Add(
+            "Saving the file failed.", Severity.Error,
+            Arg.Any<Action<SnackbarOptions>>(), Arg.Any<string>()));
+        cut.Find("button.download-all").GetAttribute("disabled").Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Downloads page left a row/button disabled with no message when `IFileSaver.SaveAsync` threw a `JSException` — the busy state cleared internally, but Blazor skips its post-event render when the event task ends faulted, so the button stayed drawn as disabled.
- Same catch shape `Profiles.razor` already uses, applied to both `DownloadProfileAsync` and `DownloadAllAsync` (the zip button had the same bug, out of scope on the original backlog item but fixed here too).

Closes backlog 057.

## Test plan
- [x] `pwsh .\scripts\test-fast.ps1 -Mode Fast` — 942/942 UI.Blazor.Tests pass, including two new bUnit tests
- [x] `pwsh .\scripts\test-fast.ps1 -Mode E2E` — 53/53 pass, including two new flow tests driving the real interop path
- [x] Canonical pre-PR gate: build, format --verify-no-changes, full coverage gate, `git diff --check` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)