### PR TITLE
docs: clarify prose authority and condense worktree instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Be concise in all interactions.
 
-Text I read in chat follows the `ASD-STE100` output style (user level).
+Your chat replies follow the `ASD-STE100` output style (user level).
 Text written into this repository — docs, specs, plans, app-facing strings — follows
 **Plain English** in AGENTS.md. Commit messages are exempt from both: be extremely
 concise, sacrifice grammar for brevity.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-Be concise in all interactions. For documentation and app-facing text, follow **Plain English** in AGENTS.md — when short and easy-to-read conflict, choose easy-to-read. In commit messages, be extremely concise — sacrifice grammar for brevity.
+The `ASD-STE100` output style governs chat text. **Plain English** in AGENTS.md governs text written into the repository: documentation, specs, plans, and app-facing strings. When short and easy-to-read conflict, choose easy-to-read. In commit messages, be extremely concise — sacrifice grammar for brevity.
 
 @../AGENTS.md
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,11 @@
-The `ASD-STE100` output style governs chat text. **Plain English** in AGENTS.md governs text written into the repository: documentation, specs, plans, and app-facing strings. When short and easy-to-read conflict, choose easy-to-read. In commit messages, be extremely concise — sacrifice grammar for brevity.
-
 @../AGENTS.md
+
+Be concise in all interactions.
+
+Text I read in chat follows the `ASD-STE100` output style (user level).
+Text written into this repository — docs, specs, plans, app-facing strings — follows
+**Plain English** in AGENTS.md. Commit messages are exempt from both: be extremely
+concise, sacrifice grammar for brevity.
 
 # Claude Code Configuration
 
@@ -28,35 +33,37 @@ both the exemption list and this paragraph, this paragraph wins: plan first.
 
 ### Create the worktree before you write the plan
 
-Create the worktree first. Do not start writing a plan in the main checkout and then move the work
-afterwards. Use `scripts/new-worktree.ps1`, or the native `EnterWorktree` tool — that tool fires the
-`WorktreeCreate` hook, which runs the same script for you.
+Create the worktree first. Never start a plan in the main checkout and move the work later.
+Use `scripts/new-worktree.ps1`, or the native `EnterWorktree` tool. That tool fires the
+`WorktreeCreate` hook, which runs the same script.
 
-Write and commit the planning documents from the **main checkout**, not from the worktree.
-`docs/superpowers/` is a separate private repo (`AHKFlowApp-plans`). The public repo ignores the
-path, so `git worktree add` never checks it out. `scripts/new-worktree.ps1` links the folder into
-each worktree instead, so a worktree can **read** its spec and plan at the same relative path.
-Treat that link as read-only: keep every plan write and plan commit in the main checkout, so the
-plans repo has one place work happens. Follow this order:
+Order of work:
 
-1. Create the worktree, but stay in the main checkout for now.
-2. Write and commit the spec and the plan there, under `docs/superpowers/specs/` and
-   `docs/superpowers/plans/`. Commit from inside `docs/superpowers/`, never from the repo root.
-   Target that repo with `git -C docs/superpowers commit`, not `cd docs/superpowers && git commit`.
-   The agent Git guard reads the command before the shell runs the `cd`, so it still sees the main
-   checkout and blocks the commit. `-C` shows it the real target, which is a different repository.
-3. Switch fully into the worktree. Everything else — code, tests, docs, config — happens there and
-   commits from there. The spec and plan stay readable at `docs/superpowers/` through the link.
-4. If a review round changes the plan, go back to the main checkout to edit and commit it. The
-   worktree sees the update straight away, because the link points at one shared working copy.
+1. Create the worktree. Stay in the main checkout.
+2. Write and commit the spec and the plan from the main checkout, under
+   `docs/superpowers/specs/` and `docs/superpowers/plans/`.
+3. Switch into the worktree. Code, tests, docs, and config happen there and commit there.
+4. If a review round changes the plan, return to the main checkout to edit and commit it.
+   The worktree sees the update at once.
 
-Step 2 does not apply to every plan. **Plans** in AGENTS.md lists the kinds that stay out of the
-private repo: agent optimization, personal workflow tuning, agent housekeeping, and one-off
-context or config cleanups. Those still get a plan. The plan just is not committed there.
+Why the split: `docs/superpowers/` is a separate private repo (`AHKFlowApp-plans`). The public
+repo ignores the path, so `git worktree add` never checks it out. `scripts/new-worktree.ps1`
+links the folder into each worktree instead. A worktree can read its spec and plan at the same
+relative path. Treat that link as read-only.
+
+Commit plans with `git -C docs/superpowers commit`. Never use `cd docs/superpowers && git commit`.
+The agent Git guard reads the command before the shell runs the `cd`, so it still sees the main
+checkout and blocks the commit. `-C` shows it the real target.
+
+Step 2 has exceptions. **Plans** in AGENTS.md lists the kinds that stay out of the private repo:
+agent optimization, personal workflow tuning, agent housekeeping, and one-off context or config
+cleanups. Those still get a plan. The plan is not committed there.
 
 ### Other
 
-- When asked to store instructions or rules, put them in CLAUDE.md (not memory files) unless explicitly told otherwise.
+- When asked to store an instruction or a rule, put it in CLAUDE.md or `.claude/rules/`.
+  Never put it in an auto memory file. Auto memory is on by default and writes notes Claude
+  chooses itself; it is not a place for instructions I gave you. Toggle it from `/memory`.
 - Verifying finished work is governed by **Verification After Implementation** in AGENTS.md. Invoke the `playwright-cli` skill via the Skill tool when that routing calls for a browser drive.
 - Before claiming a tool or capability is unavailable, check `.claude/skills/` and available skills. Never assume browser automation is missing — `playwright-cli` is installed.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -57,13 +57,14 @@ checkout and blocks the commit. `-C` shows it the real target.
 
 Step 2 has exceptions. **Plans** in AGENTS.md lists the kinds that stay out of the private repo:
 agent optimization, personal workflow tuning, agent housekeeping, and one-off context or config
-cleanups. Those still get a plan. The plan is not committed there.
+cleanups. These plans may be skipped. If you write one, keep it out of the private repo.
 
 ### Other
 
 - When asked to store an instruction or a rule, put it in CLAUDE.md or `.claude/rules/`.
-  Never put it in an auto memory file. Auto memory is on by default and writes notes Claude
-  chooses itself; it is not a place for instructions I gave you. Toggle it from `/memory`.
+  Do not put it in an auto memory file unless I ask for one in that turn. Auto memory is on by
+  default and writes notes Claude chooses itself; it is not a place for instructions I gave you.
+  Toggle it from `/memory`.
 - Verifying finished work is governed by **Verification After Implementation** in AGENTS.md. Invoke the `playwright-cli` skill via the Skill tool when that routing calls for a browser drive.
 - Before claiming a tool or capability is unavailable, check `.claude/skills/` and available skills. Never assume browser automation is missing — `playwright-cli` is installed.
 

--- a/backlog/070-personal-defaults-sync.md
+++ b/backlog/070-personal-defaults-sync.md
@@ -1,0 +1,50 @@
+# 070 - Keep personal-defaults.md in sync with the web preferences box
+
+## Problem
+
+The same content lives in three places and drifts independently:
+
+- `.github/instructions/personal-defaults.md` — read by GitHub Copilot (`applyTo: "**"`)
+- `AGENTS.md` and `.claude/CLAUDE.md` — read by Claude Code
+- The Claude web preferences box — not version controlled, not readable by any tool
+
+Found on 2026-08-10: the repo file says `explicit use cases (IUseCase/IUseCaseHandler)`.
+The web box still said `MediatR`. No MediatR package exists in `Directory.Packages.props`.
+The repo copy was corrected at some point; the web copy was not. Every chat outside this
+repository used the wrong stack description.
+
+## Approach
+
+Make the repo file canonical. Make an edit to it impossible to forget about.
+
+Reuse the hash-parity pattern from `tests/CodexSkillsHashParity.Tests.ps1`. Record a content
+hash in the file. A change to the body without a change to the recorded hash fails the suite.
+Updating the hash is the moment you also paste the file into the web box.
+
+## Acceptance criteria
+
+- [ ] `.github/instructions/personal-defaults.md` carries a sync marker: the content hash of
+      the body, and the date it was last pasted into the web preferences box.
+- [ ] `tests/PersonalDefaultsSyncMarker.Tests.ps1` fails when the body hash and the recorded
+      hash differ. The failure message names the file and says to update the web box.
+- [ ] The suite runs under `pwsh .\scripts\test-fast.ps1 -Mode PowerShell` with the other
+      suites. No separate invocation.
+- [ ] AGENTS.md names `.github/instructions/personal-defaults.md` as the single source for
+      personal defaults, and says the web box is a copy.
+- [ ] The MediatR line is gone from all copies. The repo copy is already correct — check it,
+      do not re-edit.
+
+## Out of scope
+
+The suite cannot read the web preferences box. Nothing can. It proves the repo file changed
+deliberately; it cannot prove the paste happened. That gap is accepted — the failing test is
+the reminder, not the enforcement.
+
+Do not extend this to the ASD-STE100 output style. That file lives at
+`~/.claude/output-styles/`, outside any repository. Pulling it in would put a machine-local
+path under repo test control.
+
+## Notes / dependencies
+
+The sync marker belongs in an HTML comment, not frontmatter. The file already carries
+`applyTo: "**"` for Copilot, and adding keys there risks changing how Copilot loads it.


### PR DESCRIPTION
Docs only. No code, no behaviour change.

## Why

Four issues found while auditing agent instructions against the user-level CLAUDE.md and a
new ASD-STE100 output style.

## Changes

**1. Prose authority is now explicit.**
The file set prose rules on line 1, then imported AGENTS.md, which sets prose rules too.
Import order meant AGENTS.md landed after the local instruction. The import now comes first,
and the header names which authority governs which text: output style for chat, AGENTS.md
Plain English for text written into the repo, neither for commit messages.

**2. Worktree section rewritten as a numbered list.**
It was ~350 words of prose describing a 4-step sequence, and the largest single context cost
in the file. Same rules, same exceptions, same `git -C` warning. Roughly half the tokens.
Sequence and rationale are now separated, so the steps read as steps.

**3. Auto memory bullet updated.**
"Put them in CLAUDE.md (not memory files)" predates auto memory being on by default and
writing to its own location. The bullet now names `.claude/rules/` as a valid target, says why
auto memory is not one, and points at `/memory` for the toggle.

**4. New backlog item 070.**
`.github/instructions/personal-defaults.md` and the Claude web preferences box drifted. The
web box still named MediatR, which this repo does not use. The repo copy was already correct.
The item proposes a hash-parity suite so the repo file cannot change silently.

## Verification

- `pwsh .\scripts\test-fast.ps1 -Mode PowerShell` passes. All 18 suites green, including
  `BacklogNumbering.Tests.ps1` against the new item 070.
- The pre-push hook ran the Release build and the fast test slice. Build clean, 2931 tests
  passed.
- The commit-message carve-out exists in both AGENTS.md (Plain English section) and this
  header, so the two prose rulesets do not fight.
- Worktree steps unchanged in substance; `scripts/new-worktree.ps1` untouched.

## Not in this PR

Backlog item 070 is filed, not implemented. The sync suite it describes is separate work.
The Claude web preferences box still needs the paste by hand — no tool can reach it.
