### PR TITLE
fix: guard Edit/Write into main from worktree sessions (065)

### DIFF
--- a/.claude/hooks/pre-edit-guard.sh
+++ b/.claude/hooks/pre-edit-guard.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Pre-Edit Guard - fast cwd prefilter for Claude Edit, Write, and NotebookEdit tool calls.
+#
+# Reads the native PreToolUse payload from stdin. A managed worktree always lives directly under
+# <main>/.claude/worktrees or <main>/.worktrees, so its path always carries the "worktrees"
+# segment. A payload whose cwd does not carry it cannot be a worktree session, so it exits here
+# without paying PowerShell startup. Everything else is forwarded to the shared policy core in
+# scripts/agents/invoke-agent-worktree-guard.ps1, which makes the real decision.
+#
+# Exit 2 = block. Exit 0 = allow.
+
+if [[ "${AHKFLOW_GUARD_DISABLE:-}" == "1" ]]; then
+  echo "WARNING: AHKFLOW_GUARD_DISABLE=1; all agent command guardrails are disabled." >&2
+  exit 0
+fi
+
+INPUT=$(cat)
+
+shopt -s nocasematch
+
+# Conservative superset, applied to the raw payload so the common case never pays for a jq
+# process at all. Same discipline as pre-bash-guard.sh: a false positive costs one PowerShell
+# start, a false negative silently disables the guard. An edited file whose own path contains
+# "worktrees" costs one wasted start in a main session, which is the accepted direction of error.
+WORKTREE_SESSION_PATTERN='worktrees'
+
+if [[ ! "$INPUT" =~ $WORKTREE_SESSION_PATTERN ]]; then
+  exit 0
+fi
+
+# Narrow the match to cwd when jq is available, so the wasted start above is avoided too.
+# Correctness must not depend on jq: a parse failure forwards.
+if command -v jq >/dev/null 2>&1; then
+  CWD=$(printf '%s' "$INPUT" | jq -er '.cwd // empty' 2>/dev/null) || CWD=""
+  if [[ -n "$CWD" ]] && [[ ! "$CWD" =~ $WORKTREE_SESSION_PATTERN ]]; then
+    exit 0
+  fi
+fi
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+if command -v pwsh >/dev/null 2>&1; then
+  POWERSHELL=(pwsh -NoProfile -NonInteractive)
+elif command -v powershell.exe >/dev/null 2>&1; then
+  POWERSHELL=(powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass)
+else
+  echo "WARNING: agent guard could not find PowerShell; allowing edit." >&2
+  exit 0
+fi
+
+printf '%s' "$INPUT" |
+  "${POWERSHELL[@]}" -File \
+    "$SCRIPT_DIR/../../scripts/agents/invoke-agent-worktree-guard.ps1" \
+    -Adapter Claude

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -158,6 +158,16 @@
             "statusMessage": "Checking for destructive operations..."
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-edit-guard.sh\"",
+            "statusMessage": "Checking worktree write isolation..."
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/backlog/066-ci-swallows-powershell-suite-failures-in-worktree-powershell-tests.md
+++ b/backlog/066-ci-swallows-powershell-suite-failures-in-worktree-powershell-tests.md
@@ -1,0 +1,93 @@
+# 066 - CI swallows PowerShell suite failures in worktree-powershell-tests
+
+## Metadata
+
+- **Epic**: Agent tooling
+- **Type**: Bug
+- **Interfaces**: UI | API | CLI (none — CI only)
+
+## Summary
+
+The `worktree-powershell-tests` job runs sixteen PowerShell suites inside one `run:` block. Only the
+last script decides the step's exit code, so every earlier suite can fail and the job still reports
+success. A red suite has already been shipping this way.
+
+## Evidence
+
+`.github/workflows/ci.yml:102-125` runs the suites like this:
+
+```yaml
+  worktree-powershell-tests:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run worktree PowerShell tests
+        shell: pwsh
+        run: |
+          ./tests/AgentWorktreeGuard.Tests.ps1
+          ./tests/AgentPreCommitHook.Tests.ps1
+          ...
+          ./tests/BacklogNumbering.Tests.ps1
+```
+
+Each suite ends with `exit 1` when it has failures. In a `shell: pwsh` block, that exit code only
+reaches the step when it belongs to the **last** command. Everything above it is discarded.
+
+Run `31208311085`, branch `fix/wt-058-native-edit-refusal`, job `worktree-powershell-tests`, recorded
+2026-08-07. The job conclusion was **success**. Its log contains:
+
+```
+  FAIL  Shim: a worktree-session redirect reaches the policy core
+FAILED: 1 test(s)
+  - Shim: a worktree-session redirect reaches the policy core :: Decision must be reported (expected match 'agent-worktree-main-write', got '')
+```
+
+The same failure reproduces locally from the main checkout:
+
+```powershell
+pwsh -NoProfile -File .\tests\AgentWorktreeGuard.Tests.ps1
+```
+
+That one test is being fixed on `fix/wt-065-edit-write-isolation`, because new tests cannot be added
+beside a red neighbour. The CI hole that hid it is this item, and it is untouched by that branch.
+
+## A trap the fix must avoid
+
+The obvious fix is to check `$LASTEXITCODE` after each suite in the same PowerShell process. That
+does not work. The suites call `exit 1` when they fail, but on success they simply run off the end
+with no `exit 0`. `$LASTEXITCODE` then still holds whatever the last native command inside the
+suite returned.
+
+Measured on 2026-08-07 against `fix/wt-065-edit-write-isolation`:
+`tests/WorktreeBaseRef.Tests.ps1` prints `Worktree base-ref tests passed.` and leaves
+`$LASTEXITCODE` at `1`. The same file run as its own process exits `0`.
+
+So the fix must either give each suite its own step or its own process, or add an explicit `exit 0`
+to the success path of every suite. Checking `$LASTEXITCODE` in-process would turn a green suite
+red.
+
+## Why this matters
+
+Fifteen of the sixteen suites are unguarded. A regression in any of them merges silently. The suites
+cover the agent Git guardrails, the worktree scripts, the pre-commit and pre-push hooks, and the
+backlog numbering check, so the blind spot covers most of the repository's own tooling.
+
+## Acceptance criteria
+
+- [ ] A failure in any suite in `worktree-powershell-tests` fails the job
+- [ ] Every suite still runs when an earlier one fails, so one run reports every broken suite rather
+      than only the first
+- [ ] The job's summary names which suites failed
+- [ ] A deliberately failing suite is used once to prove the job goes red, and the proof is recorded
+      in the PR
+
+## Out of scope
+
+- The content of any individual suite. Fixing a red test is that test's own work.
+- The `build-test` job. `dotnet test` already fails its step correctly.
+
+## Notes / dependencies
+
+- Found while planning `backlog/065-native-edit-isolation-misses-worktree-sessions-without-w-flag.md`
+- `scripts/test-fast.ps1` does not run these suites, so the local pre-PR gate has the same blind spot
+  unless the suites are run by hand

--- a/backlog/done/065-native-edit-isolation-misses-worktree-sessions-without-w-flag.md
+++ b/backlog/done/065-native-edit-isolation-misses-worktree-sessions-without-w-flag.md
@@ -116,12 +116,12 @@ So this item is designable now. It needs a plan before implementation, because i
       058 — answering it once serves both)
 - [x] `docs/agents/cross-agent-git-guardrails.md` corrected — the claim that native isolation covers
       `Edit`/`Write` for Claude sessions holds only for `-w` and `EnterWorktree` sessions
-- [ ] A session started inside a worktree without `-w` cannot `Edit` or `Write` into the main
+- [x] A session started inside a worktree without `-w` cannot `Edit` or `Write` into the main
       checkout, and the refusal names the real reason and a real next step
-- [ ] The `docs/superpowers` case reuses the wording already shipped at
+- [x] The `docs/superpowers` case reuses the wording already shipped at
       `scripts/agents/agent-worktree-guard.common.ps1:1647`, which never tells the agent to look for
       a worktree copy
-- [ ] A test covers the gap, in the style of the existing cases in `tests/AgentWorktreeGuard.Tests.ps1`
+- [x] A test covers the gap, in the style of the existing cases in `tests/AgentWorktreeGuard.Tests.ps1`
 
 ## Out of scope
 
@@ -138,3 +138,15 @@ So this item is designable now. It needs a plan before implementation, because i
 - 054 already guards Bash writes from a worktree using the hook payload `cwd`. The fix here is the
   same rule applied to `Edit` and `Write`, so it should reuse 054's path resolution rather than
   grow a second copy.
+- Closed by `docs/superpowers/specs/2026-08-07-worktree-edit-write-isolation-design.md` and
+  `docs/superpowers/plans/2026-08-07-worktree-edit-write-isolation.md`
+- Reusing 054's path resolution exposed three defects in it, all fixed on the same branch: a symlink
+  whose target is relative was resolved against the hook process's working directory rather than the
+  directory holding the link; a link that was the last path component indexed past the end of an
+  array, which throws under the entrypoint's strict mode; and a path the PowerShell host cannot
+  parse threw instead of reporting itself unresolved. Each of the three reached the entrypoint's
+  catch, which allows the write. They affected the Bash rule too, so 054 is now stricter as well.
+- The real-session probe that proves the fix is recorded in the pull request that closes this item.
+  Three runs, all from `.claude/worktrees/065-edit-write-isolation` with no `-w`, on Claude Code
+  2.1.225: a `Write` into the main checkout was denied, a `Write` into `docs/superpowers` was denied
+  with the plans wording, and a `Write` inside the worktree succeeded.

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -36,6 +36,7 @@ or a safe `git branch -d` on an already-merged branch. They run from main with n
 | Layer | Where | Scope |
 | --- | --- | --- |
 | `PreToolUse` command guard | `.claude/hooks/pre-bash-guard.sh` → `scripts/agents/invoke-agent-worktree-guard.ps1` | Primary. Every agent Bash/shell tool call. |
+| `PreToolUse` file-edit guard | `.claude/hooks/pre-edit-guard.sh` → `scripts/agents/invoke-agent-worktree-guard.ps1` | Claude `Edit`, `Write`, and `NotebookEdit` tool calls. |
 | `pre-commit` backstop | `.githooks/pre-commit` → `.githooks/pre-commit.ps1` | Narrow. Agent-marked commits only, after merge. |
 
 The Bash hook is a fast candidate-token filter: a command that cannot contain `git`, `rm`, or
@@ -131,8 +132,22 @@ location logic.
 ### Worktree write isolation
 
 Separate from the Git tiers. When the session's working directory is a **managed worktree**, a
-shell command that writes, moves, or deletes a path resolving under the main checkout is denied,
-with rule `agent-worktree-main-write`.
+write that resolves under the main checkout is denied, with rule `agent-worktree-main-write`. Two
+kinds of write are covered: a shell command that writes, moves, or deletes a path, and a Claude
+`Edit`, `Write`, or `NotebookEdit` tool call.
+
+The two kinds share the path rules below and the same refusal text. They differ in what has to be
+parsed. A shell command needs a command line taken apart first, so every limit further down this
+section applies to it. A tool call carries one literal path, so none of those limits apply: there
+is no redirect to find, no chained `cd` to track, and no shell to expand `$`, `%`, or a backtick,
+which are ordinary characters in a Windows file name. The path is classified exactly as the tool
+will open it, with no quote stripping and no whitespace trimming. A `~` still fails closed, because
+nothing in the payload says which home directory it means. So does a path the PowerShell host
+cannot parse at all — Windows PowerShell 5.1 rejects a `"` in a path where pwsh 7 accepts it.
+
+Symlinks are followed before classification, and a relative link target is resolved against the
+directory holding the link. That matters because a link inside a worktree can point at
+`..\..\..\README.md`, and following it lands in the main checkout.
 
 Allowed anyway:
 
@@ -303,32 +318,38 @@ An agent running the same command would need a prompt or override.
   Git after such a `cd` is unaffected. Pass an explicit `git -C <path>` to be classified normally.
 - `commit --no-verify` and `--git-dir`/`--work-tree` targeting cannot be safely inferred, so a
   mutating invocation using `--git-dir`/`--work-tree` is denied outright (unless `AHKFLOW_ALLOW_MAIN=1`).
-- Shell **writes** into main are guarded, in one direction only: a session whose working directory
-  is a managed worktree cannot write, move, or delete a path resolving under the main checkout. A
-  main-checkout session is unaffected and may still edit, build, test, and format there. `Edit` and
-  `Write` tool calls are not covered by this repository at all. Claude Code's own worktree isolation
-  covers them, but only for a session started with `-w`, `--worktree`, or the `EnterWorktree` tool.
-  That check reads a session flag, not the working directory. A Claude session that merely has a
-  worktree as its working directory gets no check, so it can `Edit` and `Write` into main freely.
-  Codex and Copilot have no equivalent isolation at all. Tracked in
-  `backlog/065-native-edit-isolation-misses-worktree-sessions-without-w-flag.md`.
+- **Writes** into main are guarded, in one direction only: a session whose working directory is a
+  managed worktree cannot write, move, or delete a path resolving under the main checkout. This
+  covers shell commands and Claude `Edit`, `Write`, and `NotebookEdit` tool calls. A main-checkout
+  session is unaffected and may still edit, build, test, and format there.
+- Claude Code has its own worktree isolation for `Edit` and `Write`, and it reads a session flag
+  rather than the working directory. It fires only for a session started with `-w`, `--worktree`, or
+  the `EnterWorktree` tool. This repository's guard reads the working directory instead, so the two
+  now overlap rather than leave a gap. In a `-w` session the harness refusal wins; in every other
+  worktree session this repository's refusal is the one that fires.
+- Codex and Copilot file-edit tool calls are **not** covered. Their tool names and payload shapes are
+  not verified here, and neither agent has native worktree isolation. Their shell commands are
+  covered as before.
 - The write scan reads a denylist of write commands, not an allowlist of safe ones. A writer
   outside that list — `del`, `python -c`, a compiled tool — is not detected. Same trade-off the
   Git mutation rule already makes.
 - `pwsh -File script.ps1` is still unread. The guard classifies the command line the hook reports,
   never a file that command line points at.
-- Claude Code's own `Edit`/`Write` refusal tells the agent to edit "the worktree copy of this
-  file". For `docs/superpowers` no worktree copy can exist, because `.gitignore` excludes the path
-  and `scripts/worktree-plans.common.ps1` links it in instead. That text belongs to the harness and
-  cannot be changed here. This was measured, not assumed: a `PreToolUse` hook on `Edit|Write` that
-  denies with its own message is silenced in a `-w` session — the harness refusal takes precedence.
-  The same hook denies normally once `-w` is dropped, which proves it was loaded. What was measured
-  is which refusal reaches the agent, not the harness's internal execution order. Method and output:
+- In a `-w` session, Claude Code's own `Edit`/`Write` refusal wins, and it tells the agent to edit
+  "the worktree copy of this file". For `docs/superpowers` no worktree copy can exist, because
+  `.gitignore` excludes the path and `scripts/worktree-plans.common.ps1` links it in instead. That
+  text belongs to the harness and cannot be changed here. This was measured, not assumed: a
+  `PreToolUse` hook on `Edit|Write` that denies with its own message is silenced in a `-w` session —
+  the harness refusal takes precedence. The same hook denies normally once `-w` is dropped, which
+  proves it was loaded. What was measured is which refusal reaches the agent, not the harness's
+  internal execution order. Method and output:
   `docs/superpowers/specs/2026-08-07-worktree-edit-isolation-precedence-design.md`. Tracked in
   `backlog/blocked/058-native-edit-refusal-names-missing-worktree-copy.md`, which is blocked: the
   only remaining step is a report to Anthropic, and that report has not been filed. Confirmed on
   Claude Code `2.1.224`. Until it changes upstream, treat the refusal text as wrong for
-  `docs/superpowers` and do not go looking for a worktree copy of a plan or spec.
+  `docs/superpowers` and do not go looking for a worktree copy of a plan or spec. This applies to a
+  `-w` session only. Outside one, this repository's own refusal fires instead, and it names the
+  symlink rather than a worktree copy.
 
 ## Version-skew and authoritative main
 

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1673,16 +1673,25 @@ function Get-AgentWriteTargetResolution {
     }
 
     $candidate = $literalParts -join '\'
-    if (-not [System.IO.Path]::IsPathRooted($candidate)) {
-        if ([string]::IsNullOrWhiteSpace($BaseDirectory)) {
-            return [pscustomobject]@{ Path = ''; Unresolved = $true }
+    try {
+        if (-not [System.IO.Path]::IsPathRooted($candidate)) {
+            if ([string]::IsNullOrWhiteSpace($BaseDirectory)) {
+                return [pscustomobject]@{ Path = ''; Unresolved = $true }
+            }
+            $candidate = Join-Path $BaseDirectory $candidate
         }
-        $candidate = Join-Path $BaseDirectory $candidate
-    }
 
-    # GetFullPath collapses '..' segments; it does not touch the filesystem.
-    try { $candidate = [System.IO.Path]::GetFullPath($candidate) }
-    catch { return [pscustomobject]@{ Path = ''; Unresolved = $true } }
+        # GetFullPath collapses '..' segments; it does not touch the filesystem.
+        $candidate = [System.IO.Path]::GetFullPath($candidate)
+    }
+    catch {
+        # Windows PowerShell 5.1 runs on .NET Framework, whose path APIs reject characters such
+        # as '"' outright, and IsPathRooted throws before GetFullPath is ever reached. A path
+        # this host cannot parse is one the guard cannot classify, so report it unresolved. The
+        # caller then denies. Letting the exception escape would instead reach the entrypoint's
+        # catch and allow the write.
+        return [pscustomobject]@{ Path = ''; Unresolved = $true }
+    }
 
     $resolved = Resolve-AgentSymlinkPath -Path $candidate
     return [pscustomobject]@{

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1586,10 +1586,13 @@ when DEST is `../../../../README.md`.
 
 Mirrors the precedent at Get-AgentCommandSegment, where a cd target matching [\$%] marks the
 following git mutation untargetable rather than guessing where it lands.
+
+Pass -Literal for a path that came from a tool call rather than a command line. That skips the
+shell-expansion rule only. Rooting, `..` collapsing, and symlink resolution are unchanged.
 #>
 function Get-AgentWriteTargetResolution {
     [CmdletBinding()]
-    param([string] $Target, [string] $BaseDirectory)
+    param([string] $Target, [string] $BaseDirectory, [switch] $Literal)
 
     if ([string]::IsNullOrWhiteSpace($Target)) {
         return [pscustomobject]@{ Path = ''; Unresolved = $true }
@@ -1600,22 +1603,28 @@ function Get-AgentWriteTargetResolution {
         return [pscustomobject]@{ Path = ''; Unresolved = $true }
     }
 
-    if ($trimmed -match $script:AgentGuardUnexpandablePattern) {
+    # A tool call carries one literal path and no shell runs over it, so '$', '%' and backtick are
+    # ordinary file name characters there. Applying the shell rule would refuse a real edit inside
+    # the session's own worktree. A '~' still fails closed under -Literal: nothing in the payload
+    # says which home directory it means.
+    if (-not $Literal -and $trimmed -match $script:AgentGuardUnexpandablePattern) {
         return [pscustomobject]@{ Path = ''; Unresolved = $true }
     }
 
     $parts = @($trimmed -split '[\\/]')
-    $literal = New-Object System.Collections.Generic.List[string]
+    # Named literalParts, not literal: PowerShell variable names are case-insensitive, so a plain
+    # $literal here would be the -Literal switch parameter above.
+    $literalParts = New-Object System.Collections.Generic.List[string]
     foreach ($part in $parts) {
         if ($part -match '[\*\?]') { break }
-        [void] $literal.Add($part)
+        [void] $literalParts.Add($part)
     }
 
-    if ($literal.Count -eq 0) {
+    if ($literalParts.Count -eq 0) {
         return [pscustomobject]@{ Path = ''; Unresolved = $true }
     }
 
-    $candidate = $literal -join '\'
+    $candidate = $literalParts -join '\'
     if (-not [System.IO.Path]::IsPathRooted($candidate)) {
         if ([string]::IsNullOrWhiteSpace($BaseDirectory)) {
             return [pscustomobject]@{ Path = ''; Unresolved = $true }
@@ -1834,6 +1843,75 @@ function Get-AgentWorktreeWriteDecision {
 
     return New-AgentGuardDecision -Action Deny -Rule 'agent-worktree-main-write' -Message `
     ([string]::Format($template, $blockingPath))
+}
+
+<#
+.SYNOPSIS
+Refuses an Edit, Write, or NotebookEdit tool call that lands in the main checkout from a session
+isolated in a managed worktree.
+
+.DESCRIPTION
+Get-AgentWorktreeWriteDecision has to parse a command line before it can find a write target. A
+tool call carries one literal path instead, so this function shares that rule's path resolution,
+allow-list, and refusal messages but none of its parsing. Like the shell rule, it only fires when
+the session's own working directory is a managed worktree, which keeps the AGENTS.md rule that
+agents may edit, build, test, and format in the main checkout.
+#>
+function Get-AgentFileEditWriteDecision {
+    [CmdletBinding()]
+    param(
+        [string] $TargetPath,
+        [string] $Cwd,
+        [string] $ProtectedRepoRoot,
+        [bool] $AllowMain = $false
+    )
+
+    # A payload with no path is malformed. The tool rejects it anyway, so there is nothing here to
+    # protect.
+    if ([string]::IsNullOrWhiteSpace($TargetPath)) { return New-AgentGuardDecision -Action Allow }
+
+    $sessionState = Get-ManagedWorktreeState -Cwd $Cwd -ProtectedRepoRoot $ProtectedRepoRoot
+    if ($sessionState -ne 'ManagedWorktree') { return New-AgentGuardDecision -Action Allow }
+
+    $protectedCommonDir = Invoke-AgentGuardGitProbe @(
+        '-C', $ProtectedRepoRoot, 'rev-parse', '--path-format=absolute', '--git-common-dir')
+    if ([string]::IsNullOrWhiteSpace($protectedCommonDir)) { return New-AgentGuardDecision -Action Allow }
+    $mainCheckout = ConvertTo-AgentGuardNormalizedPath (Split-Path -Parent (
+            ConvertTo-AgentGuardNormalizedPath $protectedCommonDir))
+    # The session's own worktree is its git top level, not the directory it happens to sit in.
+    $worktreeRoot = Get-AgentSessionWorktreeRoot -Cwd $Cwd
+
+    $resolution = Get-AgentWriteTargetResolution -Target $TargetPath -BaseDirectory $Cwd -Literal
+
+    if (-not $resolution.Unresolved) {
+        if (Test-AgentWriteTargetAllowed -ResolvedPath $resolution.Path `
+                -MainCheckout $mainCheckout -WorktreeRoot $worktreeRoot) {
+            return New-AgentGuardDecision -Action Allow
+        }
+    }
+
+    if ($AllowMain) {
+        $overrideTarget = if ($resolution.Unresolved) { 'an unexpandable target' } else { $resolution.Path }
+        return New-AgentGuardDecision -Action Warn -Rule 'agent-worktree-main-write-overridden' -Message `
+        ("WARNING: AHKFLOW_ALLOW_MAIN=1 overrode the worktree write-isolation rule for: $overrideTarget")
+    }
+
+    if ($resolution.Unresolved) {
+        return New-AgentGuardDecision -Action Deny -Rule 'agent-worktree-main-write' -Message `
+            $script:AgentGuardUnresolvedWriteMessage
+    }
+
+    $plansRoot = ConvertTo-AgentGuardNormalizedPath (Join-Path $mainCheckout 'docs\superpowers')
+    $template = if ($resolution.Path -ieq $plansRoot -or
+        $resolution.Path.StartsWith($plansRoot + '\', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $script:AgentGuardPlansDenialMessage
+    }
+    else {
+        $script:AgentGuardWriteDenialMessage
+    }
+
+    return New-AgentGuardDecision -Action Deny -Rule 'agent-worktree-main-write' -Message `
+    ([string]::Format($template, $resolution.Path))
 }
 
 $script:AgentGuardAllowedStates = @('NotRepository', 'OutsideProtectedRepository', 'ManagedWorktree')

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -16,6 +16,10 @@
 
 $script:AgentGuardShellToolNames = @('bash', 'shell', 'shell_command', 'sh', 'powershell', 'pwsh')
 
+# Claude's file-writing tools. These carry a literal path rather than a command, so they are
+# classified by Get-AgentFileEditWriteDecision instead of the command evaluators.
+$script:AgentGuardFileEditToolNames = @('edit', 'write', 'notebookedit')
+
 $script:AgentGuardProtectedCommonDirCache = @{}
 
 # Characters a backslash may escape inside double quotes (POSIX), and outside quotes. Compared
@@ -116,11 +120,16 @@ function ConvertTo-AgentGuardNormalizedPath {
 
 <#
 .SYNOPSIS
-Normalizes a native agent PreToolUse payload into { Adapter, ToolName, Command, Cwd }.
+Normalizes a native agent PreToolUse payload into
+{ Adapter, ToolName, Command, TargetPath, Cwd, AgentId, AgentType }.
 
 .DESCRIPTION
 Adapter 'Auto' infers Copilot from a top-level 'toolArgs' key and Claude otherwise; Codex
 always supplies an explicit override. Throws on malformed JSON so the caller can fail open.
+
+A shell tool name normalizes to 'shell' and fills Command. A file-writing tool name normalizes to
+'file-edit' and fills TargetPath from file_path, or from notebook_path for NotebookEdit. Any other
+tool name is returned unchanged, and both fields stay empty.
 #>
 function ConvertFrom-AgentHookInput {
     [CmdletBinding()]
@@ -143,6 +152,7 @@ function ConvertFrom-AgentHookInput {
 
     $rawToolName = ''
     $command = ''
+    $targetPath = ''
     $agentId = ''
     $agentType = ''
 
@@ -169,6 +179,8 @@ function ConvertFrom-AgentHookInput {
         if (Test-AgentGuardProperty $payload 'tool_input') {
             $toolInput = $payload.tool_input
             if (Test-AgentGuardProperty $toolInput 'command') { $command = [string] $toolInput.command }
+            if (Test-AgentGuardProperty $toolInput 'file_path') { $targetPath = [string] $toolInput.file_path }
+            elseif (Test-AgentGuardProperty $toolInput 'notebook_path') { $targetPath = [string] $toolInput.notebook_path }
         }
 
         # agent_id is present at the top level only when the call originates inside a subagent
@@ -186,14 +198,18 @@ function ConvertFrom-AgentHookInput {
     if ($script:AgentGuardShellToolNames -contains $rawToolName.ToLowerInvariant()) {
         $normalizedToolName = 'shell'
     }
+    elseif ($script:AgentGuardFileEditToolNames -contains $rawToolName.ToLowerInvariant()) {
+        $normalizedToolName = 'file-edit'
+    }
 
     return [pscustomobject]@{
-        Adapter   = $resolvedAdapter
-        ToolName  = $normalizedToolName
-        Command   = $command
-        Cwd       = (ConvertTo-AgentGuardNormalizedPath $cwd)
-        AgentId   = $agentId
-        AgentType = $agentType
+        Adapter    = $resolvedAdapter
+        ToolName   = $normalizedToolName
+        Command    = $command
+        TargetPath = $targetPath
+        Cwd        = (ConvertTo-AgentGuardNormalizedPath $cwd)
+        AgentId    = $agentId
+        AgentType  = $agentType
     }
 }
 

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1546,6 +1546,10 @@ Replaces every reparse point in a path with its target, walking from the root do
 Windows PowerShell 5.1 has no ResolveLinkTarget, so this uses (Get-Item -Force).Target, which
 both supported hosts provide. 5.1 types that property as string[] and pwsh 7 as string, so the
 array form is normalized. The iteration cap stops a symlink cycle from hanging the hook.
+
+A relative target is anchored to the directory holding the link, which is how Windows resolves
+one. Anchoring it to the process working directory instead classified the wrong file, and a
+worktree link pointing at `..\..\..\README.md` then looked like a path outside the checkout.
 #>
 function Resolve-AgentSymlinkPath {
     [CmdletBinding()]
@@ -1575,9 +1579,30 @@ function Resolve-AgentSymlinkPath {
             if ($target -is [array]) { $target = $target[0] }
             if ([string]::IsNullOrWhiteSpace($target)) { continue }
 
-            $remainder = @($parts[($i + 1)..($parts.Count - 1)]) | Where-Object { $_ }
+            # A link that IS the last component has no remainder. Taking the slice anyway asks
+            # for index $parts.Count, which strict mode rejects outright and which otherwise
+            # produces a DESCENDING range that hands back the leaf a second time.
+            $remainder = @()
+            if ($i + 1 -le $parts.Count - 1) {
+                $remainder = @($parts[($i + 1)..($parts.Count - 1)]) | Where-Object { $_ }
+            }
+
+            # A symlink target may be relative. Windows resolves it against the directory holding
+            # the link, never against the process working directory. Anchoring it here is what
+            # keeps `..\..\..\README.md` inside a worktree from classifying as outside the
+            # protected checkout. The repository tracks such a link at .github\AGENTS.md.
+            if (-not [System.IO.Path]::IsPathRooted($target)) {
+                $linkParent = Split-Path -Parent $accumulated
+                if (-not [string]::IsNullOrWhiteSpace($linkParent)) {
+                    $target = Join-Path $linkParent $target
+                }
+            }
+
             $result = $target
             foreach ($piece in $remainder) { $result = Join-Path $result $piece }
+            # Collapse the '..' segments the substitution just introduced, so the next pass walks
+            # a real path. GetFullPath is lexical; it does not touch the filesystem.
+            try { $result = [System.IO.Path]::GetFullPath($result) } catch { }
             $changed = $true
             break
         }
@@ -1604,7 +1629,9 @@ Mirrors the precedent at Get-AgentCommandSegment, where a cd target matching [\$
 following git mutation untargetable rather than guessing where it lands.
 
 Pass -Literal for a path that came from a tool call rather than a command line. That skips the
-shell-expansion rule only. Rooting, `..` collapsing, and symlink resolution are unchanged.
+shell-expansion rule, and it keeps the target byte for byte: no quote stripping and no whitespace
+trimming, because those are legal Windows file name characters and the tool will open the path
+exactly as given. Rooting, `..` collapsing, and symlink resolution are unchanged.
 #>
 function Get-AgentWriteTargetResolution {
     [CmdletBinding()]
@@ -1614,7 +1641,12 @@ function Get-AgentWriteTargetResolution {
         return [pscustomobject]@{ Path = ''; Unresolved = $true }
     }
 
-    $trimmed = $Target.Trim().Trim('"', "'")
+    # A command-line target still carries the shell's quoting, so quotes and outer whitespace are
+    # stripped off it. A tool call carries the path exactly as the tool will open it, and a quote
+    # or a leading space is a legal Windows file name character. Stripping there classified a
+    # different file: "'\..\..\..\q.tmp" became the drive-rooted "\..\..\..\q.tmp", which lands
+    # outside the checkout and was allowed.
+    $trimmed = if ($Literal) { $Target } else { $Target.Trim().Trim('"', "'") }
     if ($trimmed.StartsWith('~')) {
         return [pscustomobject]@{ Path = ''; Unresolved = $true }
     }

--- a/scripts/agents/invoke-agent-worktree-guard.ps1
+++ b/scripts/agents/invoke-agent-worktree-guard.ps1
@@ -9,6 +9,10 @@ scripts/agents/agent-worktree-guard.common.ps1, and writes the resolved agent's 
 allow/warn/deny response. Adapters normalize payloads and responses only - no policy regex or
 path decision belongs in this file.
 
+Two kinds of tool call are evaluated. A shell call is classified from its command line by
+Invoke-AgentGuardPolicy. A Claude Edit, Write, or NotebookEdit call is classified from its single
+literal path by Get-AgentFileEditWriteDecision. Every other tool call exits without a decision.
+
 Adapter 'Auto' infers Copilot from a top-level 'toolArgs' key and Claude otherwise.
 #>
 [CmdletBinding()]
@@ -62,7 +66,40 @@ catch {
     exit 0
 }
 
-if ($normalized.ToolName -ne 'shell') {
+if ($normalized.ToolName -notin @('shell', 'file-edit')) {
+    exit 0
+}
+
+# Derive the protected repository from this checked-in script's own location, never from the
+# command's target - otherwise `git -C <elsewhere>` would redefine what is being protected.
+$protectedRepoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')).Path
+
+# A file-writing tool call carries one literal path and no command, so none of the command
+# evaluators apply to it. It is answered here and never reaches the adapter switch below: the
+# only outcomes are a stderr denial, a stderr warning, or silence.
+if ($normalized.ToolName -eq 'file-edit') {
+    # Codex and Copilot are out of scope. Their file-edit tool names and payload shapes are not
+    # verified here. See docs/agents/cross-agent-git-guardrails.md.
+    if ($Adapter -ne 'Claude') { exit 0 }
+
+    try {
+        $editDecision = Get-AgentFileEditWriteDecision `
+            -TargetPath $normalized.TargetPath `
+            -Cwd $normalized.Cwd `
+            -ProtectedRepoRoot $protectedRepoRoot `
+            -AllowMain ($env:AHKFLOW_ALLOW_MAIN -eq '1')
+    }
+    catch {
+        # Fail open, same as the shell write rule: keep the agent's editor usable, but say so.
+        Write-GuardDiagnostic "the file-edit write guard could not evaluate this path; allowing. $($_.Exception.Message)"
+        exit 0
+    }
+
+    if ($editDecision.Action -eq 'Allow') { exit 0 }
+
+    Write-GuardDiagnostic "$($editDecision.Action.ToLowerInvariant()) [$($editDecision.Rule)]"
+    [Console]::Error.WriteLine($editDecision.Message)
+    if ($editDecision.Action -eq 'Deny') { exit 2 }
     exit 0
 }
 
@@ -70,10 +107,6 @@ if ([string]::IsNullOrWhiteSpace($normalized.Command)) {
     Write-GuardDiagnostic 'hook payload carried no command; allowing.'
     exit 0
 }
-
-# Derive the protected repository from this checked-in script's own location, never from the
-# command's target - otherwise `git -C <elsewhere>` would redefine what is being protected.
-$protectedRepoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')).Path
 
 $decision = Invoke-AgentGuardPolicy `
     -Command $normalized.Command `

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -141,12 +141,29 @@ function Invoke-Entrypoint {
         [string] $StdIn,
         [string] $Adapter = 'Auto',
         [hashtable] $EnvironmentOverrides = @{},
-        [string] $WorkingDirectory = $suiteRoot
+        [string] $WorkingDirectory = $suiteRoot,
+        # Defaults to the checked-in entrypoint, which protects the real repository. Pass a copy
+        # planted inside the disposable fixture to protect the fixture instead.
+        [string] $ScriptPath = $entrypointScript
     )
 
     return Invoke-CapturedProcess -FilePath $script:PowerShellHost `
-        -Arguments @('-NoProfile', '-NonInteractive', '-File', $entrypointScript, '-Adapter', $Adapter) `
+        -Arguments @('-NoProfile', '-NonInteractive', '-File', $ScriptPath, '-Adapter', $Adapter) `
         -StdIn $StdIn -EnvironmentOverrides $EnvironmentOverrides -WorkingDirectory $WorkingDirectory
+}
+
+# The entrypoint derives the repository it protects from its own location, and that cannot be
+# overridden. Planting a copy inside the fixture is therefore the only way to point it at the
+# fixture. Without this, entrypoint cases would need a managed worktree of the REAL repository,
+# which does not exist in a plain checkout or in CI.
+function New-FixtureEntrypoint {
+    param([string] $RepoRoot)
+
+    $agents = Join-Path $RepoRoot 'scripts\agents'
+    New-Item -ItemType Directory -Path $agents -Force | Out-Null
+    Copy-Item -LiteralPath $commonScript -Destination $agents
+    Copy-Item -LiteralPath $entrypointScript -Destination $agents
+    return (Resolve-Path -LiteralPath (Join-Path $agents 'invoke-agent-worktree-guard.ps1')).Path
 }
 
 function ConvertTo-BashPath {
@@ -188,6 +205,63 @@ function Invoke-BashShim {
 
     return Invoke-CapturedProcess -FilePath $script:BashExecutable `
         -Arguments (@((ConvertTo-BashPath $bashShim)) + $ShimArguments) `
+        -StdIn $StdIn -EnvironmentOverrides $EnvironmentOverrides
+}
+
+# A shim's only job is to decide whether to forward. Proving that against the real entrypoint
+# needs the suite to be running inside a managed worktree, which it is not when it runs from a
+# plain checkout or in CI. So the shim is copied into a temporary tree whose entrypoint is a stub
+# that announces itself. Forwarded and not-forwarded then differ in the output, always.
+$script:ShimStubMarker = 'STUB-ENTRYPOINT-REACHED'
+
+function New-ShimHarness {
+    param([string] $ShimFileName)
+
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) (
+        'ahkflow-shim-harness-' + [guid]::NewGuid().ToString('N'))
+    $hooks = Join-Path $root '.claude\hooks'
+    $agents = Join-Path $root 'scripts\agents'
+    New-Item -ItemType Directory -Path $hooks -Force | Out-Null
+    New-Item -ItemType Directory -Path $agents -Force | Out-Null
+
+    Copy-Item -LiteralPath (Join-Path $suiteRoot ".claude\hooks\$ShimFileName") `
+        -Destination (Join-Path $hooks $ShimFileName)
+
+    # The stub replaces the real entrypoint at the same relative path the shim resolves.
+    Set-Content -LiteralPath (Join-Path $agents 'invoke-agent-worktree-guard.ps1') -Encoding utf8 -Value @"
+param([string] `$Adapter = 'Auto')
+[Console]::Error.WriteLine("$($script:ShimStubMarker) adapter=`$Adapter")
+exit 0
+"@
+
+    return [pscustomobject]@{
+        Root = (Resolve-Path -LiteralPath $root).Path
+        Shim = (Resolve-Path -LiteralPath (Join-Path $hooks $ShimFileName)).Path
+    }
+}
+
+function Remove-ShimHarness {
+    param([object] $Harness)
+
+    if ($null -eq $Harness) { return }
+    $tempRoot = (Resolve-Path -LiteralPath ([System.IO.Path]::GetTempPath())).Path.TrimEnd('\', '/')
+    $target = $Harness.Root.TrimEnd('\', '/')
+    if (-not $target.StartsWith($tempRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to delete a shim harness outside the temp directory: $target"
+    }
+    Remove-Item -LiteralPath $target -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+function Invoke-HarnessShim {
+    param(
+        [object] $Harness,
+        [string] $StdIn,
+        [string[]] $ShimArguments = @(),
+        [hashtable] $EnvironmentOverrides = @{}
+    )
+
+    return Invoke-CapturedProcess -FilePath $script:BashExecutable `
+        -Arguments (@((ConvertTo-BashPath $Harness.Shim)) + $ShimArguments) `
         -StdIn $StdIn -EnvironmentOverrides $EnvironmentOverrides
 }
 
@@ -2004,83 +2078,70 @@ try {
         Assert-Match 'AHKFLOW_ALLOW_MAIN=1' $decision.Message 'Message'
     }
 
-    # The entrypoint derives the protected repository from its own location, so a fixture path
-    # would classify as OutsideProtectedRepository and prove nothing. These cases need a real
-    # managed worktree of this repository. There may be none, so they report that instead of
-    # passing silently.
-    function Get-RealManagedWorktree {
-        $approved = (Join-Path $script:RealMainCheckout '.claude\worktrees').ToLowerInvariant()
-        $lines = @((& git -C $script:RealMainCheckout worktree list --porcelain) -split "`r?`n")
-        foreach ($line in $lines) {
-            if ($line -notlike 'worktree *') { continue }
-            $candidate = $line.Substring('worktree '.Length).Replace('/', '\')
-            if (-not (Test-Path -LiteralPath $candidate)) { continue }
-            $parent = (Split-Path -Parent $candidate).ToLowerInvariant()
-            if ($parent -ne $approved) { continue }
-            if (-not (Test-Path -LiteralPath (Join-Path $candidate 'scripts\.env.worktree'))) { continue }
-            return (Resolve-Path -LiteralPath $candidate).Path
-        }
-        return ''
-    }
-
-    $script:RealManagedWorktree = Get-RealManagedWorktree
-    $script:NoWorktreeMessage = 'This repository has no managed worktree, so the entrypoint cases cannot run. Create one with scripts/new-worktree.ps1.'
+    # A copy of the entrypoint planted inside the fixture, so it protects the fixture's main
+    # checkout and treats $fixture.Managed as a real managed worktree. The checked-in entrypoint
+    # would protect the real repository instead, and a fixture path would classify as
+    # OutsideProtectedRepository.
+    $script:FixtureEntrypoint = New-FixtureEntrypoint -RepoRoot $fixture.Main
 
     foreach ($toolName in @('Edit', 'Write', 'NotebookEdit')) {
         Invoke-TestCase "Entrypoint: $toolName into the main checkout is denied" {
-            Assert-True (-not [string]::IsNullOrWhiteSpace($script:RealManagedWorktree)) $script:NoWorktreeMessage
-            $target = Join-Path $script:RealMainCheckout 'README.md'
-            $result = Invoke-Entrypoint -Adapter 'Claude' `
-                -StdIn (New-ClaudeEditPayload $toolName $target $script:RealManagedWorktree)
+            $target = Join-Path $fixture.Main 'README.md'
+            $result = Invoke-Entrypoint -Adapter 'Claude' -ScriptPath $script:FixtureEntrypoint `
+                -StdIn (New-ClaudeEditPayload $toolName $target $fixture.Managed)
             Assert-Equal 2 $result.ExitCode 'ExitCode'
             Assert-Match 'cannot write into the main checkout' $result.StdErr 'StdErr'
         }
     }
 
+    Invoke-TestCase 'Entrypoint: the plans refusal reaches the agent verbatim' {
+        $target = Join-Path $fixture.Managed 'docs\superpowers\x.md'
+        $result = Invoke-Entrypoint -Adapter 'Claude' -ScriptPath $script:FixtureEntrypoint `
+            -StdIn (New-ClaudeEditPayload 'Write' $target $fixture.Managed)
+        Assert-Equal 2 $result.ExitCode 'ExitCode'
+        Assert-Match 'no worktree copy' $result.StdErr 'StdErr'
+        Assert-True ($result.StdErr -notmatch 'Edit the worktree copy') 'Must not send the agent looking for a copy'
+    }
+
     Invoke-TestCase 'Entrypoint: an edit inside the session worktree is allowed' {
-        Assert-True (-not [string]::IsNullOrWhiteSpace($script:RealManagedWorktree)) $script:NoWorktreeMessage
-        $target = Join-Path $script:RealManagedWorktree 'README.md'
-        $result = Invoke-Entrypoint -Adapter 'Claude' `
-            -StdIn (New-ClaudeEditPayload 'Edit' $target $script:RealManagedWorktree)
+        $target = Join-Path $fixture.Managed 'README.md'
+        $result = Invoke-Entrypoint -Adapter 'Claude' -ScriptPath $script:FixtureEntrypoint `
+            -StdIn (New-ClaudeEditPayload 'Edit' $target $fixture.Managed)
         Assert-Equal 0 $result.ExitCode 'ExitCode'
         Assert-Equal '' $result.StdOut.Trim() 'Must produce no decision payload'
     }
 
     Invoke-TestCase 'Entrypoint: a main-checkout session may still edit the main checkout' {
-        $target = Join-Path $script:RealMainCheckout 'README.md'
-        $result = Invoke-Entrypoint -Adapter 'Claude' `
-            -StdIn (New-ClaudeEditPayload 'Edit' $target $script:RealMainCheckout)
+        $target = Join-Path $fixture.Main 'README.md'
+        $result = Invoke-Entrypoint -Adapter 'Claude' -ScriptPath $script:FixtureEntrypoint `
+            -StdIn (New-ClaudeEditPayload 'Edit' $target $fixture.Main)
         Assert-Equal 0 $result.ExitCode 'ExitCode'
     }
 
     Invoke-TestCase 'Entrypoint: AHKFLOW_ALLOW_MAIN=1 warns instead of denying an edit' {
-        Assert-True (-not [string]::IsNullOrWhiteSpace($script:RealManagedWorktree)) $script:NoWorktreeMessage
-        $target = Join-Path $script:RealMainCheckout 'README.md'
-        $result = Invoke-Entrypoint -Adapter 'Claude' `
-            -StdIn (New-ClaudeEditPayload 'Edit' $target $script:RealManagedWorktree) `
+        $target = Join-Path $fixture.Main 'README.md'
+        $result = Invoke-Entrypoint -Adapter 'Claude' -ScriptPath $script:FixtureEntrypoint `
+            -StdIn (New-ClaudeEditPayload 'Edit' $target $fixture.Managed) `
             -EnvironmentOverrides @{ AHKFLOW_ALLOW_MAIN = '1' }
         Assert-Equal 0 $result.ExitCode 'ExitCode'
         Assert-Match 'AHKFLOW_ALLOW_MAIN=1 overrode' $result.StdErr 'StdErr'
     }
 
     Invoke-TestCase 'Entrypoint: AHKFLOW_GUARD_DISABLE=1 skips the file-edit rule too' {
-        Assert-True (-not [string]::IsNullOrWhiteSpace($script:RealManagedWorktree)) $script:NoWorktreeMessage
-        $target = Join-Path $script:RealMainCheckout 'README.md'
-        $result = Invoke-Entrypoint -Adapter 'Claude' `
-            -StdIn (New-ClaudeEditPayload 'Edit' $target $script:RealManagedWorktree) `
+        $target = Join-Path $fixture.Main 'README.md'
+        $result = Invoke-Entrypoint -Adapter 'Claude' -ScriptPath $script:FixtureEntrypoint `
+            -StdIn (New-ClaudeEditPayload 'Edit' $target $fixture.Managed) `
             -EnvironmentOverrides @{ AHKFLOW_GUARD_DISABLE = '1' }
         Assert-Equal 0 $result.ExitCode 'ExitCode'
+        Assert-True ($result.StdErr -notmatch 'cannot write into the main checkout') 'Must not deny'
     }
 
-    foreach ($adapter in @('Codex', 'Copilot')) {
-        Invoke-TestCase "Entrypoint: $adapter file-edit calls stay out of scope" {
-            Assert-True (-not [string]::IsNullOrWhiteSpace($script:RealManagedWorktree)) $script:NoWorktreeMessage
-            $target = Join-Path $script:RealMainCheckout 'README.md'
-            $result = Invoke-Entrypoint -Adapter $adapter `
-                -StdIn (New-ClaudeEditPayload 'Edit' $target $script:RealManagedWorktree)
-            Assert-Equal 0 $result.ExitCode 'ExitCode'
-            Assert-Equal '' $result.StdOut.Trim() 'Must produce no decision payload'
-        }
+    Invoke-TestCase 'Entrypoint: Codex file-edit calls stay out of scope' {
+        $target = Join-Path $fixture.Main 'README.md'
+        $result = Invoke-Entrypoint -Adapter 'Codex' -ScriptPath $script:FixtureEntrypoint `
+            -StdIn (New-ClaudeEditPayload 'Edit' $target $fixture.Managed)
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+        Assert-True ($result.StdErr -notmatch 'cannot write into the main checkout') 'Must not deny'
     }
 
     Write-Host 'Bash shim prefilter for worktree writes' -ForegroundColor Cyan
@@ -2091,9 +2152,18 @@ try {
     # the shim only classifies the command text.
     $script:RealWriteCommand = 'printf probe > ' + $script:RealMainCheckout.Replace('\', '/') + '/.guard-probe.tmp'
 
-    Invoke-TestCase 'Shim: a worktree-session redirect reaches the policy core' {
-        $result = Invoke-BashShim -StdIn (New-ClaudePayload $script:RealWriteCommand $suiteRoot)
-        Assert-Match 'agent-worktree-main-write' ($result.StdOut + $result.StdErr) 'Decision must be reported'
+    # Proved against the stub entrypoint, not the real one. The old version of this case passed a
+    # payload whose cwd was $suiteRoot and expected a denial, which only happens when the suite
+    # itself runs inside a managed worktree. From a plain checkout, and in CI, it failed.
+    Invoke-TestCase 'Shim: a worktree-session write is forwarded to the policy core' {
+        $harness = New-ShimHarness -ShimFileName 'pre-bash-guard.sh'
+        try {
+            $worktreeCwd = Join-Path $script:RealMainCheckout '.claude\worktrees\probe'
+            $result = Invoke-HarnessShim -Harness $harness `
+                -StdIn (New-ClaudePayload 'printf probe > ../../../README.md' $worktreeCwd)
+            Assert-Match $script:ShimStubMarker $result.StdErr 'Must forward to the entrypoint'
+        }
+        finally { Remove-ShimHarness -Harness $harness }
     }
 
     Invoke-TestCase 'Shim: a main-session redirect still exits in Bash' {
@@ -2106,6 +2176,81 @@ try {
         $result = Invoke-BashShim -StdIn (New-ClaudePayload 'cat README.md' $suiteRoot)
         Assert-Equal 0 $result.ExitCode 'Exit code'
         Assert-Equal '' $result.StdOut.Trim() 'Must produce no decision payload'
+    }
+
+    Write-Host 'Bash shim prefilter for file-edit tool calls' -ForegroundColor Cyan
+
+    Invoke-TestCase 'Edit shim: a worktree-session edit is forwarded to the policy core' {
+        $harness = New-ShimHarness -ShimFileName 'pre-edit-guard.sh'
+        try {
+            $worktreeCwd = Join-Path $script:RealMainCheckout '.claude\worktrees\probe'
+            $target = Join-Path $script:RealMainCheckout 'README.md'
+            $result = Invoke-HarnessShim -Harness $harness `
+                -StdIn (New-ClaudeEditPayload 'Edit' $target $worktreeCwd)
+            Assert-Match $script:ShimStubMarker $result.StdErr 'Must forward to the entrypoint'
+            Assert-Match 'adapter=Claude' $result.StdErr 'Must select the Claude adapter'
+        }
+        finally { Remove-ShimHarness -Harness $harness }
+    }
+
+    Invoke-TestCase 'Edit shim: a main-session edit exits in Bash' {
+        $harness = New-ShimHarness -ShimFileName 'pre-edit-guard.sh'
+        try {
+            $target = Join-Path $script:RealMainCheckout 'README.md'
+            $result = Invoke-HarnessShim -Harness $harness `
+                -StdIn (New-ClaudeEditPayload 'Edit' $target $script:RealMainCheckout)
+            Assert-Equal 0 $result.ExitCode 'ExitCode'
+            Assert-True ($result.StdErr -notmatch $script:ShimStubMarker) 'Must not start PowerShell'
+        }
+        finally { Remove-ShimHarness -Harness $harness }
+    }
+
+    Invoke-TestCase 'Edit shim: a Write payload is forwarded too' {
+        $harness = New-ShimHarness -ShimFileName 'pre-edit-guard.sh'
+        try {
+            $worktreeCwd = Join-Path $script:RealMainCheckout '.claude\worktrees\probe'
+            $target = Join-Path $script:RealMainCheckout 'notes.md'
+            $result = Invoke-HarnessShim -Harness $harness `
+                -StdIn (New-ClaudeEditPayload 'Write' $target $worktreeCwd)
+            Assert-Match $script:ShimStubMarker $result.StdErr 'Must forward to the entrypoint'
+        }
+        finally { Remove-ShimHarness -Harness $harness }
+    }
+
+    Invoke-TestCase 'Edit shim: honors AHKFLOW_GUARD_DISABLE before doing any work' {
+        $harness = New-ShimHarness -ShimFileName 'pre-edit-guard.sh'
+        try {
+            $worktreeCwd = Join-Path $script:RealMainCheckout '.claude\worktrees\probe'
+            $target = Join-Path $script:RealMainCheckout 'README.md'
+            $result = Invoke-HarnessShim -Harness $harness `
+                -StdIn (New-ClaudeEditPayload 'Edit' $target $worktreeCwd) `
+                -EnvironmentOverrides @{ AHKFLOW_GUARD_DISABLE = '1' }
+            Assert-Equal 0 $result.ExitCode 'ExitCode'
+            Assert-Match 'AHKFLOW_GUARD_DISABLE=1' $result.StdErr 'StdErr'
+            Assert-True ($result.StdErr -notmatch $script:ShimStubMarker) 'Must not start PowerShell'
+        }
+        finally { Remove-ShimHarness -Harness $harness }
+    }
+
+    Invoke-TestCase 'Edit shim: warns and allows when no PowerShell host exists' {
+        $harness = New-ShimHarness -ShimFileName 'pre-edit-guard.sh'
+        try {
+            $pathWithoutAnyHost = (
+                $env:PATH -split ';' |
+                Where-Object {
+                    $_ -and -not (Test-Path -LiteralPath (Join-Path $_ 'pwsh.exe')) -and
+                    -not (Test-Path -LiteralPath (Join-Path $_ 'powershell.exe'))
+                }
+            ) -join ';'
+            $worktreeCwd = Join-Path $script:RealMainCheckout '.claude\worktrees\probe'
+            $target = Join-Path $script:RealMainCheckout 'README.md'
+            $result = Invoke-HarnessShim -Harness $harness `
+                -StdIn (New-ClaudeEditPayload 'Edit' $target $worktreeCwd) `
+                -EnvironmentOverrides @{ PATH = $pathWithoutAnyHost }
+            Assert-Equal 0 $result.ExitCode 'ExitCode'
+            Assert-Match 'could not find PowerShell' $result.StdErr 'StdErr'
+        }
+        finally { Remove-ShimHarness -Harness $harness }
     }
 }
 finally {

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1825,10 +1825,24 @@ try {
         Assert-Equal (Join-Path $fixture.Main '.claude\q.tmp') $resolution.Path 'Path'
     }
 
-    Invoke-TestCase 'Resolution: -Literal keeps surrounding quotes in a file name' {
-        $resolution = Get-AgentWriteTargetResolution -Target '"quoted.cs"' `
+    Invoke-TestCase 'Resolution: -Literal keeps a single quote in a file name' {
+        $resolution = Get-AgentWriteTargetResolution -Target "'quoted'.cs" `
             -BaseDirectory $fixture.Managed -Literal
-        Assert-Equal (Join-Path $fixture.Managed '"quoted.cs"') $resolution.Path 'Path'
+        Assert-Equal (Join-Path $fixture.Managed "'quoted'.cs") $resolution.Path 'Path'
+    }
+
+    # Windows PowerShell 5.1 runs on .NET Framework, whose path APIs reject '"' outright; pwsh 7
+    # accepts it. Assert the invariant both hosts must hold: never throw, and never quietly drop
+    # the character. Throwing would reach the entrypoint's catch and allow the write.
+    Invoke-TestCase 'Resolution: -Literal never throws on a double quote in a file name' {
+        $resolution = Get-AgentWriteTargetResolution -Target '"quoted".cs' `
+            -BaseDirectory $fixture.Managed -Literal
+        if ($resolution.Unresolved) {
+            Assert-Equal '' $resolution.Path 'An unresolved target carries no path'
+        }
+        else {
+            Assert-Equal (Join-Path $fixture.Managed '"quoted".cs') $resolution.Path 'Path'
+        }
     }
 
     Invoke-TestCase 'Resolution: a command-line target still has its quoting stripped' {

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -2004,6 +2004,85 @@ try {
         Assert-Match 'AHKFLOW_ALLOW_MAIN=1' $decision.Message 'Message'
     }
 
+    # The entrypoint derives the protected repository from its own location, so a fixture path
+    # would classify as OutsideProtectedRepository and prove nothing. These cases need a real
+    # managed worktree of this repository. There may be none, so they report that instead of
+    # passing silently.
+    function Get-RealManagedWorktree {
+        $approved = (Join-Path $script:RealMainCheckout '.claude\worktrees').ToLowerInvariant()
+        $lines = @((& git -C $script:RealMainCheckout worktree list --porcelain) -split "`r?`n")
+        foreach ($line in $lines) {
+            if ($line -notlike 'worktree *') { continue }
+            $candidate = $line.Substring('worktree '.Length).Replace('/', '\')
+            if (-not (Test-Path -LiteralPath $candidate)) { continue }
+            $parent = (Split-Path -Parent $candidate).ToLowerInvariant()
+            if ($parent -ne $approved) { continue }
+            if (-not (Test-Path -LiteralPath (Join-Path $candidate 'scripts\.env.worktree'))) { continue }
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+        return ''
+    }
+
+    $script:RealManagedWorktree = Get-RealManagedWorktree
+    $script:NoWorktreeMessage = 'This repository has no managed worktree, so the entrypoint cases cannot run. Create one with scripts/new-worktree.ps1.'
+
+    foreach ($toolName in @('Edit', 'Write', 'NotebookEdit')) {
+        Invoke-TestCase "Entrypoint: $toolName into the main checkout is denied" {
+            Assert-True (-not [string]::IsNullOrWhiteSpace($script:RealManagedWorktree)) $script:NoWorktreeMessage
+            $target = Join-Path $script:RealMainCheckout 'README.md'
+            $result = Invoke-Entrypoint -Adapter 'Claude' `
+                -StdIn (New-ClaudeEditPayload $toolName $target $script:RealManagedWorktree)
+            Assert-Equal 2 $result.ExitCode 'ExitCode'
+            Assert-Match 'cannot write into the main checkout' $result.StdErr 'StdErr'
+        }
+    }
+
+    Invoke-TestCase 'Entrypoint: an edit inside the session worktree is allowed' {
+        Assert-True (-not [string]::IsNullOrWhiteSpace($script:RealManagedWorktree)) $script:NoWorktreeMessage
+        $target = Join-Path $script:RealManagedWorktree 'README.md'
+        $result = Invoke-Entrypoint -Adapter 'Claude' `
+            -StdIn (New-ClaudeEditPayload 'Edit' $target $script:RealManagedWorktree)
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+        Assert-Equal '' $result.StdOut.Trim() 'Must produce no decision payload'
+    }
+
+    Invoke-TestCase 'Entrypoint: a main-checkout session may still edit the main checkout' {
+        $target = Join-Path $script:RealMainCheckout 'README.md'
+        $result = Invoke-Entrypoint -Adapter 'Claude' `
+            -StdIn (New-ClaudeEditPayload 'Edit' $target $script:RealMainCheckout)
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+    }
+
+    Invoke-TestCase 'Entrypoint: AHKFLOW_ALLOW_MAIN=1 warns instead of denying an edit' {
+        Assert-True (-not [string]::IsNullOrWhiteSpace($script:RealManagedWorktree)) $script:NoWorktreeMessage
+        $target = Join-Path $script:RealMainCheckout 'README.md'
+        $result = Invoke-Entrypoint -Adapter 'Claude' `
+            -StdIn (New-ClaudeEditPayload 'Edit' $target $script:RealManagedWorktree) `
+            -EnvironmentOverrides @{ AHKFLOW_ALLOW_MAIN = '1' }
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+        Assert-Match 'AHKFLOW_ALLOW_MAIN=1 overrode' $result.StdErr 'StdErr'
+    }
+
+    Invoke-TestCase 'Entrypoint: AHKFLOW_GUARD_DISABLE=1 skips the file-edit rule too' {
+        Assert-True (-not [string]::IsNullOrWhiteSpace($script:RealManagedWorktree)) $script:NoWorktreeMessage
+        $target = Join-Path $script:RealMainCheckout 'README.md'
+        $result = Invoke-Entrypoint -Adapter 'Claude' `
+            -StdIn (New-ClaudeEditPayload 'Edit' $target $script:RealManagedWorktree) `
+            -EnvironmentOverrides @{ AHKFLOW_GUARD_DISABLE = '1' }
+        Assert-Equal 0 $result.ExitCode 'ExitCode'
+    }
+
+    foreach ($adapter in @('Codex', 'Copilot')) {
+        Invoke-TestCase "Entrypoint: $adapter file-edit calls stay out of scope" {
+            Assert-True (-not [string]::IsNullOrWhiteSpace($script:RealManagedWorktree)) $script:NoWorktreeMessage
+            $target = Join-Path $script:RealMainCheckout 'README.md'
+            $result = Invoke-Entrypoint -Adapter $adapter `
+                -StdIn (New-ClaudeEditPayload 'Edit' $target $script:RealManagedWorktree)
+            Assert-Equal 0 $result.ExitCode 'ExitCode'
+            Assert-Equal '' $result.StdOut.Trim() 'Must produce no decision payload'
+        }
+    }
+
     Write-Host 'Bash shim prefilter for worktree writes' -ForegroundColor Cyan
 
     # These three run against the REAL repository identity, like every other shim test above: the

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -395,6 +395,19 @@ function New-GuardFixture {
             'Enable Windows Developer Mode, then re-run. See docs/development/prerequisites.md.')
     }
 
+    # A FILE symlink with a RELATIVE target, inside the worktree, pointing at the main checkout.
+    # Windows resolves such a target against the directory holding the link. This repository
+    # already tracks one of these at .github\AGENTS.md, so it is not a theoretical shape.
+    Push-Location $managedRoot
+    try { cmd /c mklink 'relative-link.md' '..\..\..\seed.txt' > $null 2>&1 }
+    finally { Pop-Location }
+
+    $relativeLink = Join-Path $managedRoot 'relative-link.md'
+    if (-not (Test-Path -LiteralPath $relativeLink)) {
+        throw ('Could not create the relative file symlink the guard tests require. ' +
+            'Enable Windows Developer Mode, then re-run. See docs/development/prerequisites.md.')
+    }
+
     # badManifest sits in an approved parent but its manifest port disagrees with its URL.
     $badRoot = (Resolve-Path -LiteralPath $badManifest).Path
     New-Item -ItemType Directory -Path (Join-Path $badRoot 'scripts') -Force | Out-Null
@@ -1788,6 +1801,41 @@ try {
         Assert-Equal (Join-Path $fixture.Main 'x.tmp') $resolution.Path 'Path'
     }
 
+    # A symlink target may be relative, and Windows resolves it against the directory holding the
+    # link. Resolving it against the hook process's working directory instead classified the wrong
+    # file, and a link that is the LAST path component indexed past the end of the split array.
+    Invoke-TestCase 'Resolution: a relative file symlink resolves against the link parent' {
+        $link = Join-Path $fixture.Managed 'relative-link.md'
+        Assert-Equal (Join-Path $fixture.Main 'seed.txt') (Resolve-AgentSymlinkPath -Path $link) 'Resolved path'
+    }
+
+    Invoke-TestCase 'Resolution: a relative file symlink is classified in the main checkout' {
+        $link = Join-Path $fixture.Managed 'relative-link.md'
+        $resolution = Get-AgentWriteTargetResolution -Target $link -BaseDirectory $fixture.Managed -Literal
+        Assert-True (-not $resolution.Unresolved) 'Must resolve'
+        Assert-Equal (Join-Path $fixture.Main 'seed.txt') $resolution.Path 'Path'
+    }
+
+    # -Literal must classify the exact path the tool will open. A quote and a leading or trailing
+    # space are legal Windows file name characters, so stripping them names a different file.
+    Invoke-TestCase 'Resolution: -Literal keeps a leading quote in the path' {
+        $resolution = Get-AgentWriteTargetResolution -Target "'\..\..\..\q.tmp" `
+            -BaseDirectory $fixture.Managed -Literal
+        Assert-True (-not $resolution.Unresolved) 'Must resolve'
+        Assert-Equal (Join-Path $fixture.Main '.claude\q.tmp') $resolution.Path 'Path'
+    }
+
+    Invoke-TestCase 'Resolution: -Literal keeps surrounding quotes in a file name' {
+        $resolution = Get-AgentWriteTargetResolution -Target '"quoted.cs"' `
+            -BaseDirectory $fixture.Managed -Literal
+        Assert-Equal (Join-Path $fixture.Managed '"quoted.cs"') $resolution.Path 'Path'
+    }
+
+    Invoke-TestCase 'Resolution: a command-line target still has its quoting stripped' {
+        $resolution = Get-AgentWriteTargetResolution -Target '"quoted.cs"' -BaseDirectory $fixture.Managed
+        Assert-Equal (Join-Path $fixture.Managed 'quoted.cs') $resolution.Path 'Path'
+    }
+
     $unresolvedCases = @('$MAIN_ROOT/x.tmp', '%USERPROFILE%\x.tmp', '~/x.tmp')
     foreach ($case in $unresolvedCases) {
         Invoke-TestCase "Resolution: unexpandable leading component is unresolved: $case" {
@@ -2047,6 +2095,16 @@ try {
         },
         @{ Name = 'a subdirectory session still cannot write the main checkout'
             Path = '<MAIN>\x.tmp'; Cwd = 'ManagedSub'; Action = 'Deny'
+        },
+        # A file symlink inside the worktree whose relative target climbs into the main checkout.
+        # Edit and Write follow the link, so the classification has to follow it too.
+        @{ Name = 'a relative file symlink into the main checkout'
+            Path = '<MANAGED>\relative-link.md'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        # A leading quote is a legal Windows file name character. Stripping it turned this path
+        # into a drive-rooted one outside the checkout, and the write was allowed.
+        @{ Name = 'a leading quote does not turn a parent escape into a rooted path'
+            Path = "'\..\..\..\q.tmp"; Cwd = 'Managed'; Action = 'Deny'
         }
     )
 

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1850,6 +1850,112 @@ try {
         Assert-Equal 'agent-main-git-mutation' $decision.Rule 'Rule'
     }
 
+    Write-Host 'File-edit write isolation' -ForegroundColor Cyan
+
+    # One literal path per case. Placeholders are replaced against the disposable fixture below,
+    # so no case names a real repository path.
+    $fileEditCases = @(
+        @{ Name = 'a file inside the session worktree'
+            Path = '<MANAGED>\src\a.cs'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        @{ Name = 'a file in the main checkout'
+            Path = '<MAIN>\README.md'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name = 'a file in a sibling worktree'
+            Path = '<MANAGED2>\src\a.cs'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name = 'build output under the main checkout'
+            Path = '<MAIN>\obj\x.dll'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        @{ Name = 'a path outside the protected checkout'
+            Path = '<UNRELATED>\x.txt'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        @{ Name = 'the worktree removal log'
+            Path = '<MAIN>\.claude\worktrees\worktree-removal.log'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        @{ Name = 'a main-checkout session may still edit main'
+            Path = '<MAIN>\README.md'; Cwd = 'Main'; Action = 'Allow'
+        },
+        @{ Name = 'an unmanaged worktree session is not covered by this rule'
+            Path = '<MAIN>\README.md'; Cwd = 'Unmanaged'; Action = 'Allow'
+        },
+        # docs\superpowers is a directory symlink back to the main checkout, so the resolved path
+        # lands in main even though the path the agent typed sits inside the worktree.
+        @{ Name = 'the plans symlink resolves back into the main checkout'
+            Path = '<MANAGED>\docs\superpowers\x.md'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name = 'a relative path resolves against the session working directory'
+            Path = 'README.md'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        @{ Name = 'a relative path can climb out into the main checkout'
+            Path = '..\..\..\README.md'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name = 'an empty path has nothing to classify'
+            Path = ''; Cwd = 'Managed'; Action = 'Allow'
+        },
+        # A tool call cannot expand '~'. Fail closed rather than guess which home directory.
+        @{ Name = 'a home-relative path fails closed'
+            Path = '~\x.txt'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        # '$', '%' and backtick are legal in a Windows file name, and a tool call carries a literal
+        # path with no shell expansion. Treating one as unexpandable would refuse a real edit
+        # inside the session's own worktree.
+        @{ Name = 'a dollar sign in a file name is not a shell expansion'
+            Path = '<MANAGED>\src\a$b.cs'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        @{ Name = 'a percent sign in a file name is not a shell expansion'
+            Path = '<MANAGED>\src\a%b.cs'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        @{ Name = 'a subdirectory session writes its own worktree root'
+            Path = '<MANAGED>\README.md'; Cwd = 'ManagedSub'; Action = 'Allow'
+        },
+        @{ Name = 'a subdirectory session still cannot write the main checkout'
+            Path = '<MAIN>\x.tmp'; Cwd = 'ManagedSub'; Action = 'Deny'
+        }
+    )
+
+    foreach ($case in $fileEditCases) {
+        Invoke-TestCase "File-edit isolation: $($case.Name)" {
+            $path = $case.Path.
+            Replace('<MANAGED2>', $fixture.Managed2).
+            Replace('<MANAGED>', $fixture.Managed).
+            Replace('<UNRELATED>', $fixture.Unrelated).
+            Replace('<MAIN>', $fixture.Main)
+            $cwd = switch ($case.Cwd) {
+                'Main' { $fixture.Main }
+                'Unmanaged' { $fixture.Unmanaged }
+                'ManagedSub' { Join-Path $fixture.Managed 'scripts' }
+                default { $fixture.Managed }
+            }
+            $decision = Get-AgentFileEditWriteDecision -TargetPath $path `
+                -Cwd $cwd -ProtectedRepoRoot $fixture.Main -AllowMain $false
+            Assert-Equal $case.Action $decision.Action 'Action'
+        }
+    }
+
+    Invoke-TestCase 'File-edit isolation: a denial carries the shared write rule name' {
+        $decision = Get-AgentFileEditWriteDecision -TargetPath (Join-Path $fixture.Main 'README.md') `
+            -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main -AllowMain $false
+        Assert-Equal 'agent-worktree-main-write' $decision.Rule 'Rule'
+        Assert-Match 'cannot write into the main checkout' $decision.Message 'Message'
+    }
+
+    Invoke-TestCase 'File-edit isolation: the plans refusal does not name a worktree copy' {
+        $path = Join-Path $fixture.Managed 'docs\superpowers\x.md'
+        $decision = Get-AgentFileEditWriteDecision -TargetPath $path `
+            -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main -AllowMain $false
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Match 'no worktree copy' $decision.Message 'Message'
+        Assert-True ($decision.Message -notmatch 'Edit the worktree copy') 'Must not send the agent looking for a copy'
+    }
+
+    Invoke-TestCase 'File-edit isolation: AHKFLOW_ALLOW_MAIN=1 downgrades to a warning' {
+        $decision = Get-AgentFileEditWriteDecision -TargetPath (Join-Path $fixture.Main 'README.md') `
+            -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main -AllowMain $true
+        Assert-Equal 'Warn' $decision.Action 'Action'
+        Assert-Match 'AHKFLOW_ALLOW_MAIN=1' $decision.Message 'Message'
+    }
+
     Write-Host 'Bash shim prefilter for worktree writes' -ForegroundColor Cyan
 
     # These three run against the REAL repository identity, like every other shim test above: the

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1626,6 +1626,20 @@ try {
         Assert-Match '-Adapter Copilot' $guards[0].powershell 'powershell adapter'
     }
 
+    Invoke-TestCase 'Claude registers the file-edit guard on all three writing tools' {
+        $settings = Get-Content -LiteralPath (Join-Path $suiteRoot '.claude\settings.json') -Raw | ConvertFrom-Json
+        $guards = @($settings.hooks.PreToolUse | Where-Object {
+                @($_.hooks) | Where-Object {
+                    $_.PSObject.Properties['command'] -and $_.command -match 'pre-edit-guard'
+                }
+            })
+
+        Assert-Equal 1 $guards.Count 'exactly one file-edit guard registration'
+        foreach ($tool in @('Edit', 'Write', 'NotebookEdit')) {
+            Assert-Match "\b$tool\b" $guards[0].matcher "matcher must cover $tool"
+        }
+    }
+
     Write-Host 'Token quote masks' -ForegroundColor Cyan
 
     $maskCases = @(

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -226,6 +226,19 @@ function New-CopilotPayload {
     } | ConvertTo-Json -Compress -Depth 4
 }
 
+function New-ClaudeEditPayload {
+    param([string] $ToolName, [string] $Path, [string] $Cwd)
+
+    # Edit and Write carry file_path; NotebookEdit carries notebook_path.
+    $pathKey = if ($ToolName -ieq 'NotebookEdit') { 'notebook_path' } else { 'file_path' }
+    return @{
+        hook_event_name = 'PreToolUse'
+        tool_name       = $ToolName
+        tool_input      = @{ $pathKey = $Path }
+        cwd             = $Cwd
+    } | ConvertTo-Json -Compress -Depth 4
+}
+
 # ── Disposable git fixture ──────────────────────────────────────────────────────────────────
 
 function New-GuardFixture {
@@ -405,6 +418,41 @@ try {
     Invoke-TestCase 'Auto adapter falls back to Claude without toolArgs' {
         $normalized = ConvertFrom-AgentHookInput -Adapter 'Auto' -InputJson (New-ClaudePayload 'git status' $fixture.Main)
         Assert-Equal 'Claude' $normalized.Adapter 'Adapter'
+    }
+
+    Invoke-TestCase 'Edit payload normalizes to the file-edit contract' {
+        $json = New-ClaudeEditPayload 'Edit' 'C:\repo\src\a.cs' $fixture.Main
+        $normalized = ConvertFrom-AgentHookInput -Adapter 'Claude' -InputJson $json
+        Assert-Equal 'file-edit' $normalized.ToolName 'ToolName'
+        Assert-Equal 'C:\repo\src\a.cs' $normalized.TargetPath 'TargetPath'
+        Assert-Equal '' $normalized.Command 'Command'
+    }
+
+    Invoke-TestCase 'Write payload normalizes to the file-edit contract' {
+        $json = New-ClaudeEditPayload 'Write' 'C:\repo\src\b.cs' $fixture.Main
+        $normalized = ConvertFrom-AgentHookInput -Adapter 'Claude' -InputJson $json
+        Assert-Equal 'file-edit' $normalized.ToolName 'ToolName'
+        Assert-Equal 'C:\repo\src\b.cs' $normalized.TargetPath 'TargetPath'
+    }
+
+    Invoke-TestCase 'NotebookEdit payload carries its path under notebook_path' {
+        $json = New-ClaudeEditPayload 'NotebookEdit' 'C:\repo\note.ipynb' $fixture.Main
+        $normalized = ConvertFrom-AgentHookInput -Adapter 'Claude' -InputJson $json
+        Assert-Equal 'file-edit' $normalized.ToolName 'ToolName'
+        Assert-Equal 'C:\repo\note.ipynb' $normalized.TargetPath 'TargetPath'
+    }
+
+    Invoke-TestCase 'A Bash payload still carries no target path' {
+        $normalized = ConvertFrom-AgentHookInput -Adapter 'Claude' `
+            -InputJson (New-ClaudePayload 'git status' $fixture.Main)
+        Assert-Equal 'shell' $normalized.ToolName 'ToolName'
+        Assert-Equal '' $normalized.TargetPath 'TargetPath'
+    }
+
+    Invoke-TestCase 'An unknown tool name stays unrecognized' {
+        $json = New-ClaudeEditPayload 'Read' 'C:\repo\src\a.cs' $fixture.Main
+        $normalized = ConvertFrom-AgentHookInput -Adapter 'Claude' -InputJson $json
+        Assert-Equal 'Read' $normalized.ToolName 'ToolName'
     }
 
     Write-Host 'Entrypoint input handling' -ForegroundColor Cyan


### PR DESCRIPTION
Closes backlog 065. A Claude session whose working directory is a managed worktree can no longer
`Edit`, `Write`, or `NotebookEdit` a file that resolves under the human-owned main checkout.

## The gap

Two guards decided who may write into main, and they disagreed.

| Guard | Decides from | Covered |
|---|---|---|
| Claude Code native isolation | a session flag set by `-w`, `--worktree`, or `EnterWorktree` | `Edit`, `Write` |
| This repository (backlog 054) | the `cwd` in the hook payload | `Bash` |

A session started **directly inside a worktree directory**, without `-w`, never gets the native
flag. It could `Edit` and `Write` into main freely, while the same write through `Bash` was denied.
The whole gap was one line — `invoke-agent-worktree-guard.ps1:65` exited early for every tool that
was not a shell.

## What changed

Three layers, copied from the `Bash` write guard that backlog 054 shipped.

- **`.claude/hooks/pre-edit-guard.sh`** (new). A prefilter on the payload `cwd`. A managed worktree
  always carries the `worktrees` path segment, so a main-checkout session exits in Bash and never
  pays a PowerShell start. Same conservative-superset discipline `pre-bash-guard.sh` documents.
- **`invoke-agent-worktree-guard.ps1`**. `ConvertFrom-AgentHookInput` gains a `file-edit` tool class
  and a `TargetPath` field, read from `file_path` or from `notebook_path`. The entrypoint answers a
  file-edit call directly: stderr plus exit 2 to deny, stderr plus exit 0 to warn, silence to allow.
- **`agent-worktree-guard.common.ps1`**. One new function, `Get-AgentFileEditWriteDecision`. A tool
  call carries one literal path, so it needs no parsing. It reuses 054's existing path resolution,
  allow-list, and refusal messages rather than growing a second copy.

Registered on `Edit|Write|NotebookEdit`. Rule name stays `agent-worktree-main-write` — same rule
about the same thing.

Codex and Copilot file-edit calls stay out of scope. Their tool names and payload shapes are not
verified here, and neither agent has native isolation to disagree with. Recorded as a limitation.

## Three fail-open defects this exposed in the shared resolver

Reusing 054's path resolution meant reading it closely, and it had three ways to let a write
through. Each one threw, and every throw reaches the entrypoint's catch, which **allows** the call.
All three affected the existing `Bash` rule too, so 054 is now stricter as well.

1. **A relative symlink target was resolved against the wrong directory.** Windows resolves it
   against the directory holding the link; the resolver used the hook process's working directory.
   A link inside a worktree pointing at `..\..\..\README.md` therefore looked like a path outside
   the checkout, while `Edit` followed it into main.
2. **A link that was the last path component indexed past the end of an array.** The remainder slice
   `$parts[($i+1)..($parts.Count-1)]` asks for index `$parts.Count`. Under the entrypoint's
   `Set-StrictMode -Version 3.0` that throws; without strict mode it silently produces a descending
   range and duplicates the leaf. Measured against the repository's own tracked relative symlink at
   `.github/AGENTS.md`.
3. **A path the PowerShell host cannot parse threw instead of failing closed.** Windows PowerShell
   5.1 runs on .NET Framework, whose `Path.IsPathRooted` rejects a `"` outright; pwsh 7 accepts it.
   Rooting and `GetFullPath` are now wrapped together and report the target unresolved, which
   denies.

A fourth issue was specific to the new code: `-Literal` skipped the shell-expansion rule but still
ran `.Trim().Trim('"', "'")`. A quote and a leading space are legal Windows file name characters, so
trimming named a different file — `'\..\..\..\..\victim.txt` became the drive-rooted
`C:\victim.txt`, outside the checkout, and was allowed. Literal mode now preserves the path exactly.

## Verification

Three real sessions, all from `.claude/worktrees/065-edit-write-isolation` with **no** `-w`, on
Claude Code 2.1.225. This is the exact case the item was filed on.

**Write into the main checkout — denied.**

```
PreToolUse:Write hook error: [bash "${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-edit-guard.sh"]: [agent-guard:Claude] deny [agent-worktree-main-write]
BLOCKED: this session is isolated in a worktree, so it cannot write into the main checkout at C:\Dev\segocom-github\AHKFlowApp\probe-065-writetest.log
Read from here. Write from the main checkout.
To override, a human must set AHKFLOW_ALLOW_MAIN=1 in the shell environment before starting the
agent session.
```

**Write into `docs/superpowers` — denied, with the plans wording.** The symlink resolves back into
main, and the message never sends the agent looking for a worktree copy that cannot exist.

```
BLOCKED: this session is isolated in a worktree, so it cannot write into the main checkout at C:\Dev\segocom-github\AHKFlowApp\docs\superpowers\probe-065-plans.md
docs/superpowers is a symlink to the main checkout. There is no worktree copy of it, so do not
look for one. Plan and spec writes belong in the main checkout by design.
Read the plan from here. Write and commit it from the main checkout.
```

**Write inside the worktree — succeeded.** The control. Without it the first two prove only that the
guard refuses everything.

No probe file was created. Main stayed clean and the plans repository stayed clean.

Test gate:

- `tests/AgentWorktreeGuard.Tests.ps1` — pass under pwsh 7 and under Windows PowerShell 5.1
- All 16 PowerShell suites CI runs, in a fresh clone with no worktrees — all green
- `dotnet build AHKFlowApp.slnx --configuration Release` — 17 projects, 0 errors, 0 warnings
- `dotnet format AHKFlowApp.slnx --verify-no-changes` — clean
- `git diff --check main...HEAD` — clean
- Pre-push quick checks — 2,925 tests, pass

`pwsh .\scripts\test-fast.ps1 -Mode Coverage` was not run. This branch changes no compiled file, so
it cannot move coverage.

## A CI hole found while planning

`tests/AgentWorktreeGuard.Tests.ps1` had a test failing on `main`, and CI reported the job green.
`ci.yml` runs sixteen suites in one `run:` block, so only the last script's exit code counts.

The failing test assumed the suite runs inside a worktree, which is not true in a plain checkout.
It is rewritten here against a stub entrypoint, so it no longer depends on where the suite runs. The
new entrypoint tests use the same idea and run against a copy planted in the disposable fixture.

The CI hole itself is **not** fixed here — it is filed as `backlog/066`, with the trap its fix must
avoid: the suites have no explicit `exit 0` on success, so `$LASTEXITCODE` leaks from their last
internal `git` call. `WorktreeBaseRef.Tests.ps1` prints "passed" and still leaves it at `1`.

## Also in this PR

- `backlog/065` ticked and moved to `backlog/done/`
- `backlog/066` filed
- `docs/agents/cross-agent-git-guardrails.md` updated — new hook row, the write-isolation section
  now covers both kinds of write and the symlink rule, and the stale "not covered by this repository
  at all" claim is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
