### PR TITLE
docs: answer 058 precedence question, file 065 for the gap it exposed

### DIFF
--- a/backlog/058-native-edit-refusal-names-missing-worktree-copy.md
+++ b/backlog/058-native-edit-refusal-names-missing-worktree-copy.md
@@ -45,7 +45,7 @@ check runs before the hook" in an upstream report without instrumenting it — `
 which hooks actually executed (https://code.claude.com/docs/en/hooks).
 
 Full method and evidence:
-[`docs/superpowers/specs/2026-08-07-worktree-edit-isolation-precedence-design.md`](../docs/superpowers/specs/2026-08-07-worktree-edit-isolation-precedence-design.md).
+`docs/superpowers/specs/2026-08-07-worktree-edit-isolation-precedence-design.md`.
 
 Two runs settled it. Both asked a fresh session to make the same `Edit` on a main-checkout path,
 with the same `PreToolUse` deny hook on `Edit|Write` supplied through `--settings`.

--- a/backlog/058-native-edit-refusal-names-missing-worktree-copy.md
+++ b/backlog/058-native-edit-refusal-names-missing-worktree-copy.md
@@ -33,25 +33,48 @@ before an item moves to `backlog/done/`.
 This item is also Claude-only. Codex and Copilot have no equivalent isolation, so they never show
 this message.
 
-## First step: is it fixable here at all?
+## First step: is it fixable here at all? Answered — no
 
-This is a real question, not a foregone conclusion. Answer it before designing anything.
+Probed on 2026-08-07, against Claude Code 2.1.224. **The harness refusal takes precedence, so no
+hook can replace its message.**
 
-A `PreToolUse` hook matching `Edit|Write` can return a deny decision with its own message. If that
-hook fires **before** the harness's own isolation check, this repository can emit a correct message
-and the item is fixable locally. If the harness checks first, its message wins and no hook can
-replace it.
+The probe measured which refusal reaches the agent, not the harness's internal execution order.
+That is enough to close this item either way: whatever runs first inside the harness, a hook that
+denies with its own message cannot get that message shown. Do not restate this as "the harness
+check runs before the hook" in an upstream report without instrumenting it — `--debug-file` records
+which hooks actually executed (https://code.claude.com/docs/en/hooks).
 
-Probe: register a temporary `PreToolUse` hook on `Edit|Write` that denies with a recognizable
-string, then attempt an `Edit` on a main-checkout path from a worktree session. Whichever message
-appears answers the question.
+Full method and evidence:
+[`docs/superpowers/specs/2026-08-07-worktree-edit-isolation-precedence-design.md`](../docs/superpowers/specs/2026-08-07-worktree-edit-isolation-precedence-design.md).
+
+Two runs settled it. Both asked a fresh session to make the same `Edit` on a main-checkout path,
+with the same `PreToolUse` deny hook on `Edit|Write` supplied through `--settings`.
+
+Control, without `-w`. The hook denied the edit, which proves the hook loaded and works:
+
+> PreToolUse:Edit hook error: PROBE-C-HOOK-DENY: this refusal came from a repo PreToolUse hook, not
+> the harness.
+
+Test, with `-w`. The same hook produced nothing. The harness answered instead:
+
+> This session is isolated in the worktree
+> C:\Dev\segocom-github\AHKFlowApp\.claude\worktrees\probe058c. Edit the worktree copy of this file
+> instead of the shared-checkout path.
+
+A second finding came out of the same probes, and it is filed separately as
+`backlog/065-native-edit-isolation-misses-worktree-sessions-without-w-flag.md`. The harness check is
+driven by a session flag, not by the working directory. It fires for `-w`, `--worktree`, and
+`EnterWorktree` sessions only. A session that merely has a worktree as its working directory gets no
+check at all, and there a `PreToolUse` hook does win.
 
 ## Acceptance criteria
 
-- [ ] The hook-versus-harness precedence question above is answered, with the observed message
+- [x] The hook-versus-harness precedence question above is answered, with the observed message
       recorded
-- [ ] If a hook can win: a refusal message that names the real reason and a real next step, and that
+- [x] If a hook can win: a refusal message that names the real reason and a real next step, and that
       never tells the agent to edit a worktree copy which cannot exist for `docs/superpowers`
+      — **not applicable.** The probe showed a hook cannot win for the sessions this item covers.
+      The case where a hook *can* win is backlog 065, not this item.
 - [ ] If a hook cannot win: an upstream report filed with Anthropic, linked from this item, and the
       limitation recorded in `docs/agents/cross-agent-git-guardrails.md`
 
@@ -66,3 +89,8 @@ appears answers the question.
 - Depends on 054 only for context, not for code. They can land in either order.
 - Design for 054: `docs/superpowers/specs/2026-08-06-worktree-guard-bash-writes-design.md`, section
   "Backlog scope"
+- Probe method and evidence:
+  `docs/superpowers/specs/2026-08-07-worktree-edit-isolation-precedence-design.md`
+- The probe also exposed a gap that **is** fixable here. Filed as
+  `backlog/065-native-edit-isolation-misses-worktree-sessions-without-w-flag.md`. Both items share
+  the one probe, so nothing needs re-running.

--- a/backlog/065-native-edit-isolation-misses-worktree-sessions-without-w-flag.md
+++ b/backlog/065-native-edit-isolation-misses-worktree-sessions-without-w-flag.md
@@ -1,0 +1,138 @@
+# 065 - Native Edit isolation misses worktree sessions started without `-w`
+
+## Metadata
+
+- **Epic**: Agent tooling
+- **Type**: Bug
+- **Interfaces**: UI | API | CLI (none — agent tooling only)
+
+## Summary
+
+Claude Code's native `Edit`/`Write` isolation and this repository's own Bash write guard disagree
+about what counts as "a session inside a worktree".
+
+| Guard | Decides from | Covers |
+|---|---|---|
+| Claude Code native isolation | a session flag set by `-w` / `--worktree` / `EnterWorktree` | `Edit`, `Write` |
+| Repository guard (backlog 054) | the `cwd` in the hook payload | `Bash` writes |
+
+A Claude session started **directly inside a worktree directory**, without `-w` and without
+`EnterWorktree`, never gets the native isolation flag. It can therefore `Edit` and `Write` files in
+the human-owned main checkout. The repository guard still blocks that session's Bash writes,
+because it reads `cwd`. So the two halves of the protection disagree, and `Edit` is the open half.
+
+## Evidence
+
+Observed on Claude Code 2.1.224, 2026-08-07, both runs launched from the main checkout.
+
+**Probe A — no `-w`, cwd is a worktree.** The edit succeeded.
+
+```bash
+cd "C:/Dev/segocom-github/AHKFlowApp/.claude/worktrees/058-native-edit-refusal"
+printf '%s' "Use the Edit tool ONCE to change 'probe target' to 'PROBE-A-EDITED' in C:\Dev\segocom-github\AHKFlowApp\probe-058-main.txt ..." \
+  | claude -p --permission-mode acceptEdits --add-dir "C:/Dev/segocom-github/AHKFlowApp" --allowed-tools Edit Read
+```
+
+Result:
+
+> The file C:\Dev\segocom-github\AHKFlowApp\probe-058-main.txt has been updated successfully.
+
+Reading the file back from the main checkout confirmed the new content, `PROBE-A-EDITED`.
+
+**Probe A2 — the same case with no `--add-dir` at all.** Probe A granted the main checkout
+explicitly, so on its own it could not tell whether that grant was what made the write possible.
+The official recipe for working in a worktree by hand does not pass the flag
+(https://code.claude.com/docs/en/worktrees), so the untested case was the one that matters. It was
+run separately, with `Write` rather than `Edit` so the target did not have to exist first:
+
+```bash
+cd "C:/Dev/segocom-github/AHKFlowApp/.claude/worktrees/058-native-edit-refusal"
+printf '%s' "Use the Write tool ONCE to create the file C:\Dev\segocom-github\AHKFlowApp\probe-063-writetest.log ..." \
+  | claude -p --permission-mode acceptEdits --allowed-tools Write Read
+```
+
+Result:
+
+> File created successfully at: C:\Dev\segocom-github\AHKFlowApp\probe-063-writetest.log
+
+The target was a `*.log` path, ignored by `.gitignore:110`, so the write left the main checkout's
+git status clean. A matching `Read` of `C:\Dev\segocom-github\AHKFlowApp\.git\HEAD` — a path that
+cannot exist inside a linked worktree — returned `ref: refs/heads/main`, which confirms the main
+checkout is inside the session's allowed directories with no grant.
+
+So `--add-dir` is not what opens the hole. The defect stands without it.
+
+**Probe B — same edit, same target, with `-w`.** The edit was refused.
+
+> This session is isolated in the worktree
+> C:\Dev\segocom-github\AHKFlowApp\.claude\worktrees\probe058b. Edit the worktree copy of this
+> file instead of the shared-checkout path.
+
+**Probe A again, but through Bash.** With the shell `cwd` inside the worktree, the repository guard
+denied the same write:
+
+> [agent-guard:Claude] deny [agent-worktree-main-write]
+> BLOCKED: this session is isolated in a worktree, so it cannot write into the main checkout at
+> C:\Dev\segocom-github\AHKFlowApp\probe-058-main.txt
+
+Same session, same target path, opposite outcomes depending on which tool made the write.
+
+## Why this is its own item
+
+Found while probing `backlog/058-native-edit-refusal-names-missing-worktree-copy.md`. 058 is about
+the **wording** of a refusal that does fire. This item is about a case where **no refusal fires at
+all**. Different defect, different fix, and 058 stays closable on its own scope.
+
+`docs/agents/cross-agent-git-guardrails.md` used to record that `Edit` and `Write` are "not covered
+by this repository at all — Claude Code's own worktree isolation covers them for Claude sessions".
+That sentence was true only for `-w` and `EnterWorktree` sessions. It was corrected when this item
+was filed, so the documentation already describes the gap. The gap itself is still open.
+
+## Blocking question: answered — a hook can win here
+
+Can a repository `PreToolUse` hook on `Edit|Write` deny the write? Answered on 2026-08-07, while
+probing 058. **Yes, for the sessions this item covers.**
+
+A `PreToolUse` hook on `Edit|Write` that denies with its own message was supplied to a session
+through `--settings`. Without `-w`, that hook denied the `Edit`:
+
+> PreToolUse:Edit hook error: PROBE-C-HOOK-DENY: this refusal came from a repo PreToolUse hook, not
+> the harness.
+
+The same hook produced nothing once `-w` was added, because the harness refusal takes precedence
+there. That half is 058, and it is not fixable in this repository. This item is the half a hook can
+close, because no harness check applies to it at all.
+
+Method and full output:
+`docs/superpowers/specs/2026-08-07-worktree-edit-isolation-precedence-design.md`.
+
+So this item is designable now. It needs a plan before implementation, because it changes the guard.
+
+## Acceptance criteria
+
+- [x] The precedence question above is answered, with the observed message recorded (shared with
+      058 — answering it once serves both)
+- [x] `docs/agents/cross-agent-git-guardrails.md` corrected — the claim that native isolation covers
+      `Edit`/`Write` for Claude sessions holds only for `-w` and `EnterWorktree` sessions
+- [ ] A session started inside a worktree without `-w` cannot `Edit` or `Write` into the main
+      checkout, and the refusal names the real reason and a real next step
+- [ ] The `docs/superpowers` case reuses the wording already shipped at
+      `scripts/agents/agent-worktree-guard.common.ps1:1647`, which never tells the agent to look for
+      a worktree copy
+- [ ] A test covers the gap, in the style of the existing cases in `tests/AgentWorktreeGuard.Tests.ps1`
+
+## Out of scope
+
+- The refusal wording for the case that already fires. That is 058.
+- The Bash write hole. That is 054, already merged.
+- Codex and Copilot. Neither has native worktree isolation, so neither has this gap.
+
+## Notes / dependencies
+
+- Shared its blocking question with 058. Answered once, for both, on 2026-08-07.
+- Probe method and full output:
+  `docs/superpowers/specs/2026-08-07-worktree-edit-isolation-precedence-design.md`
+- Backlog 054 design: `docs/superpowers/specs/2026-08-06-worktree-guard-bash-writes-design.md`
+- 054 already guards Bash writes from a worktree using the hook payload `cwd`. The fix here is the
+  same rule applied to `Edit` and `Write`, so it should reuse 054's path resolution rather than
+  grow a second copy.

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -306,8 +306,12 @@ An agent running the same command would need a prompt or override.
 - Shell **writes** into main are guarded, in one direction only: a session whose working directory
   is a managed worktree cannot write, move, or delete a path resolving under the main checkout. A
   main-checkout session is unaffected and may still edit, build, test, and format there. `Edit` and
-  `Write` tool calls are not covered by this repository at all — Claude Code's own worktree
-  isolation covers them for Claude sessions, and Codex and Copilot have no equivalent.
+  `Write` tool calls are not covered by this repository at all. Claude Code's own worktree isolation
+  covers them, but only for a session started with `-w`, `--worktree`, or the `EnterWorktree` tool.
+  That check reads a session flag, not the working directory. A Claude session that merely has a
+  worktree as its working directory gets no check, so it can `Edit` and `Write` into main freely.
+  Codex and Copilot have no equivalent isolation at all. Tracked in
+  `backlog/065-native-edit-isolation-misses-worktree-sessions-without-w-flag.md`.
 - The write scan reads a denylist of write commands, not an allowlist of safe ones. A writer
   outside that list — `del`, `python -c`, a compiled tool — is not detected. Same trade-off the
   Git mutation rule already makes.
@@ -316,7 +320,12 @@ An agent running the same command would need a prompt or override.
 - Claude Code's own `Edit`/`Write` refusal tells the agent to edit "the worktree copy of this
   file". For `docs/superpowers` no worktree copy can exist, because `.gitignore` excludes the path
   and `scripts/worktree-plans.common.ps1` links it in instead. That text belongs to the harness and
-  cannot be changed here. Tracked in `backlog/058-native-edit-refusal-names-missing-worktree-copy.md`.
+  cannot be changed here. This was measured, not assumed: a `PreToolUse` hook on `Edit|Write` that
+  denies with its own message is silenced in a `-w` session — the harness refusal takes precedence.
+  The same hook denies normally once `-w` is dropped, which proves it was loaded. What was measured
+  is which refusal reaches the agent, not the harness's internal execution order. Method and output:
+  `docs/superpowers/specs/2026-08-07-worktree-edit-isolation-precedence-design.md`. Tracked in
+  `backlog/058-native-edit-refusal-names-missing-worktree-copy.md`.
 
 ## Version-skew and authoritative main
 


### PR DESCRIPTION
Answers the blocking question in backlog 058, corrects a wrong claim in the guardrails doc, and files the gap the probe exposed.

## The question 058 asked

058 refused to design anything until one question was settled: can a repository `PreToolUse` hook on `Edit|Write` deny a write into the main checkout and show its own message, or does Claude Code's built-in worktree isolation answer first?

**Answered: the harness refusal takes precedence.** 058 is not fixable in this repository.

Two runs settled it. Both asked a fresh session to make the same `Edit` on a main-checkout path, with the same deny hook supplied through `--settings`.

Without `-w`, the hook denied the edit, which proves the hook loaded:

> PreToolUse:Edit hook error: PROBE-C-HOOK-DENY: this refusal came from a repo PreToolUse hook, not the harness.

With `-w`, the same hook produced nothing:

> This session is isolated in the worktree C:\Dev\segocom-github\AHKFlowApp\.claude\worktrees\probe058c. Edit the worktree copy of this file instead of the shared-checkout path.

What was measured is which refusal reaches the agent, not the harness's internal execution order. That distinction is recorded so nobody repeats it as a claim about ordering in an upstream report without instrumenting it first.

## The doc was wrong, and that is the part worth merging now

`docs/agents/cross-agent-git-guardrails.md` said `Edit` and `Write` are "not covered by this repository at all — Claude Code's own worktree isolation covers them for Claude sessions".

That holds only for sessions started with `-w`, `--worktree`, or `EnterWorktree`. The check reads a session flag, not the working directory. A session launched directly inside a worktree directory gets no check and can write into the human-owned main checkout. Confirmed with no `--add-dir` grant at all:

> File created successfully at: C:\Dev\segocom-github\AHKFlowApp\probe-063-writetest.log

A `Read` of `C:\Dev\segocom-github\AHKFlowApp\.git\HEAD` — a path that cannot exist inside a linked worktree — returned `ref: refs/heads/main`, confirming main is in scope unaided.

## Changes

- `backlog/058-...md` — question answered, evidence recorded, two boxes ticked
- `backlog/065-native-edit-isolation-misses-worktree-sessions-without-w-flag.md` — new item for the gap above. A hook **can** close this one, because no harness check applies to it
- `docs/agents/cross-agent-git-guardrails.md` — the claim corrected, plus the accepted limitation recorded

Numbered 065, not 063: `fix/wt-061-backlog-number-collisions` renumbers two existing collisions into `backlog/done/063-*` and `backlog/done/064-*` and adds a duplicate-key check at `scripts/backlog.common.ps1:60`.

## What stays open

058 keeps one unticked box — the upstream report to Anthropic — so it stays out of `backlog/done/`. The report is drafted but deliberately not filed yet. The guardrails correction should not wait for it.

Probe method and full output: `docs/superpowers/specs/2026-08-07-worktree-edit-isolation-precedence-design.md` (private plans repo).

## Verification

Docs-only branch — three `.md` files, no compiled sources. CI skips build, test and coverage for such a PR, so the local gate is the only gate. Ran it in full anyway:

- `dotnet build AHKFlowApp.slnx --configuration Release` — succeeded, 0 warnings, 0 errors
- `dotnet format AHKFlowApp.slnx --verify-no-changes` — clean
- `pwsh .\scripts\test-fast.ps1 -Mode Coverage` — all per-assembly thresholds met, 94.6% line / 82.7% branch
- `git diff --check main...HEAD` — clean

All probe artifacts removed: the `probe058b` and `probe058c` worktrees and branches, and every throwaway target file. Neither settings file was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
