### PR TITLE
Stop backlog numbers from colliding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
           ./tests/SkillParity.Tests.ps1
           ./tests/SkillLayout.Tests.ps1
           ./tests/PrePushHook.Tests.ps1
+          ./tests/BacklogNumbering.Tests.ps1
 
   codex-skills-hash-parity:
     # Runs on Linux: the bash setup script refuses under Windows Git Bash, and this

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,7 @@ Branch naming: `feature/NNN-short-description`, `fix/short-description`, `hotfix
 Branches created in agent git worktrees insert `wt-` after the type prefix: `fix/wt-<topic>`, `feature/wt-NNN-<topic>` — marks worktree-born branches for grepping/cleanup.
 Conventional commits: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:` — body explains "why", not "what".
 Atomic commits: one logical change per commit; feature + its tests = one commit. Don't bundle unrelated changes.
+Filing a `backlog/` item: run `pwsh ./scripts/new-backlog-item.ps1 -Title "..."`. It works out the next free number and writes the file from the template. Never pick a number by hand — two items have already ended up sharing one. CI fails when two files share a number.
 Finishing a `backlog/` item: tick its acceptance boxes **and** `git mv` the file into `backlog/done/` in the same PR that does the work. Merging that PR is what completes the item, so the move belongs there. Never open a separate PR just to mark an item done.
 Never force-push to main/master. Run the canonical pre-PR gate before creating a PR — [`docs/development/testing-workflow.md`](docs/development/testing-workflow.md#canonical-pre-pr-gate).
 Keep PRs focused on a single concern; split large changes into stacked PRs.

--- a/backlog/059-lcontrol-rcontrol-key-aliases-missing.md
+++ b/backlog/059-lcontrol-rcontrol-key-aliases-missing.md
@@ -17,7 +17,7 @@ never meet.
 
 ## Background
 
-Found while addressing review findings on item 058. The one-line alias addition was reverted,
+Found while addressing review findings on item 064 (filed as 058). The one-line alias addition was reverted,
 because it breaks a frozen invariant rather than the feature under review.
 
 `LegacyHotkeyFixtures.cs:161` builds its Send-token fixtures from `HotkeyKeys.Aliases` at run time.

--- a/backlog/done/052-hotstrings-mobile-list-column-widths-inert.md
+++ b/backlog/done/052-hotstrings-mobile-list-column-widths-inert.md
@@ -57,7 +57,7 @@ being true.
 
 ## Notes / dependencies
 
-- Found during backlog 051. See
+- Found during backlog 063 (filed as 051). See
   `docs/superpowers/specs/2026-08-04-hotstrings-mobile-branch-stale-design.md`
 - Line numbers were read on `fix/wt-051-hotstrings-mobile-branch-stale` at `5d8583c2`
 - The expanded row's `colspan="3"` (`:70`) was checked at the same time and is correct. The normal

--- a/backlog/done/061-backlog-number-collisions.md
+++ b/backlog/done/061-backlog-number-collisions.md
@@ -14,12 +14,16 @@ A new item's number is chosen by hand. The person or agent filing it has to list
 and `backlog/done/` and take the highest number. Nothing checks the result, so a wrong guess is
 saved and committed.
 
-Existing collisions:
+Existing collisions (resolved 2026-08-07):
 
-- `051` — `backlog/done/051-hotkey-raw-body-inline-error-not-rendering.md` and
-  `backlog/done/051-hotstrings-mobile-branch-stale-after-desktop-mutation.md`
-- `058` — `backlog/058-native-edit-refusal-names-missing-worktree-copy.md` and
-  `backlog/done/058-template-key-use-warning.md`
+- `051` — `backlog/done/051-hotkey-raw-body-inline-error-not-rendering.md` kept `051` (most inbound
+  references). `backlog/done/051-hotstrings-mobile-branch-stale-after-desktop-mutation.md` was
+  renumbered to `backlog/done/063-hotstrings-mobile-branch-stale-after-desktop-mutation.md`.
+- `058` — `backlog/058-native-edit-refusal-names-missing-worktree-copy.md` kept `058` (most inbound
+  references). `backlog/done/058-template-key-use-warning.md` was renumbered to
+  `backlog/done/064-template-key-use-warning.md`.
+
+Every inbound reference to the renumbered files was updated in the same change.
 
 The `b` suffix items (`022b`, `024b`, `027b`) are not collisions. Those are deliberate follow-ups to
 a parent item and this work leaves them alone.
@@ -42,15 +46,15 @@ suffix, would remove collisions but make every reference harder to read and say.
 
 ## Acceptance criteria
 
-- [ ] A script scaffolds a new backlog item from `backlog/000-backlog-item-template.md`. It takes a
+- [x] A script scaffolds a new backlog item from `backlog/000-backlog-item-template.md`. It takes a
       title, works out the next free number across `backlog/` and `backlog/done/`, and writes the
       file
-- [ ] Nobody has to read or type a backlog number by hand to file an item
-- [ ] A check fails when two files share the same numeric prefix across `backlog/` and
+- [x] Nobody has to read or type a backlog number by hand to file an item
+- [x] A check fails when two files share the same numeric prefix across `backlog/` and
       `backlog/done/`. The failure message names both files
-- [ ] The check runs in CI, so a duplicate cannot reach `main`
-- [ ] The `b` suffix items keep passing the check
-- [ ] The two existing collisions are resolved, and every reference to the renumbered items is
+- [x] The check runs in CI, so a duplicate cannot reach `main`
+- [x] The `b` suffix items keep passing the check
+- [x] The two existing collisions are resolved, and every reference to the renumbered items is
       updated in the same change
 
 ## Out of scope
@@ -68,3 +72,6 @@ suffix, would remove collisions but make every reference harder to read and say.
   Keep it out of the file name, so references stay short
 - Renumbering the existing collisions is the risky part. Search for the old number as a bare
   reference before moving any file
+- The check runs in CI only, not in `scripts/pre-push-quick-checks.ps1`. This item's acceptance
+  criteria only ask for a CI check. Adding it to pre-push as well was considered and dropped, to
+  keep this change to what the item asks for

--- a/backlog/done/063-hotstrings-mobile-branch-stale-after-desktop-mutation.md
+++ b/backlog/done/063-hotstrings-mobile-branch-stale-after-desktop-mutation.md
@@ -1,4 +1,4 @@
-# 051 - Hotstrings mobile branch goes stale after a desktop mutation
+# 063 - Hotstrings mobile branch goes stale after a desktop mutation
 
 ## Metadata
 
@@ -38,6 +38,7 @@ This is the same bug that backlog 050 fixed on the hotkeys page.
 - The cost is one extra mobile load per mutation, and at most one extra API request. `ListAsync`
   returns its cached page when the next request is equal, so a matching grid and mobile request
   costs nothing extra
+- Filed as 051. Renumbered to 063 on 2026-08-07, because two items shared 051. See backlog 061
 - `Hotkeys.razor` still has two call sites, `DeleteAsync` and `MobileBulkDeleteAsync`, that call
   `ClearListCache()` right before `ReloadAllAsync()`. `ReloadAllAsync` clears the cache itself, so
   this clears it twice. It is harmless, but it does not match the convention this branch set at the

--- a/backlog/done/064-template-key-use-warning.md
+++ b/backlog/done/064-template-key-use-warning.md
@@ -1,4 +1,4 @@
-# 058 - Hotkey warnings ignore keys a profile template already uses
+# 064 - Hotkey warnings ignore keys a profile template already uses
 
 ## Metadata
 
@@ -70,3 +70,4 @@ destination. Item 043 shipped the preset that makes it easy to hit.
 - `ShortcutWarning.razor:75` decides re-evaluation from `(Combination, Kind, RemapDest)`. Profile scope has to join it, or a Profile change is ignored
 - `CONTEXT.md:92` bans conflict, clash, collision, and duplicate for this area. The house word is "uses"
 - `docs/development/ahk-v2-syntax.md` documents none of `*`, `~`, or `up::` in prose. It needs extending as part of this work
+- Filed as 053, renumbered to 058. Renumbered again to 064 on 2026-08-07, because two items shared 058. See backlog 061

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,6 +28,7 @@ and must be changed as one set (see below).
 | `run-frontend.ps1` | Builds and starts the Blazor frontend, signed in with MSAL or (with `-NoAuth`) the no-auth test user. |
 | `publish-cli.ps1` | Publishes the `ahkflow` CLI as a native single-file executable with baked-in API/auth config. |
 | `new-worktree.ps1` | Creates a git worktree and applies AHKFlowApp local-dev isolation. |
+| `new-backlog-item.ps1` | Scaffolds a new `backlog/` item from the template with the next free number filled in. |
 
 ## CI-internal (`ci/`)
 
@@ -72,3 +73,4 @@ lists ignored local files `new-worktree.ps1` copies into a new worktree.
 | `_open-env.ps1` | `Open-Env` helper that reads a saved `.env.<env>` and opens its URLs. |
 | `test-sql-container.common.ps1` | Shared SQL Server Testcontainer settings for the coverage/test scripts. |
 | `run-frontend.common.ps1` | Shared build/run logic for `run-frontend.ps1`, dot-sourced so a test can drive it through injected scriptblocks. |
+| `backlog.common.ps1` | Shared backlog-numbering helpers for `new-backlog-item.ps1` and `tests/BacklogNumbering.Tests.ps1`. |

--- a/scripts/backlog.common.ps1
+++ b/scripts/backlog.common.ps1
@@ -1,0 +1,121 @@
+#Requires -Version 7.0
+# Shared helpers for backlog item numbering, dot-sourced by new-backlog-item.ps1 and
+# tests/BacklogNumbering.Tests.ps1.
+#
+# A backlog item's number is not only a unique key. Items, docs, and code comments cite each
+# other by bare number, so a duplicate number makes an existing reference ambiguous. See
+# backlog 061.
+
+Set-StrictMode -Version Latest
+
+function Get-BacklogItem {
+    param([Parameter(Mandatory)][string] $BacklogRoot)
+
+    $root = (Resolve-Path -LiteralPath $BacklogRoot).Path
+    $repoRoot = Split-Path -Parent $root
+
+    $files = @(Get-ChildItem -LiteralPath $root -Filter '*.md' -File)
+    $doneDir = Join-Path $root 'done'
+    if (Test-Path -LiteralPath $doneDir) {
+        $files += Get-ChildItem -LiteralPath $doneDir -Filter '*.md' -File
+    }
+
+    foreach ($file in $files) {
+        $key = $null
+        $number = $null
+        if ($file.BaseName -match '^(?<num>\d{3})(?<suffix>[a-z]?)-') {
+            $key = "$($Matches.num)$($Matches.suffix)"
+            $number = [int] $Matches.num
+        }
+
+        $headingKey = $null
+        $firstLine = Get-Content -LiteralPath $file.FullName -TotalCount 1
+        if ($firstLine -match '^#\s*(?<head>\S+)\s*-') {
+            $headingKey = $Matches.head
+        }
+
+        $relativePath = $file.FullName.Substring($repoRoot.Length + 1) -replace '\\', '/'
+
+        [PSCustomObject]@{
+            Key          = $key
+            Number       = $number
+            Path         = $file.FullName
+            RelativePath = $relativePath
+            HeadingKey   = $headingKey
+        }
+    }
+}
+
+function Get-BacklogProblem {
+    param([Parameter(Mandatory)][string] $BacklogRoot)
+
+    $items = @(Get-BacklogItem -BacklogRoot $BacklogRoot)
+    $problems = @()
+
+    # --- Bad file name: does not match NNN-slug.md or NNNx-slug.md ---
+    foreach ($item in $items | Where-Object { $null -eq $_.Key }) {
+        $problems += "Bad backlog file name: $($item.RelativePath). Expected NNN-slug.md or NNNx-slug.md."
+    }
+
+    # --- Duplicate key across backlog/ and backlog/done/ ---
+    $byKey = $items | Where-Object { $null -ne $_.Key } | Group-Object -Property Key
+    foreach ($group in $byKey | Where-Object { $_.Count -gt 1 }) {
+        $names = ($group.Group | Select-Object -ExpandProperty RelativePath) -join ', '
+        $problems += "Duplicate backlog number '$($group.Name)': $names"
+    }
+
+    # --- Heading drift: '# NNN - Title' heading number must match the file name number ---
+    foreach ($item in $items | Where-Object { $null -ne $_.Key }) {
+        if ((Split-Path -Leaf $item.Path) -eq '000-backlog-item-template.md') {
+            continue
+        }
+
+        if ($item.HeadingKey -ne $item.Key) {
+            $problems += "Heading number mismatch in $($item.RelativePath): file name says '$($item.Key)' but heading says '$($item.HeadingKey)'."
+        }
+    }
+
+    return $problems
+}
+
+function Get-NextBacklogNumber {
+    param([Parameter(Mandatory)][string] $BacklogRoot)
+
+    $items = @(Get-BacklogItem -BacklogRoot $BacklogRoot | Where-Object { $null -ne $_.Number })
+    $max = [int] ($items | Measure-Object -Property Number -Maximum).Maximum
+    return '{0:D3}' -f ($max + 1)
+}
+
+function New-BacklogFile {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][string] $Content
+    )
+
+    # FileMode.CreateNew makes the existence check and the write one atomic operation, so two
+    # processes racing to create the same path cannot have the second one silently clobber the
+    # first. A separate Test-Path check followed by a WriteAllText leaves a gap between them.
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    try {
+        $stream = [System.IO.FileStream]::new($Path, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write)
+    }
+    catch [System.IO.IOException] {
+        throw "Refusing to overwrite existing file: $Path"
+    }
+
+    try {
+        $writer = [System.IO.StreamWriter]::new($stream, $utf8NoBom)
+        $writer.Write($Content)
+        $writer.Dispose()
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function ConvertTo-BacklogSlug {
+    param([Parameter(Mandatory)][string] $Title)
+
+    $slug = $Title.ToLowerInvariant() -replace '[^a-z0-9]+', '-'
+    return $slug.Trim('-')
+}

--- a/scripts/new-backlog-item.ps1
+++ b/scripts/new-backlog-item.ps1
@@ -1,0 +1,46 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Scaffolds a new backlog/ item from the template, with the next free number filled in.
+
+.DESCRIPTION
+    Never pick a backlog number by hand — two items have already ended up sharing one
+    (see backlog 061). This script reads backlog/000-backlog-item-template.md, works out the
+    next free number across backlog/ and backlog/done/, and writes the new file.
+
+.EXAMPLE
+    pwsh ./scripts/new-backlog-item.ps1 -Title "Downloads page row stays disabled"
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $Title,
+
+    [string] $BacklogRoot = (Join-Path (Split-Path -Parent $PSScriptRoot) 'backlog')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'backlog.common.ps1')
+
+$templatePath = Join-Path $BacklogRoot '000-backlog-item-template.md'
+if (-not (Test-Path -LiteralPath $templatePath)) {
+    throw "Template not found: $templatePath"
+}
+
+$number = Get-NextBacklogNumber -BacklogRoot $BacklogRoot
+$slug = ConvertTo-BacklogSlug -Title $Title
+if (-not $slug) {
+    throw "Title '$Title' produced an empty slug."
+}
+
+$targetPath = Join-Path $BacklogRoot "$number-$slug.md"
+
+$templateLines = Get-Content -LiteralPath $templatePath
+$templateLines[0] = "# $number - $Title"
+$content = ($templateLines -join "`n") + "`n"
+
+New-BacklogFile -Path $targetPath -Content $content
+
+Write-Host "Created $targetPath"

--- a/tests/BacklogNumbering.Tests.ps1
+++ b/tests/BacklogNumbering.Tests.ps1
@@ -1,0 +1,203 @@
+#Requires -Version 7.0
+
+# Backlog item numbers are picked by hand today. Nothing checks the result, so two files have
+# already ended up sharing the same number (backlog 061). This test proves the real backlog/ is
+# clean today, and that Get-BacklogProblem and new-backlog-item.ps1 catch the failure modes that
+# let that happen.
+#
+# Run it by hand with:  pwsh ./tests/BacklogNumbering.Tests.ps1
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+. (Join-Path $repoRoot 'scripts/backlog.common.ps1')
+
+$scaffoldScript = Join-Path $repoRoot 'scripts/new-backlog-item.ps1'
+$templatePath = Join-Path $repoRoot 'backlog/000-backlog-item-template.md'
+
+$failures = @()
+
+function New-TemporaryBacklogRoot {
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) "backlog-numbering-tests-$([guid]::NewGuid())"
+    New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $tempRoot 'done') -Force | Out-Null
+    Copy-Item -LiteralPath $templatePath -Destination (Join-Path $tempRoot '000-backlog-item-template.md')
+    return $tempRoot
+}
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) {
+        $script:failures += $Message
+    }
+}
+
+# --- Case 1: the real backlog/ passes with zero problems ---
+
+$realProblems = @(Get-BacklogProblem -BacklogRoot (Join-Path $repoRoot 'backlog'))
+Assert-True ($realProblems.Count -eq 0) "Real backlog/ should have zero problems, found: $($realProblems -join ' | ')"
+
+# --- Case 2: two files sharing a number fail, naming both files ---
+
+$tempRoot = New-TemporaryBacklogRoot
+try {
+    Set-Content -LiteralPath (Join-Path $tempRoot '058-first.md') -Value "# 058 - First`n"
+    Set-Content -LiteralPath (Join-Path $tempRoot 'done/058-second.md') -Value "# 058 - Second`n"
+
+    $problems = @(Get-BacklogProblem -BacklogRoot $tempRoot)
+    $dupProblem = $problems | Where-Object { $_ -like "*Duplicate backlog number '058'*" }
+    Assert-True ($null -ne $dupProblem) "Expected a duplicate-058 problem, got: $($problems -join ' | ')"
+    if ($dupProblem) {
+        Assert-True ($dupProblem -like '*058-first.md*') "Duplicate message should name 058-first.md: $dupProblem"
+        Assert-True ($dupProblem -like '*058-second.md*') "Duplicate message should name 058-second.md: $dupProblem"
+    }
+}
+finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+}
+
+# --- Case 3: 022 plus 022b pass ---
+
+$tempRoot = New-TemporaryBacklogRoot
+try {
+    Set-Content -LiteralPath (Join-Path $tempRoot '022-parent.md') -Value "# 022 - Parent`n"
+    Set-Content -LiteralPath (Join-Path $tempRoot '022b-followup.md') -Value "# 022b - Followup`n"
+
+    $problems = @(Get-BacklogProblem -BacklogRoot $tempRoot)
+    Assert-True ($problems.Count -eq 0) "022 and 022b should both pass, found: $($problems -join ' | ')"
+}
+finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+}
+
+# --- Case 4: a file not matching NNN[a-z]?-slug.md fails ---
+
+$tempRoot = New-TemporaryBacklogRoot
+try {
+    Set-Content -LiteralPath (Join-Path $tempRoot 'notes.md') -Value "# Notes`n"
+
+    $problems = @(Get-BacklogProblem -BacklogRoot $tempRoot)
+    $badName = $problems | Where-Object { $_ -like '*notes.md*' }
+    Assert-True ($null -ne $badName) "Expected notes.md to fail the file name check, got: $($problems -join ' | ')"
+}
+finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+}
+
+# --- Case 5: heading number drift fails ---
+
+$tempRoot = New-TemporaryBacklogRoot
+try {
+    Set-Content -LiteralPath (Join-Path $tempRoot '063-x.md') -Value "# 051 - x`n"
+
+    $problems = @(Get-BacklogProblem -BacklogRoot $tempRoot)
+    $drift = $problems | Where-Object { $_ -like '*063-x.md*' -and $_ -like '*Heading number mismatch*' }
+    Assert-True ($null -ne $drift) "Expected a heading mismatch for 063-x.md, got: $($problems -join ' | ')"
+}
+finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+}
+
+# --- Case 6: the template's literal '# NNN - <Title>' heading does not fail ---
+
+$tempRoot = New-TemporaryBacklogRoot
+try {
+    $problems = @(Get-BacklogProblem -BacklogRoot $tempRoot)
+    Assert-True ($problems.Count -eq 0) "A folder with only the template should have zero problems, found: $($problems -join ' | ')"
+}
+finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+}
+
+# --- Case 7: the scaffold script picks the next free number, twice in a row ---
+
+$tempRoot = New-TemporaryBacklogRoot
+try {
+    Set-Content -LiteralPath (Join-Path $tempRoot '062-existing.md') -Value "# 062 - Existing`n"
+
+    & $scaffoldScript -Title 'Smoke test throwaway item' -BacklogRoot $tempRoot | Out-Null
+    $firstPath = Join-Path $tempRoot '063-smoke-test-throwaway-item.md'
+    Assert-True (Test-Path -LiteralPath $firstPath) "Expected $firstPath to be created"
+    if (Test-Path -LiteralPath $firstPath) {
+        $heading = Get-Content -LiteralPath $firstPath -TotalCount 1
+        Assert-True ($heading -eq '# 063 - Smoke test throwaway item') "Expected heading '# 063 - Smoke test throwaway item', got '$heading'"
+    }
+
+    & $scaffoldScript -Title 'Second throwaway item' -BacklogRoot $tempRoot | Out-Null
+    $secondPath = Join-Path $tempRoot '064-second-throwaway-item.md'
+    Assert-True (Test-Path -LiteralPath $secondPath) "Expected $secondPath to be created"
+    if (Test-Path -LiteralPath $secondPath) {
+        $heading = Get-Content -LiteralPath $secondPath -TotalCount 1
+        Assert-True ($heading -eq '# 064 - Second throwaway item') "Expected heading '# 064 - Second throwaway item', got '$heading'"
+    }
+}
+finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+}
+
+# --- Case 8: New-BacklogFile writes UTF-8 without BOM and LF-only line endings ---
+
+$tempRoot = New-TemporaryBacklogRoot
+try {
+    $targetPath = Join-Path $tempRoot '001-new-file.md'
+    New-BacklogFile -Path $targetPath -Content "# 001 - New file`nSecond line`n"
+
+    $bytes = [System.IO.File]::ReadAllBytes($targetPath)
+    $hasBom = $bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF
+    Assert-True (-not $hasBom) 'New-BacklogFile should not write a UTF-8 BOM'
+
+    $rawText = [System.IO.File]::ReadAllText($targetPath)
+    Assert-True (-not $rawText.Contains("`r")) 'New-BacklogFile should write LF-only line endings'
+    Assert-True ($rawText -eq "# 001 - New file`nSecond line`n") "Unexpected content: '$rawText'"
+}
+finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+}
+
+# --- Case 9: a concurrent writer between number selection and the write must not be clobbered ---
+#
+# This exercises the same write path new-backlog-item.ps1 uses in production, not just a
+# standalone guard function. FileMode.CreateNew (inside New-BacklogFile) makes the existence
+# check and the write one atomic operation, so a file that appears at the target path after
+# number selection but before the write causes a throw instead of a silent overwrite.
+
+$tempRoot = New-TemporaryBacklogRoot
+try {
+    $targetPath = Join-Path $tempRoot '001-race.md'
+
+    # Simulate a second process creating the file after this process picked the same number.
+    Set-Content -LiteralPath $targetPath -Value 'first writer content' -NoNewline
+
+    $threw = $false
+    try {
+        New-BacklogFile -Path $targetPath -Content 'second writer content'
+    }
+    catch {
+        $threw = $true
+    }
+    Assert-True $threw 'Expected New-BacklogFile to throw when the target already exists'
+
+    $finalContent = Get-Content -LiteralPath $targetPath -Raw
+    Assert-True ($finalContent -eq 'first writer content') "Concurrent write should not clobber the first writer's file, got: '$finalContent'"
+}
+finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+}
+
+# --- Report ---
+
+if ($failures.Count -gt 0) {
+    foreach ($failure in $failures) {
+        Write-Host ''
+        Write-Host $failure -ForegroundColor Red
+    }
+    Write-Host ''
+    throw "Backlog numbering tests failed with $($failures.Count) problem(s). See the detail above."
+}
+
+$itemCount = @(Get-BacklogItem -BacklogRoot (Join-Path $repoRoot 'backlog')).Count
+Write-Host "Backlog numbering tests passed. $itemCount backlog items checked."


### PR DESCRIPTION
## Summary
- Renumbers the two colliding backlog items (051, 058 each had two files) to the next free numbers (063, 064), updating the two inbound references
- Adds `scripts/new-backlog-item.ps1` to scaffold new backlog items with the next free number, so nobody picks a number by hand
- Adds `tests/BacklogNumbering.Tests.ps1`, wired into CI, which fails when two backlog files share a number, when a file name doesn't match the convention, or when a heading number drifts from its file name
- Closes backlog 061

## Test plan
- [x] `pwsh ./tests/BacklogNumbering.Tests.ps1` passes (68 items, zero problems)
- [x] `pwsh ./tests/SkillLayout.Tests.ps1` / `SkillParity.Tests.ps1` pass (no regression)
- [x] Live smoke: scaffold script creates `NNN-slug.md` with correct heading, refuses to clobber a concurrent write (`FileMode.CreateNew`)
- [x] Deliberately duplicated a `051` file and confirmed the check fails, naming both files
- [x] Pre-push quick checks (build + fast test slice) passed on push

Closes backlog 061.

🤖 Generated with [Claude Code](https://claude.com/claude-code)