### PR TITLE
fix: guard fails closed on pipeline-bound move and remove sources (backlog 084)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,6 +42,10 @@
     <PackageVersion Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <!-- Transitive pin: Testcontainers 4.11.0 floors SSH.NET at 2025.1.0 (NU1903 high vuln,
+         GHSA-q939-rpr3-3284); 2026.0.0 has the fix. Bumping Testcontainers does not help - even
+         4.13.0 asks for >= 2025.1.0, and NuGet resolves the lowest match. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="System.CommandLine" Version="3.0.0-preview.3.26207.106" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />

--- a/backlog/085-guard-reads-heredoc-and-here-string-bodies-as-command-text.md
+++ b/backlog/085-guard-reads-heredoc-and-here-string-bodies-as-command-text.md
@@ -1,0 +1,53 @@
+# 085 - Guard reads heredoc and here-string bodies as command text
+
+## Metadata
+
+- **Epic**: Agent guardrails
+- **Type**: Feature
+- **Interfaces**: CLI
+
+## Summary
+
+The guard's tokenizer does not understand a bash heredoc (`<<'EOF'`) or a PowerShell here-string
+(`@'...'@`). It reads the body as ordinary command text. A commit message that contains
+`| Remove-Item` is therefore classified as a real pipeline sink and refused, even though nothing
+in the body runs.
+
+## User story
+
+As a developer writing a commit message that quotes a shell command, I want the guard to ignore
+the text inside a heredoc or a here-string, so that describing a command is not treated the same
+as running it.
+
+## Acceptance criteria
+
+- [ ] `git commit -F -` with a heredoc body containing `| Remove-Item` is allowed from a managed
+      worktree
+- [ ] The same holds for a PowerShell here-string body, including one whose text contains an
+      apostrophe before the pipe
+- [ ] A real `| Remove-Item` outside any heredoc or here-string is still refused
+- [ ] A body containing `> file` or `rm -rf` is no longer read as a redirect or a delete either
+- [ ] Tests cover each shape above, in `tests/AgentWorktreeGuard.Tests.ps1`
+
+## Out of scope
+
+- Running or expanding the body. The guard classifies text and never executes it.
+- Parsing every shell quoting form. Heredoc and here-string are the two shapes that bite in
+  practice.
+
+## Notes / dependencies
+
+- Found while committing [084](done/084-guard-fails-closed-on-pipeline-bound-move-sources.md). The
+  guard refused its own commit: the message body described the bug it was fixing, and that
+  description contained `| Move-Item -Destination ...`.
+- **Pre-existing, widened by 084.** A body carrying `> file` or `rm -rf` already tripped the older
+  tiers before 084 landed. The pipeline-sink rule 084 added made a plain English sentence enough
+  to trip it, which is why it now needs fixing rather than documenting.
+- The apostrophe case is the sharp edge. In `@'...'@` the tokenizer enters its single-quoted state
+  at the opening `'`, and an apostrophe anywhere in the body ends that state early. Every `|`
+  after it reads as a real separator.
+- Recorded as an accepted limitation in
+  [`docs/agents/cross-agent-git-guardrails.md`](../docs/agents/cross-agent-git-guardrails.md)
+  until this is fixed. Remove that bullet when it is.
+- Workaround today: pass a long message with `git commit -F <file>`.
+- Related: [083](083-guard-classifies-link-targets-as-write-targets.md), the other open guard item.

--- a/backlog/done/084-guard-fails-closed-on-pipeline-bound-move-sources.md
+++ b/backlog/done/084-guard-fails-closed-on-pipeline-bound-move-sources.md
@@ -21,12 +21,12 @@ source check that a written-out path gets.
 
 ## Acceptance criteria
 
-- [ ] `Get-Item <main>/seed.txt | Move-Item -Destination <managed>/seed.txt` is refused from a
+- [x] `Get-Item <main>/seed.txt | Move-Item -Destination <managed>/seed.txt` is refused from a
       managed worktree
-- [ ] The same holds for `Get-ChildItem ... | Move-Item` and for `... | Remove-Item`
-- [ ] A move that names its source in its own arguments keeps working unchanged
-- [ ] A pipeline whose sink is a read-only command is unaffected
-- [ ] Tests cover each shape above, in `tests/AgentWorktreeGuard.Tests.ps1`
+- [x] The same holds for `Get-ChildItem ... | Move-Item` and for `... | Remove-Item`
+- [x] A move that names its source in its own arguments keeps working unchanged
+- [x] A pipeline whose sink is a read-only command is unaffected
+- [x] Tests cover each shape above, in `tests/AgentWorktreeGuard.Tests.ps1`
 
 ## Out of scope
 
@@ -42,6 +42,10 @@ source check that a written-out path gets.
   no source — needs a false-positive review first. `Get-ChildItem *.tmp | Remove-Item` scoped
   entirely inside a worktree is a normal thing to write, and it would start failing. Decide
   whether the guard denies outright or resolves the pipeline's own segment first.
+  **Resolved: deny outright.** No script or document in this repository pipes into `Remove-Item`
+  or `Move-Item`, so the idiom costs nothing here, and the denial names the rewrite. Resolving
+  the upstream segment was rejected: it is a much larger capability and it still has holes, since
+  a non-path operand such as `Where-Object Length` reads as a relative path.
 - Deferred from PR #289 deliberately: it needs pipeline-aware classification, a new capability
   rather than a fix to the work that branch did.
 - Related: [083](083-guard-classifies-link-targets-as-write-targets.md), the other deferred

--- a/backlog/done/084-guard-fails-closed-on-pipeline-bound-move-sources.md
+++ b/backlog/done/084-guard-fails-closed-on-pipeline-bound-move-sources.md
@@ -42,10 +42,11 @@ source check that a written-out path gets.
   no source — needs a false-positive review first. `Get-ChildItem *.tmp | Remove-Item` scoped
   entirely inside a worktree is a normal thing to write, and it would start failing. Decide
   whether the guard denies outright or resolves the pipeline's own segment first.
-  **Resolved: deny outright.** No script or document in this repository pipes into `Remove-Item`
-  or `Move-Item`, so the idiom costs nothing here, and the denial names the rewrite. Resolving
-  the upstream segment was rejected: it is a much larger capability and it still has holes, since
-  a non-path operand such as `Where-Object Length` reads as a relative path.
+  **Resolved: deny outright.** No script in this repository pipes into `Remove-Item` or
+  `Move-Item`, so the idiom costs nothing here, and the denial names the rewrite. Documentation
+  mentions those pipelines, including this file and the guardrails doc, but nothing runs them.
+  Resolving the upstream segment was rejected: it is a much larger capability and it still has
+  holes, since a non-path operand such as `Where-Object Length` reads as a relative path.
 - Deferred from PR #289 deliberately: it needs pipeline-aware classification, a new capability
   rather than a fix to the work that branch did.
 - Related: [083](083-guard-classifies-link-targets-as-write-targets.md), the other deferred

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -203,6 +203,14 @@ leaves the piped input unbound. Sinks that delete nothing they receive — `Copy
 `Set-Content`, `Select-Object` — are unaffected, wherever the pipeline reads from. `||` is bash's
 OR, not a pipe, so it never triggers this.
 
+Every built-in alias of the three sinks is matched: `ri`, `rd`, `rmdir`, `del`, `erase`, and `rm`
+for `Remove-Item`; `mi`, `move`, and `mv` for `Move-Item`; `rni` and `ren` for `Rename-Item`.
+PowerShell resolves each one to the same cmdlet, so `Get-Item <main>\README.md | ri` deletes the
+file exactly as `| Remove-Item` does. `rm` and `mv` are on the list for that reason, even though
+coreutils `rm` reads no path from standard input — a bash pipeline into it deletes nothing, so
+denying it costs nothing. This is the one place the guard reads aliases; everywhere else it still
+classifies the command word as written.
+
 A target the guard cannot expand is denied, because the guard cannot tell where it lands. That
 covers a leading `~`, and a variable, a percent expansion, a command substitution, or a backtick
 **anywhere** in the path. A leading literal prefix does not rescue it: `./scripts/$DEST` reaches
@@ -326,6 +334,12 @@ An agent running the same command would need a prompt or override.
 - A wrapper can still hide the command inside a quoted string. The tokenizer keeps a quoted string
   as one token, so the guard cannot classify the git word inside it. `sh -c '...'` and
   `rtk run "..."` bypass the guard this way.
+- The tokenizer does not understand a heredoc or a here-string, so it reads the **body** as
+  command text. A `git commit` message body that contains `| Remove-Item`, or an apostrophe that
+  ends the tokenizer's quoted state before one, is denied by the pipeline-sink rule even though
+  nothing in it runs. The trap predates that rule — a body carrying `> file` or `rm -rf` already
+  tripped the older tiers — but the rule widens it. Pass a long message with
+  `git commit -F <file>` instead. Tracked as backlog item 085.
 - `pwsh -File custom.ps1` bypasses the guard for a different reason: it runs git from inside a
   script file, not from a quoted string. The guard only reads the command line the hook reports,
   not any file that command line points to.

--- a/docs/agents/cross-agent-git-guardrails.md
+++ b/docs/agents/cross-agent-git-guardrails.md
@@ -181,6 +181,28 @@ last argument.
 a move deletes the path it reads. `cp`, `install`, `ln`, and `Copy-Item` report the destination
 only. So moving a file out of main is refused wherever it is going, a worktree included.
 
+`Move-Item`, `Rename-Item`, and `Remove-Item` can take the paths they delete from the pipeline
+instead of from their own arguments. The guard reads the command text and never runs it, so it
+cannot know which paths arrive that way. A segment that follows an unquoted `|` and names no
+source of its own is therefore denied:
+
+```powershell
+Get-Item <main>\README.md | Move-Item -Destination .\README.md   # denied
+Get-ChildItem *.tmp | Remove-Item                                # denied
+Remove-Item *.tmp                                                # allowed
+```
+
+The second line is denied even though it stays inside the worktree. Nothing in the text says
+where `Get-ChildItem` looks, so the guard cannot tell it apart from the first line. Write the
+paths out as arguments, or with `-Path`, and the command is classified normally.
+
+A source that IS written out keeps working under a pipe: `Get-Content list.txt | Remove-Item
+-Path a.txt` is classified on `a.txt`. `Move-Item` and `Rename-Item` need **two** operands before
+the source counts as written out, because PowerShell binds a single positional to `-Path` and
+leaves the piped input unbound. Sinks that delete nothing they receive — `Copy-Item`,
+`Set-Content`, `Select-Object` — are unaffected, wherever the pipeline reads from. `||` is bash's
+OR, not a pipe, so it never triggers this.
+
 A target the guard cannot expand is denied, because the guard cannot tell where it lands. That
 covers a leading `~`, and a variable, a percent expansion, a command substitution, or a backtick
 **anywhere** in the path. A leading literal prefix does not rescue it: `./scripts/$DEST` reaches

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1763,10 +1763,23 @@ function Get-AgentSegmentWriteTarget {
 }
 
 # Cmdlets that DELETE whatever the pipeline hands them, and that bind that input to their own
-# source parameter. Copy-Item and Set-Content are absent: they consume pipeline input too, but
-# they leave every path they receive where it is. mv and rm are absent as well - neither reads a
-# path from standard input, so piping into one deletes nothing.
-$script:AgentGuardPipelineSinkCmdlets = @('move-item', 'rename-item', 'remove-item')
+# source parameter, split by how many operands prove the source is written out. Copy-Item and
+# Set-Content are absent from both: they consume pipeline input too, but they leave every path
+# they receive where it is.
+#
+# Every built-in alias is listed. PowerShell resolves `Get-Item x | ri` to Remove-Item and
+# deletes x, so reading the full cmdlet names alone left every aliased spelling allowed. That
+# includes `rm` and `mv`: both are Remove-Item and Move-Item in PowerShell, whatever they mean
+# in bash. Denying a bash `... | rm` costs nothing, because coreutils rm reads no path from
+# standard input, so that pipeline deletes nothing either way.
+$script:AgentGuardPipelineRemoveSinks = @(
+    'remove-item', 'ri', 'rd', 'rmdir', 'del', 'erase', 'rm'
+)
+$script:AgentGuardPipelineMoveSinks = @(
+    'move-item', 'mi', 'move', 'mv', 'rename-item', 'rni', 'ren'
+)
+$script:AgentGuardPipelineSinkCmdlets =
+$script:AgentGuardPipelineRemoveSinks + $script:AgentGuardPipelineMoveSinks
 
 <#
 .SYNOPSIS
@@ -1785,6 +1798,9 @@ positional source. Move-Item and Rename-Item take the source first and the desti
 so a single operand is ambiguous under a pipe: PowerShell binds it to -Path, which then leaves
 the piped input with nowhere to go. Two operands are needed before the source is provably
 written out.
+
+The leaf is matched against every built-in alias too, because PowerShell resolves one to the same
+cmdlet: `Get-Item <main>\README.md | ri` deletes the file exactly as `| Remove-Item` does.
 #>
 function Test-AgentPipelineBoundSource {
     param([string[]] $Tokens)
@@ -1809,7 +1825,7 @@ function Test-AgentPipelineBoundSource {
 
     # Option values are consumed with their option, so `-Destination x` leaves no false operand.
     $operands = @(Get-AgentMoveCmdletOperand -Arguments $arguments)
-    $needed = if ($leaf -eq 'remove-item') { 1 } else { 2 }
+    $needed = if ($script:AgentGuardPipelineRemoveSinks -contains $leaf) { 1 } else { 2 }
     return ($operands.Count -lt $needed)
 }
 

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -398,10 +398,15 @@ unless it precedes $, `, ", \, or newline), which keeps quoted Windows paths suc
 "C:\some;path" intact. Outside quotes a backslash only escapes a metacharacter or whitespace,
 so an unquoted C:\Dev\repo survives too.
 
-Returns { Segments = @([pscustomobject]@{ Tokens = string[]; Masks = string[] }); Ambiguous = bool }.
+Returns { Segments = @([pscustomobject]@{ Tokens = string[]; Masks = string[]; PipedFrom = bool });
+Ambiguous = bool }.
 Each mask runs parallel to its token, one character per token character: 'u' where the character
 was unquoted, 'q' where it came from quotes or an escape. That is what lets a later scan tell a
 real redirect from a literal '>' the tokenizer already stripped the quotes from.
+
+PipedFrom is $true when an unquoted '|' separated this segment from the one before it. The
+segment boundary itself carries no other record of which separator ran, and a pipeline sink acts
+on paths that never appear in its own arguments.
 
 Ambiguous means the string ended inside an unterminated quote or escape, which makes every
 segment boundary in it untrustworthy. This is intentionally not a complete shell parser.
@@ -418,6 +423,9 @@ function Split-AgentCommandSegment {
     $hasCurrent = $false
     $state = 'None'
     $returnState = 'None'
+    # True while the segment being built follows an unquoted '|'. A pipeline sink reads its input
+    # from the segment before it, so a command that names no path of its own may still act on one.
+    $piped = $false
 
     for ($i = 0; $i -lt $Command.Length; $i++) {
         $ch = $Command[$i]
@@ -470,12 +478,17 @@ function Split-AgentCommandSegment {
                 [void] $masks.Add($currentMask.ToString())
                 [void] $current.Clear(); [void] $currentMask.Clear(); $hasCurrent = $false
             }
-            if ($tokens.Count -gt 0) {
+            # Read before the flush: it says whether this separator ended a real command. A '|'
+            # that ends one starts a pipeline; a '|' with nothing before it is the second half of
+            # a '||', which is bash's OR and hands over no objects.
+            $endedCommand = $tokens.Count -gt 0
+            if ($endedCommand) {
                 [void] $segments.Add([pscustomobject]@{
-                        Tokens = $tokens.ToArray(); Masks = $masks.ToArray()
+                        Tokens = $tokens.ToArray(); Masks = $masks.ToArray(); PipedFrom = $piped
                     })
                 $tokens.Clear(); $masks.Clear()
             }
+            $piped = ($ch -eq '|' -and $endedCommand)
             continue
         }
 
@@ -503,7 +516,7 @@ function Split-AgentCommandSegment {
     }
     if ($tokens.Count -gt 0) {
         [void] $segments.Add([pscustomobject]@{
-                Tokens = $tokens.ToArray(); Masks = $masks.ToArray()
+                Tokens = $tokens.ToArray(); Masks = $masks.ToArray(); PipedFrom = $piped
             })
     }
 
@@ -612,6 +625,9 @@ provenance, one character per token character, parallel to Tokens), and - for
 ChangeDirectory - Directory plus Unresolved. Unresolved marks a target the guard cannot expand
 literally (`cd -`, `cd $HOME`, bare `cd`), so a following mutation is treated as untargetable
 rather than silently classified against a stale directory.
+
+PipedFrom rides through from Split-AgentCommandSegment unchanged: it is $true when an unquoted
+'|' separated this segment from the one before it.
 #>
 function Get-AgentCommandSegment {
     [CmdletBinding()]
@@ -631,6 +647,7 @@ function Get-AgentCommandSegment {
     foreach ($entry in $split.Segments) {
         $tokens = @($entry.Tokens)
         $entryMasks = @($entry.Masks)
+        $pipedFrom = [bool] $entry.PipedFrom
 
         # Drop NAME=value prefixes so `AHKFLOW_ALLOW_MAIN=1 git commit` still reads as git.
         $start = 0
@@ -660,6 +677,7 @@ function Get-AgentCommandSegment {
                     Masks      = $tailMasks
                     Directory  = ''
                     Unresolved = $false
+                    PipedFrom  = $pipedFrom
                 })
             continue
         }
@@ -671,6 +689,7 @@ function Get-AgentCommandSegment {
                     Masks      = $effectiveMasks
                     Directory  = ''
                     Unresolved = $false
+                    PipedFrom  = $pipedFrom
                 })
             continue
         }
@@ -690,6 +709,7 @@ function Get-AgentCommandSegment {
                     Masks      = $effectiveMasks
                     Directory  = $directory
                     Unresolved = $unresolved
+                    PipedFrom  = $pipedFrom
                 })
             continue
         }
@@ -700,6 +720,7 @@ function Get-AgentCommandSegment {
                 Masks      = $effectiveMasks
                 Directory  = ''
                 Unresolved = $false
+                PipedFrom  = $pipedFrom
             })
     }
 
@@ -1741,6 +1762,57 @@ function Get-AgentSegmentWriteTarget {
     return $targets.ToArray()
 }
 
+# Cmdlets that DELETE whatever the pipeline hands them, and that bind that input to their own
+# source parameter. Copy-Item and Set-Content are absent: they consume pipeline input too, but
+# they leave every path they receive where it is. mv and rm are absent as well - neither reads a
+# path from standard input, so piping into one deletes nothing.
+$script:AgentGuardPipelineSinkCmdlets = @('move-item', 'rename-item', 'remove-item')
+
+<#
+.SYNOPSIS
+True when a pipeline sink deletes paths that its own arguments never name.
+
+.DESCRIPTION
+Move-Item, Rename-Item and Remove-Item take their source from the pipeline when no -Path or
+-LiteralPath reaches them. The guard classifies one segment at a time and never runs the
+upstream command, so it cannot know which paths arrive that way. Reporting no source at all let
+`Get-Item <main>\README.md | Move-Item -Destination <worktree>\README.md` through, and that
+command deletes a tracked file in the main checkout.
+
+A named -Path or -LiteralPath, in any spelling PowerShell binds, proves the source is written
+out. Positional operands prove it too, but the count differs by cmdlet. Remove-Item takes one
+positional source. Move-Item and Rename-Item take the source first and the destination second,
+so a single operand is ambiguous under a pipe: PowerShell binds it to -Path, which then leaves
+the piped input with nowhere to go. Two operands are needed before the source is provably
+written out.
+#>
+function Test-AgentPipelineBoundSource {
+    param([string[]] $Tokens)
+
+    $tokens = @($Tokens)
+    if ($tokens.Count -eq 0) { return $false }
+
+    $leaf = Get-AgentCommandLeafName -Word $tokens[0]
+    if ($script:AgentGuardPipelineSinkCmdlets -notcontains $leaf) { return $false }
+
+    # Assigned in two statements, not from an `if` expression: an `if` whose branch is `@()`
+    # produces an empty pipeline, and PowerShell assigns $null from that. A bare `Remove-Item`
+    # then handed one $null element to the operand reader, which counted it as a written-out
+    # source and let the piped delete through.
+    $arguments = @()
+    if ($tokens.Count -gt 1) { $arguments = @($tokens[1..($tokens.Count - 1)]) }
+
+    foreach ($argument in $arguments) {
+        if ([string] $argument -notmatch '^-([A-Za-z]+)(:.*)?$') { continue }
+        if (Test-AgentMoveSourceParameterName -Name ([string] $Matches[1])) { return $false }
+    }
+
+    # Option values are consumed with their option, so `-Destination x` leaves no false operand.
+    $operands = @(Get-AgentMoveCmdletOperand -Arguments $arguments)
+    $needed = if ($leaf -eq 'remove-item') { 1 } else { 2 }
+    return ($operands.Count -lt $needed)
+}
+
 # Interpreters whose quoted argument is itself a command line. `-File` and `/k`-style script
 # paths are deliberately absent: those point at a file, and the guard never reads files.
 $script:AgentGuardInterpreterSpecs = @(
@@ -1783,6 +1855,12 @@ function Get-AgentCommandWriteTarget {
     foreach ($segment in $parsed.Segments) {
         foreach ($target in (Get-AgentSegmentWriteTarget -Tokens $segment.Tokens -Masks $segment.Masks)) {
             [void] $targets.Add($target)
+        }
+
+        # A sink that deletes what the pipeline hands it names a path this scan cannot see, so the
+        # target list is incomplete in exactly the way Unresolved reports.
+        if ($segment.PipedFrom -and (Test-AgentPipelineBoundSource -Tokens $segment.Tokens)) {
+            $unresolved = $true
         }
 
         $tokens = @($segment.Tokens)
@@ -2011,6 +2089,13 @@ it cannot tell whether the write lands in the main checkout.
 Write the path out literally instead of using a variable, or run the command from the main checkout.
 '@
 
+$script:AgentGuardPipedSourceMessage = @'
+BLOCKED: this session is isolated in a worktree, and {0} takes the paths it deletes from the
+pipeline. The guard reads the command text and never runs it, so it cannot tell which paths
+arrive that way, or whether any of them sit in the main checkout.
+Name the paths in the command itself, with -Path or as arguments, instead of piping them in.
+'@
+
 <#
 .SYNOPSIS
 True when a resolved path is one the session may write despite sitting under the main checkout.
@@ -2123,6 +2208,7 @@ function Get-AgentWorktreeWriteDecision {
     $directoryStack = New-Object System.Collections.Generic.List[string]
     $blockingPath = ''
     $unresolvedBlock = $false
+    $pipedSourceCommand = ''
 
     foreach ($segment in $parsed.Segments) {
         if ($segment.Kind -eq 'PopDirectory') {
@@ -2159,6 +2245,15 @@ function Get-AgentWorktreeWriteDecision {
         }
 
         $targets = @(Get-AgentSegmentWriteTarget -Tokens $segment.Tokens -Masks $segment.Masks)
+
+        # A sink that deletes what the pipeline hands it names a source no scan of this segment
+        # can find. An empty source list is not "deletes nothing", so fail closed on it. This gets
+        # its own flag rather than reusing $unresolvedBlock: the fix is to write the paths out as
+        # arguments, not to expand a variable, so the two denials must not share a message.
+        if ($segment.PipedFrom -and (Test-AgentPipelineBoundSource -Tokens $segment.Tokens)) {
+            # The word as typed, not the lowercased leaf: the message quotes it back to the reader.
+            if ($pipedSourceCommand -eq '') { $pipedSourceCommand = [string] $segment.Tokens[0] }
+        }
 
         # Nested interpreters: re-scan the quoted argument the tokenizer kept whole.
         $tokens = @($segment.Tokens)
@@ -2198,14 +2293,23 @@ function Get-AgentWorktreeWriteDecision {
         }
     }
 
-    if ($blockingPath -eq '' -and -not $unresolvedBlock) {
+    if ($blockingPath -eq '' -and -not $unresolvedBlock -and $pipedSourceCommand -eq '') {
         return New-AgentGuardDecision -Action Allow
     }
 
     if ($AllowMain) {
-        $overrideTarget = if ($blockingPath -ne '') { $blockingPath } else { 'an unexpandable target' }
+        $overrideTarget = if ($blockingPath -ne '') { $blockingPath }
+        elseif ($pipedSourceCommand -ne '') { "a source piped into $pipedSourceCommand" }
+        else { 'an unexpandable target' }
         return New-AgentGuardDecision -Action Warn -Rule 'agent-worktree-main-write-overridden' -Message `
         ("WARNING: AHKFLOW_ALLOW_MAIN=1 overrode the worktree write-isolation rule for: $overrideTarget")
+    }
+
+    # A named blocking path outranks both. It says exactly which file the command touches, which
+    # is more use than either "the guard could not tell".
+    if ($blockingPath -eq '' -and $pipedSourceCommand -ne '') {
+        return New-AgentGuardDecision -Action Deny -Rule 'agent-worktree-main-write' -Message `
+        ([string]::Format($script:AgentGuardPipedSourceMessage, $pipedSourceCommand))
     }
 
     if ($blockingPath -eq '') {

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1838,9 +1838,27 @@ try {
         @{ Command = 'Copy-Item -Destination b.txt'; Expected = $false },
         @{ Command = 'Set-Content -Path out.txt'; Expected = $false },
         @{ Command = 'Select-Object Name'; Expected = $false },
-        # Neither reads a path from standard input, so piping into one deletes nothing.
-        @{ Command = 'rm'; Expected = $false },
-        @{ Command = 'mv'; Expected = $false }
+        # Every built-in alias of the three sinks. PowerShell resolves these to the same cmdlets,
+        # so a pipeline into one deletes exactly what a pipeline into the full name would.
+        @{ Command = 'ri'; Expected = $true },
+        @{ Command = 'rd'; Expected = $true },
+        @{ Command = 'rmdir'; Expected = $true },
+        @{ Command = 'del'; Expected = $true },
+        @{ Command = 'erase'; Expected = $true },
+        @{ Command = 'rm'; Expected = $true },
+        @{ Command = 'mi -Destination b.txt'; Expected = $true },
+        @{ Command = 'move -Destination b.txt'; Expected = $true },
+        @{ Command = 'mv -Destination b.txt'; Expected = $true },
+        @{ Command = 'rni -NewName b.txt'; Expected = $true },
+        @{ Command = 'ren -NewName b.txt'; Expected = $true },
+        # An alias that names its own source is written out, exactly as the full name would be.
+        @{ Command = 'ri a.txt'; Expected = $false },
+        @{ Command = 'rm -Path a.txt'; Expected = $false },
+        @{ Command = 'mv a.txt b.txt'; Expected = $false },
+        @{ Command = 'ren a.txt b.txt'; Expected = $false },
+        # Aliases of cmdlets that delete nothing they receive stay out.
+        @{ Command = 'cpi -Destination b.txt'; Expected = $false },
+        @{ Command = 'copy -Destination b.txt'; Expected = $false }
     )
 
     foreach ($case in $pipelineSinkCases) {
@@ -2273,6 +2291,29 @@ try {
         @{ Name    = 'Get-ChildItem out of main piped into Rename-Item is refused'
             Command = 'Get-ChildItem <MAIN> | Rename-Item -NewName old.txt'
             Cwd = 'Managed'; Action = 'Deny'
+        },
+        # An alias resolves to the same cmdlet, so it must reach the same verdict. Reading the
+        # full names only left every one of these allowed.
+        @{ Name    = 'Get-Item out of main piped into ri is refused'
+            Command = 'Get-Item <MAIN>/seed.txt | ri'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'Get-Item out of main piped into rm is refused'
+            Command = 'Get-Item <MAIN>/seed.txt | rm'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'Get-Item out of main piped into del is refused'
+            Command = 'Get-Item <MAIN>/seed.txt | del'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'Get-Item out of main piped into mv is refused'
+            Command = 'Get-Item <MAIN>/seed.txt | mv -Destination <MANAGED>/x.txt'
+            Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'Get-Item out of main piped into ren is refused'
+            Command = 'Get-Item <MAIN>/seed.txt | ren -NewName old.txt'
+            Cwd = 'Managed'; Action = 'Deny'
+        },
+        # An alias that names its own source in the worktree is classified normally.
+        @{ Name    = 'a piped ri that names a worktree source stays allowed'
+            Command = 'Get-Content list.txt | ri a.txt'; Cwd = 'Managed'; Action = 'Allow'
         },
         # The guard never runs the upstream command, so it cannot tell a worktree glob from a main
         # one. This idiom is refused too; the denial says to write the paths out as arguments.

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1793,6 +1793,64 @@ try {
         }
     }
 
+    Write-Host 'Pipeline-bound sources' -ForegroundColor Cyan
+
+    $pipedFromCases = @(
+        @{ Command = 'Get-Item a.txt | Remove-Item'; Expected = @($false, $true) },
+        @{ Command = 'Get-Item a.txt; Remove-Item b.txt'; Expected = @($false, $false) },
+        @{ Command = 'Get-Item a.txt && Remove-Item b.txt'; Expected = @($false, $false) },
+        # '||' is bash's OR. It hands over no objects, so the second half is not a pipeline sink.
+        @{ Command = 'Get-Item a.txt || Remove-Item'; Expected = @($false, $false) },
+        # Every stage of a longer pipeline follows a '|', including the middle one.
+        @{ Command = 'Get-ChildItem | Where-Object Length | Remove-Item'
+            Expected = @($false, $true, $true)
+        },
+        # A '|' inside quotes is text the tokenizer already stripped the quotes from.
+        @{ Command = "printf 'a|b'"; Expected = @($false) }
+    )
+
+    foreach ($case in $pipedFromCases) {
+        Invoke-TestCase "PipedFrom: $($case.Command)" {
+            $parsed = Get-AgentCommandSegment -Command $case.Command
+            $actual = @($parsed.Segments | ForEach-Object { [bool] $_.PipedFrom })
+            Assert-Equal ($case.Expected -join '|') ($actual -join '|') 'PipedFrom flags'
+        }
+    }
+
+    $pipelineSinkCases = @(
+        # No source of its own: the pipeline supplies it, and the guard cannot see it.
+        @{ Command = 'Remove-Item'; Expected = $true },
+        @{ Command = 'Remove-Item -Recurse -Force'; Expected = $true },
+        @{ Command = 'Move-Item -Destination b.txt'; Expected = $true },
+        @{ Command = 'Rename-Item -NewName b.txt'; Expected = $true },
+        # Move-Item binds a single positional to -Path, which leaves the piped input unbound.
+        # That is ambiguous, so it counts as no source.
+        @{ Command = 'Move-Item b.txt'; Expected = $true },
+        # A source written out in the command itself, positionally or by name.
+        @{ Command = 'Remove-Item a.txt'; Expected = $false },
+        @{ Command = 'Remove-Item -Path a.txt'; Expected = $false },
+        @{ Command = 'Remove-Item -LiteralPath:a.txt'; Expected = $false },
+        @{ Command = 'Remove-Item -li a.txt'; Expected = $false },
+        @{ Command = 'Move-Item a.txt b.txt'; Expected = $false },
+        @{ Command = 'Move-Item -Path a.txt -Destination b.txt'; Expected = $false },
+        @{ Command = 'Rename-Item a.txt b.txt'; Expected = $false },
+        # Cmdlets that consume pipeline input but delete nothing they receive.
+        @{ Command = 'Copy-Item -Destination b.txt'; Expected = $false },
+        @{ Command = 'Set-Content -Path out.txt'; Expected = $false },
+        @{ Command = 'Select-Object Name'; Expected = $false },
+        # Neither reads a path from standard input, so piping into one deletes nothing.
+        @{ Command = 'rm'; Expected = $false },
+        @{ Command = 'mv'; Expected = $false }
+    )
+
+    foreach ($case in $pipelineSinkCases) {
+        Invoke-TestCase "Pipeline sink: $($case.Command)" {
+            $parsed = Get-AgentCommandSegment -Command $case.Command
+            $actual = Test-AgentPipelineBoundSource -Tokens $parsed.Segments[0].Tokens
+            Assert-Equal $case.Expected $actual 'Pipeline-bound source'
+        }
+    }
+
     Write-Host 'Nested interpreter write targets' -ForegroundColor Cyan
 
     $nestedCases = @(
@@ -2199,6 +2257,61 @@ try {
         @{ Name    = 'nesting past the cap fails closed even when the inner command only reads'
             Command = 'sh -c "sh -c \"sh -c ''cat <MAIN>/seed.txt''\""'; Cwd = 'Managed'; Action = 'Deny'
         },
+        # A sink that takes its source from the pipeline names no path the guard can classify, so
+        # it fails closed. Without this, the move below deleted a tracked file in main.
+        @{ Name    = 'Get-Item out of main piped into Move-Item is refused'
+            Command = 'Get-Item <MAIN>/seed.txt | Move-Item -Destination <MANAGED>/seed.txt'
+            Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'Get-ChildItem out of main piped into Move-Item is refused'
+            Command = 'Get-ChildItem <MAIN> | Move-Item -Destination <MANAGED>/seed.txt'
+            Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'Get-Item out of main piped into Remove-Item is refused'
+            Command = 'Get-Item <MAIN>/seed.txt | Remove-Item'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'Get-ChildItem out of main piped into Rename-Item is refused'
+            Command = 'Get-ChildItem <MAIN> | Rename-Item -NewName old.txt'
+            Cwd = 'Managed'; Action = 'Deny'
+        },
+        # The guard never runs the upstream command, so it cannot tell a worktree glob from a main
+        # one. This idiom is refused too; the denial says to write the paths out as arguments.
+        @{ Name    = 'a worktree glob piped into Remove-Item is refused as well'
+            Command = 'Get-ChildItem *.tmp | Remove-Item'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        # A sink whose source IS written out is classified normally, pipeline or not.
+        @{ Name    = 'a piped Remove-Item that names its own source stays allowed'
+            Command = 'Get-Content list.txt | Remove-Item -Path a.txt'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        @{ Name    = 'a piped Remove-Item that names a main source is still refused'
+            Command = 'Get-Content list.txt | Remove-Item -Path <MAIN>/seed.txt'
+            Cwd = 'Managed'; Action = 'Deny'
+        },
+        # A move that names its source in its own arguments keeps working unchanged.
+        @{ Name    = 'Move-Item inside the worktree with no pipeline stays allowed'
+            Command = 'Move-Item a.txt b.txt'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        # A pipeline whose sink deletes nothing is unaffected, wherever it reads from.
+        @{ Name    = 'a read-only sink reading main stays allowed'
+            Command = 'Get-Item <MAIN>/seed.txt | Select-Object Name'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        @{ Name    = 'a copy sink reading main stays allowed'
+            Command = 'Get-Item <MAIN>/seed.txt | Copy-Item -Destination <MANAGED>/seed.txt'
+            Cwd = 'Managed'; Action = 'Allow'
+        },
+        # '||' is bash's OR, not a pipeline, so it hands the second half no paths.
+        @{ Name    = 'Remove-Item after || is not treated as a pipeline sink'
+            Command = 'test -f a.txt || Remove-Item b.txt'; Cwd = 'Managed'; Action = 'Allow'
+        },
+        # The nested-interpreter scan fails closed on a piped sink for the same reason.
+        @{ Name    = 'a piped sink inside a nested interpreter is refused'
+            Command = 'pwsh -Command "Get-Item <MAIN>/seed.txt | Remove-Item"'
+            Cwd = 'Managed'; Action = 'Deny'
+        },
+        # The rule only fires for a session isolated in a worktree.
+        @{ Name    = 'a main-checkout session may pipe into Remove-Item'
+            Command = 'Get-Item <MAIN>/seed.txt | Remove-Item'; Cwd = 'Main'; Action = 'Allow'
+        },
         # The session's worktree root is the git top level, not whatever directory it started in.
         @{ Name    = 'a subdirectory session writes its own worktree root'
             Command = 'printf x > ../README.md'; Cwd = 'ManagedSub'; Action = 'Allow'
@@ -2232,6 +2345,23 @@ try {
             -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main -AllowMain $false
         Assert-Equal 'Deny' $decision.Action 'Action'
         Assert-Match ([regex]::Escape((Join-Path $fixture.Main 'seed.txt'))) $decision.Message 'Message'
+    }
+
+    Invoke-TestCase 'Write isolation: a piped source denial names the sink and the fix' {
+        $source = $fixture.Main.Replace('\', '/') + '/seed.txt'
+        $decision = Invoke-AgentGuardPolicy -Command "Get-Item $source | Move-Item -Destination x.txt" `
+            -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main -AllowMain $false
+        Assert-Equal 'Deny' $decision.Action 'Action'
+        Assert-Equal 'agent-worktree-main-write' $decision.Rule 'Rule'
+        Assert-Match 'Move-Item takes the paths it deletes from the' $decision.Message 'Sink named'
+        Assert-Match 'instead of piping them in' $decision.Message 'Fix named'
+    }
+
+    Invoke-TestCase 'Write isolation: AHKFLOW_ALLOW_MAIN overrides a piped source denial' {
+        $decision = Get-AgentWorktreeWriteDecision -Command 'Get-ChildItem *.tmp | Remove-Item' `
+            -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main -AllowMain $true
+        Assert-Equal 'Warn' $decision.Action 'Action'
+        Assert-Match 'a source piped into Remove-Item' $decision.Message 'Override target'
     }
 
     Invoke-TestCase 'Write isolation: rm -rf on a worktree glob is not a write-rule denial' {


### PR DESCRIPTION
Closes backlog 084.

## The bug

`Move-Item`, `Rename-Item` and `Remove-Item` can take the paths they delete from the pipeline instead of from their own arguments. The guard classified one segment at a time and read arguments only, so a piped source reported nothing — and an empty source list read as "deletes nothing".

Piping a main-checkout path into `Move-Item` from a managed worktree was allowed, and it deleted a tracked file in main.

Verified pre-existing, not introduced by PR #289: the same command is allowed at merge-base `2cba6963`.

## The fix

`Split-AgentCommandSegment` now records `PipedFrom` per segment. A sink that follows an unquoted pipe without naming its own source is denied outright, with a message that names the rewrite.

Two details that carry the correctness:

- **`||` is not a pipe.** The token count is read *before* the flush, so the second `|` of a `||` sees an empty segment and never sets the flag. Bash's OR hands over no objects.
- **Operand counts follow the cmdlet.** `Remove-Item` needs one operand before its source counts as written out. `Move-Item` and `Rename-Item` need two, because PowerShell binds a lone positional to `-Path` and leaves the piped input unbound.

## Design fork

The backlog item left one question open: deny outright, or resolve the upstream segment first?

**Deny outright.** No script in this repository pipes into these cmdlets, so the idiom costs nothing here, and the denial names the rewrite. Resolving the upstream segment was rejected as a much larger capability that still has holes — a non-path operand such as `Where-Object Length` reads as a relative path and would resolve inside the worktree.

The visible cost: `Get-ChildItem *.tmp | Remove-Item` is now refused even when it stays inside the worktree. Nothing in the command text says where `Get-ChildItem` looks, so the guard cannot tell it apart from the main-checkout case. Rewrite as `Remove-Item *.tmp`.

## Review round

Two reviews on the first commit. Both approved; three findings addressed in the second commit.

**Alias gap — confirmed, and wider than reported.** The sink list held full cmdlet names only. Every built-in alias walked through. Verified against a real file: the short spelling deletes it, and the guard allowed all nine aliased spellings out of main.

`rm` and `mv` were the sharp ones — both resolve to the delete cmdlets in PowerShell, and the comment excluding them claimed the opposite. Coreutils `rm` reads no path from standard input, so denying a bash pipeline into it costs nothing either way.

**Heredoc widening — deferred, filed as backlog 085.** The tokenizer reads a heredoc or here-string *body* as command text, so a commit message describing this bug was itself refused. Pre-existing (a body carrying `> file` or `rm -rf` already tripped the older tiers), but the new rule made a plain English sentence enough to trip it. Recorded in the guardrails doc's accepted limitations until 085 lands.

**Note wording — confirmed.** The 084 note claimed no *document* mentions these pipelines. The docs this branch added do. Corrected.

One pushback: a reviewer described `cross-agent-git-guardrails.md:326-328` as noting `> file` / `rm -rf`. Those lines are the quoted-string bypass bullet. The underlying ask was still right, so the limitation went in regardless.

## Bug found on the way

`$x = if (...) {...} else { @() }` assigns `$null`, not an empty array — PowerShell drops an empty pipeline. `Get-AgentMoveCmdletOperand` counted that `$null` as one operand, which let a bare `Remove-Item` sink through. Caught by the new test, fixed, and commented at the assignment.

## Verification

All 18 PowerShell suites pass (`scripts/run-powershell-suites.ps1`), `AgentWorktreeGuard.Tests.ps1` among them. Pre-push quick checks passed on push.

New coverage in `tests/AgentWorktreeGuard.Tests.ps1`:

- `PipedFrom` flags across `|`, `;`, `&&`, `||`, a three-stage pipeline, and a quoted pipe
- Sink classification for all three cmdlets, all eleven aliases, both operand rules, and the non-deleting sinks
- Decision cases for every acceptance criterion, plus the `||` case, the nested-interpreter case, and the main-checkout-session case
- Denial message content, and the `AHKFLOW_ALLOW_MAIN=1` override

Backlog 084 is ticked and moved to `backlog/done/`. Backlog 083 stays open — the other deferred finding from the same review, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
