### PR TITLE
test: fix flake B, make flake A locatable (068, partial)

### DIFF
--- a/backlog/068-two-flaky-tests-fail-intermittently-in-full-suite-runs.md
+++ b/backlog/068-two-flaky-tests-fail-intermittently-in-full-suite-runs.md
@@ -64,21 +64,114 @@ would fail exactly this way, and only sometimes.
 It passed alone with a filtered `dotnet test` run, and passed on a full rerun of the fast slice
 (950 of 950).
 
+## Findings
+
+### Flake B - reproduced, cause named, fixed
+
+The whole `AHKFlowApp.UI.Blazor.Tests` project was run in Release with `--no-build`, twice in a
+row: 25 runs, then 40 runs. One run in each batch failed, always the same test and the same line.
+
+```
+KnownShortcutsPageTests.IgnoredUse_OffersRestore_AndCallsIt [FAIL]
+NSubstitute.Exceptions.ReceivedCallsException : Expected to receive exactly 1 call matching:
+	RestoreAsync("windows.file-explorer", "Windows", any CancellationToken)
+Actually received no matching calls.
+   at ...KnownShortcutsPageTests.cs:line 143
+```
+
+Two things follow from that text. The restore button was found and clicked, because lines 140 and
+141 ran without error. And the substitute had recorded **no** call at all, not a call with other
+arguments.
+
+One theory was ruled out by probe. A test stubbed `RestoreAsync` with a genuinely asynchronous
+result (`await Task.Delay(50)`), clicked, and asserted `Received(1)` straight away on an idle
+machine. It passed. `KnownShortcuts.razor:337` returns `RunMutationAsync(...)`, and
+`RunMutationAsync` at `KnownShortcuts.razor:342-357` runs `await call()`, so the delegate is
+invoked before the first suspension point. Slowness inside the API task cannot cause this failure.
+
+What is left is the dispatch. In bUnit 2.7.2 the synchronous `Click()` discards the task its async
+counterpart returns, and the event travels through the renderer's dispatcher. So the handler can
+still be pending when `Click()` returns. `WaitForAssertion` runs the assertion immediately, then
+again after each render, until it passes or the timeout expires.
+
+The fix wraps that assertion, and every other assertion in the file that reads a **positive**
+result after a click. The three assertions that read a **negative** after a click were left alone
+on purpose and moved to `backlog/069-...`. `WaitForAssertion` passes on its first try, which is
+exactly the moment a queued handler has not run, so it would make those tests look careful while
+proving nothing.
+
+Version pinned at `Directory.Packages.props:13`. bUnit documentation for the behavior:
+https://bunit.dev/docs/verification/async-assertion.html
+
+### Flake A - not reproduced, every lead ruled out
+
+The suite ran 40 times standalone and passed every time. The full runner
+(`scripts/run-powershell-suites.ps1`, 18 suites) ran 12 times with the diagnostic in place. All 12
+passed and the diagnostic never fired.
+
+Those numbers close nothing. A check that never triggers says nothing about a fault seen once.
+
+The backlog's original lead is **wrong**. A probe ran `Wait-ForCondition` in isolation and printed
+the returned type. It returns `System.Boolean` on the success path **and** on the timeout path. It
+cannot return an array.
+
+`Test-Path -LiteralPath` returns `System.Object[]` only when its path argument is already an array.
+No path variable in this suite can become one:
+
+- `New-TempGitRepo` and `Add-TestWorktree` send every command's output to `Out-Null`, and both end
+  with `(Resolve-Path -LiteralPath ...).Path`, which is one string.
+- All four `$log` reads use `Get-Content -Raw`, which returns one string for one file. So
+  `$log -match ...` returns a `System.Boolean`, not an array of matches.
+
+So reading the code says the failure is impossible, and it still happened once. The call site is
+**not identified**. Rather than guess, the fix removes the reason the call site stayed hidden. The
+`Assert-True` parameter was typed `[bool]`, so an array argument failed during parameter binding,
+and a binding failure reports no line number. The parameter is untyped now, with an explicit type
+check that throws a message carrying the runtime type, the values, and the caller's line. The suite
+still fails on a recurrence. It now says where.
+
+A test covers that check, because a passing suite never reaches it. Putting the `[bool]` type back
+makes the new test fail, and the failure quotes the original error word for word:
+
+```
+Expected the caller's line number in the message. Got: Cannot process argument transformation on
+parameter 'Condition'. Cannot convert value "System.Object[]" to type "System.Boolean".
+```
+
+**`Wait-ForCondition` was left unchanged, on purpose.** A first draft made it return a scalar
+boolean. That was speculative hardening for a function already ruled out, and it was also wrong:
+the loop's `if (& $Condition)` treats any non-empty array as true, so normalizing only the timeout
+path made one function answer the same script block two different ways. It was reverted.
+
 ## Acceptance criteria
 
-- [ ] Each flake has a named root cause with `file:line` evidence, or a written record of what was
+- [x] Each flake has a named root cause with `file:line` evidence, or a written record of what was
       ruled out and why it could not be reproduced
-- [ ] `KnownShortcutsPageTests.IgnoredUse_OffersRestore_AndCallsIt` no longer races - the fix makes
+- [x] `KnownShortcutsPageTests.IgnoredUse_OffersRestore_AndCallsIt` no longer races - the fix makes
       the assertion wait for the click handler rather than assuming it finished
 - [ ] `WorktreeRemoveHook.Tests.ps1` cannot pass an array to `Assert-True`, and the fix names which
       call site did it
 - [ ] Both are exercised repeatedly enough to give confidence - run each in its normal full-suite
       context several times in a row and record the results
 
+**This item stays open.** Criterion 3 is not met and is not being claimed. Nothing stops an array
+from reaching `Assert-True`; the change only makes such a call fail with a location instead of
+failing during parameter binding with none. The call site that failed on 2026-08-08 is still
+unknown, and the only honest way to name it is to see it happen again.
+
+Criterion 4 is met for flake B and not for flake A. Flake A cannot be closed by green runs: a
+diagnostic that never fires proves nothing about a fault that appeared once.
+
 ## Out of scope
 
 - A general retry or rerun-on-failure setting for the test runners. Hiding a flake is not fixing it.
-- Any other test that has not actually failed. This item covers the two named above.
+- Any other test that has not actually failed. This item covers the two named above. The one
+  exception is the rest of `KnownShortcutsPageTests.cs`: the assertions that read a positive result
+  after a click share the proven mechanism, so they were fixed in the same pass.
+- Negative assertions after a click. Moved to
+  `backlog/069-negative-post-click-assertions-in-knownshortcutspagetests-need-a-positive-wait-signal.md`.
+- The other 15 PowerShell suites that define their own `Assert-True`. If the diagnostic proves
+  useful, spreading it is separate work.
 
 ## Notes / dependencies
 

--- a/backlog/068-two-flaky-tests-fail-intermittently-in-full-suite-runs.md
+++ b/backlog/068-two-flaky-tests-fail-intermittently-in-full-suite-runs.md
@@ -103,6 +103,16 @@ proving nothing.
 Version pinned at `Directory.Packages.props:13`. bUnit documentation for the behavior:
 https://bunit.dev/docs/verification/async-assertion.html
 
+**Confidence runs.** After the fix, and against a rebuilt Release assembly, the whole
+`AHKFlowApp.UI.Blazor.Tests` project ran 50 times. All 50 passed, 950 of 950 tests each time.
+
+Read that honestly. At the observed rate of about 1 failure in 32 runs, 50 clean runs would happen
+by luck roughly 20% of the time if nothing had been fixed. So the runs support the named mechanism.
+They do not prove it on their own. The argument is the mechanism plus the runs, not the runs.
+
+The 65 runs made **before** the fix are not counted here. They found the bug; they say nothing about
+whether it is gone.
+
 ### Flake A - not reproduced, every lead ruled out
 
 The suite ran 40 times standalone and passed every time. The full runner

--- a/backlog/068-two-flaky-tests-fail-intermittently-in-full-suite-runs.md
+++ b/backlog/068-two-flaky-tests-fail-intermittently-in-full-suite-runs.md
@@ -103,8 +103,12 @@ proving nothing.
 Version pinned at `Directory.Packages.props:13`. bUnit documentation for the behavior:
 https://bunit.dev/docs/verification/async-assertion.html
 
-**Confidence runs.** After the fix, and against a rebuilt Release assembly, the whole
-`AHKFlowApp.UI.Blazor.Tests` project ran 50 times. All 50 passed, 950 of 950 tests each time.
+**Confidence runs.** After the last test change, and against a Release assembly rebuilt from it,
+the whole `AHKFlowApp.UI.Blazor.Tests` project ran 50 times. All 50 passed, 950 of 950 tests each
+time.
+
+An earlier batch of 50 also passed, but review then changed the same file again, so that batch
+described an older assembly. It is not counted. Only runs made after the final change count.
 
 Read that honestly. At the observed rate of about 1 failure in 32 runs, 50 clean runs would happen
 by luck roughly 20% of the time if nothing had been fixed. So the runs support the named mechanism.

--- a/backlog/069-negative-post-click-assertions-in-knownshortcutspagetests-need-a-positive-wait-signal.md
+++ b/backlog/069-negative-post-click-assertions-in-knownshortcutspagetests-need-a-positive-wait-signal.md
@@ -1,0 +1,60 @@
+# 069 - Negative post-click assertions in KnownShortcutsPageTests need a positive wait signal
+
+## Metadata
+
+- **Epic**: Test reliability
+- **Type**: Bug
+- **Interfaces**: UI | API | CLI (none — test code only)
+
+## Summary
+
+Three tests click a button and then assert that something did **not** happen. If the click has not
+been handled yet, the assertion passes for the wrong reason. It cannot fail, so it proves nothing.
+
+This came out of backlog 068. That item fixed the assertions that read a **positive** result after a
+click, by wrapping them in `page.WaitForAssertion(...)`. The negative ones were left alone on
+purpose, because `WaitForAssertion` does not help them.
+
+## Why WaitForAssertion is the wrong tool here
+
+In bUnit 2.7.2 `WaitForAssertion` runs the assertion straight away, then again after each render,
+and stops as soon as it passes. A negative assertion passes on the very first try. That first try
+is exactly the moment when a queued click handler has not run yet. So wrapping it changes nothing
+and hides the problem behind a call that looks careful.
+
+Each test needs a **positive** signal to wait for first. That signal is some rendered state which
+only appears once the click has been handled. Picking the right one differs per test, which is why
+this is its own item rather than a line in backlog 068.
+
+## The three tests
+
+All in `tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs`:
+
+- `Delete_WhenTheConfirmationIsCancelled_RemovesNothing` — asserts
+  `_api.DidNotReceive().DeleteAsync(...)` after clicking delete.
+- `AFailedMutation_DoesNotInvalidateTheDialogCache` — asserts `_catalog.DidNotReceive().Invalidate()`
+  after each of four mutations.
+- `SignedOut_SaysSo_AndReadsNothing` — asserts `_api.DidNotReceive().ListManagedAsync(...)`. This one
+  has no click at all, so check whether it belongs here before changing it.
+
+None of these has ever failed. This is a correctness problem in the tests, not a known flake.
+
+## Acceptance criteria
+
+- [ ] Each named test waits for a positive signal before it asserts the negative
+- [ ] Each chosen signal is written down in a comment, saying what it proves the page has finished
+- [ ] Each changed test is shown to fail when the behavior it guards is broken on purpose, and the
+      failure output is recorded
+- [ ] `SignedOut_SaysSo_AndReadsNothing` is either changed or explicitly ruled out, with the reason
+
+## Out of scope
+
+- The positive assertions in the same file. Backlog 068 already changed those.
+- Any change to `KnownShortcuts.razor` itself. The page is not at fault.
+
+## Notes / dependencies
+
+- Split out of `backlog/068-two-flaky-tests-fail-intermittently-in-full-suite-runs.md` on
+  2026-08-08, during review of the fix for that item
+- bUnit `WaitForAssertion` behavior: https://bunit.dev/docs/verification/async-assertion.html
+- bUnit version is pinned at `Directory.Packages.props:13`

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
@@ -126,7 +126,8 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         IRenderedComponent<KnownShortcuts> page = RenderPage();
         Button(page, "ignore-use", "browser.new-window", "Chrome").Click();
 
-        _api.Received(1).IgnoreAsync("browser.new-window", "Chrome", Arg.Any<CancellationToken>());
+        page.WaitForAssertion(() =>
+            _api.Received(1).IgnoreAsync("browser.new-window", "Chrome", Arg.Any<CancellationToken>()));
     }
 
     [Fact]
@@ -140,10 +141,15 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         page.FindAll(".desktop-branch button.ignore-use").Should().BeEmpty();
         Button(page, "restore-use", "windows.file-explorer", "Windows").Click();
 
-        // The assertion waits. Click hands the event to the renderer and returns, so the handler
-        // can still be queued. On a loaded machine this read the substitute first and reported
-        // "Actually received no matching calls" — once in 65 full-project runs. WaitForAssertion
-        // retries until the handler has run.
+        // The assertion waits. In bUnit 2.7.2 the synchronous Click() discards the task its async
+        // counterpart returns, and the event goes through the renderer's dispatcher, so the
+        // handler can still be pending when Click() returns. On a loaded machine this read the
+        // substitute first and reported "Actually received no matching calls" — once in 65
+        // full-project runs. WaitForAssertion runs the assertion immediately and again after each
+        // render, until it passes or the timeout expires.
+        //
+        // Every other click in this file that then reads a positive result waits the same way.
+        // The negative ones do not — see the note above the delete-cancelled test.
         page.WaitForAssertion(() =>
             _api.Received(1).RestoreAsync("windows.file-explorer", "Windows", Arg.Any<CancellationToken>()));
     }
@@ -215,7 +221,8 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
 
         Button(page, "ignore-use", "browser.new-window", "Chrome").Click();
 
-        Button(page, "restore-use", "browser.new-window", "Chrome").Should().NotBeNull();
+        page.WaitForAssertion(() =>
+            Button(page, "restore-use", "browser.new-window", "Chrome").Should().NotBeNull());
         Button(page, "ignore-use", "browser.new-window", "Edge").Should().NotBeNull();
     }
 
@@ -231,8 +238,11 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
 
         Button(page, "ignore-use", "windows.file-explorer", "Windows").Click();
 
-        _api.Received(2).ListManagedAsync(Arg.Any<CancellationToken>());
-        page.FindAll(".desktop-branch button.restore-use").Should().ContainSingle();
+        page.WaitForAssertion(() =>
+        {
+            _api.Received(2).ListManagedAsync(Arg.Any<CancellationToken>());
+            page.FindAll(".desktop-branch button.restore-use").Should().ContainSingle();
+        });
     }
 
     [Fact]
@@ -249,10 +259,13 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         page.Find("[data-test=\"known-shortcut-does-input\"]").Input("open my notes");
         page.Find("button.commit-edit").Click();
 
-        _api.Received(1).CreateAsync(
-            Arg.Is<CreateCustomKnownShortcutDto>(d => d.UsedBy == "My notes tool" && d.Does == "open my notes"),
-            Arg.Any<CancellationToken>());
-        page.FindAll(".desktop-branch [data-test=\"known-shortcut-row\"]").Should().ContainSingle();
+        page.WaitForAssertion(() =>
+        {
+            _api.Received(1).CreateAsync(
+                Arg.Is<CreateCustomKnownShortcutDto>(d => d.UsedBy == "My notes tool" && d.Does == "open my notes"),
+                Arg.Any<CancellationToken>());
+            page.FindAll(".desktop-branch [data-test=\"known-shortcut-row\"]").Should().ContainSingle();
+        });
     }
 
     [Fact]
@@ -268,8 +281,11 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         page.Find("button.add-known-shortcut").Click();
         page.Find("button.commit-edit").Click();
 
-        page.Markup.Should().Contain("You have already recorded this one.");
-        page.FindAll("button.commit-edit").Should().ContainSingle("the form stays open");
+        page.WaitForAssertion(() =>
+        {
+            page.Markup.Should().Contain("You have already recorded this one.");
+            page.FindAll("button.commit-edit").Should().ContainSingle("the form stays open");
+        });
     }
 
     [Fact]
@@ -350,6 +366,12 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         page.Find("button.reload-known-shortcuts").HasAttribute("disabled").Should().BeTrue();
     }
 
+    // The two "nothing happened" tests below, and AFailedMutation_DoesNotInvalidateTheDialogCache,
+    // read a negative straight after a click. WaitForAssertion cannot help them: it passes on the
+    // first try, which is exactly the moment a queued handler has not run yet, so it would prove
+    // nothing. They need a positive signal to wait for first — a rendered state that only appears
+    // once the click has been handled — and picking that signal per test is its own piece of work.
+    // Backlog 069 covers it. Neither test has ever failed.
     [Fact]
     public void Delete_WhenTheConfirmationIsCancelled_RemovesNothing()
     {
@@ -391,8 +413,11 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         IRenderedComponent<KnownShortcuts> page = RenderPage();
         page.Find(".desktop-branch button.ignore-use").Click();
 
-        page.Find(".desktop-branch button.ignore-use").HasAttribute("disabled").Should().BeTrue();
-        page.Find("button.reload-known-shortcuts").HasAttribute("disabled").Should().BeTrue();
+        page.WaitForAssertion(() =>
+        {
+            page.Find(".desktop-branch button.ignore-use").HasAttribute("disabled").Should().BeTrue();
+            page.Find("button.reload-known-shortcuts").HasAttribute("disabled").Should().BeTrue();
+        });
 
         pending.SetResult(ApiResult.Ok());
         page.WaitForAssertion(() =>
@@ -554,7 +579,8 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         IRenderedComponent<KnownShortcuts> page = RenderPage();
         Button(page, "ignore-use", "browser.new-window", "Edge", ".mobile-branch").Click();
 
-        _api.Received(1).IgnoreAsync("browser.new-window", "Edge", Arg.Any<CancellationToken>());
+        page.WaitForAssertion(() =>
+            _api.Received(1).IgnoreAsync("browser.new-window", "Edge", Arg.Any<CancellationToken>()));
     }
 
     [Fact]
@@ -589,7 +615,8 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         // Both assertions wait. MudPagination handles the click asynchronously, so the render it
         // causes can still be queued when Click returns. The typed term then lands behind that
         // render. On a loaded CI runner this test read the page-2 rows back and failed, while it
-        // passed every time on a quiet machine. WaitForAssertion retries until the queue drains.
+        // passed every time on a quiet machine. WaitForAssertion runs the assertion immediately and
+        // again after each render, until it passes or the timeout expires.
         page.WaitForAssertion(() =>
             page.FindAll(".mobile-branch [data-test=\"known-shortcut-row\"]").Should().HaveCount(5));
 

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
@@ -140,7 +140,12 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         page.FindAll(".desktop-branch button.ignore-use").Should().BeEmpty();
         Button(page, "restore-use", "windows.file-explorer", "Windows").Click();
 
-        _api.Received(1).RestoreAsync("windows.file-explorer", "Windows", Arg.Any<CancellationToken>());
+        // The assertion waits. Click hands the event to the renderer and returns, so the handler
+        // can still be queued. On a loaded machine this read the substitute first and reported
+        // "Actually received no matching calls" — once in 65 full-project runs. WaitForAssertion
+        // retries until the handler has run.
+        page.WaitForAssertion(() =>
+            _api.Received(1).RestoreAsync("windows.file-explorer", "Windows", Arg.Any<CancellationToken>()));
     }
 
     [Fact]

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Pages/KnownShortcutsPageTests.cs
@@ -96,6 +96,17 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
         Services.AddSingleton(dialogService);
     }
 
+    // Opening the add form is a click like any other, so the form can still be pending when Click
+    // returns. Reading a field straight after throws ElementNotFoundException, and a
+    // WaitForAssertion further down the test never runs, because the throw happens first. So wait
+    // for the form here. The Save button and both text fields sit in one @if (_adding) block in
+    // KnownShortcuts.razor, so the button appearing means the whole form is there.
+    private static void OpenAddForm(IRenderedComponent<KnownShortcuts> page)
+    {
+        page.Find("button.add-known-shortcut").Click();
+        page.WaitForElement("button.commit-edit");
+    }
+
     // Both branches render this button with the same class and the same pair, so every lookup has
     // to say which branch it means. CSS hides one; bunit sees both.
     private static IElement Button(
@@ -254,7 +265,7 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
                 [Shortcut("owner.1", "F7", OwnerUse(Guid.NewGuid()))])));
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
-        page.Find("button.add-known-shortcut").Click();
+        OpenAddForm(page);
         page.Find("[data-test=\"known-shortcut-usedby-input\"]").Input("My notes tool");
         page.Find("[data-test=\"known-shortcut-does-input\"]").Input("open my notes");
         page.Find("button.commit-edit").Click();
@@ -278,7 +289,7 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
                 new ApiProblemDetails(null, "Conflict", 409, "You have already recorded this one.", null, null)));
 
         IRenderedComponent<KnownShortcuts> page = RenderPage();
-        page.Find("button.add-known-shortcut").Click();
+        OpenAddForm(page);
         page.Find("button.commit-edit").Click();
 
         page.WaitForAssertion(() =>
@@ -540,7 +551,7 @@ public sealed class KnownShortcutsPageTests : BunitContext, IAsyncLifetime
                 page.Find(".desktop-branch button.delete-use").Click();
                 break;
             default:
-                page.Find("button.add-known-shortcut").Click();
+                OpenAddForm(page);
                 page.Find("button.commit-edit").Click();
                 break;
         }

--- a/tests/WorktreeRemoveHook.Tests.ps1
+++ b/tests/WorktreeRemoveHook.Tests.ps1
@@ -11,7 +11,19 @@ $scriptsDir = Join-Path $suiteRoot 'scripts'
 $removeScript = Join-Path $scriptsDir 'remove-worktree-local-dev.ps1'
 
 function Assert-True {
-    param([bool] $Condition, [string] $Message)
+    param($Condition, [string] $Message)
+
+    # The parameter used to be typed [bool]. An array argument then failed during parameter
+    # binding, and a binding failure names no line, so backlog 068 could not find the call site.
+    # The type is checked here instead. The suite still fails, but it says which line handed over
+    # what.
+    if ($Condition -isnot [bool]) {
+        $caller = (Get-PSCallStack)[1]
+        $typeName = if ($null -eq $Condition) { 'null' } else { $Condition.GetType().FullName }
+        throw ("Assert-True needs a boolean. Got [$typeName] with $(@($Condition).Count) value(s) " +
+            "from line $($caller.ScriptLineNumber): $(@($Condition) -join ' | '). Original message: $Message")
+    }
+
     if (-not $Condition) { throw $Message }
 }
 
@@ -159,7 +171,11 @@ function Wait-ForCondition {
         if (& $Condition) { return $true }
         Start-Sleep -Milliseconds 250
     }
-    return & $Condition
+
+    # A script block that writes more than one value to the pipeline would otherwise make this
+    # function return an array, which no caller expects. Take the last value and make it boolean.
+    $values = @(& $Condition)
+    return ($values.Count -gt 0) -and [bool]$values[-1]
 }
 
 # --- Test: merged + clean -> folder removed (unchanged behavior) ---------------

--- a/tests/WorktreeRemoveHook.Tests.ps1
+++ b/tests/WorktreeRemoveHook.Tests.ps1
@@ -171,12 +171,28 @@ function Wait-ForCondition {
         if (& $Condition) { return $true }
         Start-Sleep -Milliseconds 250
     }
-
-    # A script block that writes more than one value to the pipeline would otherwise make this
-    # function return an array, which no caller expects. Take the last value and make it boolean.
-    $values = @(& $Condition)
-    return ($values.Count -gt 0) -and [bool]$values[-1]
+    return & $Condition
 }
+
+# --- Test: Assert-True names the call site when handed a non-boolean -----------
+# Backlog 068 saw an array reach Assert-True once, and never found which line sent it. A typed
+# [bool] parameter fails during parameter binding, and a binding failure names no line. This test
+# is the only thing that exercises the replacement check, because a passing suite never reaches it.
+$diagnosticFired = $false
+$diagnosticMessage = ''
+try {
+    # Test-Path with two paths returns System.Object[], which is the shape that was reported.
+    Assert-True (Test-Path -LiteralPath @($suiteRoot, $scriptsDir)) 'array argument'
+} catch {
+    $diagnosticFired = $true
+    $diagnosticMessage = $_.Exception.Message
+}
+
+Assert-True $diagnosticFired 'Assert-True must refuse a non-boolean argument instead of accepting it.'
+Assert-True ($diagnosticMessage -match 'System\.Object\[\]') `
+    "Expected the runtime type in the message. Got: $diagnosticMessage"
+Assert-True ($diagnosticMessage -match 'from line \d+') `
+    "Expected the caller's line number in the message. Got: $diagnosticMessage"
 
 # --- Test: merged + clean -> folder removed (unchanged behavior) ---------------
 $repo = New-TempGitRepo

--- a/tests/WorktreeRemoveHook.Tests.ps1
+++ b/tests/WorktreeRemoveHook.Tests.ps1
@@ -182,17 +182,28 @@ $diagnosticFired = $false
 $diagnosticMessage = ''
 try {
     # Test-Path with two paths returns System.Object[], which is the shape that was reported.
-    Assert-True (Test-Path -LiteralPath @($suiteRoot, $scriptsDir)) 'array argument'
+    Assert-True (Test-Path -LiteralPath @($suiteRoot, $scriptsDir)) 'array argument' # ARRAY-CALL-SITE
 } catch {
     $diagnosticFired = $true
     $diagnosticMessage = $_.Exception.Message
 }
 
+# The line the message must name, read out of this file rather than typed in, so editing the suite
+# cannot leave a stale number behind. The token is joined at run time, so the search below does not
+# find itself - only the tagged call above carries the whole string.
+$callSiteToken = 'ARRAY-CALL' + '-SITE'
+$expectedLine = (Select-String -LiteralPath $PSCommandPath -SimpleMatch -Pattern $callSiteToken |
+    Select-Object -First 1).LineNumber
+
 Assert-True $diagnosticFired 'Assert-True must refuse a non-boolean argument instead of accepting it.'
 Assert-True ($diagnosticMessage -match 'System\.Object\[\]') `
     "Expected the runtime type in the message. Got: $diagnosticMessage"
-Assert-True ($diagnosticMessage -match 'from line \d+') `
-    "Expected the caller's line number in the message. Got: $diagnosticMessage"
+
+# Checking for any number here would pass on a message reporting Assert-True's own line, which is
+# the exact bug this test exists to catch. The number has to be the caller's.
+Assert-True ($null -ne $expectedLine) 'Could not find the tagged call site in this file.'
+Assert-True ($diagnosticMessage -match "from line ${expectedLine}:") `
+    "Expected the message to name line $expectedLine. Got: $diagnosticMessage"
 
 # --- Test: merged + clean -> folder removed (unchanged behavior) ---------------
 $repo = New-TempGitRepo


### PR DESCRIPTION
## Partial by design — read this first

Backlog 068 named two flaky tests. **One is fixed. The other is not, and this PR does not claim it is.**

Item 068 stays in `backlog/`. Acceptance criterion 3 is left unticked, and the file is **not** moved to `backlog/done/`.

## Flake B — fixed

`KnownShortcutsPageTests.IgnoredUse_OffersRestore_AndCallsIt`.

Reproduced twice before any fix, by running the whole `AHKFlowApp.UI.Blazor.Tests` project in Release: 1 failure in 25 runs, then 1 failure in 40 runs. Same test, same line both times.

```
NSubstitute.Exceptions.ReceivedCallsException : Expected to receive exactly 1 call matching:
	RestoreAsync("windows.file-explorer", "Windows", any CancellationToken)
Actually received no matching calls.
   at ...KnownShortcutsPageTests.cs:line 143
```

"No matching calls" is the key part. The button was found and clicked, and the substitute had recorded nothing at all.

**Cause.** bUnit is pinned at 2.7.2 (`Directory.Packages.props:13`). Its generated synchronous event helpers discard the task their async counterpart returns, and dispatch goes through the renderer's dispatcher. So the handler can still be pending when `Click()` returns, and the next line reads the substitute too early.

- https://github.com/bUnit-dev/bUnit/blob/v2.7.2/src/bunit.generators.internal/Blazor/EventDispatcherExtensionGenerator.cs#L185-L203
- https://github.com/bUnit-dev/bUnit/blob/v2.7.2/src/bunit/EventDispatchExtensions/TriggerEventDispatchExtensions.cs#L48-L77

One theory was ruled out by probe: stubbing `RestoreAsync` with a real `await Task.Delay(50)` still passed. `RunMutationAsync` (`KnownShortcuts.razor:342-357`) invokes the delegate before its first await, so slowness inside the API task cannot cause this.

**Fix.** The whole file was audited. Every assertion that reads a **positive** result after a click now waits, and the three add-form flows wait for the form to render before reading its fields — `Find()` there would throw `ElementNotFoundException`, which no later `WaitForAssertion` can catch.

**Evidence.** 50 consecutive runs of the project, 950 of 950 tests each, against the build made from the final commit. Earlier batches ran against superseded builds and are not counted.

## Flake A — not fixed

`WorktreeRemoveHook.Tests.ps1`, which failed once with an array reaching `Assert-True`.

**Not reproduced.** 40 standalone runs and 12 full `run-powershell-suites.ps1` runs, all green.

**Every lead ruled out**, each by running code rather than reading it:

- The backlog blamed `Wait-ForCondition`. A probe printed its return type: `System.Boolean` on the success path and on the timeout path. It cannot return an array.
- `Test-Path -LiteralPath` returns `System.Object[]` only when its path argument is already an array. No path variable here can become one — `New-TempGitRepo` and `Add-TestWorktree` send every command's output to `Out-Null` and end with `(Resolve-Path ...).Path`.
- All four `$log` reads use `Get-Content -Raw`, so `$log -match ...` returns a boolean, not an array of matches.

Reading the code says the failure is impossible. It happened anyway. **The call site is unknown, and this PR does not guess it.**

**What this PR does instead.** `Assert-True` took a `[bool]` parameter, so an array failed during parameter binding — and a binding failure names no line. That is why the original investigation had nothing to go on. The parameter is untyped now, with an explicit check that throws a message carrying the runtime type, the values, and the caller's line.

The suite still fails on a recurrence. It now says where.

A test covers that branch, because a passing suite never reaches it. Putting `[bool]` back makes the test fail, quoting the original error word for word. The test pins the exact caller line, read out of the file at run time, so a message naming the helper's own line does not pass.

**This does not meet criterion 3.** That criterion asks that an array *cannot* reach `Assert-True`, and that the fix names the call site. This does neither. It converts an unlocatable failure into a located one.

## Also rejected

An earlier draft made `Wait-ForCondition` return a scalar boolean. It was speculative — the function was already ruled out — and it was wrong: it normalized only the timeout path, while the loop's `if (& $Condition)` still treats any non-empty array as true. One function, two answers for the same script block. Reverted; the function is untouched.

## Follow-up filed

`backlog/069-negative-post-click-assertions-in-knownshortcutspagetests-need-a-positive-wait-signal.md` covers the three assertions that read a **negative** result after a click. `WaitForAssertion` cannot help those: it passes on the first try, which is exactly when a pending handler has not run. Each needs a positive signal to wait for first.

## Gate

All five canonical steps pass: build, format, PowerShell suites (18), coverage, `git diff --check main...HEAD`. Line coverage 94.6%, branch 82.6%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
