### PR TITLE
fix: accept LControl and RControl key spellings

### DIFF
--- a/backlog/done/059-lcontrol-rcontrol-key-aliases-missing.md
+++ b/backlog/done/059-lcontrol-rcontrol-key-aliases-missing.md
@@ -30,10 +30,10 @@ So adding any alias whose canonical key carries the `SendToken` role fails that 
 
 ## Acceptance criteria
 
-- [ ] `LControl` canonicalizes to `LCtrl`, and `RControl` to `RCtrl`
-- [ ] Both spellings are accepted at the create and update boundaries
-- [ ] A template line `*LControl::` warns for a row on `LCtrl`
-- [ ] The migration parity test still passes, and the reason it passes is written down
+- [x] `LControl` canonicalizes to `LCtrl`, and `RControl` to `RCtrl`
+- [x] Both spellings are accepted at the create and update boundaries
+- [x] A template line `*LControl::` warns for a row on `LCtrl`
+- [x] The migration parity test still passes, and the reason it passes is written down
 
 ## Out of scope
 
@@ -45,3 +45,7 @@ So adding any alias whose canonical key carries the `SendToken` role fails that 
 - Decide first how the fixture set should treat aliases added after a migration shipped. Either the
   fixtures snapshot the alias list that migration knew, or the parity test excludes later aliases
 - Same question applies to every future alias, not only these two
+- Answered by: `docs/superpowers/specs/2026-08-07-lcontrol-rcontrol-aliases-design.md`. The fixture
+  set becomes an additions allow-list — `LegacyHotkeyFixtures.s_spellingsAddedAfterMigrationA` names
+  later spellings and skips them. Both sides of the resulting split are pinned by tests. ADR 0004
+  carries the reason under "Adding a key spelling after Migration A"

--- a/docs/adr/0004-hotkey-typed-actions-and-raw-escape-hatch.md
+++ b/docs/adr/0004-hotkey-typed-actions-and-raw-escape-hatch.md
@@ -18,7 +18,7 @@ That is what closes the injection hazard the feature carried (issue #195), and i
 
 ## Migrating off the legacy pair
 
-The typed columns replaced a two-value `HotkeyAction` plus one opaque `Parameters` string, in two migrations rather than one: the first adds the typed columns and back-fills them, a later one drops the legacy pair, so every commit in between runs against a database of either shape. The back-fill is hand-written T-SQL and the identical transform exists in C# as `LegacyHotkeyDefinitionConverter`, because history JSON written before the change still has to be read on Restore and Revert; a Testcontainers parity test runs the same fixtures through both and requires identical output.
+The typed columns replaced a two-value `HotkeyAction` plus one opaque `Parameters` string, in two migrations rather than one: the first adds the typed columns and back-fills them, a later one drops the legacy pair, so every commit in between runs against a database of either shape. The back-fill is hand-written T-SQL and the identical transform exists in C# as `LegacyHotkeyDefinitionConverter`, because history JSON written before the change still has to be read on Restore and Revert; a Testcontainers parity test runs the same fixtures through both and requires identical output, for every key spelling that migration knew — see "Adding a key spelling after Migration A" below.
 
 The mapping preserves what the app already emitted, with one deliberate exception. `Run` becomes `Run`, and every `Send` whose parameters do *not* parse as a valid key token becomes `Raw` with a body reproducing the previously emitted `Send("…")` line byte for byte — which is the reason Raw emits verbatim instead of wrapping the body in braces. Those two branches regenerate identically.
 
@@ -31,3 +31,30 @@ Adding an Action kind is now a schema change plus a branch in the validator, emi
 Snapshots are immutable, so pre-existing history keeps its legacy `Action`/`Parameters` members forever and the converter can never be deleted — only the live columns were dropped.
 
 Deploying the migration that drops the legacy pair costs a brief outage, accepted rather than engineered away. `deploy-api.yml` gates `deploy` on `migrate-db`, so the columns are gone before the new build is swapped in, and the still-running previous build maps them as required — every hotkey read returns 500 until the swap completes. The alternative, holding the drop for a later release, buys a zero-downtime cutover at the cost of carrying dead columns across two releases; this project already ships `DropColumn` through the same pipeline and accepts the same window. Two operational consequences follow: take a database backup first, because the back-fill migration's `Down` throws and the drop's `Down` restores structure but not data, so recovery is point-in-time restore only; and treat hotkeys as unavailable until both the API and frontend deploys are green.
+
+## Adding a key spelling after Migration A
+
+> **Amendment, 2026-08-07 (backlog 059):** `20260722105522_HotkeyTypedActions` carries a hard-coded
+> name list, and it is applied, so it cannot gain a spelling after the fact — rows are already
+> back-filled with the classification it made. Adding `LControl` and `RControl` to `HotkeyKeys`
+> therefore takes the "accept Raw for the new names" branch that migration's own comment offers.
+>
+> `LegacyHotkeyFixtures.s_spellingsAddedAfterMigrationA` names the spellings the frozen classifier
+> never knew, and no Send-token fixture is generated for them. This is an additions allow-list, not
+> a snapshot: every other live spelling still gets a fixture, so the Testcontainers parity test
+> still fails loudly for the next spelling added. That failure is the signal to make this decision
+> again, not a reason to edit the migration.
+>
+> The accepted cost: a pre-W1 row whose legacy `Parameters` was exactly `{LControl}` was migrated to
+> `Raw` with `Body = Send("{LControl}")`, while the same value read out of a pre-W1 history snapshot
+> converts to `SendKeys`, because that path runs live C# (ADR 0005). Both emit the same `Send` call,
+> but the left-hand side differs and that is behavioral: `SendKeys` carries the auto `$` prefix,
+> which forces the keyboard hook so the binding cannot retrigger the script's own hotkeys, and `Raw`
+> does not. The migrated row can retrigger; the restored snapshot cannot. How many such rows exist
+> is unknown — no data audit was run. Both halves of the split are pinned by tests, so neither side
+> can move unnoticed.
+>
+> A top-up migration that reclassifies those rows was rejected. `20260722182812_DropLegacyHotkeyAction`
+> dropped `Action` and `Parameters`, so a later migration cannot tell a `Raw` row this migration
+> produced from a `Raw` row a user wrote on purpose with the same body. Matching on body text would
+> silently rewrite the second kind.

--- a/src/Backend/AHKFlowApp.Application/Constants/HotkeyKeys.cs
+++ b/src/Backend/AHKFlowApp.Application/Constants/HotkeyKeys.cs
@@ -118,6 +118,8 @@ internal static class HotkeyKeys
         ["PageUp"] = "PgUp",
         ["PageDown"] = "PgDn",
         ["Control"] = "Ctrl",
+        ["LControl"] = "LCtrl",
+        ["RControl"] = "RCtrl",
         ["Windows"] = "LWin",
         ["Win"] = "LWin",
     };
@@ -133,8 +135,9 @@ internal static class HotkeyKeys
     /// Accepted non-canonical spellings, keyed by alias (<c>Esc</c> → <c>Escape</c>), each
     /// mapped to the entry it resolves to. Exposed so the key picker can treat an aliased legacy
     /// value (<c>Esc</c>) as valid rather than demoting the row to the dialog with an error on a
-    /// key AutoHotkey accepts, and read by the Migration A name-list generator, which must accept
-    /// every spelling <see cref="TryCanonicalize"/> resolves — the migration itself never canonicalizes.
+    /// key AutoHotkey accepts. The Migration A name-list generator read this map once, when that
+    /// migration was written; the list it produced is frozen in the migration and cannot gain an
+    /// alias added later. See ADR 0004, "Adding a key spelling after Migration A".
     /// </summary>
     public static IReadOnlyDictionary<string, string> Aliases => s_aliases;
 

--- a/src/Backend/AHKFlowApp.Application/Services/LegacyHotkeyDefinitionConverter.cs
+++ b/src/Backend/AHKFlowApp.Application/Services/LegacyHotkeyDefinitionConverter.cs
@@ -9,7 +9,9 @@ namespace AHKFlowApp.Application.Services;
 /// free <c>Parameters</c>) into the
 /// typed W1 columns. The single C# home of the transform, shared by the write paths (expand phase)
 /// and history restore/revert. The EF data migration hand-writes the same logic in T-SQL; a
-/// Testcontainers parity test proves the two agree. Mirrors <c>ScriptToRawComposer</c>.
+/// Testcontainers parity test proves the two agree on every spelling that migration knew. Key
+/// spellings added to <c>HotkeyKeys</c> afterwards are the documented exception — see ADR 0004,
+/// "Adding a key spelling after Migration A". Mirrors <c>ScriptToRawComposer</c>.
 /// </summary>
 /// <remarks>
 /// Rules (spec §8): <c>Run</c> → <see cref="HotkeyActionKind.Run"/> with <c>RunTarget = Parameters</c>

--- a/tests/AHKFlowApp.API.Tests/Hotkeys/HotkeyKeysEndpointTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Hotkeys/HotkeyKeysEndpointTests.cs
@@ -24,6 +24,10 @@ public sealed class HotkeyKeysEndpointTests(ApiTestFixture fixture)
         catalog.Should().NotBeNull();
         catalog!.Keys.Should().NotBeEmpty();
         catalog.Aliases.Should().ContainKey("Esc").WhoseValue.Should().Be("Escape");
+        // The frontend key catalog canonicalizes from this dictionary, so a missing alias here is
+        // what makes a template line "*LControl::" miss a row on "LCtrl".
+        catalog.Aliases.Should().ContainKey("LControl").WhoseValue.Should().Be("LCtrl");
+        catalog.Aliases.Should().ContainKey("RControl").WhoseValue.Should().Be("RCtrl");
     }
 
     [Fact]

--- a/tests/AHKFlowApp.API.Tests/Hotkeys/HotkeysEndpointsTests.cs
+++ b/tests/AHKFlowApp.API.Tests/Hotkeys/HotkeysEndpointsTests.cs
@@ -793,4 +793,34 @@ public sealed class HotkeysEndpointsTests(ApiTestFixture fixture)
 
         second.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
+
+    // AutoHotkey spells each side-specific control key two ways. Both reach the boundary, and the
+    // row stores the canonical one. Driven over HTTP on purpose: the validator that rejects an
+    // unknown key runs in the ValidatingUseCase decorator, which a handler test never reaches.
+    [Theory]
+    [InlineData("LControl", "LCtrl")]
+    [InlineData("RControl", "RCtrl")]
+    public async Task PostThenPut_SideSpecificControlAlias_PersistsCanonicalSpelling(
+        string alias, string canonical)
+    {
+        using HttpClient client = CreateAuthed();
+
+        HttpResponseMessage created =
+            await client.PostAsJsonAsync("/api/v1/hotkeys", NewHotkey("Alias create", alias));
+
+        created.StatusCode.Should().Be(HttpStatusCode.Created);
+        HotkeyDto? body = await created.Content.ReadFromJsonAsync<HotkeyDto>();
+        body!.Key.Should().Be(canonical);
+
+        // The update path canonicalizes through the same map, so send the alias again and change
+        // one other field, making this a real update rather than a no-op.
+        HttpResponseMessage put = await client.PutAsJsonAsync(
+            $"/api/v1/hotkeys/{body.Id}", EditHotkey("Alias update", alias, ctrl: false));
+
+        put.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        HotkeyDto readBack = (await client.GetFromJsonAsync<HotkeyDto>($"/api/v1/hotkeys/{body.Id}"))!;
+        readBack.Key.Should().Be(canonical);
+        readBack.Description.Should().Be("Alias update");
+    }
 }

--- a/tests/AHKFlowApp.Application.Tests/Constants/HotkeyKeysTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Constants/HotkeyKeysTests.cs
@@ -27,6 +27,9 @@ public sealed class HotkeyKeysTests
     [InlineData("Del", "Delete")]
     [InlineData("Ins", "Insert")]
     [InlineData("BS", "Backspace")]
+    [InlineData("LControl", "LCtrl")]
+    [InlineData("RControl", "RCtrl")]
+    [InlineData("lcontrol", "LCtrl")]
     public void TryCanonicalize_Alias_ResolvesToCanonicalName(string alias, string expected)
     {
         bool ok = HotkeyKeys.TryCanonicalize(alias, out string canonical);

--- a/tests/AHKFlowApp.Application.Tests/Services/LegacyHotkeyDefinitionConverterTests.cs
+++ b/tests/AHKFlowApp.Application.Tests/Services/LegacyHotkeyDefinitionConverterTests.cs
@@ -1,4 +1,5 @@
 using AHKFlowApp.Application.Services;
+using AHKFlowApp.Domain.Enums;
 using AHKFlowApp.TestUtilities.Fixtures;
 using FluentAssertions;
 using Xunit;
@@ -28,5 +29,19 @@ public sealed class LegacyHotkeyDefinitionConverterTests
         foreach (LegacyHotkeyFixture f in LegacyHotkeyFixtures.All)
             data.Add(f);
         return data;
+    }
+
+    // The other half of the divergence ADR 0004 records. The live converter resolves LControl
+    // through the alias map, so a legacy history snapshot restores as SendKeys where the migrated
+    // row stays Raw. Both halves are pinned, so neither side can move unnoticed.
+    [Fact]
+    public void ToTyped_SpellingAddedAfterMigrationA_IsSendKeys()
+    {
+        LegacyHotkeyDefinitionConverter.TypedAction typed = LegacyHotkeyDefinitionConverter.ToTyped(
+            LegacyHotkeyDefinitionConverter.HotkeyAction.Send, "{LControl}");
+
+        typed.ActionKind.Should().Be(HotkeyActionKind.SendKeys);
+        typed.SendKeysContent.Should().Be("{LControl}");
+        typed.Body.Should().BeNull();
     }
 }

--- a/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
@@ -282,6 +282,34 @@ public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifet
         await page.WaitForSelectorAsync("text=Hotkey created.");
     }
 
+    // AutoHotkey spells one key two ways. The template says LControl, the row says LCtrl, and the
+    // warning has to see them as the same key. Both sides canonicalize through the key registry.
+    [Fact]
+    public async Task AHotkeyOnAKeyTheHeaderSpellsDifferently_IsWarnedAbout()
+    {
+        await using IBrowserContext context = await fixture.Browser.NewContextAsync();
+        IPage page = await context.NewPageAsync();
+
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/profiles");
+        await page.WaitForSelectorAsync("button.start-edit");
+        await page.ClickAsync("button.start-edit");
+        await page.WaitForSelectorAsync("textarea[data-test=\"profile-header-input\"]");
+        await page.FillAsync("textarea[data-test=\"profile-header-input\"]",
+            "#Requires AutoHotkey v2.0\n\n*LControl::\n{\n    Send \"{Blind}{LAlt DownR}\"\n}");
+        await page.ClickAsync("button.commit-edit");
+        await page.WaitForSelectorAsync("text=Profile updated.");
+
+        await OpenCreateDialogAsync(page);
+        await CommitKeyAsync(page, "LCtrl");
+        await page.CheckAsync(".hotkey-edit-dialog input[data-test=\"applies-to-all-checkbox\"]");
+
+        await page.WaitForSelectorAsync(".hotkey-edit-dialog [data-test=\"template-warning\"]");
+        string warning = await page.InnerTextAsync(".hotkey-edit-dialog [data-test=\"template-warning\"]");
+
+        Assert.Contains("also uses LCtrl", warning, StringComparison.Ordinal);
+        Assert.Contains("Your hotkey may not fire.", warning, StringComparison.Ordinal);
+    }
+
     // The table holds a row per use, over a hundred of them, and pages at 25. Every row this file
     // acts on is addressed through the search box, never by paging to it.
     private async Task OpenKnownShortcutsAsync(IPage page, string? search = null)

--- a/tests/AHKFlowApp.Infrastructure.Tests/Migrations/HotkeyTypedActionsMigrationTests.cs
+++ b/tests/AHKFlowApp.Infrastructure.Tests/Migrations/HotkeyTypedActionsMigrationTests.cs
@@ -1,4 +1,5 @@
 using AHKFlowApp.Application.Services;
+using AHKFlowApp.Domain.Enums;
 using AHKFlowApp.Infrastructure.Persistence;
 using AHKFlowApp.TestUtilities.Fixtures;
 using FluentAssertions;
@@ -19,10 +20,12 @@ namespace AHKFlowApp.Infrastructure.Tests.Migrations;
 public sealed class HotkeyTypedActionsMigrationTests(SqlContainerFixture sqlFixture)
 {
     private const string DbName = "HotkeyTypedActions_Parity";
+    private const string DivergenceDbName = "HotkeyTypedActions_Divergence";
 
-    private AppDbContext CreateContext()
+    // Each fact migrates from scratch, so each needs its own database.
+    private AppDbContext CreateContext(string dbName = DbName)
     {
-        SqlConnectionStringBuilder csb = new(sqlFixture.ConnectionString) { InitialCatalog = DbName };
+        SqlConnectionStringBuilder csb = new(sqlFixture.ConnectionString) { InitialCatalog = dbName };
 
         DbContextOptions<AppDbContext> options = new DbContextOptionsBuilder<AppDbContext>()
             .UseSqlServer(csb.ConnectionString, sql => sql.EnableRetryOnFailure())
@@ -84,5 +87,46 @@ public sealed class HotkeyTypedActionsMigrationTests(SqlContainerFixture sqlFixt
             row.RemapDest.Should().Be(expected.RemapDest, "fixture '{0}'", f.Name);
             row.Body.Should().Be(expected.Body, "fixture '{0}'", f.Name);
         }
+    }
+
+    // LControl was added to HotkeyKeys after this migration shipped, so its frozen name list does
+    // not hold it and LegacyHotkeyFixtures skips it. The parity test therefore never seeds this
+    // value. Pin what the migration actually does with it, so the divergence ADR 0004 records is a
+    // tested decision rather than an untested paragraph.
+    [Fact]
+    public async Task Migration_SpellingAddedAfterItShipped_StaysRaw()
+    {
+        var id = Guid.NewGuid();
+
+        await using (AppDbContext setup = CreateContext(DivergenceDbName))
+        {
+            IMigrator migrator = ((IInfrastructure<IServiceProvider>)setup).Instance.GetRequiredService<IMigrator>();
+            await migrator.MigrateAsync("AddHotstringDelivery");
+
+            // Legacy Action: Send = 0, Run = 1. Parameters is a SQL parameter, not embedded in the
+            // literal text — ExecuteSqlRawAsync treats the raw SQL as a composite format string, and
+            // a literal '{LControl}' in the text would be misread as a format placeholder.
+            await setup.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO Hotkeys
+                    (Id, OwnerOid, Description, [Key], Ctrl, Alt, Shift, Win,
+                     Action, Parameters, AppliesToAllProfiles, CreatedAt, UpdatedAt)
+                VALUES
+                    (@id, @owner, 'legacy LControl', 'a', 0, 0, 0, 0,
+                     0, @params, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET());
+                """,
+                new SqlParameter("@id", id),
+                new SqlParameter("@owner", Guid.NewGuid()),
+                new SqlParameter("@params", "{LControl}"));
+
+            await setup.Database.MigrateAsync();
+        }
+
+        await using AppDbContext verify = CreateContext(DivergenceDbName);
+        Domain.Entities.Hotkey row = await verify.Hotkeys.AsNoTracking().SingleAsync(h => h.Id == id);
+
+        row.ActionKind.Should().Be(HotkeyActionKind.Raw);
+        row.Body.Should().Be("""Send("{LControl}")""");
+        row.SendKeysContent.Should().BeNull();
     }
 }

--- a/tests/AHKFlowApp.TestUtilities/Fixtures/LegacyHotkeyFixtures.cs
+++ b/tests/AHKFlowApp.TestUtilities/Fixtures/LegacyHotkeyFixtures.cs
@@ -29,10 +29,41 @@ public sealed record LegacyHotkeyFixture(
 /// catalog's Reload / paste / date rows are now typed (<c>Raw</c>) and no longer feed this set, but
 /// real databases and snapshots still hold their legacy inputs (<c>run-not-a-path</c>,
 /// <c>send-ctrl-v</c>, <c>send-macro-leak</c>), so the cases stay to guard the transform regardless.
-/// Mirrors <c>ScriptToRawFixtures</c>.
+/// Mirrors <c>ScriptToRawFixtures</c>. The guard is not total: spellings named in
+/// <c>s_spellingsAddedAfterMigrationA</c> are left out, because the applied migration cannot learn
+/// a name. See that field's remarks.
 /// </summary>
 public static class LegacyHotkeyFixtures
 {
+    /// <summary>
+    /// Spellings <c>HotkeyKeys</c> accepts today that the frozen migration classifier never knew,
+    /// because they were added after <c>20260722105522_HotkeyTypedActions</c> shipped. No fixture is
+    /// generated for them. That migration's name list cannot gain a name after the fact: rows are
+    /// already back-filled with the classification it made.
+    /// <para>
+    /// This is an additions allow-list, not a snapshot of what the migration knew. The loops below
+    /// still read the live registry, so a spelling the migration knew that is later removed, or that
+    /// loses its <see cref="HotkeyKeyRoles.SendToken"/> role, silently loses its fixture too. Catching
+    /// that would need a pasted baseline list, which this set is not.
+    /// </para>
+    /// <para>
+    /// The accepted cost is a split, pinned by two tests:
+    /// <c>HotkeyTypedActionsMigrationTests.Migration_SpellingAddedAfterItShipped_StaysRaw</c> and
+    /// <c>LegacyHotkeyDefinitionConverterTests.ToTyped_SpellingAddedAfterMigrationA_IsSendKeys</c>.
+    /// See ADR 0004, "Adding a key spelling after Migration A".
+    /// </para>
+    /// <para>
+    /// A spelling that is not listed here still gets a fixture, so the parity test still fails
+    /// loudly for the next one. That failure is the signal to make this same decision again, not a
+    /// reason to edit the migration.
+    /// </para>
+    /// </summary>
+    private static readonly HashSet<string> s_spellingsAddedAfterMigrationA =
+        new(StringComparer.OrdinalIgnoreCase) { "LControl", "RControl" };
+
+    private static bool KnownToMigrationA(string spelling) =>
+        !s_spellingsAddedAfterMigrationA.Contains(spelling);
+
     public static IReadOnlyList<LegacyHotkeyFixture> All { get; } = Build();
 
     /// <summary>A lone C1 control character (U+0085), written as an escape so the source file
@@ -134,7 +165,8 @@ public static class LegacyHotkeyFixtures
             $"Send(\"{AhkEscaping.EscapeStringLiteral(parameters)}\")");
     }
 
-    // Every spelling the C# grammar accepts — not only `HotkeyKeys.All`. `IsValidSendKeysContent`
+    // Every spelling the C# grammar accepts, minus the ones named in
+    // s_spellingsAddedAfterMigrationA — not only `HotkeyKeys.All`. `IsValidSendKeysContent`
     // defers to `TryCanonicalize`, which also resolves aliases (Esc → Escape) and vk/sc codes, and
     // its bare branch takes any single printable character. The migration's frozen SQL classifier
     // must mirror all of that: a spelling accepted by one side and not the other silently splits
@@ -143,7 +175,8 @@ public static class LegacyHotkeyFixtures
     {
         // Braced registry names, bare and modified. Not filtered on RequiresBracesInSend: `{a}` is
         // braced-legal too, and the SQL name list must therefore carry the letters and digits.
-        foreach (HotkeyKeyEntry e in HotkeyKeys.All.Where(e => e.Roles.HasFlag(HotkeyKeyRoles.SendToken)))
+        foreach (HotkeyKeyEntry e in HotkeyKeys.All.Where(e =>
+                     e.Roles.HasFlag(HotkeyKeyRoles.SendToken) && KnownToMigrationA(e.Canonical)))
         {
             yield return SendKeysCase($"{{{e.Canonical}}}");
             yield return SendKeysCase($"^{{{e.Canonical}}}");
@@ -151,7 +184,9 @@ public static class LegacyHotkeyFixtures
 
         // The unbraced half of the same entries — the C# bare-character branch.
         foreach (HotkeyKeyEntry e in HotkeyKeys.All.Where(e =>
-                     e.Roles.HasFlag(HotkeyKeyRoles.SendToken) && !e.RequiresBracesInSend))
+                     e.Roles.HasFlag(HotkeyKeyRoles.SendToken)
+                     && !e.RequiresBracesInSend
+                     && KnownToMigrationA(e.Canonical)))
         {
             yield return SendKeysCase(e.Canonical);
         }
@@ -159,7 +194,8 @@ public static class LegacyHotkeyFixtures
         // Alias spellings resolve to a canonical entry, so {Esc} is SendKeys — the SQL list must
         // hold the alias itself, since the migration never canonicalizes.
         foreach (string alias in HotkeyKeys.Aliases
-                     .Where(kv => HotkeyKeys.HotkeyKeyEntryByCanonical(kv.Value).Roles.HasFlag(HotkeyKeyRoles.SendToken))
+                     .Where(kv => HotkeyKeys.HotkeyKeyEntryByCanonical(kv.Value).Roles.HasFlag(HotkeyKeyRoles.SendToken)
+                                  && KnownToMigrationA(kv.Key))
                      .Select(kv => kv.Key))
         {
             yield return SendKeysCase($"{{{alias}}}");


### PR DESCRIPTION
## Summary

- `LControl` and `RControl` now canonicalize to `LCtrl` and `RCtrl` (backlog 059)
- Both spellings accepted at create/update boundaries; template warnings match across spellings
- Migration A's frozen name list can't gain the new spellings after the fact, so `LegacyHotkeyFixtures` gains an additions allow-list, and the resulting Raw/SendKeys divergence is pinned by tests on both sides — recorded in ADR 0004

## Test plan

- [x] `HotkeyKeysTests.TryCanonicalize_Alias_ResolvesToCanonicalName` — new alias rows
- [x] `HotkeyKeysEndpointTests.GetKeys_ReturnsRegistryWithRolesAndAliases` — aliases over the wire
- [x] `HotkeysEndpointsTests.PostThenPut_SideSpecificControlAlias_PersistsCanonicalSpelling` — real write boundary
- [x] `HotkeyTypedActionsMigrationTests.Migration_SpellingAddedAfterItShipped_StaysRaw` — migration half of the divergence
- [x] `LegacyHotkeyDefinitionConverterTests.ToTyped_SpellingAddedAfterMigrationA_IsSendKeys` — converter half
- [x] `ShortcutWarningFlowTests.AHotkeyOnAKeyTheHeaderSpellsDifferently_IsWarnedAbout` — E2E template warning
- [x] Canonical pre-PR gate: build, format, coverage (all thresholds met), `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)