### PR TITLE
feat: run the PowerShell suites from test-fast

### DIFF
--- a/backlog/067-make-the-powershell-suites-ci-check-required-and-runnable-from-test-fast.md
+++ b/backlog/067-make-the-powershell-suites-ci-check-required-and-runnable-from-test-fast.md
@@ -31,9 +31,17 @@ touch `tests/*.Tests.ps1`.
 ## Acceptance criteria
 
 - [ ] `powershell-suites` is a required status check on `main`, so a red run blocks the merge
-- [ ] `scripts/test-fast.ps1` gains a mode that runs `scripts/run-powershell-suites.ps1`
-- [ ] The new mode appears in `scripts/README.md` and in `docs/development/testing-workflow.md`
-- [ ] The canonical pre-PR gate in `docs/development/testing-workflow.md` names the new mode
+- [x] `scripts/test-fast.ps1` gains a mode that runs `scripts/run-powershell-suites.ps1`
+- [x] The new mode appears in `scripts/README.md` and in `docs/development/testing-workflow.md`
+- [x] The canonical pre-PR gate in `docs/development/testing-workflow.md` names the new mode
+
+## Status
+
+The local half is done. `pwsh .\scripts\test-fast.ps1 -Mode PowerShell` runs the suites, and the
+canonical pre-PR gate names it.
+
+One criterion is left, and an agent cannot do it. Making `powershell-suites` a required status check
+is a repository settings change on `s205109/AHKFlowApp`, so it needs a human with admin rights.
 
 ## Out of scope
 

--- a/docs/development/testing-workflow.md
+++ b/docs/development/testing-workflow.md
@@ -10,11 +10,12 @@ For small, unrelated doc or config tweaks — backlog notes, minor rule edits, o
 
 ## Canonical pre-PR gate
 
-Four steps, in order. Nothing else counts as the gate.
+Five steps, in order. Nothing else counts as the gate.
 
 ```bash
 dotnet build AHKFlowApp.slnx --configuration Release
 dotnet format AHKFlowApp.slnx --verify-no-changes
+pwsh .\scripts\test-fast.ps1 -Mode PowerShell
 pwsh .\scripts\test-fast.ps1 -Mode Coverage
 git diff --check main...HEAD
 ```
@@ -23,7 +24,7 @@ Pass the `main...HEAD` range to `git diff --check`. The bare form inspects only 
 
 Then verify the change actually works — see **Verification After Implementation** in [`AGENTS.md`](../../AGENTS.md). A green gate proves nothing regressed; it does not prove the new behavior happened.
 
-CI enforces the same build, format, and coverage-threshold steps on every **non-docs** PR. A PR touching only `**/*.md`, `docs/**`, or `.claude/**` skips build, test, and coverage entirely — see the `dorny/paths-filter` step in `ci.yml`. On a docs-only branch CI proves nothing, so this local gate is the only gate. The pre-push hook is a faster subset (incremental build + fast slice, `scripts/pre-push-quick-checks.ps1`), not this gate.
+CI enforces the same build, format, and coverage-threshold steps on every **non-docs** PR. On a PR touching only `**/*.md`, `docs/**`, or `.claude/**`, the `build-test` job still starts, but every one of its .NET steps is skipped — build, test, coverage, thresholds, and the format check are all guarded by the `dorny/paths-filter` step in `ci.yml`. Two things still run on such a PR. The changelog check (`scripts/ci/generate-changelog-json.ps1 -Check`) sits above that filter in `build-test`, so it runs on every PR. And the `powershell-suites`, `codex-skills-hash-parity`, and `bicep-lint` jobs carry no filter at all, so they run on every PR too. Nothing checks the .NET side of a docs-only branch, which makes this local gate matter more there, not less. The pre-push hook is a faster subset (incremental build + fast slice, `scripts/pre-push-quick-checks.ps1`), not this gate.
 
 ## Fast inner loop
 
@@ -105,6 +106,25 @@ Four rules that are easy to get wrong:
 - **Debounced fields only refresh a preview while the panel is already open.** Expand first, then fill, or the preview stays stale.
 
 Assert on something a user would see — rendered text, a grid cell, a snackbar — not on internal component state.
+
+## PowerShell script suites
+
+```bash
+pwsh .\scripts\test-fast.ps1 -Mode PowerShell
+```
+
+This mode runs every non-excluded `tests/*.Tests.ps1` suite through
+`scripts/run-powershell-suites.ps1`. Use it when you change a git hook, a worktree script, the
+backlog numbering rules, or the skill layout.
+
+Each suite runs as its own process, so one failing suite does not stop the rest. The run prints a
+table naming every suite, its result, and how long it took. The whole run takes about three minutes.
+
+`CodexSkillsHashParity.Tests.ps1` is skipped. CI runs it in its own Linux job, because the bash
+script it compares against refuses to run under Windows Git Bash.
+
+CI runs the same script in the `powershell-suites` job, and that job has no docs-only filter, so it
+runs on every PR.
 
 ## Full coverage gate
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,7 +20,7 @@ and must be changed as one set (see below).
 
 | Script | Purpose |
 | --- | --- |
-| `test-fast.ps1` | Runs explicit local test slices (fast, integration, E2E, coverage). |
+| `test-fast.ps1` | Runs explicit local test slices (fast, integration, E2E, PowerShell suites, coverage). |
 | `run-coverage.ps1` | Runs tests with coverage, builds the merged report, enforces the CI coverage gate. |
 | `pre-push-quick-checks.ps1` | Incremental build + container-free fast test slice; runs automatically via the pre-push hook. |
 | `run-powershell-suites.ps1` | Runs every `tests/*.Tests.ps1` suite as its own process, so one failing suite fails the run and the rest still run. Prints a table naming the failures. CI runs the same script in the `powershell-suites` job. |

--- a/scripts/test-fast.ps1
+++ b/scripts/test-fast.ps1
@@ -5,16 +5,27 @@
 .DESCRIPTION
   Fast mode runs whole-project fast suites plus non-integration slices from mixed projects.
   Integration mode runs integration slices from mixed projects plus whole-project SQL/API suites.
+  PowerShell mode runs every tests/*.Tests.ps1 suite through scripts/run-powershell-suites.ps1.
+  It ignores -Configuration and -NoBuild, because PowerShell suites are not built.
   Each selected test project must discover at least one test.
 #>
 [CmdletBinding()]
 param(
-    [ValidateSet('Fast', 'Integration', 'E2E', 'Coverage')]
+    [ValidateSet('Fast', 'Integration', 'E2E', 'Coverage', 'PowerShell')]
     [string]$Mode = 'Fast',
 
     [string]$Configuration = 'Release',
 
-    [switch]$NoBuild
+    [switch]$NoBuild,
+
+    # PowerShell mode only. Forwarded to run-powershell-suites.ps1 so a test can point the mode at a
+    # folder of fake suites. Empty means the runner picks its own default of tests/.
+    #
+    # This goes last on purpose. An unattributed parameter takes an implicit position in declaration
+    # order, and switches take none, so putting it here leaves $Mode at position 0 and
+    # $Configuration at position 1. Put it above $Configuration instead and 'test-fast.ps1 Fast
+    # Debug' silently binds Debug to $SuiteRoot while $Configuration stays Release.
+    [string]$SuiteRoot
 )
 
 $ErrorActionPreference = 'Stop'
@@ -155,6 +166,20 @@ try {
         & (Join-Path $PSScriptRoot 'run-coverage.ps1') -Configuration $Configuration
         if ($LASTEXITCODE -ne 0) {
             throw 'Coverage mode failed.'
+        }
+
+        return
+    }
+
+    if ($Mode -eq 'PowerShell') {
+        $suiteArguments = @{}
+        if (-not [string]::IsNullOrWhiteSpace($SuiteRoot)) {
+            $suiteArguments['SuiteRoot'] = $SuiteRoot
+        }
+
+        & (Join-Path $PSScriptRoot 'run-powershell-suites.ps1') @suiteArguments
+        if ($LASTEXITCODE -ne 0) {
+            throw 'PowerShell suites failed.'
         }
 
         return

--- a/tests/TestFastPowerShellMode.Tests.ps1
+++ b/tests/TestFastPowerShellMode.Tests.ps1
@@ -1,0 +1,190 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+Tests for the PowerShell mode of scripts/test-fast.ps1.
+
+.DESCRIPTION
+The mode hands every tests/*.Tests.ps1 suite to scripts/run-powershell-suites.ps1. Each case here
+builds a disposable folder of tiny fake suites under the system temp directory and points the mode
+at it with -SuiteRoot. No case runs the mode against the repository's real tests folder.
+
+That last rule is not a style preference, and a comment alone would not enforce it. The defect these
+cases exist to catch is a -SuiteRoot passthrough that does not work. When the passthrough is broken
+the runner falls back to its own default of tests/, finds this very file, and starts it again -
+forever. So Invoke-Wrapper sets AHKFLOW_TESTFAST_MODE_TEST, and the guard at the top of this file
+turns that runaway into one failed suite with a message that names the cause.
+#>
+[CmdletBinding()]
+param()
+
+# Recursion guard. Read the description above before removing it.
+if ($env:AHKFLOW_TESTFAST_MODE_TEST -eq '1') {
+    Write-Host 'Recursion guard hit: test-fast.ps1 did not forward -SuiteRoot.' -ForegroundColor Red
+    exit 9
+}
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# PowerShell 7.4 turns a non-zero native exit code into a terminating error while
+# $ErrorActionPreference is 'Stop'. Most cases here expect a failing child run, so opt out.
+$PSNativeCommandUseErrorActionPreference = $false
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+$script:WrapperPath = Join-Path $repoRoot 'scripts\test-fast.ps1'
+$script:HostExe = [System.Diagnostics.Process]::GetCurrentProcess().Path
+
+$script:Failures = New-Object System.Collections.Generic.List[string]
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { throw $Message }
+}
+
+function Invoke-TestCase {
+    param([string] $Name, [scriptblock] $Body)
+    try {
+        & $Body
+        Write-Host "  PASS  $Name" -ForegroundColor Green
+    }
+    catch {
+        $script:Failures.Add("$Name :: $($_.Exception.Message)")
+        Write-Host "  FAIL  $Name" -ForegroundColor Red
+        Write-Host "        $($_.Exception.Message)" -ForegroundColor DarkRed
+    }
+}
+
+# The runner rejects an exclusion that names a file it cannot find, and it checks that before it
+# runs anything (scripts/run-powershell-suites.ps1:60-65). Its default exclusion is
+# CodexSkillsHashParity.Tests.ps1. The wrapper exposes no -Exclude, so every fixture must contain a
+# file with that name or the runner exits 1 before a single fake suite starts. The file is excluded,
+# so it never runs.
+function New-SuiteFixture {
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ('ahkflow-testfast-mode-' + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $root 'CodexSkillsHashParity.Tests.ps1') `
+        -Value '# Placeholder so the runner default exclusion matches a real file. Never runs.' `
+        -Encoding utf8
+    return (Resolve-Path -LiteralPath $root).Path
+}
+
+function Remove-SuiteFixture {
+    param([string] $Root)
+    if (Test-Path -LiteralPath $Root) {
+        Remove-Item -LiteralPath $Root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Add-FakeSuite {
+    param(
+        [string] $Root,
+        [string] $Name,
+
+        # pass     - prints and runs off the end (no exit)
+        # exit-one - prints, then 'exit 1'
+        # throw    - prints, then throws
+        [ValidateSet('pass', 'exit-one', 'throw')]
+        [string] $Ending
+    )
+
+    $body = New-Object System.Collections.Generic.List[string]
+    $body.Add("Write-Host 'ran $Name'")
+
+    switch ($Ending) {
+        'pass' { }
+        'exit-one' { $body.Add('exit 1') }
+        'throw' { $body.Add("throw 'deliberate failure'") }
+    }
+
+    Set-Content -LiteralPath (Join-Path $Root $Name) -Value ($body -join [Environment]::NewLine) -Encoding utf8
+}
+
+# Runs the wrapper as its own process and returns its exit code and everything it printed.
+#
+# Two environment variables are handled here. AHKFLOW_TESTFAST_MODE_TEST arms the recursion guard at
+# the top of this file. GITHUB_STEP_SUMMARY is redirected because the child inherits it: under CI the
+# runner would otherwise append these fake tables, deliberate failures included, to the real
+# powershell-suites job summary (scripts/run-powershell-suites.ps1:128-131).
+function Invoke-Wrapper {
+    param([string] $SuiteRoot)
+
+    $summaryPath = Join-Path ([System.IO.Path]::GetTempPath()) ('ahkflow-testfast-mode-summary-' + [guid]::NewGuid().ToString('N') + '.md')
+    $previousSummary = $env:GITHUB_STEP_SUMMARY
+    $previousGuard = $env:AHKFLOW_TESTFAST_MODE_TEST
+    $env:GITHUB_STEP_SUMMARY = $summaryPath
+    $env:AHKFLOW_TESTFAST_MODE_TEST = '1'
+
+    try {
+        $output = & $script:HostExe -NoProfile -File $script:WrapperPath `
+            -Mode PowerShell -SuiteRoot $SuiteRoot 2>&1 | Out-String
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $env:GITHUB_STEP_SUMMARY = $previousSummary
+        $env:AHKFLOW_TESTFAST_MODE_TEST = $previousGuard
+        Remove-Item -LiteralPath $summaryPath -Force -ErrorAction SilentlyContinue
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $exitCode
+        Output   = $output
+    }
+}
+
+Write-Host "Testing $script:WrapperPath"
+Assert-True (Test-Path -LiteralPath $script:WrapperPath) "Wrapper script not found at $script:WrapperPath."
+
+Invoke-TestCase 'All suites pass -> exit code 0' {
+    $root = New-SuiteFixture
+    try {
+        Add-FakeSuite -Root $root -Name '01-pass.Tests.ps1' -Ending 'pass'
+        Add-FakeSuite -Root $root -Name '02-pass.Tests.ps1' -Ending 'pass'
+
+        $result = Invoke-Wrapper -SuiteRoot $root
+        Assert-True ($result.ExitCode -eq 0) "Expected exit code 0, got $($result.ExitCode). Output: $($result.Output)"
+        Assert-True ($result.Output -match 'All 2 suite\(s\) passed\.') "Expected the all-passed summary line. Output: $($result.Output)"
+    }
+    finally {
+        Remove-SuiteFixture -Root $root
+    }
+}
+
+Invoke-TestCase 'A suite that exits 1 fails the run' {
+    $root = New-SuiteFixture
+    try {
+        Add-FakeSuite -Root $root -Name '01-pass.Tests.ps1' -Ending 'pass'
+        Add-FakeSuite -Root $root -Name '02-exit-one.Tests.ps1' -Ending 'exit-one'
+
+        $result = Invoke-Wrapper -SuiteRoot $root
+        Assert-True ($result.ExitCode -ne 0) "Expected a non-zero exit code. Output: $($result.Output)"
+        Assert-True ($result.Output -match '02-exit-one\.Tests\.ps1') "Expected the failing suite to be named. Output: $($result.Output)"
+    }
+    finally {
+        Remove-SuiteFixture -Root $root
+    }
+}
+
+Invoke-TestCase 'A suite that throws fails the run' {
+    $root = New-SuiteFixture
+    try {
+        Add-FakeSuite -Root $root -Name '01-pass.Tests.ps1' -Ending 'pass'
+        Add-FakeSuite -Root $root -Name '02-throw.Tests.ps1' -Ending 'throw'
+
+        $result = Invoke-Wrapper -SuiteRoot $root
+        Assert-True ($result.ExitCode -ne 0) "Expected a non-zero exit code. Output: $($result.Output)"
+        Assert-True ($result.Output -match '02-throw\.Tests\.ps1') "Expected the failing suite to be named. Output: $($result.Output)"
+    }
+    finally {
+        Remove-SuiteFixture -Root $root
+    }
+}
+
+Write-Host ''
+if ($script:Failures.Count -gt 0) {
+    Write-Host "FAILED: $($script:Failures.Count) test(s)" -ForegroundColor Red
+    foreach ($failure in $script:Failures) { Write-Host "  - $failure" -ForegroundColor Red }
+    exit 1
+}
+
+Write-Host 'test-fast PowerShell mode tests passed.' -ForegroundColor Green
+exit 0


### PR DESCRIPTION
## What changed

`scripts/test-fast.ps1` gains a `PowerShell` mode. It hands every non-excluded `tests/*.Tests.ps1`
suite to `scripts/run-powershell-suites.ps1` and fails when any suite fails.

```
pwsh .\scripts\test-fast.ps1 -Mode PowerShell
```

Until now nothing ran those suites locally, so a broken script was found only after a push.

## Also in this PR

- The canonical pre-PR gate in `docs/development/testing-workflow.md` is five steps now. The suites
  run third, before coverage.
- A new `## PowerShell script suites` section in the same file.
- The `test-fast.ps1` row in `scripts/README.md` names the new mode.
- The docs-only paragraph in `testing-workflow.md` is corrected. It said CI proves nothing on a
  docs-only branch. In fact the changelog check and three unfiltered jobs still run.

## Testing

`tests/TestFastPowerShellMode.Tests.ps1` drives the mode against a temp folder of fake suites. Three
traps shaped it, and each one is commented in the file:

- A broken `-SuiteRoot` passthrough would send the runner at the real `tests/` folder and recurse
  forever. An environment-variable guard turns that into one named failure.
- The runner rejects an exclusion naming a missing file, so every fixture creates a placeholder
  `CodexSkillsHashParity.Tests.ps1`.
- The child inherits `GITHUB_STEP_SUMMARY`, so the helper redirects it and the deliberate failures
  stay out of the real job summary.

Real run of the new mode (tail):

```
| SkillParity.Tests.ps1 | passed | 0 | 2.7s |
| TestFastPowerShellMode.Tests.ps1 | passed | 0 | 7.5s |
| WorktreeBaseRef.Tests.ps1 | passed | 0 | 1.5s |
| WorktreeBranchName.Tests.ps1 | passed | 0 | 0.6s |
| WorktreeJsonEdit.Tests.ps1 | passed | 0 | 1.4s |
| WorktreeLocalDevSetup.Tests.ps1 | passed | 0 | 9.6s |
| WorktreeMergedCleanup.Tests.ps1 | passed | 0 | 85s |
| WorktreePlansSymlink.Tests.ps1 | passed | 0 | 2s |
| WorktreePowerShellHost.Tests.ps1 | passed | 0 | 0.8s |
| WorktreeRemoveHook.Tests.ps1 | passed | 0 | 12.5s |

All 18 suite(s) passed.
```

Known flake, not from this branch: `WorktreeRemoveHook.Tests.ps1` failed once in a full runner pass
with `Cannot process argument transformation on parameter 'Condition'`. It passed on rerun, passed
standalone, and its watcher timing is the likely cause.

## Not in this PR

Backlog item 067 has a fourth acceptance criterion: make `powershell-suites` a required status check
on `main`. That is a repository settings change and needs a human with admin rights on
`s205109/AHKFlowApp`, so the item stays open in `backlog/` rather than moving to `backlog/done/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
