### PR TITLE
feat: guard reads link targets as write targets (backlog 083)

### DIFF
--- a/backlog/083-guard-classifies-link-targets-as-write-targets.md
+++ b/backlog/083-guard-classifies-link-targets-as-write-targets.md
@@ -6,7 +6,7 @@
 - **Type**: Feature
 - **Interfaces**: CLI
 - **Difficulty**: complex
-- **Stage**: 1-pickup
+- **Stage**: 2-design
 
 ## Summary
 

--- a/backlog/083-guard-classifies-link-targets-as-write-targets.md
+++ b/backlog/083-guard-classifies-link-targets-as-write-targets.md
@@ -6,7 +6,7 @@
 - **Type**: Feature
 - **Interfaces**: CLI
 - **Difficulty**: complex
-- **Stage**: 2-design
+- **Stage**: 3-plan
 
 ## Summary
 

--- a/backlog/083-guard-classifies-link-targets-as-write-targets.md
+++ b/backlog/083-guard-classifies-link-targets-as-write-targets.md
@@ -5,6 +5,8 @@
 - **Epic**: Agent guardrails
 - **Type**: Feature
 - **Interfaces**: CLI
+- **Difficulty**: complex
+- **Stage**: 1-pickup
 
 ## Summary
 


### PR DESCRIPTION
## Backlog

Closes backlog 083 - Guard classifies link targets as write targets.

## Problem

The agent worktree guard reads the path a link is created AT, but never the path the link
points TO. A session in a managed worktree can create a link inside an allowed location
that aims at a file in the main checkout, then write through it. The write that follows
looks allowed, because the guard only ever sees the allowed path.

## Scope

Teach the write-target grammar in `scripts/agents/agent-worktree-guard.common.ps1` to read
the link target as well as the link path, for these spellings:

- `New-Item -ItemType HardLink | SymbolicLink | Junction` with `-Target`
- `ln` (hard and `-s`)
- `mklink` (`/D`, `/H`, `/J`)

A link whose target is inside the session's own worktree stays allowed.

## Out of scope

Links that already exist on disk before the session starts. This item is about link
CREATION only.

## Status

Draft. Stage: 1-pickup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
