### PR TITLE
chore: add backlog/blocked/ folder, block item 058

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -70,7 +70,7 @@ Pending features are tracked in `backlog/`.
 
 - Rules (always loaded): `.claude/rules/`
 - Skills (on demand): `.claude/skills/`
-- Backlog: `backlog/` (repo root) — open items; completed items live in `done/`. The PR that finishes an item also moves its file into `done/` — see **Git Workflow** in AGENTS.md
+- Backlog: `backlog/` (repo root) — open items; completed items live in `done/`; items blocked on something outside this repository live in `blocked/`. The PR that finishes an item also moves its file into `done/` — see **Git Workflow** in AGENTS.md
 - Frontend instructions: `src/Frontend/AHKFlowApp.UI.Blazor/CLAUDE.md`
 - Private/local config: `.claude/CLAUDE.local.md` (gitignored)
 - Documentation: `docs/` — architecture, azure, development guides

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,7 @@ Conventional commits: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:` �
 Atomic commits: one logical change per commit; feature + its tests = one commit. Don't bundle unrelated changes.
 Filing a `backlog/` item: run `pwsh ./scripts/new-backlog-item.ps1 -Title "..."`. It works out the next free number and writes the file from the template. Never pick a number by hand — two items have already ended up sharing one. CI fails when two files share a number.
 Finishing a `backlog/` item: tick its acceptance boxes **and** `git mv` the file into `backlog/done/` in the same PR that does the work. Merging that PR is what completes the item, so the move belongs there. Never open a separate PR just to mark an item done.
+Blocking a `backlog/` item: `git mv` it into `backlog/blocked/` when it is blocked on something outside this repository — an upstream bug report, an unreleased platform feature, a decision the human deferred. The test is whether the work is possible right now, not whether it is worth doing. A low-priority item stays in `backlog/`. A blocked item keeps its number and its unticked boxes, and must say near the top what would unblock it. All three folders are scanned for duplicate numbers, so blocking never frees a number.
 Never force-push to main/master. Run the canonical pre-PR gate before creating a PR — [`docs/development/testing-workflow.md`](docs/development/testing-workflow.md#canonical-pre-pr-gate).
 Keep PRs focused on a single concern; split large changes into stacked PRs.
 

--- a/backlog/065-native-edit-isolation-misses-worktree-sessions-without-w-flag.md
+++ b/backlog/065-native-edit-isolation-misses-worktree-sessions-without-w-flag.md
@@ -79,9 +79,11 @@ Same session, same target path, opposite outcomes depending on which tool made t
 
 ## Why this is its own item
 
-Found while probing `backlog/058-native-edit-refusal-names-missing-worktree-copy.md`. 058 is about
-the **wording** of a refusal that does fire. This item is about a case where **no refusal fires at
-all**. Different defect, different fix, and 058 stays closable on its own scope.
+Found while probing `backlog/blocked/058-native-edit-refusal-names-missing-worktree-copy.md`.
+058 is about the **wording** of a refusal that does fire. This item is about a case where **no
+refusal fires at all**. Different defect, different fix, and 058 stays closable on its own scope.
+058 is now blocked, because its only remaining step is an upstream report. This item is not
+blocked by that, and stays open.
 
 `docs/agents/cross-agent-git-guardrails.md` used to record that `Edit` and `Write` are "not covered
 by this repository at all — Claude Code's own worktree isolation covers them for Claude sessions".

--- a/backlog/blocked/058-native-edit-refusal-names-missing-worktree-copy.md
+++ b/backlog/blocked/058-native-edit-refusal-names-missing-worktree-copy.md
@@ -5,6 +5,35 @@
 - **Epic**: Agent tooling
 - **Type**: Bug
 - **Interfaces**: UI | API | CLI (none — agent tooling only)
+- **Status**: Blocked since 2026-08-07 — see the section below
+
+## Blocked — waiting on an upstream report that has not been filed
+
+Nothing in this repository can fix this. The probe below settled that. The only work left is the
+third acceptance box: file a report with Anthropic. That report was deliberately deferred on
+2026-08-07, so the item is blocked rather than open. Do not pick it up as available work.
+
+**What would unblock it:**
+
+- The report gets filed. Then link it here, tick the last box, and move the file to
+  `backlog/done/`.
+- Or Anthropic changes the refusal wording in a later Claude Code release. Then re-run the check
+  below, record the new text, and close the item as fixed upstream.
+
+**Evidence freshness.** The probes ran against Claude Code `2.1.224`. That is still the installed
+version as of 2026-08-07, so the recorded messages have not gone stale. Re-check before filing:
+
+```powershell
+claude --version
+```
+
+**Neighbouring upstream reports**, none of which covers this wording bug:
+
+- [anthropics/claude-code#84258](https://github.com/anthropics/claude-code/issues/84258) — worktree
+  isolation hard-blocks `git -C <main-checkout>` even after a `PreToolUse` hook approves it. Filed
+  by someone else, and independent support for finding 1 below.
+- [anthropics/claude-code#64322](https://github.com/anthropics/claude-code/issues/64322) — closed.
+  Asks for `Edit`-tool path validation in `isolation: "worktree"` agents. Different request.
 
 ## Summary
 

--- a/backlog/done/054-worktree-isolation-guard-misses-bash-file-writes.md
+++ b/backlog/done/054-worktree-isolation-guard-misses-bash-file-writes.md
@@ -57,7 +57,8 @@ The message therefore names a file that cannot exist, and sends the next agent l
 - [x] A test covers both probes above — the symlinked path and a plain main-checkout path
 
 The Edit tool's refusal message is Claude Code's own text, not this repo's. It moved to
-`backlog/058-native-edit-refusal-names-missing-worktree-copy.md`, so this item stays closable.
+`backlog/blocked/058-native-edit-refusal-names-missing-worktree-copy.md`, so this item stays
+closable.
 
 ## Out of scope
 

--- a/backlog/done/061-backlog-number-collisions.md
+++ b/backlog/done/061-backlog-number-collisions.md
@@ -19,9 +19,10 @@ Existing collisions (resolved 2026-08-07):
 - `051` — `backlog/done/051-hotkey-raw-body-inline-error-not-rendering.md` kept `051` (most inbound
   references). `backlog/done/051-hotstrings-mobile-branch-stale-after-desktop-mutation.md` was
   renumbered to `backlog/done/063-hotstrings-mobile-branch-stale-after-desktop-mutation.md`.
-- `058` — `backlog/058-native-edit-refusal-names-missing-worktree-copy.md` kept `058` (most inbound
-  references). `backlog/done/058-template-key-use-warning.md` was renumbered to
-  `backlog/done/064-template-key-use-warning.md`.
+- `058` — `backlog/blocked/058-native-edit-refusal-names-missing-worktree-copy.md` kept `058` (most
+  inbound references). `backlog/done/058-template-key-use-warning.md` was renumbered to
+  `backlog/done/064-template-key-use-warning.md`. It sat in `backlog/` at the time and moved to
+  `backlog/blocked/` later; the number never changed.
 
 Every inbound reference to the renumbered files was updated in the same change.
 
@@ -36,7 +37,7 @@ documents and commit messages. Some examples in the repo today:
 - `backlog/042-key-rebinds-as-first-class-rows.md:42` points at item 044
 - `backlog/056-disabled-button-reason-unreachable-by-keyboard-and-touch.md:38` points at item 053
 - `backlog/057-downloads-page-row-stays-disabled-when-the-file-save-fails.md:23` points at item 055
-- `backlog/058-native-edit-refusal-names-missing-worktree-copy.md:25` points at item 054
+- `backlog/blocked/058-native-edit-refusal-names-missing-worktree-copy.md:53` points at item 054
 
 So a duplicate number does not only break sorting. It makes an existing reference point at two
 different items, and the reader cannot tell which one was meant.

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -325,7 +325,10 @@ An agent running the same command would need a prompt or override.
   The same hook denies normally once `-w` is dropped, which proves it was loaded. What was measured
   is which refusal reaches the agent, not the harness's internal execution order. Method and output:
   `docs/superpowers/specs/2026-08-07-worktree-edit-isolation-precedence-design.md`. Tracked in
-  `backlog/058-native-edit-refusal-names-missing-worktree-copy.md`.
+  `backlog/blocked/058-native-edit-refusal-names-missing-worktree-copy.md`, which is blocked: the
+  only remaining step is a report to Anthropic, and that report has not been filed. Confirmed on
+  Claude Code `2.1.224`. Until it changes upstream, treat the refusal text as wrong for
+  `docs/superpowers` and do not go looking for a worktree copy of a plan or spec.
 
 ## Version-skew and authoritative main
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -73,4 +73,4 @@ lists ignored local files `new-worktree.ps1` copies into a new worktree.
 | `_open-env.ps1` | `Open-Env` helper that reads a saved `.env.<env>` and opens its URLs. |
 | `test-sql-container.common.ps1` | Shared SQL Server Testcontainer settings for the coverage/test scripts. |
 | `run-frontend.common.ps1` | Shared build/run logic for `run-frontend.ps1`, dot-sourced so a test can drive it through injected scriptblocks. |
-| `backlog.common.ps1` | Shared backlog-numbering helpers for `new-backlog-item.ps1` and `tests/BacklogNumbering.Tests.ps1`. |
+| `backlog.common.ps1` | Shared backlog-numbering helpers for `new-backlog-item.ps1` and `tests/BacklogNumbering.Tests.ps1`. Scans all three item folders — `backlog/`, `backlog/done/`, and `backlog/blocked/` — so a number stays taken wherever its item sits. |

--- a/scripts/backlog.common.ps1
+++ b/scripts/backlog.common.ps1
@@ -14,10 +14,15 @@ function Get-BacklogItem {
     $root = (Resolve-Path -LiteralPath $BacklogRoot).Path
     $repoRoot = Split-Path -Parent $root
 
+    # Every folder that holds a real item must be scanned, or its number stops counting as taken
+    # and the duplicate check below goes blind to it. 'done' is finished work; 'blocked' is work
+    # blocked on something outside this repository. Both keep their numbers reserved.
     $files = @(Get-ChildItem -LiteralPath $root -Filter '*.md' -File)
-    $doneDir = Join-Path $root 'done'
-    if (Test-Path -LiteralPath $doneDir) {
-        $files += Get-ChildItem -LiteralPath $doneDir -Filter '*.md' -File
+    foreach ($subfolder in @('done', 'blocked')) {
+        $subfolderPath = Join-Path $root $subfolder
+        if (Test-Path -LiteralPath $subfolderPath) {
+            $files += Get-ChildItem -LiteralPath $subfolderPath -Filter '*.md' -File
+        }
     }
 
     foreach ($file in $files) {
@@ -57,7 +62,7 @@ function Get-BacklogProblem {
         $problems += "Bad backlog file name: $($item.RelativePath). Expected NNN-slug.md or NNNx-slug.md."
     }
 
-    # --- Duplicate key across backlog/ and backlog/done/ ---
+    # --- Duplicate key across backlog/, backlog/done/, and backlog/blocked/ ---
     $byKey = $items | Where-Object { $null -ne $_.Key } | Group-Object -Property Key
     foreach ($group in $byKey | Where-Object { $_.Count -gt 1 }) {
         $names = ($group.Group | Select-Object -ExpandProperty RelativePath) -join ', '

--- a/scripts/new-backlog-item.ps1
+++ b/scripts/new-backlog-item.ps1
@@ -6,7 +6,8 @@
 .DESCRIPTION
     Never pick a backlog number by hand — two items have already ended up sharing one
     (see backlog 061). This script reads backlog/000-backlog-item-template.md, works out the
-    next free number across backlog/ and backlog/done/, and writes the new file.
+    next free number across backlog/, backlog/done/, and backlog/blocked/, and writes the new
+    file. A finished or blocked item keeps its number reserved, so no folder frees a number.
 
 .EXAMPLE
     pwsh ./scripts/new-backlog-item.ps1 -Title "Downloads page row stays disabled"

--- a/tests/BacklogNumbering.Tests.ps1
+++ b/tests/BacklogNumbering.Tests.ps1
@@ -25,6 +25,7 @@ function New-TemporaryBacklogRoot {
     $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) "backlog-numbering-tests-$([guid]::NewGuid())"
     New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $tempRoot 'done') -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $tempRoot 'blocked') -Force | Out-Null
     Copy-Item -LiteralPath $templatePath -Destination (Join-Path $tempRoot '000-backlog-item-template.md')
     return $tempRoot
 }
@@ -183,6 +184,60 @@ try {
 
     $finalContent = Get-Content -LiteralPath $targetPath -Raw
     Assert-True ($finalContent -eq 'first writer content') "Concurrent write should not clobber the first writer's file, got: '$finalContent'"
+}
+finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+}
+
+# --- Case 10: a blocked item in blocked/ still holds its number ---
+#
+# A blocked item is not finished, so it keeps its number reserved. If the scan skipped
+# blocked/, this duplicate would go unreported and two files could end up sharing one number —
+# the exact failure backlog 061 was filed for.
+
+$tempRoot = New-TemporaryBacklogRoot
+try {
+    Set-Content -LiteralPath (Join-Path $tempRoot '058-open.md') -Value "# 058 - Open`n"
+    Set-Content -LiteralPath (Join-Path $tempRoot 'blocked/058-blocked.md') -Value "# 058 - Blocked`n"
+
+    $problems = @(Get-BacklogProblem -BacklogRoot $tempRoot)
+    $dupProblem = $problems | Where-Object { $_ -like "*Duplicate backlog number '058'*" }
+    Assert-True ($null -ne $dupProblem) "Expected a duplicate-058 problem across backlog/ and blocked/, got: $($problems -join ' | ')"
+    if ($dupProblem) {
+        Assert-True ($dupProblem -like '*058-open.md*') "Duplicate message should name 058-open.md: $dupProblem"
+        Assert-True ($dupProblem -like '*blocked/058-blocked.md*') "Duplicate message should name blocked/058-blocked.md: $dupProblem"
+    }
+}
+finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+}
+
+# --- Case 11: a blocked item counts toward the next free number ---
+
+$tempRoot = New-TemporaryBacklogRoot
+try {
+    Set-Content -LiteralPath (Join-Path $tempRoot '060-open.md') -Value "# 060 - Open`n"
+    Set-Content -LiteralPath (Join-Path $tempRoot 'blocked/071-blocked.md') -Value "# 071 - Blocked`n"
+
+    $next = Get-NextBacklogNumber -BacklogRoot $tempRoot
+    Assert-True ($next -eq '072') "Expected the next number to follow the blocked item, got '$next'"
+}
+finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+}
+
+# --- Case 12: a backlog root with no blocked/ folder still works ---
+#
+# The folder is optional. A checkout that has never blocked an item has no blocked/ directory, and
+# the scan must not fail on that.
+
+$tempRoot = New-TemporaryBacklogRoot
+try {
+    Remove-Item -LiteralPath (Join-Path $tempRoot 'blocked') -Recurse -Force
+    Set-Content -LiteralPath (Join-Path $tempRoot '060-open.md') -Value "# 060 - Open`n"
+
+    $problems = @(Get-BacklogProblem -BacklogRoot $tempRoot)
+    Assert-True ($problems.Count -eq 0) "A root with no blocked/ folder should pass, found: $($problems -join ' | ')"
 }
 finally {
     Remove-Item -LiteralPath $tempRoot -Recurse -Force


### PR DESCRIPTION
## Why

Backlog 058 has one acceptance box left: file an upstream report with Anthropic. That report was
deliberately deferred, so the item is stuck in a state the backlog has no place for. It is not open
work — nobody should pick it up, because there is nothing to build. It is not done either, because
`AGENTS.md` requires every box ticked before an item moves to `backlog/done/`. Sitting in
`backlog/`, it reads as available work.

So the backlog gets a third state.

## What "blocked" means

An item in `backlog/blocked/` is stuck on something this repository does not control — an upstream
bug report, an unreleased platform feature, a deferred decision. It is not "low priority". A
low-priority item stays in `backlog/`. The test is whether the work is possible right now, not
whether it is worth doing. Every blocked item says near the top what would unblock it.

## Why this is more than a `git mv`

`Get-BacklogItem` scanned exactly two folders (`scripts/backlog.common.ps1:17-21`). Everything
downstream reads that one list: the duplicate-number check, the bad-file-name check, the
heading-drift check, and `Get-NextBacklogNumber`. CI runs the set at `.github/workflows/ci.yml:124`.

Moving 058 into an unscanned folder would have made number 058 invisible to the duplicate check —
the exact failure backlog 061 was filed for. So the scan learns about `blocked/`, and tests cover it.

## Changes

- `scripts/backlog.common.ps1` scans `done` and `blocked`, each behind its own `Test-Path` guard.
- `tests/BacklogNumbering.Tests.ps1` — three new cases: a duplicate across `backlog/` and
  `blocked/`, a blocked item counting toward `Get-NextBacklogNumber`, and a root with no `blocked/`
  folder still passing.
- `backlog/058-*.md` → `backlog/blocked/058-*.md`, with a `## Blocked` section: what it waits on,
  the two things that would unblock it, and the version the evidence holds for (`2.1.224`).
- Stale two-folder text fixed in `scripts/new-backlog-item.ps1:9` and `scripts/backlog.common.ps1:65`.
  Logic was already fine; only the text was wrong.
- Every reference to the moved file repointed, including a line anchor in
  `backlog/done/061-*.md` that pointed at `:25` when the target had moved to `:53`.
- Folder documented in `AGENTS.md`, `.claude/CLAUDE.md`, `scripts/README.md`.

## Nothing filed upstream

No GitHub issue was created on `anthropics/claude-code`. That stays deferred, and it is what keeps
058 blocked.

## Verification

Full gate, green: build 17 projects 0 errors · `dotnet format --verify-no-changes` clean · coverage
94.6% line / 82.7% branch, all per-assembly thresholds met · 16/16 PowerShell suites · `git diff
--check` clean.

The two new duplicate/numbering cases were proven red against the pre-fix scan:

> Expected a duplicate-058 problem across backlog/ and blocked/, got:
> Expected the next number to follow the blocked item, got '061'

The missing-folder case passes either way by design — it is a regression guard, not a demonstration
of the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
