### PR TITLE
fix: stop concurrent test runs from destroying coverage data (backlog 082)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,13 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+      # tests/CoverageInputCompleteness.Tests.ps1 runs `dotnet sln list` and the coverage gate.
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       # The script runs every tests/*.Tests.ps1 as its own process, so one failing suite fails
       # this job and the rest still run. Listing the suites here let fifteen of them fail
       # silently - see backlog/done/066-ci-swallows-powershell-suite-failures-in-worktree-powershell-tests.md.

--- a/.gitignore
+++ b/.gitignore
@@ -461,6 +461,10 @@ coverage-report/
 CoverageReport/
 **/TestResults/
 
+# Shared test-run lock (scripts/test-run-lock.common.ps1)
+.test-run.lock
+.test-run.lock.owner
+
 # Superpowers brainstorming scratch (local-only)
 .superpowers/
 

--- a/backlog/082-concurrent-coverage-runs-corrupt-each-others-results.md
+++ b/backlog/082-concurrent-coverage-runs-corrupt-each-others-results.md
@@ -6,7 +6,7 @@
 - **Type**: Bug
 - **Interfaces**: none (test scripts)
 - **Difficulty**: moderate
-- **Stage**: 1-pickup
+- **Stage**: 3-plan
 
 ## Summary
 

--- a/backlog/082-concurrent-coverage-runs-corrupt-each-others-results.md
+++ b/backlog/082-concurrent-coverage-runs-corrupt-each-others-results.md
@@ -77,29 +77,42 @@ destroys the first's evidence mid-flight.
 
 ## Acceptance criteria
 
-- [ ] **A second concurrent run cannot start, or cannot collide — across scripts, not just
+- [x] **A second concurrent run cannot start, or cannot collide — across scripts, not just
       within one.** The lock must be shared by `run-coverage.ps1` and `test-fast.ps1`, since
       the observed collision was between them. A lock held only by `run-coverage.ps1` would
       not have prevented it.
-- [ ] The coverage gate refuses to report when its input is **incomplete**, measured in
+- [x] The coverage gate refuses to report when its input is **incomplete**, measured in
       **coverage artifacts** — the per-assembly Cobertura XML it actually consumes at
       `run-coverage.ps1:79-82` — not in TRX files, which Coverage never produces.
-- [ ] The threshold error stops claiming coverage when the cause is missing input. The
+- [x] The threshold error stops claiming coverage when the cause is missing input. The
       current text sends a reader hunting for a coverage regression that does not exist.
-- [ ] Timestamps are **not** used to prove freshness. With concurrent runs a file newer than
+- [x] Timestamps are **not** used to prove freshness. With concurrent runs a file newer than
       this run's start may have been written by the other one. Identity — expected assembly
       set, or a per-run output path — is what the check needs.
-- [ ] A test covers the incomplete-result-set path by removing one expected TRX.
-- [ ] The failure mode is documented in `docs/development/testing-workflow.md`.
+- [x] A test covers the incomplete-result-set path by removing one expected per-project
+      `coverage.cobertura.xml`. The original wording said "TRX", which contradicted the
+      criterion above it: Coverage produces no TRX files. See the plan for the correction.
+- [x] The failure mode is documented in `docs/development/testing-workflow.md`.
 
-### Open questions, not yet findings
+### Answers to the open questions
 
-- Which phase held the `AHKFlowApp.Application.dll` and `ahkflow.dll` locks seen in the
-  output. `--disable-build-servers` is already set for build and test, so the holder was
-  something else — plausibly the other run's test hosts, unverified.
-- Whether a test can ever execute against an assembly the run did not produce. If it can,
-  that is a separate and more serious item; if it cannot, the incomplete-data path above is
-  the whole defect. Answer this before designing the fix.
+Both questions are now answered by experiment. The experiment held a read-only lock on
+`tests/AHKFlowApp.UI.Blazor.Tests/bin/Release/net10.0/AHKFlowApp.Application.dll` and then ran
+only the coverage collector for that project.
+
+- **Which phase held the locks.** Neither the build nor the test execution. The **collector**
+  holds the write. coverlet instruments every module in the test output folder at test-session
+  start: it copies each module aside and writes an instrumented module back over it.
+  `coverlet.runsettings` has no `<Include>` filter, so `AHKFlowApp.Application.dll` inside
+  `AHKFlowApp.UI.Blazor.Tests\bin` is instrumented too. The other side of the collision is any
+  process holding those files open without sharing writes.
+- **Whether a test can execute against an assembly the run did not produce.** No. The run
+  either loads the correct assembly and passes, or fails to load it and reports a test failure.
+  The withdrawn false-green claim stays withdrawn, and no more serious item is needed. The
+  whole defect is **coverage-data loss**.
+
+The measured consequence: `dotnet test` exits 0, coverlet writes no coverage file for that
+project, and the merged report silently loses every assembly only that project covered.
 
 ## Out of scope
 

--- a/backlog/082-concurrent-coverage-runs-corrupt-each-others-results.md
+++ b/backlog/082-concurrent-coverage-runs-corrupt-each-others-results.md
@@ -6,7 +6,7 @@
 - **Type**: Bug
 - **Interfaces**: none (test scripts)
 - **Difficulty**: moderate
-- **Stage**: 3-plan
+- **Stage**: 4-execute
 
 ## Summary
 

--- a/backlog/done/082-concurrent-coverage-runs-corrupt-each-others-results.md
+++ b/backlog/done/082-concurrent-coverage-runs-corrupt-each-others-results.md
@@ -6,7 +6,7 @@
 - **Type**: Bug
 - **Interfaces**: none (test scripts)
 - **Difficulty**: moderate
-- **Stage**: 4-execute
+- **Stage**: 9-ship
 
 ## Summary
 

--- a/docs/development/coverage.md
+++ b/docs/development/coverage.md
@@ -57,6 +57,10 @@ Prefer `SKIP_PUSH_HOOK=1` — it skips only this repo's pre-push hook, while `--
 - `CoverageReport/SummaryGithub.md` — markdown summary used in the PR sticky comment and Actions job summary.
 - `TestResults/**/coverage.cobertura.xml` — per-project coverage files produced by `dotnet test`.
 
+Per-project coverage lands under `TestResults/coverage/<ProjectName>/`. The run checks that
+every test project the solution names produced a file there, and stops before the report when
+one did not. See [One test run at a time](testing-workflow.md#one-test-run-at-a-time).
+
 ## CI gate
 
 CI and the local verification path both use `scripts/ci/check-coverage-thresholds.py` to enforce per-assembly line and branch thresholds from the merged Cobertura report.

--- a/docs/development/testing-workflow.md
+++ b/docs/development/testing-workflow.md
@@ -149,6 +149,34 @@ pwsh .\scripts\test-fast.ps1 -Mode Coverage
 
 Coverage mode delegates to `scripts/run-coverage.ps1`. Run it before you mark a PR ready; CI enforces the same coverage + threshold gate on every non-docs PR. The pre-push hook itself only runs quick checks (incremental build + fast slice, see `scripts/pre-push-quick-checks.ps1`), not this full coverage path. The local coverage script uses the same disposable shared SQL container behavior as Integration mode for the SQL-backed suites.
 
+### One test run at a time
+
+`test-fast.ps1` and `run-coverage.ps1` share one exclusive lock file, `.test-run.lock`, at the
+repository root. The second of those two scripts to start fails immediately and names the
+first run's mode and process id. This includes the pre-push hook, which runs the Fast slice.
+
+The lock only covers those two scripts. A `dotnet test` or `dotnet build` you type yourself,
+and a build started from an IDE, take no lock and can still collide with a run in progress.
+The completeness check below is what catches that case.
+
+The lock exists because two runs in one repository destroy each other's coverage data.
+coverlet instruments every assembly in a test project's output folder at test-session start.
+When another run holds one of those files open, instrumentation fails and coverlet writes **no**
+coverage file for that project — while `dotnet test` still exits 0.
+
+The old result was a coverage-threshold failure with no real cause, several hundred lines below
+the file-lock error that produced it. Two checks now stop that. `run-coverage.ps1` compares the
+coverage files each test project produced against the projects the solution names, and refuses
+to report when any are missing. The threshold gate reports a missing assembly under
+`Coverage input incomplete`, not as a threshold failure.
+
+Different worktrees do not collide. Each has its own repository root, its own `bin` folders, and
+its own lock file.
+
+If a run is killed, Windows releases the lock automatically. Never delete `.test-run.lock` to
+recover. Only a live run blocks you, and the file stays on disk between runs by design. A
+leftover `.test-run.lock.owner` file alone never blocks a run either.
+
 ## Trait contract
 
 `Application.Tests` classes using these collections must have `[Trait("Category", "Integration")]`:

--- a/scripts/ci/check-coverage-thresholds.py
+++ b/scripts/ci/check-coverage-thresholds.py
@@ -171,19 +171,24 @@ def print_per_assembly_results(results: list[AssemblyResult]) -> None:
 
 
 def print_failure_summary(failures: list[AssemblyResult]) -> None:
-    print()
-    print(f"Coverage gate failed for {len(failures)} assembly(s):")
+    missing = [failure for failure in failures if failure.missing]
+    below = [failure for failure in failures if not failure.missing]
 
-    for failure in failures:
-        print(f"- {failure.name}")
-
-        if failure.missing:
+    if missing:
+        print()
+        print(f"Coverage input is incomplete. {len(missing)} assembly(s) never reached the merged report:")
+        for failure in missing:
+            print(f"- {failure.name}")
             print("  - package missing from CoverageReport\\Cobertura.xml")
-            continue
 
-        for metric in (failure.line, failure.branch):
-            if metric is not None and not metric.passed:
-                print(format_metric(metric))
+    if below:
+        print()
+        print(f"Coverage gate failed for {len(below)} assembly(s):")
+        for failure in below:
+            print(f"- {failure.name}")
+            for metric in (failure.line, failure.branch):
+                if metric is not None and not metric.passed:
+                    print(format_metric(metric))
 
 
 def print_next_steps(results: list[AssemblyResult]) -> None:
@@ -241,11 +246,27 @@ def main() -> int:
         print_failure_summary(failures)
         print_next_steps(results)
         print()
-        print(
-            "::error title=Coverage gate failed::"
-            f"{len(failures)} assembly(s) failed per-assembly coverage thresholds. "
-            f"Run `{LOCAL_REPRO_COMMAND}` from the repo root to reproduce locally."
-        )
+
+        missing = [result for result in failures if result.missing]
+        below = [result for result in failures if not result.missing]
+
+        if missing:
+            print(
+                "::error title=Coverage input incomplete::"
+                f"{len(missing)} assembly(s) are missing from the merged Cobertura report: "
+                f"{', '.join(result.name for result in missing)}. "
+                "This is missing measurement, not a coverage regression. "
+                "The usual local cause is a second test run in the same repository. "
+                f"Run `{LOCAL_REPRO_COMMAND}` from the repo root with no other test run active."
+            )
+
+        if below:
+            print(
+                "::error title=Coverage gate failed::"
+                f"{len(below)} assembly(s) failed per-assembly coverage thresholds. "
+                f"Run `{LOCAL_REPRO_COMMAND}` from the repo root to reproduce locally."
+            )
+
         return 1
 
     print()

--- a/scripts/coverage-inputs.common.ps1
+++ b/scripts/coverage-inputs.common.ps1
@@ -1,0 +1,66 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Name the test projects a coverage run must produce data for, and find the ones that did not.
+.DESCRIPTION
+  coverlet instruments every module in a test project's output folder at test-session start.
+  When another process holds one of those modules open, instrumentation fails, coverlet writes
+  no coverage file for that project, and dotnet test still exits 0. Backlog 082 measured this.
+
+  The merged report then silently loses every assembly only that project covered, and the
+  threshold gate calls it a coverage regression. This check catches the missing input first.
+
+  The expected project list is derived, never hard-coded. dotnet sln list gives the projects
+  the run covers. The coverlet.collector reference decides which of those can produce a
+  coverage file.
+#>
+
+# dotnet sln list prints a 'Project(s)' header and a '----------' separator before the paths,
+# and the paths are relative to the solution folder. The .csproj filter drops both header lines.
+function Get-AhkFlowCoverageProject {
+    param([Parameter(Mandatory = $true)][string]$RepoRoot)
+
+    $solutionProjects = & dotnet sln $RepoRoot list
+    if ($LASTEXITCODE -ne 0) { throw "dotnet sln list failed in $RepoRoot" }
+
+    $projects = New-Object System.Collections.Generic.List[object]
+    foreach ($line in $solutionProjects) {
+        $relative = "$line".Trim()
+        if ([string]::IsNullOrWhiteSpace($relative)) { continue }
+        if (-not $relative.EndsWith('.csproj', [System.StringComparison]::OrdinalIgnoreCase)) { continue }
+
+        $full = Join-Path $RepoRoot $relative
+        if (-not (Test-Path -LiteralPath $full -PathType Leaf)) { continue }
+
+        $content = Get-Content -LiteralPath $full -Raw
+        if ($content -notmatch 'coverlet\.collector') { continue }
+
+        $projects.Add([pscustomobject]@{
+                Name = [System.IO.Path]::GetFileNameWithoutExtension($full)
+                Path = (Resolve-Path -LiteralPath $full).Path
+            })
+    }
+
+    return @($projects | Sort-Object -Property Name)
+}
+
+function Get-AhkFlowMissingCoverageInput {
+    param(
+        [Parameter(Mandatory = $true)][string]$ResultsRoot,
+        [Parameter(Mandatory = $true)][string[]]$ExpectedProjectName
+    )
+
+    $missing = New-Object System.Collections.Generic.List[string]
+    foreach ($name in $ExpectedProjectName) {
+        $folder = Join-Path $ResultsRoot $name
+        if (-not (Test-Path -LiteralPath $folder -PathType Container)) {
+            $missing.Add($name)
+            continue
+        }
+
+        $produced = @(Get-ChildItem -LiteralPath $folder -Recurse -Filter 'coverage.cobertura.xml' -File -ErrorAction SilentlyContinue)
+        if ($produced.Count -eq 0) { $missing.Add($name) }
+    }
+
+    return @($missing)
+}

--- a/scripts/run-coverage.ps1
+++ b/scripts/run-coverage.ps1
@@ -25,10 +25,12 @@ $coverageReportDirectory = Join-Path $repoRoot 'CoverageReport'
 $summaryJsonPath = Join-Path $coverageReportDirectory 'Summary.json'
 $summaryGithubPath = Join-Path $coverageReportDirectory 'SummaryGithub.md'
 $thresholdScriptPath = Join-Path $repoRoot 'scripts' 'ci' 'check-coverage-thresholds.py'
+$coverageResultsRoot = Join-Path $repoRoot 'TestResults' 'coverage'
 $sharedSqlScript = Join-Path $PSScriptRoot 'test-sql-container.common.ps1'
 . $sharedSqlScript
 . "$PSScriptRoot\Common.ps1"
 . "$PSScriptRoot\test-run-lock.common.ps1"
+. "$PSScriptRoot\coverage-inputs.common.ps1"
 
 $testRunLock = Enter-AhkFlowTestRunLock -RepoRoot $repoRoot -Mode 'Coverage'
 Push-Location $repoRoot
@@ -62,14 +64,27 @@ try {
         $env:AHKFLOW_TEST_SQL_CONNECTION_STRING = $sharedSqlContainer.ConnectionString
         Write-Success ("Shared SQL test container ready in {0} ms." -f $sharedSqlContainer.ElapsedMilliseconds)
 
-        dotnet test --configuration $Configuration `
-            --disable-build-servers `
-            --no-build `
-            --no-restore `
-            --collect:"XPlat Code Coverage" `
-            --results-directory TestResults `
-            --settings coverlet.runsettings
-        $testExitCode = $LASTEXITCODE
+        $coverageProject = Get-AhkFlowCoverageProject -RepoRoot $repoRoot
+        if ($coverageProject.Count -eq 0) {
+            throw "No test project in the solution references coverlet.collector. A coverage run with nothing to measure must not look green."
+        }
+
+        $expectedProjectName = @($coverageProject | ForEach-Object { $_.Name })
+
+        foreach ($project in $coverageProject) {
+            $projectName = $project.Name
+            $projectResultsDirectory = Join-Path $coverageResultsRoot $projectName
+
+            Write-Step "Collecting coverage for $projectName"
+            dotnet test $project.Path --configuration $Configuration `
+                --disable-build-servers `
+                --no-build `
+                --no-restore `
+                --collect:"XPlat Code Coverage" `
+                --results-directory $projectResultsDirectory `
+                --settings coverlet.runsettings
+            if ($LASTEXITCODE -ne 0) { $testExitCode = $LASTEXITCODE }
+        }
     }
     finally {
         $env:AHKFLOW_TEST_SQL_CONNECTION_STRING = $previousSharedSqlConnectionString
@@ -77,6 +92,24 @@ try {
     }
 
     if ($testExitCode -ne 0) { throw "dotnet test failed" }
+
+    $missingCoverageInput = Get-AhkFlowMissingCoverageInput `
+        -ResultsRoot $coverageResultsRoot `
+        -ExpectedProjectName $expectedProjectName
+    if ($missingCoverageInput.Count -gt 0) {
+        Write-Fail 'Coverage input is incomplete. This run measured nothing for these test projects:'
+        foreach ($name in $missingCoverageInput) { Write-Host "  - $name" -ForegroundColor Red }
+        throw @"
+$($missingCoverageInput.Count) test project(s) produced no coverage.cobertura.xml.
+This is missing input, not a coverage regression. Do not read the numbers from this run.
+
+The usual cause is a second test run in the same repository. coverlet instruments every
+assembly in a test project's output folder, so another run holding one of those files makes
+instrumentation fail while dotnet test still exits 0.
+
+Make sure no other test run is active, then run this script again.
+"@
+    }
 
     reportgenerator `
         -reports:"TestResults/**/coverage.cobertura.xml" `

--- a/scripts/run-coverage.ps1
+++ b/scripts/run-coverage.ps1
@@ -28,7 +28,9 @@ $thresholdScriptPath = Join-Path $repoRoot 'scripts' 'ci' 'check-coverage-thresh
 $sharedSqlScript = Join-Path $PSScriptRoot 'test-sql-container.common.ps1'
 . $sharedSqlScript
 . "$PSScriptRoot\Common.ps1"
+. "$PSScriptRoot\test-run-lock.common.ps1"
 
+$testRunLock = Enter-AhkFlowTestRunLock -RepoRoot $repoRoot -Mode 'Coverage'
 Push-Location $repoRoot
 try {
     if (-not (Get-Command reportgenerator -ErrorAction SilentlyContinue)) {
@@ -106,4 +108,5 @@ try {
 }
 finally {
     Pop-Location
+    Exit-AhkFlowTestRunLock -Handle $testRunLock
 }

--- a/scripts/test-fast.ps1
+++ b/scripts/test-fast.ps1
@@ -35,6 +35,7 @@ $resultsRoot = Join-Path $repoRoot "TestResults\test-fast\$Mode"
 $sharedSqlScript = Join-Path $PSScriptRoot 'test-sql-container.common.ps1'
 . $sharedSqlScript
 . "$PSScriptRoot\Common.ps1"
+. "$PSScriptRoot\test-run-lock.common.ps1"
 
 function New-TestRun {
     param(
@@ -158,6 +159,7 @@ function Invoke-TestRun {
 }
 
 $sharedSqlContainer = $null
+$testRunLock = $null
 $previousSharedSqlConnectionString = $env:AHKFLOW_TEST_SQL_CONNECTION_STRING
 
 Push-Location $repoRoot
@@ -184,6 +186,8 @@ try {
 
         return
     }
+
+    $testRunLock = Enter-AhkFlowTestRunLock -RepoRoot $repoRoot -Mode $Mode
 
     if ($Mode -eq 'Integration' -or $Mode -eq 'E2E') {
         Write-Step 'Starting shared SQL test container'
@@ -212,5 +216,6 @@ finally {
         Stop-AhkFlowTestSqlContainer -ContainerName $sharedSqlContainer.ContainerName
     }
 
+    Exit-AhkFlowTestRunLock -Handle $testRunLock
     Pop-Location
 }

--- a/scripts/test-run-lock.common.ps1
+++ b/scripts/test-run-lock.common.ps1
@@ -1,0 +1,88 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  One exclusive lock shared by every local test run that builds and runs .NET tests.
+.DESCRIPTION
+  Two overlapping runs build into the same bin folders and instrument the same assemblies.
+  Backlog 082 measured the result: coverlet cannot write the module it is instrumenting,
+  writes no coverage file for that project, and dotnet test still exits 0. The coverage gate
+  then reports a threshold failure that has nothing to do with coverage.
+
+  The lock is one file per repository root, held open with FileShare::None for the life of
+  the run. A second run cannot open it and fails immediately with a message naming the holder.
+  The open handle blocks, never the file. The release step closes the handle and leaves the
+  file, so the file is present between runs and a run always takes the lock again.
+
+  A blocked run cannot read the lock file itself, because the holder shares nothing. So the
+  holder also writes a readable sibling file describing itself. That file is advisory only.
+  A killed run leaves it behind while Windows releases the real handle, so its presence alone
+  must never block anybody.
+#>
+
+function Get-AhkFlowTestRunLockPath {
+    param([Parameter(Mandatory = $true)][string]$RepoRoot)
+    return (Join-Path $RepoRoot '.test-run.lock')
+}
+
+function Get-AhkFlowTestRunLockOwnerPath {
+    param([Parameter(Mandatory = $true)][string]$RepoRoot)
+    return (Join-Path $RepoRoot '.test-run.lock.owner')
+}
+
+function Enter-AhkFlowTestRunLock {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepoRoot,
+        [Parameter(Mandatory = $true)][string]$Mode
+    )
+
+    $lockPath = Get-AhkFlowTestRunLockPath -RepoRoot $RepoRoot
+    $ownerPath = Get-AhkFlowTestRunLockOwnerPath -RepoRoot $RepoRoot
+
+    try {
+        $stream = [System.IO.File]::Open(
+            $lockPath,
+            [System.IO.FileMode]::OpenOrCreate,
+            [System.IO.FileAccess]::ReadWrite,
+            [System.IO.FileShare]::None)
+    }
+    catch [System.IO.IOException] {
+        $holder = 'unknown'
+        if (Test-Path -LiteralPath $ownerPath) {
+            $holder = (Get-Content -LiteralPath $ownerPath -Raw -ErrorAction SilentlyContinue).Trim()
+        }
+
+        throw @"
+Another AHKFlowApp test run holds the test-run lock, so this $Mode run cannot start.
+Holder: $holder
+Lock file: $lockPath
+
+Two overlapping runs build into the same bin folders and instrument the same assemblies.
+That destroys coverage data and produces a coverage failure with no real cause.
+Wait for the other run to finish, then start this one again.
+Only a live run blocks you. A lock file left behind by an earlier run does not.
+"@
+    }
+
+    $description = "Mode=$Mode; ProcessId=$PID; Started=$([DateTime]::UtcNow.ToString('o'))"
+    Set-Content -LiteralPath $ownerPath -Value $description -Encoding utf8
+
+    return [pscustomobject]@{
+        Path      = $lockPath
+        OwnerPath = $ownerPath
+        Stream    = $stream
+    }
+}
+
+function Exit-AhkFlowTestRunLock {
+    param([object]$Handle)
+
+    if (-not $Handle) { return }
+
+    if ($Handle.Stream) {
+        try { $Handle.Stream.Dispose() } catch { }
+    }
+
+    if ($Handle.OwnerPath) {
+        Remove-Item -LiteralPath $Handle.OwnerPath -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/tests/CoverageInputCompleteness.Tests.ps1
+++ b/tests/CoverageInputCompleteness.Tests.ps1
@@ -1,0 +1,127 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+Tests the coverage-input completeness check in scripts/coverage-inputs.common.ps1.
+
+.DESCRIPTION
+Backlog 082: when coverlet cannot instrument a locked assembly it writes no coverage file for
+that test project, and dotnet test still exits 0. The coverage gate then blames coverage for
+missing input. These cases prove the run notices the missing file first.
+
+The cases build a fake results tree under the system temp directory. No case runs dotnet.
+#>
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+. (Join-Path $repoRoot 'scripts\coverage-inputs.common.ps1')
+
+$script:Failures = New-Object System.Collections.Generic.List[string]
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { throw $Message }
+}
+
+function Invoke-TestCase {
+    param([string] $Name, [scriptblock] $Body)
+    try {
+        & $Body
+        Write-Host "  PASS  $Name" -ForegroundColor Green
+    }
+    catch {
+        $script:Failures.Add("$Name :: $($_.Exception.Message)")
+        Write-Host "  FAIL  $Name" -ForegroundColor Red
+        Write-Host "        $($_.Exception.Message)" -ForegroundColor DarkRed
+    }
+}
+
+# Builds <root>\<project>\<guid>\coverage.cobertura.xml for each named project, which is the
+# shape coverlet produces under a per-project results directory.
+function New-ResultsFixture {
+    param([string[]] $ProjectName)
+
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ('ahkflow-coverage-' + [guid]::NewGuid().ToString('N'))
+    foreach ($name in $ProjectName) {
+        $folder = Join-Path (Join-Path $root $name) ([guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $folder -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $folder 'coverage.cobertura.xml') `
+            -Value '<coverage><packages /></coverage>' -Encoding utf8
+    }
+
+    return (Resolve-Path -LiteralPath $root).Path
+}
+
+function Remove-ResultsFixture {
+    param([string] $Root)
+    if (Test-Path -LiteralPath $Root) {
+        Remove-Item -LiteralPath $Root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Invoke-TestCase 'A complete result set reports nothing missing' {
+    $expected = @('AHKFlowApp.Domain.Tests', 'AHKFlowApp.UI.Blazor.Tests')
+    $root = New-ResultsFixture -ProjectName $expected
+    try {
+        $missing = @(Get-AhkFlowMissingCoverageInput -ResultsRoot $root -ExpectedProjectName $expected)
+        Assert-True ($missing.Count -eq 0) "Expected nothing missing, got: $($missing -join ', ')"
+    }
+    finally {
+        Remove-ResultsFixture -Root $root
+    }
+}
+
+Invoke-TestCase 'Removing one expected coverage file names that project' {
+    $expected = @('AHKFlowApp.Domain.Tests', 'AHKFlowApp.UI.Blazor.Tests')
+    $root = New-ResultsFixture -ProjectName $expected
+    try {
+        Get-ChildItem -LiteralPath (Join-Path $root 'AHKFlowApp.UI.Blazor.Tests') -Recurse -Filter 'coverage.cobertura.xml' |
+            Remove-Item -Force
+
+        $missing = @(Get-AhkFlowMissingCoverageInput -ResultsRoot $root -ExpectedProjectName $expected)
+        Assert-True ($missing.Count -eq 1) "Expected exactly one missing project, got: $($missing -join ', ')"
+        Assert-True ($missing[0] -eq 'AHKFlowApp.UI.Blazor.Tests') "Expected the UI project, got: $($missing[0])"
+    }
+    finally {
+        Remove-ResultsFixture -Root $root
+    }
+}
+
+Invoke-TestCase 'A project folder that was never created counts as missing' {
+    $expected = @('AHKFlowApp.Domain.Tests', 'AHKFlowApp.CLI.Tests')
+    $root = New-ResultsFixture -ProjectName @('AHKFlowApp.Domain.Tests')
+    try {
+        $missing = @(Get-AhkFlowMissingCoverageInput -ResultsRoot $root -ExpectedProjectName $expected)
+        Assert-True ($missing.Count -eq 1) "Expected exactly one missing project, got: $($missing -join ', ')"
+        Assert-True ($missing[0] -eq 'AHKFlowApp.CLI.Tests') "Expected the CLI project, got: $($missing[0])"
+    }
+    finally {
+        Remove-ResultsFixture -Root $root
+    }
+}
+
+Invoke-TestCase 'The expected project list comes from the solution and coverlet' {
+    $projects = @(Get-AhkFlowCoverageProject -RepoRoot $repoRoot)
+    $names = @($projects | ForEach-Object { $_.Name })
+    Assert-True ($names.Count -ge 1) 'Expected at least one coverage-producing test project.'
+    Assert-True ($names -contains 'AHKFlowApp.UI.Blazor.Tests') "Expected the UI test project. Got: $($names -join ', ')"
+    Assert-True ($names -notcontains 'AHKFlowApp.TestUtilities') 'TestUtilities is a library, not a test project.'
+
+    foreach ($project in $projects) {
+        Assert-True (Test-Path -LiteralPath $project.Path -PathType Leaf) "Project path does not exist: $($project.Path)"
+    }
+}
+
+Write-Host ''
+if ($script:Failures.Count -gt 0) {
+    Write-Host "FAILED: $($script:Failures.Count) test(s)" -ForegroundColor Red
+    foreach ($failure in $script:Failures) { Write-Host "  - $failure" -ForegroundColor Red }
+    exit 1
+}
+
+Write-Host 'Coverage input completeness tests passed.' -ForegroundColor Green
+exit 0

--- a/tests/CoverageInputCompleteness.Tests.ps1
+++ b/tests/CoverageInputCompleteness.Tests.ps1
@@ -63,6 +63,33 @@ function Remove-ResultsFixture {
     }
 }
 
+# Writes a merged Cobertura report holding every threshold assembly except the excluded one.
+# Rates are set high so nothing fails on its numbers, which keeps the case about missing input.
+function New-MergedCobertura {
+    param([string] $ExcludeAssembly)
+
+    $assemblies = @(
+        'AHKFlowApp.Domain', 'AHKFlowApp.Application', 'AHKFlowApp.Infrastructure',
+        'AHKFlowApp.API', 'AHKFlowApp.UI.Blazor'
+    ) | Where-Object { $_ -ne $ExcludeAssembly }
+
+    $packages = ($assemblies | ForEach-Object {
+        "    <package name=`"$_`" line-rate=`"0.99`" branch-rate=`"0.99`" />"
+    }) -join [Environment]::NewLine
+
+    $path = Join-Path ([System.IO.Path]::GetTempPath()) ('ahkflow-cobertura-' + [guid]::NewGuid().ToString('N') + '.xml')
+    $xml = @"
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="0.99" branch-rate="0.99">
+  <packages>
+$packages
+  </packages>
+</coverage>
+"@
+    Set-Content -LiteralPath $path -Value $xml -Encoding utf8
+    return $path
+}
+
 Invoke-TestCase 'A complete result set reports nothing missing' {
     $expected = @('AHKFlowApp.Domain.Tests', 'AHKFlowApp.UI.Blazor.Tests')
     $root = New-ResultsFixture -ProjectName $expected
@@ -113,6 +140,26 @@ Invoke-TestCase 'The expected project list comes from the solution and coverlet'
 
     foreach ($project in $projects) {
         Assert-True (Test-Path -LiteralPath $project.Path -PathType Leaf) "Project path does not exist: $($project.Path)"
+    }
+}
+
+Invoke-TestCase 'The gate calls a missing assembly incomplete input, not a threshold failure' {
+    $cobertura = New-MergedCobertura -ExcludeAssembly 'AHKFlowApp.UI.Blazor'
+    try {
+        $gate = Join-Path $repoRoot 'scripts\ci\check-coverage-thresholds.py'
+        $output = & python $gate --cobertura-path $cobertura 2>&1 | Out-String
+        $exitCode = $LASTEXITCODE
+
+        Assert-True ($exitCode -ne 0) "Expected a non-zero exit code. Output: $output"
+        Assert-True ($output -match 'Coverage input incomplete') `
+            "Expected the incomplete-input error title. Output: $output"
+        Assert-True ($output -match 'AHKFlowApp\.UI\.Blazor') `
+            "Expected the missing assembly to be named. Output: $output"
+        Assert-True ($output -notmatch 'failed per-assembly coverage thresholds') `
+            "Missing input must not be reported as a threshold failure. Output: $output"
+    }
+    finally {
+        Remove-Item -LiteralPath $cobertura -Force -ErrorAction SilentlyContinue
     }
 }
 

--- a/tests/CoverageRunLock.Tests.ps1
+++ b/tests/CoverageRunLock.Tests.ps1
@@ -1,0 +1,143 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+Tests for the shared test-run lock in scripts/test-run-lock.common.ps1.
+
+.DESCRIPTION
+The lock stops two local test runs from building and instrumenting the same output folders at
+the same time. Backlog 082 recorded what happens without it: coverlet fails to instrument a
+locked module, writes no coverage file for that project, and dotnet test still exits 0.
+
+Every case uses a disposable folder under the system temp directory as the repository root.
+No case takes the lock in the real repository root.
+#>
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+. (Join-Path $repoRoot 'scripts\test-run-lock.common.ps1')
+
+$script:Failures = New-Object System.Collections.Generic.List[string]
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { throw $Message }
+}
+
+function Invoke-TestCase {
+    param([string] $Name, [scriptblock] $Body)
+    try {
+        & $Body
+        Write-Host "  PASS  $Name" -ForegroundColor Green
+    }
+    catch {
+        $script:Failures.Add("$Name :: $($_.Exception.Message)")
+        Write-Host "  FAIL  $Name" -ForegroundColor Red
+        Write-Host "        $($_.Exception.Message)" -ForegroundColor DarkRed
+    }
+}
+
+function New-FakeRepoRoot {
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ('ahkflow-lock-' + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+    return (Resolve-Path -LiteralPath $root).Path
+}
+
+function Remove-FakeRepoRoot {
+    param([string] $Root)
+    if (Test-Path -LiteralPath $Root) {
+        Remove-Item -LiteralPath $Root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Invoke-TestCase 'A second run cannot take the lock' {
+    $root = New-FakeRepoRoot
+    $first = $null
+    try {
+        $first = Enter-AhkFlowTestRunLock -RepoRoot $root -Mode 'Coverage'
+        $threw = $false
+        $message = ''
+        try { Enter-AhkFlowTestRunLock -RepoRoot $root -Mode 'Fast' }
+        catch { $threw = $true; $message = $_.Exception.Message }
+        Assert-True $threw 'Expected the second acquisition to throw.'
+        Assert-True ($message -match 'Coverage') "Expected the holder's mode in the message. Got: $message"
+        Assert-True ($message -match [regex]::Escape($PID)) "Expected the holder's process id. Got: $message"
+    }
+    finally {
+        if ($first) { Exit-AhkFlowTestRunLock -Handle $first }
+        Remove-FakeRepoRoot -Root $root
+    }
+}
+
+Invoke-TestCase 'Releasing the lock lets the next run take it' {
+    $root = New-FakeRepoRoot
+    try {
+        $first = Enter-AhkFlowTestRunLock -RepoRoot $root -Mode 'Fast'
+        Exit-AhkFlowTestRunLock -Handle $first
+        $second = Enter-AhkFlowTestRunLock -RepoRoot $root -Mode 'Coverage'
+        Assert-True ($null -ne $second) 'Expected the second acquisition to succeed.'
+        Exit-AhkFlowTestRunLock -Handle $second
+    }
+    finally {
+        Remove-FakeRepoRoot -Root $root
+    }
+}
+
+Invoke-TestCase 'A stale owner file alone does not block a run' {
+    $root = New-FakeRepoRoot
+    try {
+        Set-Content -LiteralPath (Join-Path $root '.test-run.lock.owner') `
+            -Value 'Mode=Coverage; ProcessId=999999; Started=2026-01-01T00:00:00Z' -Encoding utf8
+        $handle = Enter-AhkFlowTestRunLock -RepoRoot $root -Mode 'Fast'
+        Assert-True ($null -ne $handle) 'Expected the run to take the lock despite a stale owner file.'
+        $owner = Get-Content -LiteralPath $handle.OwnerPath -Raw
+        Assert-True ($owner -match 'Mode=Fast') "Expected the owner file to be overwritten. Got: $owner"
+        Exit-AhkFlowTestRunLock -Handle $handle
+    }
+    finally {
+        Remove-FakeRepoRoot -Root $root
+    }
+}
+
+# The lock file is never deleted, so every run after the first one meets a file that is already
+# there. Only a live handle blocks. This case proves the error message tells the truth when it
+# says a lock file left behind by an earlier run does not block.
+Invoke-TestCase 'A leftover lock file with no open handle does not block a run' {
+    $root = New-FakeRepoRoot
+    try {
+        Set-Content -LiteralPath (Join-Path $root '.test-run.lock') -Value 'leftover' -Encoding utf8
+        $handle = Enter-AhkFlowTestRunLock -RepoRoot $root -Mode 'Fast'
+        Assert-True ($null -ne $handle) 'Expected the run to take the lock despite a leftover lock file.'
+        Exit-AhkFlowTestRunLock -Handle $handle
+    }
+    finally {
+        Remove-FakeRepoRoot -Root $root
+    }
+}
+
+Invoke-TestCase 'Releasing the lock deletes the owner file' {
+    $root = New-FakeRepoRoot
+    try {
+        $handle = Enter-AhkFlowTestRunLock -RepoRoot $root -Mode 'Fast'
+        $ownerPath = $handle.OwnerPath
+        Exit-AhkFlowTestRunLock -Handle $handle
+        Assert-True (-not (Test-Path -LiteralPath $ownerPath)) 'Expected the owner file to be deleted.'
+    }
+    finally {
+        Remove-FakeRepoRoot -Root $root
+    }
+}
+
+Write-Host ''
+if ($script:Failures.Count -gt 0) {
+    Write-Host "FAILED: $($script:Failures.Count) test(s)" -ForegroundColor Red
+    foreach ($failure in $script:Failures) { Write-Host "  - $failure" -ForegroundColor Red }
+    exit 1
+}
+
+Write-Host 'Test-run lock tests passed.' -ForegroundColor Green
+exit 0


### PR DESCRIPTION
## What

Backlog 082: two overlapping local test runs destroyed each other's coverage data, and the
resulting failure blamed coverage.

Three layers, in order of how much they prevent.

**1. A shared exclusive lock.** `scripts/test-run-lock.common.ps1` holds one `.test-run.lock`
per repository root with `FileShare::None`. `test-fast.ps1` and `run-coverage.ps1` both take
it. The second run to start fails immediately and names the first run's mode and process id.
The lock covers those two scripts only — a bare `dotnet test`, a bare `dotnet build`, and an
IDE build take no lock and can still collide.

**2. A completeness check.** `run-coverage.ps1` now runs each test project into
`TestResults/coverage/<ProjectName>/` and compares the coverage files produced against the
projects the solution names. When any project produced no `coverage.cobertura.xml`, the run
throws before ReportGenerator, so no number from an incomplete run is ever printed. This is
the safety net for every collision the lock cannot see.

**3. An honest gate message.** `check-coverage-thresholds.py` reports a missing assembly under
`::error title=Coverage input incomplete`, separate from the threshold error. A real
regression still prints `failed per-assembly coverage thresholds`.

## Root cause, measured

The **collector** holds the write, not the build and not the test execution. coverlet
instruments every module in a test project's output folder at test-session start: it copies
each module aside and writes an instrumented module back over it. `coverlet.runsettings` has
no `<Include>` filter, so `AHKFlowApp.Application.dll` inside `AHKFlowApp.UI.Blazor.Tests\bin`
is instrumented too — which is why the reported failure named a file that does not look like
it belongs to that project.

The dangerous part: `dotnet test` **exits 0** while coverlet writes **no** coverage file for
that project. The merged report then silently loses every assembly only that project covered,
and the gate calls it a coverage regression.

The item's second open question is also answered: no test ever executes against an assembly
the run did not produce. The run either loads the correct assembly and passes, or fails to
load it and reports a test failure. The withdrawn false-green claim stays withdrawn. The whole
defect is coverage-data loss.

## Verification

- `tests/CoverageRunLock.Tests.ps1` — 5 cases, pass.
- `tests/CoverageInputCompleteness.Tests.ps1` — 5 cases, pass.
- Live collision check: second run refused, named holder mode `Coverage` and process id.
- `pwsh .\scripts\test-fast.ps1 -Mode PowerShell` — all 20 suites pass.
- `dotnet build AHKFlowApp.slnx --configuration Release` — 17 projects, 0 errors, 0 warnings.
- `dotnet format AHKFlowApp.slnx --verify-no-changes` — clean.
- `pwsh .\scripts\test-fast.ps1 -Mode Coverage` — gate green, line 94.6%, branch 82.6%,
  identical to before the change.
- `git diff --check main...HEAD` — clean.

Per-project `dotnet test` cost: 431 seconds wall clock for the whole coverage path, gate
included. Acceptable, so the fallback to one solution-wide run is not needed.

## Notes

- `ci.yml` now pins the SDK from `global.json` and Python 3.12 in the `powershell-suites` job.
  The new suite is the first PowerShell suite that starts `dotnet` and calls `python`.
- CI runs its own `dotnet test` in `ci.yml`, not `run-coverage.ps1`, so CI gets the gate
  message change but not the completeness check. CI runners are single-run. Left alone on
  purpose.
- One acceptance criterion was corrected in the backlog item. Criterion 5 said the test must
  remove one expected TRX, which contradicted criterion 2: Coverage produces no TRX files. It
  now removes one expected per-project `coverage.cobertura.xml`.

Closes backlog 082 — item moved to `backlog/done/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
