### PR TITLE
chore: add PR-Agent review
  workflow

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -39,6 +39,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # PR-Agent caps each model call at 120 seconds, but nothing caps the job. A
+    # stalled pull or a connection that hangs would otherwise run to GitHub's
+    # 6-hour default.
+    timeout-minutes: 15
+
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,30 @@
+name: PR-Agent
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  pr_agent:
+    if: >
+      github.event.issue.pull_request &&
+      github.event.sender.type != 'Bot' &&
+      contains(
+        fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+        github.event.comment.author_association
+      )
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Run PR-Agent
+        # pragent/pr-agent:0.41.1-github_action
+        uses: docker://pragent/pr-agent@sha256:ec267eb168375c150d75efc024e2b10e0e2768ad0c000f15fd2378fe63abfe98
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          openrouter__key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -3,15 +3,38 @@ name: PR-Agent
 on:
   issue_comment:
     types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+# One PR-Agent run at a time per pull request. PR-Agent edits its previous
+# comment instead of posting a new one, so two runs would overwrite each other.
+# Runs queue rather than cancel, so a /review is not killed by a later /improve.
+concurrency:
+  group: pr-agent-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   pr_agent:
+    # PR-Agent strips a leading slash rather than requiring one, so a plain
+    # comment starting with "describe ..." would run /describe and overwrite the
+    # pull request body. Only run for an explicit command we want, which also
+    # keeps /oc comments meant for the opencode workflow from starting a job.
     if: >
-      github.event.issue.pull_request &&
       github.event.sender.type != 'Bot' &&
+      (
+        (github.event.issue.pull_request && github.event.issue.state == 'open') ||
+        (github.event.pull_request && github.event.pull_request.state == 'open')
+      ) &&
       contains(
         fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
         github.event.comment.author_association
+      ) &&
+      (
+        startsWith(github.event.comment.body, '/review') ||
+        startsWith(github.event.comment.body, '/describe') ||
+        startsWith(github.event.comment.body, '/improve') ||
+        startsWith(github.event.comment.body, '/ask') ||
+        startsWith(github.event.comment.body, '/help')
       )
 
     runs-on: ubuntu-latest

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -20,7 +20,7 @@ require_tests_review = true
 require_estimate_effort_to_review = false
 num_max_findings = 5
 
-extra_instructions = """
+extra_instructions = '''
 Focus on:
 - correctness
 - regressions
@@ -32,14 +32,14 @@ Focus on:
 
 Only report actionable findings.
 Do not invent issues.
-"""
+'''
 
 [pr_code_suggestions]
 commitable_code_suggestions = true
 
 # /improve reads its own extra_instructions, not the reviewer's. It writes
 # committable code onto the diff, so it needs the same limits.
-extra_instructions = """
+extra_instructions = '''
 Focus on:
 - correctness
 - regressions
@@ -51,4 +51,4 @@ Focus on:
 
 Only report actionable findings.
 Do not invent issues.
-"""
+'''

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,27 @@
+[config]
+restricted_mode = true
+model = "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"
+fallback_models = []
+
+[pr_reviewer]
+require_security_review = true
+require_tests_review = true
+require_estimate_effort_to_review = false
+num_max_findings = 5
+
+extra_instructions = """
+Focus on:
+- correctness
+- regressions
+- security
+- concurrency
+- error handling
+- maintainability
+- missing tests
+
+Only report actionable findings.
+Do not invent issues.
+"""
+
+[pr_code_suggestions]
+commitable_code_suggestions = true

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,7 +1,18 @@
 [config]
 restricted_mode = true
 model = "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"
-fallback_models = []
+fallback_models = ["openrouter/nvidia/nemotron-3-super-120b-a12b:free"]
+
+# PR-Agent only knows the context size of models in its own built-in table, and
+# this one is not in it. Without custom_model_max_tokens it raises before the
+# first call. The model itself accepts 1M tokens.
+custom_model_max_tokens = 1000000
+
+# The real cap on how much diff we send. PR-Agent defaults this to 32000, which
+# would silently truncate a large pull request. Raise it, but stay well under
+# the model limit: quality drops on very long input, and this is a free
+# endpoint with shared capacity.
+max_model_tokens = 64000
 
 [pr_reviewer]
 require_security_review = true
@@ -25,3 +36,19 @@ Do not invent issues.
 
 [pr_code_suggestions]
 commitable_code_suggestions = true
+
+# /improve reads its own extra_instructions, not the reviewer's. It writes
+# committable code onto the diff, so it needs the same limits.
+extra_instructions = """
+Focus on:
+- correctness
+- regressions
+- security
+- concurrency
+- error handling
+- maintainability
+- missing tests
+
+Only report actionable findings.
+Do not invent issues.
+"""


### PR DESCRIPTION
## Summary

- add a comment-triggered PR-Agent workflow for trusted repository members
- route requests through Nemotron on OpenRouter
- pin PR-Agent to an immutable container digest
- enable restricted mode with limited repository permissions

## Verification

- TOML and YAML parsing passed
- pinned Docker digest matched the registry
- `git diff --check main...HEAD` passed

## Manual verification

After merge, comment `/review` on an open pull request and confirm PR-Agent posts a review.