### PR TITLE
chore: block backlog 068 pending flake A recurrence

### DIFF
--- a/backlog/blocked/068-two-flaky-tests-fail-intermittently-in-full-suite-runs.md
+++ b/backlog/blocked/068-two-flaky-tests-fail-intermittently-in-full-suite-runs.md
@@ -5,6 +5,28 @@
 - **Epic**: Test reliability
 - **Type**: Bug
 - **Interfaces**: UI | API | CLI (none — test code only)
+- **Status**: Blocked since 2026-08-10 — see the section below
+
+## Blocked — waiting for flake A to fail again
+
+Flake B is fixed and merged. Flake A has one open acceptance box, and no work in this repository
+can tick it. The box asks which call site passed an array to `Assert-True`. Reading the code says
+no call site can do that, and the failure still happened once on 2026-08-08. The only honest way
+to name the line is to see the failure again.
+
+The diagnostic that will name it is already merged, at `tests/WorktreeRemoveHook.Tests.ps1:13-27`.
+It replaces the `[bool]` parameter type with an explicit check. A recurrence now reports the
+runtime type, the values, and the caller's line number.
+
+Do not pick this up as available work. Adding more green runs proves nothing: a diagnostic that
+never fires says nothing about a fault seen once.
+
+**What would unblock it:**
+
+- The suite fails again, in CI or locally. The new message names the call site. Then fix that call
+  site, tick the last two boxes, and move the file to `backlog/done/`.
+- Or a decision that one unexplained failure, now made locatable, is enough. Then close the item
+  with that reason written down.
 
 ## Summary
 
@@ -96,7 +118,7 @@ again after each render, until it passes or the timeout expires.
 
 The fix wraps that assertion, and every other assertion in the file that reads a **positive**
 result after a click. The three assertions that read a **negative** after a click were left alone
-on purpose and moved to `backlog/069-...`. `WaitForAssertion` passes on its first try, which is
+on purpose and moved to `backlog/done/069-...`. `WaitForAssertion` passes on its first try, which is
 exactly the moment a queued handler has not run, so it would make those tests look careful while
 proving nothing.
 
@@ -168,7 +190,7 @@ path made one function answer the same script block two different ways. It was r
 - [ ] Both are exercised repeatedly enough to give confidence - run each in its normal full-suite
       context several times in a row and record the results
 
-**This item stays open.** Criterion 3 is not met and is not being claimed. Nothing stops an array
+**This item is blocked, not open.** Criterion 3 is not met and is not being claimed. Nothing stops an array
 from reaching `Assert-True`; the change only makes such a call fail with a location instead of
 failing during parameter binding with none. The call site that failed on 2026-08-08 is still
 unknown, and the only honest way to name it is to see it happen again.
@@ -183,7 +205,8 @@ diagnostic that never fires proves nothing about a fault that appeared once.
   exception is the rest of `KnownShortcutsPageTests.cs`: the assertions that read a positive result
   after a click share the proven mechanism, so they were fixed in the same pass.
 - Negative assertions after a click. Moved to
-  `backlog/069-negative-post-click-assertions-in-knownshortcutspagetests-need-a-positive-wait-signal.md`.
+  `backlog/done/069-negative-post-click-assertions-in-knownshortcutspagetests-need-a-positive-wait-signal.md`,
+  and finished there.
 - The other 15 PowerShell suites that define their own `Assert-True`. If the diagnostic proves
   useful, spreading it is separate work.
 

--- a/backlog/done/069-negative-post-click-assertions-in-knownshortcutspagetests-need-a-positive-wait-signal.md
+++ b/backlog/done/069-negative-post-click-assertions-in-knownshortcutspagetests-need-a-positive-wait-signal.md
@@ -197,7 +197,7 @@ form was shown blind to a real regression, and the new form was shown to catch i
 
 ## Notes / dependencies
 
-- Split out of `backlog/068-two-flaky-tests-fail-intermittently-in-full-suite-runs.md` on
-  2026-08-08, during review of the fix for that item
+- Split out of `backlog/blocked/068-two-flaky-tests-fail-intermittently-in-full-suite-runs.md` on
+  2026-08-08, during review of the fix for that item. Item 068 moved to `blocked/` on 2026-08-10
 - bUnit `WaitForAssertion` behavior: https://bunit.dev/docs/verification/async-assertion.html
 - bUnit version is pinned at `Directory.Packages.props:13`


### PR DESCRIPTION
## What

Moves `backlog/068-two-flaky-tests-fail-intermittently-in-full-suite-runs.md` into
`backlog/blocked/`. Adds the status line and the section that says what would unblock it.

## Why

Item 068 covered two flaky tests. Flake B is fixed and merged. Flake A has one acceptance box
left: name the call site that passed an array to `Assert-True`.

No work in this repository can tick that box. The findings already ruled out every lead by
reading the code, and the failure still happened once on 2026-08-08. The only honest way to name
the line is to see the failure again.

The diagnostic that will name it is merged, at `tests/WorktreeRemoveHook.Tests.ps1:13-27`. It
drops the `[bool]` parameter type and checks the type explicitly, so a recurrence reports the
runtime type, the values, and the caller's line number.

AGENTS.md sets the test for `blocked/`: whether the work is possible right now, not whether it is
worth doing. It is not possible right now, so the item does not belong in `backlog/` where an
agent will pick it up and add more green runs. A diagnostic that never fires proves nothing about
a fault seen once.

## Changes

- `git mv` 068 into `backlog/blocked/`
- Add `**Status**: Blocked since 2026-08-10` to the metadata
- Add a "Blocked — waiting for flake A to fail again" section near the top, with two unblock paths:
  the suite fails again and the message names the call site, or the human decides one locatable
  failure is enough and closes the item with that reason written down
- Change "This item stays open" to "This item is blocked, not open"
- Fix the stale `backlog/069-...` paths in both files — item 069 is in `backlog/done/` now

Acceptance boxes are unchanged. Blocking keeps the number and keeps the unticked boxes.

## Verification

Docs only, nothing compiled — exemption 1 in AGENTS.md.

`tests/BacklogNumbering.Tests.ps1`:

```
Backlog numbering tests passed. 74 backlog items checked.
```

All three backlog folders are scanned, so the move freed no number and made no duplicate.

The pre-push hook also ran the full quick-check gate on this branch: build in Release plus the
fast test slice. It passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
