### PR TITLE
feat: guard reads link targets as write targets (backlog 083, redelivery)

### DIFF
--- a/backlog/086-guard-reads-the-link-kind-before-anchoring-a-relative-target.md
+++ b/backlog/086-guard-reads-the-link-kind-before-anchoring-a-relative-target.md
@@ -1,0 +1,79 @@
+# 086 - Guard reads the link kind before anchoring a relative target
+
+## Metadata
+
+- **Epic**: Agent guardrails
+- **Type**: Feature
+- **Interfaces**: none (agent git guard)
+- **Stage**: 0-intake
+
+## Summary
+
+The guard offers a relative link target three ways, because it does not know whether the command
+creates a symbolic link or a hard link. Reading the kind first would let each form keep only the
+anchor that matches how the operating system resolves it. That removes a refusal that stops
+ordinary work, without giving up any denial the guard makes today.
+
+## User story
+
+As an agent working in a worktree, I want a relative link that stays inside my own worktree to be
+allowed, so that I do not have to rewrite ordinary link commands to get past the guard.
+
+## Detail
+
+`Add-AgentLinkTargetCandidate` in `scripts/agents/agent-worktree-guard.common.ps1` adds three
+candidates for a relative target: as written, joined to the link path, and joined to the link
+path's parent. Each anchor is correct for one case and wrong for the other:
+
+- Windows resolves a **symbolic** link target against the directory that holds the link. The two
+  joined anchors are correct. The as-written anchor is not.
+- A **hard** link resolves its source against the working directory. The as-written anchor is
+  correct. The two joined anchors are not.
+
+Keeping all three fails closed, which is the right default. It also refuses work that is allowed:
+
+```powershell
+# From the worktree root. The link stays inside the worktree, and the guard refuses it.
+ln -s ../src/a.cs deep/bait.md
+```
+
+The as-written anchor resolves that target to `<main>\.claude\worktrees\src\a.cs`, which is in
+the main checkout, so Deny wins. The refusal message then names a path that no write would have
+landed on.
+
+The as-written anchor cannot simply be dropped. This hard link is denied by that anchor alone:
+
+```powershell
+# The source is <main>\.claude\worktrees\README.md - a file in the main checkout.
+ln ../README.md deep/bait.md
+```
+
+Both behaviours are pinned in `tests/AgentWorktreeGuard.Tests.ps1` under "Link creation".
+
+Every command form already carries its kind, so the guard can read it:
+
+| Command | Symbolic | Hard | Junction |
+|---|---|---|---|
+| `ln` | `-s`, `--symbolic`, or a cluster holding `s` | no `-s` | n/a |
+| `cp` | `-s` | `-l` | n/a |
+| `mklink` | default | `/H` | `/J` |
+| `New-Item` | `-ItemType SymbolicLink` | `HardLink` | `Junction` |
+
+## Acceptance criteria
+
+- [ ] A relative symbolic-link target uses the two link-relative anchors only
+- [ ] A relative hard-link source uses the working-directory anchor only
+- [ ] A command whose kind the guard cannot read keeps all three anchors and stays fail-closed
+- [ ] `ln -s ../src/a.cs deep/bait.md` inside a worktree is allowed, and the test that pins today's
+      Deny is rewritten to expect Allow
+- [ ] Every link denial the suite makes today still denies
+
+## Out of scope
+
+- Any change to the absolute-target path, which means one file from every directory
+- Reading the kind for commands the guard does not treat as link commands today
+
+## Notes / dependencies
+
+- Found in review of pull request #296 (backlog 083 redelivery)
+- The reasoning lives in the `Add-AgentLinkTargetCandidate` comment; keep the two in step

--- a/backlog/087-backlog-template-carries-the-stage-field.md
+++ b/backlog/087-backlog-template-carries-the-stage-field.md
@@ -1,0 +1,51 @@
+# 087 - Backlog template carries the Stage field
+
+## Metadata
+
+- **Epic**: Development process
+- **Type**: Tooling
+- **Interfaces**: none (repo process)
+- **Stage**: 0-intake
+
+## Summary
+
+`docs/development/workflow.md` names the item's `Stage` field as the durable record of where the
+work stands, but `backlog/000-backlog-item-template.md` has no such field. So every item either
+grows one by hand or never gets one, and a resumed session cannot tell which.
+
+## User story
+
+As a session picking work up after a cleared context, I want every backlog item to carry a Stage
+field, so that I can read the stage instead of guessing it from the branch and the commit log.
+
+## Detail
+
+The workflow document treats the field as required. `docs/development/workflow.md:78` calls the
+`Stage` field in the backlog item the durable stage record, and line 80 tells a resumed session to
+read it first. The template does not produce one, so items drift three ways:
+
+- `backlog/done/084-guard-fails-closed-on-pipeline-bound-move-sources.md` has no Stage line
+- `backlog/done/076-guard-exception-commit-to-plans-repo-from-worktree.md` reached `backlog/done/`
+  still reading `Stage: 3-plan` (corrected in pull request #296)
+- Other items carry a Stage line that matches nothing in the template
+
+Adding the field to the template settles the spelling and the starting value. Items are filed at
+Intake, and `workflow.md:257` says an item keeps `Stage: 1-pickup` until the Difficulty stamp
+lands, so the template's own starting value needs deciding rather than guessing.
+
+## Acceptance criteria
+
+- [ ] The template carries a Stage line, with a starting value the workflow document supports
+- [ ] The existing items in `backlog/`, `backlog/done/`, and `backlog/blocked/` either carry an
+      accurate Stage line or are listed here as deliberately left alone
+- [ ] The rule that ships an item sets `Stage: 9-ship`, already in `workflow.md:480`, is checked
+      by something other than a reviewer's eye, or the item records why it cannot be
+
+## Out of scope
+
+- Any change to the stage names or the stage sequence
+- Adding other missing metadata fields, such as Difficulty
+
+## Notes / dependencies
+
+- Found in review of pull request #296 (backlog 083 redelivery)

--- a/backlog/done/076-guard-exception-commit-to-plans-repo-from-worktree.md
+++ b/backlog/done/076-guard-exception-commit-to-plans-repo-from-worktree.md
@@ -6,7 +6,7 @@
 - **Type**: Tooling
 - **Interfaces**: none (agent git guard)
 - **Difficulty**: complex
-- **Stage**: 3-plan
+- **Stage**: 9-ship
 
 ## Summary
 

--- a/backlog/done/083-guard-classifies-link-targets-as-write-targets.md
+++ b/backlog/done/083-guard-classifies-link-targets-as-write-targets.md
@@ -6,7 +6,7 @@
 - **Type**: Feature
 - **Interfaces**: CLI
 - **Difficulty**: complex
-- **Stage**: 3-plan
+- **Stage**: 9-ship
 
 ## Summary
 

--- a/backlog/done/083-guard-classifies-link-targets-as-write-targets.md
+++ b/backlog/done/083-guard-classifies-link-targets-as-write-targets.md
@@ -23,12 +23,12 @@ through a link it made itself.
 
 ## Acceptance criteria
 
-- [ ] `New-Item -ItemType HardLink -Path <allowed>\x.md -Target <main>\README.md` is refused from a
+- [x] `New-Item -ItemType HardLink -Path <allowed>\x.md -Target <main>\README.md` is refused from a
       managed worktree
-- [ ] The same holds for `-ItemType SymbolicLink` and `-ItemType Junction`
-- [ ] The same holds for the `ln` and `mklink` spellings
-- [ ] Creating a link whose target is inside the session's own worktree stays allowed
-- [ ] Tests cover each spelling above, in `tests/AgentWorktreeGuard.Tests.ps1`
+- [x] The same holds for `-ItemType SymbolicLink` and `-ItemType Junction`
+- [x] The same holds for the `ln` and `mklink` spellings
+- [x] Creating a link whose target is inside the session's own worktree stays allowed
+- [x] Tests cover each spelling above, in `tests/AgentWorktreeGuard.Tests.ps1`
 
 ## Out of scope
 

--- a/backlog/done/084-guard-fails-closed-on-pipeline-bound-move-sources.md
+++ b/backlog/done/084-guard-fails-closed-on-pipeline-bound-move-sources.md
@@ -5,6 +5,7 @@
 - **Epic**: Agent guardrails
 - **Type**: Feature
 - **Interfaces**: CLI
+- **Stage**: 9-ship
 
 ## Summary
 

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1581,6 +1581,54 @@ function Get-AgentMoveArgumentSet {
 
 <#
 .SYNOPSIS
+Adds every path a link target could mean to a write-target list.
+
+.DESCRIPTION
+Windows resolves a RELATIVE link target against the directory holding the link, not against the
+working directory (see the CreateSymbolicLink reference, and the same note on
+Resolve-AgentSymlinkPath below). The resolver this guard uses anchors a relative write target to
+the working directory instead, so one anchor is not enough: `ln -s ../../../../../README.md
+deep/dir/x` walks ABOVE the checkout from the working directory and INTO it from the link's own
+directory. Anchoring one way only would allow that link.
+
+So a relative target is offered three ways - as written, joined to the link path, and joined to
+the link path's parent - and whichever one lands in the main checkout produces the denial. All
+three are paths, so this over-reports only paths, which is the safe direction for this grammar.
+
+An absolute target means the same file from every directory, so it is added once.
+#>
+function Add-AgentLinkTargetCandidate {
+    param(
+        [string] $LinkPath,
+        [string] $Target,
+        [System.Collections.Generic.List[string]] $Sink
+    )
+
+    $target = [string] $Target
+    if ([string]::IsNullOrWhiteSpace($target)) { return }
+
+    [void] $Sink.Add($target)
+
+    # Tested with a pattern rather than [System.IO.Path]::IsPathRooted, which throws on Windows
+    # PowerShell 5.1 for characters that host rejects outright. A throw here would escape into the
+    # entrypoint's catch, and that catch ALLOWS the write.
+    if ($target -match '^([A-Za-z]:|[\\/])') { return }
+
+    $link = [string] $LinkPath
+    if ([string]::IsNullOrWhiteSpace($link)) { return }
+
+    # The link path names a directory the link is created inside.
+    [void] $Sink.Add((Join-Path $link $target))
+
+    # The link path names the link file itself, so its parent holds the link.
+    $parent = Split-Path -Parent $link
+    if (-not [string]::IsNullOrWhiteSpace($parent)) {
+        [void] $Sink.Add((Join-Path $parent $target))
+    }
+}
+
+<#
+.SYNOPSIS
 Every path one command segment would write, move, or delete.
 
 .DESCRIPTION

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -899,6 +899,32 @@ function Test-AgentGuardHasForceFlag {
 
 <#
 .SYNOPSIS
+True when a cp invocation carries a flag that makes it create a link instead of a copy.
+
+.DESCRIPTION
+cp -l / --link makes a hard link and cp -s / --symbolic-link makes a symbolic one, so a cp
+carrying either aims at a path the way ln does. Shaped exactly like Test-AgentGuardHasForceFlag
+above, and for the same reason: short options cluster, so `cp -al src dst` carries -l inside a
+token that equals neither '-l' nor '--link', and a literal list of spellings would miss it.
+
+The cluster match is deliberately loose - any cp cluster holding 'l' or 's' sends the command
+down the link branch. Every cp operand is a path, so the worst outcome is that a plain copy
+reports its sources as well as its destination, which is the same over-report mv already makes.
+
+Case-sensitive: -S is --suffix, a different option that takes a value and names no link.
+#>
+function Test-AgentGuardHasLinkFlag {
+    param([string[]] $Arguments)
+    foreach ($arg in $Arguments) {
+        if ($arg -ceq '--link') { return $true }
+        if ($arg -ceq '--symbolic-link') { return $true }
+        if ($arg -cmatch '^-[a-zA-Z]*[ls]') { return $true }
+    }
+    return $false
+}
+
+<#
+.SYNOPSIS
 True when the tokenized git invocation mutates repository state.
 
 .DESCRIPTION
@@ -1749,7 +1775,8 @@ function Get-AgentSegmentWriteTarget {
     # First in the chain on purpose. cp is in the last-positional table below, so a link branch
     # placed after that one would never run for a linking cp: the elseif would win every time and
     # the rule would be dead rather than wrong.
-    if ($script:AgentGuardLinkCommands -contains $leaf) {
+    if (($script:AgentGuardLinkCommands -contains $leaf) -or
+        ($leaf -eq 'cp' -and (Test-AgentGuardHasLinkFlag -Arguments $arguments))) {
         foreach ($target in (Get-AgentLinkWriteTarget -Leaf $leaf -Arguments $arguments)) {
             [void] $targets.Add($target)
         }

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1318,6 +1318,10 @@ $script:AgentGuardWriteLastPositional = @('cp', 'mv', 'install')
 # would otherwise see only the first. ln leaves the last-positional table above for this reason.
 $script:AgentGuardLinkCommands = @('ln', 'mklink')
 
+# The New-Item item types that make a link. Matched without case, because -ItemType is not
+# case-sensitive.
+$script:AgentGuardLinkItemTypes = @('symboliclink', 'hardlink', 'junction')
+
 # Cmdlet name -> the parameter naming its write target. Positional fallbacks are handled below.
 $script:AgentGuardWriteCmdlets = @{
     'set-content'   = @('Path', 'LiteralPath')
@@ -1720,6 +1724,43 @@ function Get-AgentLinkWriteTarget {
 
 <#
 .SYNOPSIS
+The path a New-Item link points at, or nothing when the command creates no link.
+
+.DESCRIPTION
+Target is an ALIAS for the Value parameter, and Type an alias for ItemType. So -Target and
+-Value are one parameter with two spellings, and the value is a path only when the item type
+says a link is being created. On a File the same value is content:
+`New-Item -ItemType File -Path notes.md -Value 'cost is $5'` would otherwise be read as a path,
+meet AgentGuardUnexpandablePattern, and be refused as an unresolved write target.
+
+Three things decide the gate. A named link kind reads the value. A named non-link kind does not.
+An ItemType the guard cannot expand - a variable - could still be a link, so it reads the value
+and fails closed. No -ItemType at all creates a file, so it reads nothing.
+#>
+function Get-AgentNewItemLinkTarget {
+    param([string[]] $Arguments, [string] $LinkPath)
+
+    $found = New-Object System.Collections.Generic.List[string]
+
+    $itemType = Get-AgentPrefixedParameterValue -Arguments $Arguments -Names @('ItemType', 'Type')
+    if ($null -eq $itemType) { return $found.ToArray() }
+
+    # The tokenizer strips quotes, so this trim only ever matters for a spelling it kept.
+    $kind = ([string] $itemType).Trim().Trim("'", '"').ToLowerInvariant()
+    $canExpand = $kind -notmatch $script:AgentGuardUnexpandablePattern
+    if ($canExpand -and ($script:AgentGuardLinkItemTypes -notcontains $kind)) {
+        return $found.ToArray()
+    }
+
+    $linkTarget = Get-AgentPrefixedParameterValue -Arguments $Arguments -Names @('Target', 'Value')
+    if ($null -eq $linkTarget) { return $found.ToArray() }
+
+    Add-AgentLinkTargetCandidate -LinkPath $LinkPath -Target $linkTarget -Sink $found
+    return $found.ToArray()
+}
+
+<#
+.SYNOPSIS
 Every path one command segment would write, move, or delete.
 
 .DESCRIPTION
@@ -1826,8 +1867,33 @@ function Get-AgentSegmentWriteTarget {
         # Prefix-aware: `Set-Content -Pa:<path>` names the same target as `-Path <path>`, and the
         # colon token is dropped as an option, so no positional fallback could recover it.
         $named = Get-AgentPrefixedParameterValue -Arguments $arguments -Names $script:AgentGuardWriteCmdlets[$leaf]
-        if ($null -ne $named) { [void] $targets.Add($named) }
-        elseif ($positionals.Count -ge 1) { [void] $targets.Add($positionals[0]) }
+        $linkPath = ''
+        if ($null -ne $named) {
+            [void] $targets.Add($named)
+            $linkPath = [string] $named
+        }
+        elseif ($positionals.Count -ge 1) {
+            [void] $targets.Add($positionals[0])
+            $linkPath = [string] $positionals[0]
+        }
+
+        if ($leaf -eq 'new-item') {
+            # -Name reads through its own call: Get-AgentPrefixedParameterValue returns the FIRST
+            # match and stops, so one call naming both Path and Name would drop whichever came
+            # second. The -Path value stays the anchor for a relative link target, because in this
+            # parameter set it is the directory holding the link.
+            $itemName = Get-AgentPrefixedParameterValue -Arguments $arguments -Names @('Name')
+            if ($null -ne $itemName -and $linkPath -ne '') {
+                [void] $targets.Add((Join-Path $linkPath $itemName))
+            }
+            elseif ($null -ne $itemName) {
+                [void] $targets.Add($itemName)
+            }
+
+            foreach ($target in (Get-AgentNewItemLinkTarget -Arguments $arguments -LinkPath $linkPath)) {
+                [void] $targets.Add($target)
+            }
+        }
     }
     elseif ($script:AgentGuardWriteDestinationCmdlets -contains $leaf) {
         # Operands with option values removed, so `-Filter *.tmp` does not look like a file.

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1407,6 +1407,24 @@ $script:AgentGuardMoveValueParameters = @(
     'path', 'literalpath', 'destination', 'newname', 'filter', 'include', 'exclude', 'credential'
 )
 
+# The same list for the content-writing cmdlets in AgentGuardWriteCmdlets. Every name here
+# consumes the token after it, so none of those tokens is a path the command writes. The common
+# parameters are on the list because `Set-Content -ErrorAction Stop <path>` hides a path behind
+# 'Stop' exactly as `-Encoding utf8` hides one behind 'utf8'.
+#
+# Switches are absent on purpose: -Force, -Confirm, -WhatIf, -PassThru, -Append, -NoClobber,
+# -NoNewline, -Recurse, -UseTransaction, -Verbose, -Debug. Listing one would consume the path
+# that follows it and lose the target. No full switch name here is a prefix of a listed name,
+# so the prefix match cannot confuse the two; an abbreviation short enough to match both, such
+# as -F, is ambiguous to PowerShell too and the command does not run.
+$script:AgentGuardWriteCmdletValueParameters = @(
+    'path', 'literalpath', 'filepath', 'value', 'itemtype', 'type', 'name', 'target',
+    'encoding', 'filter', 'include', 'exclude', 'stream', 'delimiter', 'inputobject',
+    'width', 'credential', 'erroraction', 'warningaction', 'informationaction',
+    'errorvariable', 'warningvariable', 'informationvariable', 'outvariable', 'outbuffer',
+    'pipelinevariable'
+)
+
 <#
 .SYNOPSIS
 An option's value, rejoined across the tokens an array value splits into.
@@ -1433,16 +1451,21 @@ function Get-AgentOptionValueSpan {
 
 <#
 .SYNOPSIS
-The true positional operands of a move cmdlet, with option values removed.
+The true positional operands of a cmdlet, with option values removed.
 
 .DESCRIPTION
 Get-AgentGitPositionals drops every '-*' token but keeps the token AFTER it, so the value of
-`-Filter *.tmp` is left behind and read as though it were a file the move touches. That
-over-reports a target and refuses ordinary in-worktree moves. This reader consumes each
-value-taking option together with its value.
+`-Filter *.tmp` is left behind and read as though it were a file the command touches. This
+reader consumes each value-taking option together with its value.
+
+The two callers fail in opposite directions without it. A move over-reports a target and
+refuses ordinary in-worktree moves. A content write does worse: `Set-Content -Encoding utf8
+<main>\README.md hello` reads 'utf8' as operand 0, so the real path is never scanned and the
+write into the main checkout is ALLOWED. So ValueParameters is per caller, and each list holds
+only parameters that consume a value - a switch such as -Force takes none and must stay out.
 #>
-function Get-AgentMoveCmdletOperand {
-    param([string[]] $Arguments)
+function Get-AgentCmdletOperand {
+    param([string[]] $Arguments, [string[]] $ValueParameters)
 
     $operands = New-Object System.Collections.Generic.List[string]
     $list = @($Arguments)
@@ -1454,7 +1477,7 @@ function Get-AgentMoveCmdletOperand {
 
         if ($argument -match '^-([A-Za-z]+)$') {
             $name = [string] $Matches[1]
-            if (Test-AgentParameterNamePrefix -Name $name -Candidates $script:AgentGuardMoveValueParameters) {
+            if (Test-AgentParameterNamePrefix -Name $name -Candidates $ValueParameters) {
                 # Consume the whole value, including the tokens an array value splits into.
                 if (($i + 1) -lt $list.Count) {
                     $i = (Get-AgentOptionValueSpan -List $list -Index ($i + 1)).LastIndex
@@ -1650,6 +1673,18 @@ directory. Anchoring one way only would allow that link.
 So a relative target is offered three ways - as written, joined to the link path, and joined to
 the link path's parent - and whichever one lands in the main checkout produces the denial. All
 three are paths, so this over-reports only paths, which is the safe direction for this grammar.
+
+The as-written anchor stays even though Windows never resolves a SYMBOLIC link that way, because
+a HARD link resolves its source exactly that way: `ln ../README.md deep/bait.md` names
+<main>\.claude\worktrees\README.md, and only the as-written anchor reaches it. Drop that anchor
+and the hard link is allowed, which hands the session a second name for a file in the main
+checkout. Reading the link kind first would let each form keep only its own anchor, and backlog
+086 holds that work.
+
+The cost of keeping all three is a real over-report, and it is not theoretical: `ln -s ../src/a.cs
+deep/bait.md` from the worktree root stays inside the worktree, and the guard still refuses it.
+The message then names a main-checkout path that no write would have landed on. Use a target with
+no '..' in it, or an absolute one. Both directions are pinned by tests.
 
 An absolute target means the same file from every directory, so it is added once.
 #>
@@ -1885,6 +1920,13 @@ function Get-AgentSegmentWriteTarget {
         }
     }
     elseif ($script:AgentGuardWriteCmdlets.ContainsKey($leaf)) {
+        # Operands with option values removed. Reading $positionals here was a hole rather than a
+        # wart: `Set-Content -Encoding utf8 <main>\README.md hello` left 'utf8' in operand 0, so
+        # the guard reported a relative path inside the worktree, never scanned the real target,
+        # and ALLOWED a write into the main checkout.
+        $cmdletOperands = @(Get-AgentCmdletOperand -Arguments $arguments `
+                -ValueParameters $script:AgentGuardWriteCmdletValueParameters)
+
         # Prefix-aware: `Set-Content -Pa:<path>` names the same target as `-Path <path>`, and the
         # colon token is dropped as an option, so no positional fallback could recover it.
         $named = Get-AgentPrefixedParameterValue -Arguments $arguments -Names $script:AgentGuardWriteCmdlets[$leaf]
@@ -1893,9 +1935,9 @@ function Get-AgentSegmentWriteTarget {
             [void] $targets.Add($named)
             $linkPath = [string] $named
         }
-        elseif ($positionals.Count -ge 1) {
-            [void] $targets.Add($positionals[0])
-            $linkPath = [string] $positionals[0]
+        elseif ($cmdletOperands.Count -ge 1) {
+            [void] $targets.Add($cmdletOperands[0])
+            $linkPath = [string] $cmdletOperands[0]
         }
 
         if ($leaf -eq 'new-item') {
@@ -1918,7 +1960,8 @@ function Get-AgentSegmentWriteTarget {
     }
     elseif ($script:AgentGuardWriteDestinationCmdlets -contains $leaf) {
         # Operands with option values removed, so `-Filter *.tmp` does not look like a file.
-        $cmdletOperands = @(Get-AgentMoveCmdletOperand -Arguments $arguments)
+        $cmdletOperands = @(Get-AgentCmdletOperand -Arguments $arguments `
+                -ValueParameters $script:AgentGuardMoveValueParameters)
 
         $named = Get-AgentPrefixedParameterValue -Arguments $arguments -Names @('Destination', 'NewName')
         if ($null -ne $named) { [void] $targets.Add($named) }
@@ -2038,7 +2081,8 @@ function Test-AgentPipelineBoundSource {
     }
 
     # Option values are consumed with their option, so `-Destination x` leaves no false operand.
-    $operands = @(Get-AgentMoveCmdletOperand -Arguments $arguments)
+    $operands = @(Get-AgentCmdletOperand -Arguments $arguments `
+            -ValueParameters $script:AgentGuardMoveValueParameters)
     $needed = if ($script:AgentGuardPipelineRemoveSinks -contains $leaf) { 1 } else { 2 }
     return ($operands.Count -lt $needed)
 }

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1649,6 +1649,20 @@ function Get-AgentLinkWriteTarget {
 
     $found = New-Object System.Collections.Generic.List[string]
 
+    if ($Leaf -eq 'mklink') {
+        # mklink [[/d] | [/h] | [/j]] <link> <target>. All three options are switches: none of
+        # them consumes the token that follows, so the reader drops the option and reads on. The
+        # '-*' test stays because Get-AgentGitPositionals cannot be reused here - it keeps
+        # '/'-prefixed tokens, and they would be read as the link and the target.
+        $linkOperands = @($Arguments | Where-Object { $_ -notlike '-*' -and $_ -notlike '/*' })
+        if ($linkOperands.Count -ge 1) { [void] $found.Add([string] $linkOperands[0]) }
+        if ($linkOperands.Count -ge 2) {
+            Add-AgentLinkTargetCandidate -LinkPath ([string] $linkOperands[0]) `
+                -Target ([string] $linkOperands[1]) -Sink $found
+        }
+        return $found.ToArray()
+    }
+
     $set = Get-AgentMoveArgumentSet -Arguments $Arguments
     $operands = @($set.Operands)
     $targetDirectory = Get-AgentTargetDirectoryOption -Arguments $set.Options

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1963,10 +1963,84 @@ $script:AgentGuardInterpreterSpecs = @(
     @{ Leaf = 'zsh'; Flags = @('-c') },
     @{ Leaf = 'pwsh'; Flags = @('-command', '-c') },
     @{ Leaf = 'powershell'; Flags = @('-command', '-c') },
-    @{ Leaf = 'cmd'; Flags = @('/c', '/k') }
+    # '//c' and '//k' are how Git Bash writes these: MSYS rewrites a leading '//' to '/' on the
+    # way to cmd, and this guard reads the command text before that rewrite happens.
+    @{ Leaf = 'cmd'; Flags = @('/c', '/k', '//c', '//k') }
 )
 
 $script:AgentGuardMaxInterpreterDepth = 2
+
+<#
+.SYNOPSIS
+Write targets carried by the inner command of an interpreter invocation.
+
+.DESCRIPTION
+Two shapes reach an interpreter, and each needs its own reader.
+
+Quoted - `cmd /c "mklink /D a b"` - hands the whole inner command over as ONE token, so it is
+re-tokenized through Get-AgentCommandWriteTarget.
+
+Unquoted - `cmd /c mklink /D a b` - leaves the inner command as the rest of THIS segment, already
+split into tokens. Reading only the token after the flag would see 'mklink' and lose every
+operand. Re-joining the tokens into a string would break any path holding a space. So the slice
+travels whole, with the masks that say which characters were quoted: Get-AgentSegmentWriteTarget
+reads them to tell an unquoted '>' from a quoted one, and a regenerated mask would call quoted
+text unquoted.
+
+The two do not double-count. A quoted inner command leaves nothing after the flag, so the
+remainder slice is empty; an unquoted one leaves a first token whose leaf matches no table.
+
+This lives in one function because the policy core needs the same logic, and two copies of a
+security rule drift silently.
+#>
+function Get-AgentInterpreterInnerTarget {
+    [CmdletBinding()]
+    param([string[]] $Tokens, [string[]] $Masks, [int] $Depth)
+
+    $found = New-Object System.Collections.Generic.List[string]
+    $unresolved = $false
+    $tokens = @($Tokens)
+    $masks = @($Masks)
+
+    if ($tokens.Count -lt 3) {
+        return [pscustomobject]@{ Targets = $found.ToArray(); Unresolved = $false }
+    }
+
+    $leaf = Get-AgentCommandLeafName -Word $tokens[0]
+    $spec = $script:AgentGuardInterpreterSpecs | Where-Object { $_.Leaf -eq $leaf } | Select-Object -First 1
+    if ($null -eq $spec) {
+        return [pscustomobject]@{ Targets = $found.ToArray(); Unresolved = $false }
+    }
+
+    for ($i = 1; $i -lt $tokens.Count - 1; $i++) {
+        if ($spec.Flags -notcontains ([string] $tokens[$i]).ToLowerInvariant()) { continue }
+
+        # The depth test lives here, not at the top: a segment that is not an interpreter carrying
+        # an inner command was already scanned in full by the caller, so it must not be reported
+        # as unresolved just because the recursion budget ran out.
+        if ($Depth -ge $script:AgentGuardMaxInterpreterDepth) {
+            $unresolved = $true
+            break
+        }
+
+        $inner = Get-AgentCommandWriteTarget -Command ([string] $tokens[$i + 1]) -Depth ($Depth + 1)
+        foreach ($target in $inner.Targets) { [void] $found.Add($target) }
+        if ($inner.Unresolved) { $unresolved = $true }
+
+        $last = $tokens.Count - 1
+        if (($i + 1) -lt $last) {
+            $restTokens = @($tokens[($i + 1)..$last])
+            $maskEnd = [Math]::Min($last, $masks.Count - 1)
+            $restMasks = if (($i + 1) -le $maskEnd) { @($masks[($i + 1)..$maskEnd]) } else { @() }
+            foreach ($target in (Get-AgentSegmentWriteTarget -Tokens $restTokens -Masks $restMasks)) {
+                [void] $found.Add($target)
+            }
+        }
+        break
+    }
+
+    return [pscustomobject]@{ Targets = $found.ToArray(); Unresolved = $unresolved }
+}
 
 <#
 .SYNOPSIS
@@ -1999,29 +2073,9 @@ function Get-AgentCommandWriteTarget {
             [void] $targets.Add($target)
         }
 
-        $tokens = @($segment.Tokens)
-        if ($tokens.Count -lt 3) { continue }
-
-        $leaf = Get-AgentCommandLeafName -Word $tokens[0]
-        $spec = $script:AgentGuardInterpreterSpecs | Where-Object { $_.Leaf -eq $leaf } | Select-Object -First 1
-        if ($null -eq $spec) { continue }
-
-        for ($i = 1; $i -lt $tokens.Count - 1; $i++) {
-            if ($spec.Flags -notcontains ([string] $tokens[$i]).ToLowerInvariant()) { continue }
-
-            # The depth test lives here, not at the top of the loop: a segment that is not an
-            # interpreter carrying an inner command was already scanned in full above, so it must
-            # not be reported as unresolved just because the recursion budget ran out.
-            if ($Depth -ge $script:AgentGuardMaxInterpreterDepth) {
-                $unresolved = $true
-                break
-            }
-
-            $inner = Get-AgentCommandWriteTarget -Command ([string] $tokens[$i + 1]) -Depth ($Depth + 1)
-            foreach ($target in $inner.Targets) { [void] $targets.Add($target) }
-            if ($inner.Unresolved) { $unresolved = $true }
-            break
-        }
+        $inner = Get-AgentInterpreterInnerTarget -Tokens $segment.Tokens -Masks $segment.Masks -Depth $Depth
+        foreach ($target in $inner.Targets) { [void] $targets.Add($target) }
+        if ($inner.Unresolved) { $unresolved = $true }
     }
 
     return [pscustomobject]@{ Targets = $targets.ToArray(); Unresolved = $unresolved }
@@ -2374,23 +2428,13 @@ function Get-AgentWorktreeWriteDecision {
 
         $targets = @(Get-AgentSegmentWriteTarget -Tokens $segment.Tokens -Masks $segment.Masks)
 
-        # Nested interpreters: re-scan the quoted argument the tokenizer kept whole.
-        $tokens = @($segment.Tokens)
-        if ($tokens.Count -ge 3) {
-            $leaf = Get-AgentCommandLeafName -Word $tokens[0]
-            $spec = $script:AgentGuardInterpreterSpecs | Where-Object { $_.Leaf -eq $leaf } | Select-Object -First 1
-            if ($null -ne $spec) {
-                for ($i = 1; $i -lt $tokens.Count - 1; $i++) {
-                    if ($spec.Flags -notcontains ([string] $tokens[$i]).ToLowerInvariant()) { continue }
-                    $nested = Get-AgentCommandWriteTarget -Command ([string] $tokens[$i + 1]) -Depth 1
-                    $targets += @($nested.Targets)
-                    # An inner command that was never scanned is not an inner command that writes
-                    # nothing. Fail closed on it.
-                    if ($nested.Unresolved) { $unresolvedBlock = $true }
-                    break
-                }
-            }
-        }
+        # Nested interpreters, quoted and unquoted alike. Same reader as
+        # Get-AgentCommandWriteTarget uses, so the two cannot drift.
+        $nested = Get-AgentInterpreterInnerTarget -Tokens $segment.Tokens -Masks $segment.Masks -Depth 0
+        $targets += @($nested.Targets)
+        # An inner command that was never scanned is not an inner command that writes nothing.
+        # Fail closed on it.
+        if ($nested.Unresolved) { $unresolvedBlock = $true }
 
         foreach ($target in $targets) {
             # A relative target after an unexpandable cd cannot be placed. Passing no base

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1285,7 +1285,12 @@ function Test-AgentWorktreeManifest {
 $script:AgentGuardWriteEveryPositional = @(
     'rm', 'unlink', 'shred', 'truncate', 'touch', 'mkdir', 'rmdir', 'tee'
 )
-$script:AgentGuardWriteLastPositional = @('cp', 'mv', 'install', 'ln')
+$script:AgentGuardWriteLastPositional = @('cp', 'mv', 'install')
+
+# Commands that CREATE a link. Both endpoints are write targets: the path the link is created
+# at, and the path it points to. A write through the link lands on the second one, and the guard
+# would otherwise see only the first. ln leaves the last-positional table above for this reason.
+$script:AgentGuardLinkCommands = @('ln', 'mklink')
 
 # Cmdlet name -> the parameter naming its write target. Positional fallbacks are handled below.
 $script:AgentGuardWriteCmdlets = @{
@@ -1629,6 +1634,52 @@ function Add-AgentLinkTargetCandidate {
 
 <#
 .SYNOPSIS
+Every path a link-creation command would write or aim at.
+
+.DESCRIPTION
+ln has three forms - `ln TARGET LINK_NAME`, `ln TARGET... DIRECTORY`, and
+`ln -t DIRECTORY TARGET...` - and every operand of all three is a path. So every operand is
+reported, and each link target is expanded through Add-AgentLinkTargetCandidate.
+
+Get-AgentMoveArgumentSet does the option/operand split. Its name says move; its behaviour is the
+general split these commands share, including honouring '--' and consuming the -t value.
+#>
+function Get-AgentLinkWriteTarget {
+    param([string] $Leaf, [string[]] $Arguments)
+
+    $found = New-Object System.Collections.Generic.List[string]
+
+    $set = Get-AgentMoveArgumentSet -Arguments $Arguments
+    $operands = @($set.Operands)
+    $targetDirectory = Get-AgentTargetDirectoryOption -Arguments $set.Options
+
+    # With -t the named directory holds every link, so no operand is the link path.
+    if ($null -ne $targetDirectory) {
+        [void] $found.Add($targetDirectory)
+        foreach ($operand in $operands) {
+            Add-AgentLinkTargetCandidate -LinkPath $targetDirectory -Target ([string] $operand) -Sink $found
+        }
+        return $found.ToArray()
+    }
+
+    if ($operands.Count -eq 0) { return $found.ToArray() }
+
+    # One operand names a link in the working directory. There is no target to expand.
+    if ($operands.Count -eq 1) {
+        [void] $found.Add([string] $operands[0])
+        return $found.ToArray()
+    }
+
+    $linkPath = [string] $operands[$operands.Count - 1]
+    [void] $found.Add($linkPath)
+    foreach ($operand in ($operands | Select-Object -SkipLast 1)) {
+        Add-AgentLinkTargetCandidate -LinkPath $linkPath -Target ([string] $operand) -Sink $found
+    }
+    return $found.ToArray()
+}
+
+<#
+.SYNOPSIS
 Every path one command segment would write, move, or delete.
 
 .DESCRIPTION
@@ -1681,12 +1732,20 @@ function Get-AgentSegmentWriteTarget {
     }
     $positionals = @(Get-AgentGitPositionals -Arguments $arguments)
 
-    if ($script:AgentGuardWriteEveryPositional -contains $leaf) {
+    # First in the chain on purpose. cp is in the last-positional table below, so a link branch
+    # placed after that one would never run for a linking cp: the elseif would win every time and
+    # the rule would be dead rather than wrong.
+    if ($script:AgentGuardLinkCommands -contains $leaf) {
+        foreach ($target in (Get-AgentLinkWriteTarget -Leaf $leaf -Arguments $arguments)) {
+            [void] $targets.Add($target)
+        }
+    }
+    elseif ($script:AgentGuardWriteEveryPositional -contains $leaf) {
         foreach ($positional in $positionals) { [void] $targets.Add($positional) }
     }
     elseif ($script:AgentGuardWriteLastPositional -contains $leaf) {
         # A move reads its own operands, because a moved file may be named '-something' and only
-        # a '--'-aware reader keeps it. cp, install and ln do not delete, so they keep the older
+        # a '--'-aware reader keeps it. cp and install do not delete, so they keep the older
         # positional reader.
         $isMove = $script:AgentGuardMoveCommands -contains $leaf
         $moveSet = if ($isMove) { Get-AgentMoveArgumentSet -Arguments $arguments } else { $null }

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1805,6 +1805,21 @@ try {
         # cp, install and ln leave the source in place, so they stay destination-only.
         @{ Command = 'cp -t out a.txt'; Expected = @('out') },
         @{ Command = 'cp -tout a.txt'; Expected = @('out') },
+        # Every operand of ln is a path, so every operand is a write target: a link created at an
+        # allowed path but AIMED at the main checkout is a write into the main checkout.
+        @{ Command = 'ln -s a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
+        @{ Command = 'ln a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
+        @{ Command = 'ln -s C:\repo\README.md b.md'; Expected = @('b.md', 'C:\repo\README.md') },
+        # With -t every operand is a link target and the named directory holds the links.
+        @{ Command = 'ln -t out a.md b.md'
+            Expected = @('out', 'a.md', 'out\a.md', 'b.md', 'out\b.md')
+        },
+        # '--' keeps a target whose own name begins with a dash.
+        @{ Command = 'ln -s -- -a.md link.md'
+            Expected = @('link.md', '-a.md', 'link.md\-a.md')
+        },
+        # One operand names a link in the working directory and nothing else.
+        @{ Command = 'ln -s a.md'; Expected = @('a.md') },
         @{ Command = 'Copy-Item a.txt -Destination b.txt'; Expected = @('b.txt') },
         @{ Command = 'rm a.txt b.txt'; Expected = @('a.txt', 'b.txt') },
         @{ Command = 'tee out.txt'; Expected = @('out.txt') },

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1705,6 +1705,47 @@ try {
         Assert-Equal 'uuuuuuuuu' $segment.Masks[1] 'Mask'
     }
 
+    Write-Host 'Link target candidates' -ForegroundColor Cyan
+
+    # A relative link target is resolved against the directory holding the link, not the working
+    # directory, so one target has to be offered in every form it could mean.
+    $linkCandidateCases = @(
+        @{ Name = 'an absolute target says the same thing from every directory'
+            LinkPath = 'link.md'; Target = 'C:\repo\README.md'
+            Expected = @('C:\repo\README.md')
+        },
+        @{ Name = 'a UNC target is absolute too'
+            LinkPath = 'link.md'; Target = '\\server\share\x.md'
+            Expected = @('\\server\share\x.md')
+        },
+        @{ Name = 'a relative target with a parentless link drops the parent form'
+            LinkPath = 'link.md'; Target = '..\README.md'
+            Expected = @('..\README.md', 'link.md\..\README.md')
+        },
+        @{ Name = 'a relative target with a nested link carries all three forms'
+            LinkPath = 'deep\x.md'; Target = '..\..\README.md'
+            Expected = @('..\..\README.md', 'deep\x.md\..\..\README.md', 'deep\..\..\README.md')
+        },
+        # Join-Path rewrites every separator in BOTH arguments to the OS one, so the joined forms
+        # come back fully backslashed. The raw target is added as written and keeps its slashes.
+        @{ Name = 'a forward-slash link path splits the same way'
+            LinkPath = 'deep/x.md'; Target = '../README.md'
+            Expected = @('../README.md', 'deep\x.md\..\README.md', 'deep\..\README.md')
+        },
+        @{ Name = 'an empty target adds nothing'
+            LinkPath = 'link.md'; Target = ''
+            Expected = @()
+        }
+    )
+
+    foreach ($case in $linkCandidateCases) {
+        Invoke-TestCase "Link candidate: $($case.Name)" {
+            $sink = New-Object System.Collections.Generic.List[string]
+            Add-AgentLinkTargetCandidate -LinkPath $case.LinkPath -Target $case.Target -Sink $sink
+            Assert-Equal ($case.Expected -join '|') ($sink.ToArray() -join '|') 'Candidates'
+        }
+    }
+
     Write-Host 'Write-target extraction' -ForegroundColor Cyan
 
     $writeTargetCases = @(

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1924,6 +1924,23 @@ try {
         @{ Command = "sh -c 'printf x > out.txt'"; Expected = @('out.txt') },
         @{ Command = "bash -c 'rm out.txt'"; Expected = @('out.txt') },
         @{ Command = 'cmd /c "del out.txt"'; Expected = @() },
+        # mklink is a cmd builtin, so the rule only ever fires through cmd. Unquoted, the inner
+        # command is the REST of this segment, already tokenized.
+        @{ Command = 'cmd /c mklink /D linkdir C:\repo\docs'
+            Expected = @('linkdir', 'C:\repo\docs')
+        },
+        # Git Bash writes the flag '//c'; MSYS rewrites it to '/c' on the way to cmd, and the
+        # guard reads the text before that happens.
+        @{ Command = 'cmd //c mklink /H link.md C:\repo\README.md'
+            Expected = @('link.md', 'C:\repo\README.md')
+        },
+        # Quoted, the whole inner command is one token, which the existing recursion already
+        # handles. It must be reported once, not twice.
+        @{ Command = 'cmd /c "mklink /D linkdir C:\repo\docs"'
+            Expected = @('linkdir', 'C:\repo\docs')
+        },
+        # The remainder scan is general, so an unquoted inner write is now seen too.
+        @{ Command = 'sh -c rm out.txt'; Expected = @('out.txt') },
         @{ Command = 'powershell -Command "Remove-Item out.txt"'; Expected = @('out.txt') },
         # Depth 2 is reached and still scanned.
         @{ Command = 'sh -c "pwsh -Command ''Set-Content out.txt x''"'; Expected = @('out.txt') },

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -2520,6 +2520,99 @@ try {
         }
     }
 
+    Write-Host 'Link creation aimed at the main checkout' -ForegroundColor Cyan
+
+    # A link created at an allowed path but AIMED at the main checkout is a write into the main
+    # checkout: the next Set-Content through the link lands on the protected file, and names only
+    # an allowed path while doing it.
+    $linkDecisionCases = @(
+        @{ Name = 'New-Item HardLink into main'
+            Command = 'New-Item -ItemType HardLink -Path <MANAGED>\bait.md -Target <MAIN>\README.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'New-Item SymbolicLink into main'
+            Command = 'New-Item -ItemType SymbolicLink -Path <MANAGED>\bait.md -Target <MAIN>\README.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'New-Item Junction into main'
+            Command = 'New-Item -ItemType Junction -Path <MANAGED>\baitdir -Target <MAIN>\docs'
+            Action = 'Deny'
+        },
+        @{ Name = 'New-Item using the -Value spelling'
+            Command = 'New-Item -ItemType SymbolicLink -Path <MANAGED>\bait.md -Value <MAIN>\README.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'ln -s into main'
+            Command = 'ln -s <MAIN>\README.md <MANAGED>\bait.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'ln hard link into main'
+            Command = 'ln <MAIN>\README.md <MANAGED>\bait.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'mklink through cmd, unquoted'
+            Command = 'cmd /c mklink /H <MANAGED>\bait.md <MAIN>\README.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'mklink through cmd, Git Bash flag spelling'
+            Command = 'cmd //c mklink /D <MANAGED>\baitdir <MAIN>\docs'
+            Action = 'Deny'
+        },
+        @{ Name = 'cp with a clustered link flag into main'
+            Command = 'cp -al <MAIN>\README.md <MANAGED>\bait.md'
+            Action = 'Deny'
+        },
+        # The regression the three-form emission exists for. Anchored to the working directory
+        # this target lands ABOVE the checkout and looks allowed; anchored to the directory
+        # holding the link, which is how Windows resolves it, it lands inside main.
+        @{ Name = 'a relative target only the parent anchor catches'
+            Command = 'ln -s ../../../../README.md deep/bait.md'
+            Action = 'Deny'
+        },
+        # A link that stays inside the session's own worktree is ordinary work.
+        @{ Name = 'a link inside the session worktree'
+            Command = 'New-Item -ItemType SymbolicLink -Path <MANAGED>\bait.md -Target <MANAGED>\src\a.cs'
+            Action = 'Allow'
+        },
+        @{ Name = 'ln inside the session worktree'
+            Command = 'ln -s <MANAGED>\src\a.cs <MANAGED>\bait.md'
+            Action = 'Allow'
+        },
+        # Every one of the three anchors has to stay inside the worktree for this to be Allow.
+        # '../src/a.cs' would NOT: from the worktree root it climbs into .claude\worktrees, which
+        # is main.
+        @{ Name = 'a relative link that stays inside the session worktree'
+            Command = 'ln -s src/a.cs deep/bait.md'
+            Action = 'Allow'
+        },
+        # The gate from Task 5, proved at the decision layer: content is not a path.
+        @{ Name = 'an ordinary file write with a value is untouched'
+            Command = 'New-Item -ItemType File -Path <MANAGED>\notes.md -Value plain-text'
+            Action = 'Allow'
+        }
+    )
+
+    foreach ($case in $linkDecisionCases) {
+        Invoke-TestCase "Link creation: $($case.Name)" {
+            $command = $case.Command.
+            Replace('<MANAGED>', $fixture.Managed).
+            Replace('<MAIN>', $fixture.Main)
+            $decision = Invoke-AgentGuardPolicy -Command $command `
+                -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main -AllowMain $false
+            Assert-Equal $case.Action $decision.Action 'Action'
+        }
+    }
+
+    Invoke-TestCase 'Link creation: a refused link names the file the write would land on' {
+        $command = 'New-Item -ItemType HardLink -Path ' + $fixture.Managed +
+        '\bait.md -Target ' + $fixture.Main + '\README.md'
+        $decision = Invoke-AgentGuardPolicy -Command $command `
+            -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main -AllowMain $false
+        Assert-Equal 'agent-worktree-main-write' $decision.Rule 'Rule'
+        Assert-Match 'cannot write into the main checkout' $decision.Message 'Message'
+        Assert-Match 'README.md' $decision.Message 'Message names the target'
+    }
+
     Invoke-TestCase 'File-edit isolation: a denial carries the shared write rule name' {
         $decision = Get-AgentFileEditWriteDecision -TargetPath (Join-Path $fixture.Main 'README.md') `
             -Cwd $fixture.Managed -ProtectedRepoRoot $fixture.Main -AllowMain $false

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1847,6 +1847,47 @@ try {
         @{ Command = 'cp -S .bak a.md b.md'; Expected = @('b.md') },
         # A plain copy is untouched by the new branch and still reports its destination alone.
         @{ Command = 'cp a.md b.md'; Expected = @('b.md') },
+        # New-Item creates every link kind Windows has, and -Target is where it aims.
+        @{ Command = 'New-Item -ItemType HardLink -Path link.md -Target C:\repo\README.md'
+            Expected = @('link.md', 'C:\repo\README.md')
+        },
+        @{ Command = 'New-Item -ItemType SymbolicLink -Path link.md -Target C:\repo\README.md'
+            Expected = @('link.md', 'C:\repo\README.md')
+        },
+        @{ Command = 'New-Item -ItemType Junction -Path linkdir -Target C:\repo\docs'
+            Expected = @('linkdir', 'C:\repo\docs')
+        },
+        # -Target IS -Value, so the -Value spelling reaches the same place.
+        @{ Command = 'New-Item -ItemType SymbolicLink -Path link.md -Value C:\repo\README.md'
+            Expected = @('link.md', 'C:\repo\README.md')
+        },
+        # -Type is an alias of -ItemType, and the kind is matched without case.
+        @{ Command = 'New-Item -Type symboliclink -Path link.md -Target C:\repo\README.md'
+            Expected = @('link.md', 'C:\repo\README.md')
+        },
+        # A relative link target needs all three forms.
+        @{ Command = 'New-Item -ItemType SymbolicLink -Path deep\link.md -Target ..\..\README.md'
+            Expected = @('deep\link.md', '..\..\README.md',
+                'deep\link.md\..\..\README.md', 'deep\..\..\README.md')
+        },
+        # The gate. On a File the same parameter is CONTENT, under either spelling, so reading it
+        # as a path would refuse an ordinary write.
+        @{ Command = 'New-Item -ItemType File -Path notes.md -Value plain-text'
+            Expected = @('notes.md')
+        },
+        @{ Command = 'New-Item -ItemType File -Path notes.md -Target plain-text'
+            Expected = @('notes.md')
+        },
+        @{ Command = 'New-Item -Path notes.md -Value plain-text'; Expected = @('notes.md') },
+        @{ Command = 'New-Item -ItemType Directory -Path sub'; Expected = @('sub') },
+        # An item type the guard cannot expand could still be a link, so it fails closed.
+        @{ Command = 'New-Item -ItemType $kind -Path link.md -Target C:\repo\README.md'
+            Expected = @('link.md', 'C:\repo\README.md')
+        },
+        # -Name puts the leaf under -Path, and the -Path value stays the anchor.
+        @{ Command = 'New-Item -Path deep -Name link.md -ItemType SymbolicLink -Target ..\README.md'
+            Expected = @('deep', 'deep\link.md', '..\README.md', 'deep\..\README.md')
+        },
         @{ Command = 'Copy-Item a.txt -Destination b.txt'; Expected = @('b.txt') },
         @{ Command = 'rm a.txt b.txt'; Expected = @('a.txt', 'b.txt') },
         @{ Command = 'tee out.txt'; Expected = @('out.txt') },

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1833,6 +1833,20 @@ try {
         @{ Command = 'mklink /d deep\linkdir ..\..\docs'
             Expected = @('deep\linkdir', '..\..\docs', 'deep\linkdir\..\..\docs', 'deep\..\..\docs')
         },
+        # cp --link and cp --symbolic-link create links, so they carry the same hole as ln.
+        @{ Command = 'cp -l a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
+        @{ Command = 'cp -s a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
+        @{ Command = 'cp --link a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
+        @{ Command = 'cp --symbolic-link a.md b.md'
+            Expected = @('b.md', 'a.md', 'b.md\a.md')
+        },
+        # Short options cluster. A literal list of four spellings would miss every one of these.
+        @{ Command = 'cp -al a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
+        @{ Command = 'cp -rs a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
+        # Case matters: -S is --suffix, a different option that names no link.
+        @{ Command = 'cp -S .bak a.md b.md'; Expected = @('b.md') },
+        # A plain copy is untouched by the new branch and still reports its destination alone.
+        @{ Command = 'cp a.md b.md'; Expected = @('b.md') },
         @{ Command = 'Copy-Item a.txt -Destination b.txt'; Expected = @('b.txt') },
         @{ Command = 'rm a.txt b.txt'; Expected = @('a.txt', 'b.txt') },
         @{ Command = 'tee out.txt'; Expected = @('out.txt') },

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1901,6 +1901,22 @@ try {
         @{ Command = 'Copy-Item a.txt -Destination b.txt'; Expected = @('b.txt') },
         @{ Command = 'Copy-Item a.txt b.txt'; Expected = @('b.txt') },
         @{ Command = 'Remove-Item -LiteralPath out.txt'; Expected = @('out.txt') },
+        # An option value standing before the path used to become operand 0, so the path itself
+        # was never reported. The command still wrote it.
+        @{ Command = 'Set-Content -Encoding utf8 out.txt x'; Expected = @('out.txt') },
+        @{ Command = 'Set-Content -ErrorAction Stop out.txt x'; Expected = @('out.txt') },
+        @{ Command = 'Add-Content -Encoding utf8 out.txt x'; Expected = @('out.txt') },
+        @{ Command = 'Out-File -Encoding utf8 out.txt'; Expected = @('out.txt') },
+        @{ Command = 'Remove-Item -Filter *.md out'; Expected = @('out') },
+        @{ Command = 'New-Item -ItemType File -Value hello out.txt'; Expected = @('out.txt') },
+        # Same root cause, harmless face: -Name with no -Path read the -ItemType value as the
+        # link path, so the reported paths were 'SymbolicLink' and 'SymbolicLink\bait'.
+        @{ Command = 'New-Item -ItemType SymbolicLink -Name bait -Target C:\repo\README.md'
+            Expected = @('bait', 'C:\repo\README.md')
+        },
+        # A switch takes no value, so the token after it stays a path.
+        @{ Command = 'Set-Content -Force out.txt x'; Expected = @('out.txt') },
+        @{ Command = 'Remove-Item -Recurse out'; Expected = @('out') },
         # Reads produce nothing
         @{ Command = 'cat out.txt'; Expected = @() },
         @{ Command = 'Get-Content out.txt'; Expected = @() }
@@ -2245,6 +2261,33 @@ try {
         @{ Name    = 'an -Exclude value is not treated as a move source'
             Command = 'Move-Item -Path a.txt -Destination b.txt -Exclude <MAIN>/seed.txt'
             Cwd = 'Managed'; Action = 'Allow'
+        },
+        # The same reader now serves the content-writing cmdlets. Without it an option value
+        # standing before the path took the operand 0 slot, the guard scanned that value instead
+        # of the path, and every one of these writes into main was ALLOWED.
+        @{ Name    = 'an -Encoding value before a main path does not hide the write'
+            Command = 'Set-Content -Encoding utf8 <MAIN>/x.txt hello'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'a common parameter before a main path does not hide the write'
+            Command = 'Set-Content -ErrorAction Stop <MAIN>/x.txt hello'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'an -Encoding value before a main Out-File path does not hide the write'
+            Command = 'Out-File -Encoding utf8 <MAIN>/x.txt'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'a -Value before a main New-Item path does not hide the write'
+            Command = 'New-Item -ItemType File -Value hello <MAIN>/x.txt'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        @{ Name    = 'a -Filter value before a main Remove-Item path does not hide the delete'
+            Command = 'Remove-Item -Filter x.md <MAIN>/docs'; Cwd = 'Managed'; Action = 'Deny'
+        },
+        # The other direction: the option value itself is not a path the command writes.
+        @{ Name    = 'a Set-Content -Filter value is not treated as a write target'
+            Command = 'Set-Content -Path notes.tmp -Filter <MAIN>/seed.txt -Value y'
+            Cwd = 'Managed'; Action = 'Allow'
+        },
+        # A switch consumes nothing, so the path after it must still be read.
+        @{ Name    = 'a switch before a main path does not hide the write'
+            Command = 'Set-Content -Force <MAIN>/x.txt hello'; Cwd = 'Managed'; Action = 'Deny'
         },
         # A provider-qualified path names a real location, but it is not a rooted path, so it
         # would otherwise be anchored under the session worktree and wrongly allowed.
@@ -2750,11 +2793,25 @@ try {
             Action = 'Allow'
         },
         # Every one of the three anchors has to stay inside the worktree for this to be Allow.
-        # '../src/a.cs' would NOT: from the worktree root it climbs into .claude\worktrees, which
-        # is main.
         @{ Name = 'a relative link that stays inside the session worktree'
             Command = 'ln -s src/a.cs deep/bait.md'
             Action = 'Allow'
+        },
+        # The over-report the three anchors cost, pinned rather than left to a comment. Windows
+        # resolves this symbolic link inside the worktree, so the link is legitimate work. The
+        # as-written anchor climbs into <main>\.claude\worktrees, and Deny wins. Backlog 086
+        # reads the link kind and turns this case into Allow; until then the refusal is the
+        # documented price, and the message names a path no write would land on.
+        @{ Name = 'a relative symbolic link inside the worktree is over-reported'
+            Command = 'ln -s ../src/a.cs deep/bait.md'
+            Action = 'Deny'
+        },
+        # Why the as-written anchor cannot simply be dropped. A HARD link resolves its source
+        # against the working directory, so this one names <main>\.claude\worktrees\README.md.
+        # The two link-relative anchors both land inside the worktree and would allow it.
+        @{ Name = 'a relative hard link only the as-written anchor catches'
+            Command = 'ln ../README.md deep/bait.md'
+            Action = 'Deny'
         },
         # The gate from Task 5, proved at the decision layer: content is not a path.
         @{ Name = 'an ordinary file write with a value is untouched'

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1820,6 +1820,19 @@ try {
         },
         # One operand names a link in the working directory and nothing else.
         @{ Command = 'ln -s a.md'; Expected = @('a.md') },
+        # mklink puts the LINK first and the TARGET second, and its options are '/'-prefixed.
+        @{ Command = 'mklink link.md C:\repo\README.md'
+            Expected = @('link.md', 'C:\repo\README.md')
+        },
+        @{ Command = 'mklink /D linkdir C:\repo\docs'; Expected = @('linkdir', 'C:\repo\docs') },
+        @{ Command = 'mklink /H link.md C:\repo\README.md'
+            Expected = @('link.md', 'C:\repo\README.md')
+        },
+        @{ Command = 'mklink /J linkdir C:\repo\docs'; Expected = @('linkdir', 'C:\repo\docs') },
+        # Lower case spells the same switch, and a relative target needs all three forms.
+        @{ Command = 'mklink /d deep\linkdir ..\..\docs'
+            Expected = @('deep\linkdir', '..\..\docs', 'deep\linkdir\..\..\docs', 'deep\..\..\docs')
+        },
         @{ Command = 'Copy-Item a.txt -Destination b.txt'; Expected = @('b.txt') },
         @{ Command = 'rm a.txt b.txt'; Expected = @('a.txt', 'b.txt') },
         @{ Command = 'tee out.txt'; Expected = @('out.txt') },


### PR DESCRIPTION
## What

Closes backlog 083. The agent worktree guard now reads the path a link **points to**, not
only the path it is created **at**.

Before this, a worktree session could create a link inside an allowed location aimed at a
file in the main checkout, then write through it. The write looked allowed, because the
guard only ever saw the allowed path.

## Why this PR exists

PR #291 merged early. It carried only the three `chore:` stage commits (pickup, 2-design,
3-plan) — the seven implementation commits never reached the remote, and the branch was
deleted after the merge. `origin/main` still has the item open at `backlog/083-*.md` with
no link handling in the guard. This PR delivers the work that #291 was supposed to.

## Spellings covered

| Spelling | Target read from |
|---|---|
| `New-Item -ItemType HardLink\|SymbolicLink\|Junction` | `-Target`, `-Value` |
| `ln`, `ln -s` | every operand |
| `mklink`, `/D`, `/H`, `/J` | link and target |
| `cp --link`, `cp --symbolic-link` | sources |
| `cmd /c ...`, `cmd //c "..."` | the inner command |

`New-Item` reads a target only behind an `ItemType` gate, so a plain file or directory
creation is unaffected. A link whose target is inside the session's own worktree stays
allowed.

## Merge note

`origin/main` moved while this sat undelivered (084 pipeline-bound sources, 085 item,
SSH.NET pin). Merged in and resolved two conflicts in
`scripts/agents/agent-worktree-guard.common.ps1`. Both were the same shape: 084 added a
pipeline-bound source check inline, this branch had extracted the interpreter scan into
`Get-AgentInterpreterInnerTarget`. Kept both — 084's check, then the shared helper, which
is a superset of the inline block it replaces (same depth cap and spec matching, plus the
unquoted-rest scan).

## Verification

Canonical five-step gate, all green:

- `dotnet build AHKFlowApp.slnx --configuration Release` — 17 projects, 0 errors, 0 warnings
- `dotnet format AHKFlowApp.slnx --verify-no-changes` — exit 0
- `pwsh .\scripts\test-fast.ps1 -Mode PowerShell` — 18/18 suites passed
- `pwsh .\scripts\test-fast.ps1 -Mode Coverage` — all thresholds met, line 94.6% / branch 82.6%
- `git diff --check origin/main...HEAD` — exit 0

`AgentWorktreeGuard.Tests.ps1`: 673 assertions, 0 failures. 084's `PipedFrom:` tests and
083's link tests both green in one tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
