### PR TITLE
fix: show hover text on disabled shortcut action buttons

### DIFF
--- a/backlog/done/053-title-tooltip-dead-on-disabled-action-buttons.md
+++ b/backlog/done/053-title-tooltip-dead-on-disabled-action-buttons.md
@@ -27,15 +27,25 @@ name.
 
 ## Acceptance criteria
 
-- [ ] Hovering a disabled known-shortcut action button shows its short text
-- [ ] The fix wraps the button rather than styling the disabled state. `LoginDisplay.razor:17-19`
+- [x] Hovering a disabled known-shortcut action button shows its short text
+- [x] The fix wraps the button rather than styling the disabled state. `LoginDisplay.razor:17-19`
       is the pattern already in the repo — a disabled `MudButton` inside a `MudTooltip`. The
       tooltip root is a plain div, it is not disabled, so it receives the hover
-- [ ] The `aria-label` at `:53` keeps naming the use in full, so the desktop table and the mobile
+- [x] The `aria-label` at `:53` keeps naming the use in full, so the desktop table and the mobile
       list can still tell the Chrome row from the Edge row on the same combination
-- [ ] A bUnit test renders the component with `Busy="true"` and asserts the wrapper is present and
+- [x] A bUnit test renders the component with `Busy="true"` and asserts the wrapper is present and
       carries the text. Assert on markup that is always rendered, not on `MudTooltip Text` — that
       text only reaches the DOM once a `MudPopoverProvider` is rendered and the popover opens
+
+      Done as written: the wrapper is found by `data-test="use-action-tooltip"`, and the text is
+      read out of the popover after a real `PointerEnter`, not off `MudTooltip.Text`. The bUnit
+      test renders `MudPopoverProvider` first, because the popover text renders into that tree.
+      An E2E flow test repeats the same hover in a real browser while a write is held open.
+      The E2E test needed one more step: a preceding click leaves the pointer inside the tooltip
+      root, so `HoverAsync` alone would move to a point the pointer already occupies and fire no
+      `pointerenter`. The test parks the pointer with `Mouse.MoveAsync(0, 0)` first, then hovers,
+      and asserts on `.mud-popover-open.use-action-tooltip-text` because MudBlazor keeps every
+      matching popover mounted and the search text matches more than one row.
 
 ## Out of scope
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md
@@ -16,6 +16,7 @@ Blazor WebAssembly PWA frontend for AHKFlowApp.
 - No `StateHasChanged()` after standard event handlers — Blazor re-renders automatically
 - For list pages that need mobile support: render both branches as plain `.desktop-branch` and `.mobile-branch` containers, then gate visibility in the page's scoped `.razor.css` at `959.95px`. Desktop uses `MudDataGrid`; mobile uses a compact list component, full-screen `MudDialog`, and `MudFab`. See `Components/Hotstrings/` and `Components/Hotkeys/` for examples.
 - Reuse shared selection/chip components in `Components/Common/` — `EntityMultiSelect` (multi-select over an `EntityOption` list), `EntityChips` (read-only id→name chips; its `AppliesToAllProfiles` parameter renders a single "All profiles" chip), `CategoryFilterChips` (category filter chipset). Don't hand-roll `MudSelect`/`MudChip` blocks for profiles/categories.
+- Never put hover text in a `title` attribute on a control that can be disabled. MudBlazor sets `pointer-events: none` on a disabled control, so the browser never fires the hover and the text never appears. Wrap the control in a `MudTooltip` instead. The tooltip root is a plain `<div>` that is never disabled, so it still receives the hover. Keep `aria-label` and any `data-*` hooks on the control itself — a `<div>` has no role, so a screen reader ignores a label on the wrapper. Examples: `Components/KnownShortcuts/KnownShortcutUseActions.razor`, `Pages/Profiles.razor` (blocked download button).
 
 ## MudBlazor API Verification
 

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/KnownShortcuts/KnownShortcutUseActions.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/KnownShortcuts/KnownShortcutUseActions.razor
@@ -6,26 +6,36 @@
 
    The bell shows the state of the row, matching its chip: crossed out on a silenced use, ringing
    on one that still warns. It used to show the action instead, which put a ringing bell next to
-   the word "Silenced". The tooltip carries what the click does.
+   the word "Silenced". The tooltip carries what the click does. It wraps the button rather than sitting on it, so the
+   text still appears while the button is disabled.
 
    Lives in its own component so the desktop table and the mobile list cannot drift apart. *@
 @if (Row.Use.Origin == ShortcutRecordOrigin.Owner)
 {
-    <MudIconButton Class="delete-use" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
-                   OnClick="() => OnDelete.InvokeAsync(Row)" Disabled="@Busy"
-                   UserAttributes="@Attributes("Delete this record", $"Delete the record that {Row.Use.UsedBy} uses {Row.ComboLabel}")" />
+    <MudTooltip Text="Delete this record" Class="use-action-tooltip-text"
+                UserAttributes="@TooltipAttributes()">
+        <MudIconButton Class="delete-use" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
+                       OnClick="() => OnDelete.InvokeAsync(Row)" Disabled="@Busy"
+                       UserAttributes="@Attributes($"Delete the record that {Row.Use.UsedBy} uses {Row.ComboLabel}")" />
+    </MudTooltip>
 }
 else if (Row.Use.IsIgnored)
 {
-    <MudIconButton Class="restore-use" Icon="@Icons.Material.Filled.NotificationsOff"
-                   OnClick="() => OnRestore.InvokeAsync(Row)" Disabled="@Busy"
-                   UserAttributes="@Attributes("Warn about this again", $"Warn again that {Row.Use.UsedBy} uses {Row.ComboLabel}")" />
+    <MudTooltip Text="Warn about this again" Class="use-action-tooltip-text"
+                UserAttributes="@TooltipAttributes()">
+        <MudIconButton Class="restore-use" Icon="@Icons.Material.Filled.NotificationsOff"
+                       OnClick="() => OnRestore.InvokeAsync(Row)" Disabled="@Busy"
+                       UserAttributes="@Attributes($"Warn again that {Row.Use.UsedBy} uses {Row.ComboLabel}")" />
+    </MudTooltip>
 }
 else
 {
-    <MudIconButton Class="ignore-use" Icon="@Icons.Material.Filled.NotificationsActive"
-                   OnClick="() => OnIgnore.InvokeAsync(Row)" Disabled="@Busy"
-                   UserAttributes="@Attributes("Stop warning about this", $"Stop warning that {Row.Use.UsedBy} uses {Row.ComboLabel}")" />
+    <MudTooltip Text="Stop warning about this" Class="use-action-tooltip-text"
+                UserAttributes="@TooltipAttributes()">
+        <MudIconButton Class="ignore-use" Icon="@Icons.Material.Filled.NotificationsActive"
+                       OnClick="() => OnIgnore.InvokeAsync(Row)" Disabled="@Busy"
+                       UserAttributes="@Attributes($"Stop warning that {Row.Use.UsedBy} uses {Row.ComboLabel}")" />
+    </MudTooltip>
 }
 
 @code {
@@ -41,15 +51,26 @@ else
     // The button carries the pair that names its use, so a selector can tell the Chrome row from
     // the Edge row on the same combination.
     //
-    // Both text attributes ride along as plain attributes: MudIconButton has no Title and no
-    // AriaLabel parameter, so they reach the rendered button through MudComponentBase's
-    // UserAttributes. The title is the short hover tooltip. The aria-label names the use in full,
-    // because the button shows an icon and no text, so "this" would be all a screen reader heard.
-    private Dictionary<string, object?> Attributes(string title, string ariaLabel) => new()
+    // The label rides along as a plain attribute: MudIconButton has no AriaLabel parameter, so it
+    // reaches the rendered button through MudComponentBase's UserAttributes. It names the use in
+    // full, because the button shows an icon and no text, so "this" would be all a screen reader
+    // heard.
+    private Dictionary<string, object?> Attributes(string ariaLabel) => new()
     {
         ["data-shortcut-id"] = Row.ShortcutId,
         ["data-used-by"] = Row.Use.UsedBy,
-        ["title"] = title,
         ["aria-label"] = ariaLabel,
+    };
+
+    // The short hover text sits on the MudTooltip, not on the button. MudBlazor sets
+    // pointer-events: none on a disabled button, so a title on the button itself would never fire
+    // while Busy is true. The tooltip root is a plain div, it is never disabled, and it still
+    // receives the hover. Same reason as Profiles.razor's blocked download button.
+    //
+    // The label cannot move here with it: a div has no role, so a screen reader ignores a label on
+    // the wrapper.
+    private static Dictionary<string, object?> TooltipAttributes() => new()
+    {
+        ["data-test"] = "use-action-tooltip",
     };
 }

--- a/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
@@ -162,6 +162,57 @@ public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifet
         await page.WaitForSelectorAsync(".hotkey-edit-dialog [data-test=\"shortcut-warning\"]");
     }
 
+    // The wrapper that holds the Windows use of Win+E. :has() picks the tooltip root by the button
+    // inside it, because the identifying pair lives on the button, not on the wrapper.
+    private const string WindowsFileExplorerWrapper =
+        ".desktop-branch [data-test=\"use-action-tooltip\"]:has(button.ignore-use" +
+        "[data-shortcut-id=\"windows.file-explorer\"][data-used-by=\"Windows\"])";
+
+    [Fact]
+    public async Task WhileAWriteIsInFlight_HoveringADisabledAction_StillShowsItsText()
+    {
+        await using IBrowserContext context = await fixture.Browser.NewContextAsync();
+        IPage page = await context.NewPageAsync();
+
+        // Hold the write open, so the button is really disabled while the hover happens. The
+        // handler waits on the source below instead of on a fixed delay, so the test never races.
+        TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        await context.RouteAsync("**/api/v1/knownshortcuts/ignore", async route =>
+        {
+            await release.Task;
+            await route.ContinueAsync();
+        });
+
+        await OpenKnownShortcutsAsync(page, "Win+E");
+        await page.ClickAsync(string.Format(WindowsFileExplorerUse, ".ignore-use"));
+
+        // MudBlazor sets pointer-events: none on a disabled button, so a title on the button would
+        // be dead right here. The tooltip root still takes the hover.
+        await Assertions.Expect(page.Locator(string.Format(WindowsFileExplorerUse, ".ignore-use")))
+            .ToBeDisabledAsync();
+
+        // The click left the pointer inside this same tooltip root, and MudTooltip closes on click.
+        // A tooltip opens on pointerenter, which only fires when the pointer crosses into the root
+        // from outside. Hovering a point the pointer is already on fires nothing, so the tooltip
+        // would stay shut forever. Park the pointer off the wrapper first, so the hover below is a
+        // real entry.
+        await page.Mouse.MoveAsync(0, 0);
+        await page.HoverAsync(WindowsFileExplorerWrapper);
+
+        // "Win+E" filters to more than one row, so more than one tooltip popover exists in the DOM
+        // at once, all sharing the .use-action-tooltip-text class from Task 1 — MudBlazor keeps
+        // every one mounted, off-screen, until it opens (MudBlazor.min.css, MudPopover 9.3.0:
+        // .mud-popover{opacity:0;top:-9999px;left:-9999px}). mud-popover-open is the class
+        // MudBlazor adds to the one actually shown (MudPopover.razor.cs PopoverClass,
+        // .AddClass($"mud-popover-open", Open)), so it picks out this hover's popover specifically.
+        await Assertions.Expect(page.Locator(".mud-popover-open.use-action-tooltip-text"))
+            .ToContainTextAsync("Stop warning about this");
+
+        // Let the write finish, so the test leaves the page in a settled state.
+        release.SetResult();
+        await page.WaitForSelectorAsync(string.Format(WindowsFileExplorerUse, ".restore-use"));
+    }
+
     [Fact]
     public async Task AnOwnerRecord_WarnsOnItsOwnCombination()
     {

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/KnownShortcuts/KnownShortcutMobileListTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/KnownShortcuts/KnownShortcutMobileListTests.cs
@@ -2,6 +2,7 @@ using AHKFlowApp.UI.Blazor.Components.KnownShortcuts;
 using AHKFlowApp.UI.Blazor.DTOs;
 using Bunit;
 using FluentAssertions;
+using MudBlazor;
 using MudBlazor.Services;
 using Xunit;
 
@@ -15,7 +16,11 @@ public sealed class KnownShortcutMobileListTests : BunitContext, IAsyncLifetime
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
 
-    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    Task IAsyncLifetime.InitializeAsync()
+    {
+        Render<MudPopoverProvider>();
+        return Task.CompletedTask;
+    }
 
     async Task IAsyncLifetime.DisposeAsync() => await DisposeAsync();
 

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/KnownShortcuts/KnownShortcutUseActionsTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/KnownShortcuts/KnownShortcutUseActionsTests.cs
@@ -1,7 +1,10 @@
 using AHKFlowApp.UI.Blazor.Components.KnownShortcuts;
 using AHKFlowApp.UI.Blazor.DTOs;
+using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor;
 using MudBlazor.Services;
 using Xunit;
 
@@ -9,13 +12,19 @@ namespace AHKFlowApp.UI.Blazor.Tests.Components.KnownShortcuts;
 
 public sealed class KnownShortcutUseActionsTests : BunitContext, IAsyncLifetime
 {
+    private IRenderedComponent<MudPopoverProvider>? _popovers;
+
     public KnownShortcutUseActionsTests()
     {
         Services.AddMudServices();
         JSInterop.Mode = JSRuntimeMode.Loose;
     }
 
-    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    Task IAsyncLifetime.InitializeAsync()
+    {
+        _popovers = Render<MudPopoverProvider>();
+        return Task.CompletedTask;
+    }
 
     async Task IAsyncLifetime.DisposeAsync() => await DisposeAsync();
 
@@ -66,13 +75,29 @@ public sealed class KnownShortcutUseActionsTests : BunitContext, IAsyncLifetime
         cut.Find($"button.{cssClass}").GetAttribute("aria-label").Should().Be(expectedLabel);
     }
 
-    [Fact]
-    public void TheButton_KeepsAShortHoverTooltip()
+    [Theory]
+    // MudBlazor sets pointer-events: none on a disabled button, so a title on the button itself
+    // would never fire. The tooltip root is a plain div, it is never disabled, and it still
+    // receives the hover. Busy is true here because that is the state the fix is for.
+    [InlineData(ShortcutRecordOrigin.BuiltIn, false, "ignore-use", "Stop warning about this")]
+    [InlineData(ShortcutRecordOrigin.BuiltIn, true, "restore-use", "Warn about this again")]
+    [InlineData(ShortcutRecordOrigin.Owner, false, "delete-use", "Delete this record")]
+    public void WhileBusy_HoveringTheWrapper_ShowsTheShortText(
+        ShortcutRecordOrigin origin, bool ignored, string cssClass, string expectedText)
     {
-        IRenderedComponent<KnownShortcutUseActions> cut =
-            Render<KnownShortcutUseActions>(p => p.Add(c => c.Row, Row()));
+        IRenderedComponent<KnownShortcutUseActions> cut = Render<KnownShortcutUseActions>(p => p
+            .Add(c => c.Row, Row(origin, ignored, origin == ShortcutRecordOrigin.Owner ? Guid.NewGuid() : null))
+            .Add(c => c.Busy, true));
 
-        cut.Find("button.ignore-use").GetAttribute("title").Should().Be("Stop warning about this");
+        IElement wrapper = cut.Find("[data-test=\"use-action-tooltip\"]");
+        IElement? button = wrapper.QuerySelector($"button.{cssClass}");
+        button.Should().NotBeNull();
+        button!.HasAttribute("disabled").Should().BeTrue();
+
+        wrapper.PointerEnter(new PointerEventArgs());
+
+        _popovers!.WaitForAssertion(() =>
+            _popovers!.Find(".use-action-tooltip-text").TextContent.Should().Contain(expectedText));
     }
 
     [Theory]


### PR DESCRIPTION
## What

Show the hover text on a known-shortcut action button while the button is disabled.

Closes backlog 053.

## Why

The three action buttons on a known-shortcut row (delete, restore, ignore) get disabled while a
write is in flight. Their hover text lived in a `title` attribute on the button. MudBlazor sets
`pointer-events: none` on a disabled button, so the browser never fired the hover and the text
never appeared — exactly when a user is most likely to hover and ask "why can I not click this?"

## How

Each `MudIconButton` is now wrapped in a `MudTooltip`. The tooltip root is a plain `<div>` that is
never disabled, so it still receives the hover. Hit testing falls through the disabled button to
that wrapper. The short text moved from the button's `title` to `MudTooltip Text`.

`aria-label`, `data-shortcut-id` and `data-used-by` stay on the button, not on the wrapper. A
`<div>` has no role, so a label on the wrapper would be ignored by a screen reader.

## Verification

- bUnit theory test, one case per action button, rendered with `Busy="true"`: asserts the wrapper
  exists, the button really is disabled, and the text appears after a real `PointerEnter`
- Playwright E2E test hovers the same wrapper in a real browser while an ignore-write is held open
  with a routed `TaskCompletionSource`
- Canonical pre-PR gate: build (17 projects, 0 errors), `dotnet format --verify-no-changes`,
  coverage (3,616 tests, thresholds met), `git diff --check main...HEAD`
- E2E slice: 54/54

## Note for reviewers

Two details in the E2E test look odd but are load-bearing:

1. `Mouse.MoveAsync(0, 0)` before the hover. `ClickAsync` leaves the pointer inside the tooltip
   root. MudTooltip closes on click and the pointer never leaves, so a following `HoverAsync` moves
   to a point it already occupies and Chromium fires no `pointerenter`.
2. The assertion targets `.mud-popover-open.use-action-tooltip-text`, not the bare class. MudBlazor
   keeps every popover mounted off-screen, so the bare class matches every row on the page.

The plan document still carries the original, non-working test code for both points. Correcting it
is follow-up work in the plans repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
