### PR TITLE
fix: hide watcher console window on worktree removal

### DIFF
--- a/backlog/done/088-worktree-removal-watcher-flashes-a-console-window.md
+++ b/backlog/done/088-worktree-removal-watcher-flashes-a-console-window.md
@@ -5,8 +5,8 @@
 - **Epic**: Development process
 - **Type**: Tooling
 - **Interfaces**: none (scripts)
-- **Difficulty**: trivial
-- **Stage**: 0-intake
+- **Difficulty**: moderate
+- **Stage**: 9-ship
 
 ## Summary
 
@@ -50,20 +50,39 @@ appear, so that my typing is never interrupted.
 
 ## Acceptance criteria
 
-- [ ] Removing a worktree creates no visible window, not even for a few milliseconds.
-- [ ] The watcher still runs outside the Claude job object, so it survives the session that
+- [x] Removing a worktree creates no visible window, not even for a few milliseconds.
+- [x] The watcher still runs outside the Claude job object, so it survives the session that
       started it. This is why the script uses WMI, and it must stay true.
-- [ ] `tests/WorktreeRemoveHook.Tests.ps1` and `tests/WorktreeMergedCleanup.Tests.ps1` stay
+- [x] `tests/WorktreeRemoveHook.Tests.ps1` and `tests/WorktreeMergedCleanup.Tests.ps1` stay
       green.
 
-## Proposed fix
+## Fix that shipped
 
-Pass a second argument to `Win32_Process.Create`: a `Win32_ProcessStartup` instance with
-`CreateFlags = 0x08000000` (`CREATE_NO_WINDOW`). The process still gets a console, so it stays
-detached from the job object, but no window is ever created, so there is nothing to hide.
+`Win32_Process.Create` now receives a second argument: a `Win32_ProcessStartup` instance with
+`ShowWindow = 0` (`SW_HIDE`). The system applies that value when it creates the window, so the
+window is never shown. The process still gets a console, so the PowerShell host starts
+normally, and `WmiPrvSE.exe` still creates it, so it still escapes the job object.
 
-`ShowWindow = 0` (`SW_HIDE`) is the weaker alternative. It hides the window at creation rather
-than after the host starts, which removes the flash but still creates the window.
+`scripts/worktree-powershell.common.ps1` builds the instance in `New-HiddenProcessStartup`.
+`tests/WorktreeWatcherWindow.Tests.ps1` spawns a probe the same way and asserts that no
+visible window ever belongs to it.
+
+### Why the originally proposed fix was wrong
+
+This item first proposed `CreateFlags = 0x08000000` (`CREATE_NO_WINDOW`) and called
+`ShowWindow = 0` the weaker alternative. Measurement reversed that.
+
+| Variant | Result |
+|---|---|
+| No startup information (the old code) | Visible `PseudoConsoleWindow` about 215 ms after the spawn |
+| `ShowWindow = 0` | No visible window |
+| `CreateFlags = 8` (`Detached_Process`) | `Create` returns 0, but the child never runs: a PowerShell host with no console does nothing |
+| `CreateFlags = 0x08000000` (`CREATE_NO_WINDOW`) | `Create` returns **21**, invalid parameter, and creates no process |
+
+`CREATE_NO_WINDOW` is not in the accepted `CreateFlags` values that
+[the `Win32_ProcessStartup` documentation](https://learn.microsoft.com/windows/win32/cimwin32prov/win32-processstartup)
+lists. `ShowWindow = 0` is the
+[documented way to run a process hidden through WMI](https://learn.microsoft.com/windows/win32/wmisdk/wmi-tasks--processes).
 
 ## Out of scope
 

--- a/scripts/remove-worktree-local-dev.ps1
+++ b/scripts/remove-worktree-local-dev.ps1
@@ -89,6 +89,10 @@ if (-not (Get-Command Resolve-PowerShellExecutable -ErrorAction SilentlyContinue
     }
 }
 
+if (-not (Get-Command New-HiddenProcessStartup -ErrorAction SilentlyContinue)) {
+    function New-HiddenProcessStartup { return $null }
+}
+
 if (-not (Get-Command Write-WorktreeLog -ErrorAction SilentlyContinue)) {
     function Write-WorktreeLog {
         param(
@@ -667,12 +671,24 @@ function Invoke-HookMode {
     $psExe = Resolve-PowerShellExecutable
     $watcherCmd = '"{0}" -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "{1}" -Mode Watcher -ParamFile "{2}"' -f $psExe, $watcherScript, $paramFile
 
+    # Without ProcessStartupInformation the new process gets a visible console window, and
+    # -WindowStyle Hidden above only hides it after the host starts. The user sees that gap as
+    # a black flash on every removal.
+    $cimArguments = @{
+        CommandLine      = $watcherCmd
+        CurrentDirectory = $tempDir
+    }
+    $startupInformation = New-HiddenProcessStartup
+    if ($startupInformation) {
+        $cimArguments['ProcessStartupInformation'] = $startupInformation
+    } else {
+        Write-Log 'Could not build hidden process startup information; the watcher window may flash.'
+    }
+
     $spawned = $false
     try {
-        $result = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{
-            CommandLine      = $watcherCmd
-            CurrentDirectory = $tempDir
-        } -ErrorAction Stop
+        $result = Invoke-CimMethod -ClassName Win32_Process -MethodName Create `
+            -Arguments $cimArguments -ErrorAction Stop
         if ($result.ReturnValue -eq 0) {
             Write-Log "Watcher spawned via WMI. PID=$($result.ProcessId) ParamFile=$paramFile"
             $spawned = $true

--- a/scripts/worktree-powershell.common.ps1
+++ b/scripts/worktree-powershell.common.ps1
@@ -1,5 +1,5 @@
 #Requires -Version 5.1
-# Shared PowerShell host resolution for worktree lifecycle scripts.
+# Shared PowerShell host resolution and process startup for worktree lifecycle scripts.
 
 function Resolve-PowerShellExecutable {
     $currentProcessPath = [System.Diagnostics.Process]::GetCurrentProcess().Path
@@ -20,6 +20,27 @@ function Resolve-PowerShellExecutable {
     }
 
     throw 'Could not resolve a PowerShell executable. Expected current host, pwsh.exe, or powershell.exe to be available.'
+}
+
+# Builds the Win32_ProcessStartup instance that Win32_Process.Create needs so the spawned
+# process never shows its console window. Without it the window is created visible, and
+# PowerShell's own -WindowStyle Hidden hides it only milliseconds later, which the user sees
+# as a black flash.
+#
+# ShowWindow = 0 is SW_HIDE, applied by the system when it creates the window. It is the only
+# setting that works here. CreateFlags does not accept CREATE_NO_WINDOW: Win32_Process.Create
+# returns 21 (invalid parameter) and creates nothing. Detached_Process leaves the PowerShell
+# host with no console at all, and then the script never runs.
+#
+# Returns $null when the CIM class is unavailable, so the caller can spawn without startup
+# information. A visible flash is better than no spawn at all.
+function New-HiddenProcessStartup {
+    try {
+        return [CimInstance] (New-CimInstance -ClassName Win32_ProcessStartup `
+                -Namespace 'root/cimv2' -ClientOnly -Property @{ ShowWindow = [uint16] 0 })
+    } catch {
+        return $null
+    }
 }
 
 function Write-Stderr {

--- a/tests/WorktreeWatcherWindow.Tests.ps1
+++ b/tests/WorktreeWatcherWindow.Tests.ps1
@@ -1,0 +1,126 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Asserts that the detached worktree removal watcher never shows a console window.
+.DESCRIPTION
+  remove-worktree-local-dev.ps1 spawns its watcher through Win32_Process.Create so the
+  watcher escapes Claude's job object. Windows gives that process a console window unless the
+  call passes ProcessStartupInformation with ShowWindow = 0. PowerShell's own
+  -WindowStyle Hidden is too late: it hides the window after the host has started, and the
+  user sees the gap as a black flash on every removal.
+
+  This suite spawns a real probe process the same way the script does and asserts that no
+  visible window ever belongs to it.
+#>
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+Add-Type -TypeDefinition @'
+using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+public static class WorktreeWindowScan {
+    delegate bool EnumProc(IntPtr window, IntPtr param);
+
+    [DllImport("user32.dll")] static extern bool EnumWindows(EnumProc callback, IntPtr param);
+    [DllImport("user32.dll")] static extern bool IsWindowVisible(IntPtr window);
+    [DllImport("user32.dll")] static extern uint GetWindowThreadProcessId(IntPtr window, out uint processId);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)] static extern int GetClassName(IntPtr window, StringBuilder text, int count);
+
+    // Returns "handle:classname" for every visible top-level window owned by the process,
+    // or an empty string when it owns none.
+    public static string VisibleWindowsFor(uint targetProcessId) {
+        var found = new List<string>();
+        EnumWindows((window, param) => {
+            uint owner;
+            GetWindowThreadProcessId(window, out owner);
+            if (owner == targetProcessId && IsWindowVisible(window)) {
+                var name = new StringBuilder(256);
+                GetClassName(window, name, name.Capacity);
+                found.Add(window.ToString() + ":" + name.ToString());
+            }
+            return true;
+        }, IntPtr.Zero);
+        return string.Join(", ", found);
+    }
+}
+'@
+
+# --- the shared helper builds a hidden startup instance -----------------------------------
+
+$helperPath = Join-Path $repoRoot 'scripts\worktree-powershell.common.ps1'
+Assert-True (Test-Path -LiteralPath $helperPath) "Expected the shared PowerShell helper to exist: $helperPath"
+
+. $helperPath
+
+$startup = New-HiddenProcessStartup
+Assert-True ($null -ne $startup) 'New-HiddenProcessStartup returned $null; Win32_ProcessStartup should be available on Windows.'
+Assert-True ($startup.ShowWindow -eq 0) "Expected ShowWindow = 0 (SW_HIDE), got '$($startup.ShowWindow)'."
+
+# --- a process spawned with it never shows a window ---------------------------------------
+
+$probeScript = Join-Path ([System.IO.Path]::GetTempPath()) "ahkflowapp-window-probe-$([guid]::NewGuid().ToString('N')).ps1"
+Set-Content -LiteralPath $probeScript -Value 'Start-Sleep -Seconds 3' -Encoding utf8
+
+$probeProcessId = 0
+try {
+    $psExe = Resolve-PowerShellExecutable
+    $commandLine = '"{0}" -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "{1}"' -f $psExe, $probeScript
+
+    $result = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{
+        CommandLine               = $commandLine
+        CurrentDirectory          = [System.IO.Path]::GetTempPath()
+        ProcessStartupInformation = $startup
+    } -ErrorAction Stop
+
+    # 21 is "invalid parameter". Win32_ProcessStartup rejects CreateFlags values it does not
+    # document, CREATE_NO_WINDOW among them, and then no process is created at all. Fail here
+    # rather than let the removal silently fall back to the killable Start-Process path.
+    Assert-True ($result.ReturnValue -eq 0) "Win32_Process.Create returned $($result.ReturnValue); expected 0. The startup information is not accepted."
+
+    $probeProcessId = [uint32] $result.ProcessId
+    Assert-True ($probeProcessId -ne 0) 'Win32_Process.Create reported success but returned no process id.'
+
+    # Poll rather than sample once: the window this guards against appeared about 200 ms after
+    # the spawn, so a single check right after the call would miss it.
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $seen = ''
+    while ($stopwatch.ElapsedMilliseconds -lt 2000) {
+        $seen = [WorktreeWindowScan]::VisibleWindowsFor($probeProcessId)
+        if ($seen) { break }
+        Start-Sleep -Milliseconds 5
+    }
+
+    Assert-True ([string]::IsNullOrEmpty($seen)) "A visible window appeared for the spawned watcher after $($stopwatch.ElapsedMilliseconds)ms: $seen"
+} finally {
+    if ($probeProcessId -ne 0) {
+        Stop-Process -Id $probeProcessId -Force -ErrorAction SilentlyContinue
+    }
+    Remove-Item -LiteralPath $probeScript -Force -ErrorAction SilentlyContinue
+}
+
+# --- the removal script actually passes it ------------------------------------------------
+
+$removeScriptPath = Join-Path $repoRoot 'scripts\remove-worktree-local-dev.ps1'
+$removeScriptContent = Get-Content -LiteralPath $removeScriptPath -Raw
+
+Assert-True ($removeScriptContent -match 'ProcessStartupInformation') 'remove-worktree-local-dev.ps1 must pass ProcessStartupInformation to Win32_Process.Create, or the watcher window flashes.'
+Assert-True ($removeScriptContent -match 'New-HiddenProcessStartup') 'remove-worktree-local-dev.ps1 should build its startup information with the shared New-HiddenProcessStartup helper.'
+
+Write-Host 'Worktree watcher window tests passed.'

--- a/tests/WorktreeWatcherWindow.Tests.ps1
+++ b/tests/WorktreeWatcherWindow.Tests.ps1
@@ -75,8 +75,17 @@ Assert-True ($startup.ShowWindow -eq 0) "Expected ShowWindow = 0 (SW_HIDE), got 
 
 # --- a process spawned with it never shows a window ---------------------------------------
 
-$probeScript = Join-Path ([System.IO.Path]::GetTempPath()) "ahkflowapp-window-probe-$([guid]::NewGuid().ToString('N')).ps1"
-Set-Content -LiteralPath $probeScript -Value 'Start-Sleep -Seconds 3' -Encoding utf8
+$probeId = [guid]::NewGuid().ToString('N')
+$probeScript = Join-Path ([System.IO.Path]::GetTempPath()) "ahkflowapp-window-probe-$probeId.ps1"
+$probeMarker = Join-Path ([System.IO.Path]::GetTempPath()) "ahkflowapp-window-probe-$probeId.started"
+
+# The marker tells the scan below when the PowerShell host has finished starting. The window
+# this suite guards against is created before that point, so the scan must cover the whole
+# startup, however slow the machine is that day.
+Set-Content -LiteralPath $probeScript -Encoding utf8 -Value @"
+New-Item -ItemType File -Path '$probeMarker' -Force | Out-Null
+Start-Sleep -Seconds 3
+"@
 
 $probeProcessId = 0
 try {
@@ -97,22 +106,38 @@ try {
     $probeProcessId = [uint32] $result.ProcessId
     Assert-True ($probeProcessId -ne 0) 'Win32_Process.Create reported success but returned no process id.'
 
-    # Poll rather than sample once: the window this guards against appeared about 200 ms after
-    # the spawn, so a single check right after the call would miss it.
+    # Poll rather than sample once: the window this guards against appeared 135-369 ms after the
+    # spawn on a developer machine, so a single check right after the call would miss it.
+    #
+    # Scan until the host has started, plus a short tail, rather than for a fixed span. A fixed
+    # span turns into a false pass on a loaded CI runner, where the process can start after the
+    # scan has already given up.
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $seen = ''
-    while ($stopwatch.ElapsedMilliseconds -lt 2000) {
+    $hostStartedAt = $null
+    while ($stopwatch.ElapsedMilliseconds -lt 30000) {
         $seen = [WorktreeWindowScan]::VisibleWindowsFor($probeProcessId)
         if ($seen) { break }
+
+        if ($null -eq $hostStartedAt) {
+            if (Test-Path -LiteralPath $probeMarker) { $hostStartedAt = $stopwatch.ElapsedMilliseconds }
+        } elseif (($stopwatch.ElapsedMilliseconds - $hostStartedAt) -ge 500) {
+            break
+        }
+
         Start-Sleep -Milliseconds 5
     }
 
     Assert-True ([string]::IsNullOrEmpty($seen)) "A visible window appeared for the spawned watcher after $($stopwatch.ElapsedMilliseconds)ms: $seen"
+
+    # No marker means the probe never ran, so the scan proved nothing. Detached_Process fails
+    # exactly this way: Create returns 0 and the child does nothing.
+    Assert-True ($null -ne $hostStartedAt) 'The probe process never started; the window scan proved nothing.'
 } finally {
     if ($probeProcessId -ne 0) {
         Stop-Process -Id $probeProcessId -Force -ErrorAction SilentlyContinue
     }
-    Remove-Item -LiteralPath $probeScript -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $probeScript, $probeMarker -Force -ErrorAction SilentlyContinue
 }
 
 # --- the removal script actually passes it ------------------------------------------------


### PR DESCRIPTION
## What

The worktree removal watcher no longer flashes a console window.

`Win32_Process.Create` received no `ProcessStartupInformation`, so Windows created the
watcher with a visible console window. `-WindowStyle Hidden` is a PowerShell host argument,
so the host hid that window only after it started. The gap is what the user saw as a black
flash — measured at 135-369 ms. A full PowerShell suite run drives five removals, so it
flashed five times.

The spawn now passes a `Win32_ProcessStartup` instance with `ShowWindow = 0` (`SW_HIDE`),
which the system applies when it creates the window. The window is never shown.

## The backlog item's proposed fix does not work

Backlog 088 proposed `CreateFlags = 0x08000000` (`CREATE_NO_WINDOW`) and called
`ShowWindow = 0` "the weaker alternative". Measurement reversed that:

| Variant | Result |
|---|---|
| No startup information (old code) | Visible `PseudoConsoleWindow` 135-369 ms after the spawn |
| `ShowWindow = 0` | No visible window |
| `CreateFlags = 8` (`Detached_Process`) | `Create` returns 0, but the child never runs: a PowerShell host with no console does nothing |
| `CreateFlags = 0x08000000` (`CREATE_NO_WINDOW`) | `Create` returns **21**, invalid parameter, and creates no process |

`CREATE_NO_WINDOW` is not in the accepted `CreateFlags` values that the
[`Win32_ProcessStartup` documentation](https://learn.microsoft.com/windows/win32/cimwin32prov/win32-processstartup)
lists. `ShowWindow = 0` is the
[documented way to run a process hidden through WMI](https://learn.microsoft.com/windows/win32/wmisdk/wmi-tasks--processes).

Shipping `CREATE_NO_WINDOW` would have sent every removal down the `Start-Process` fallback,
which the session can kill. The reversal is recorded in the closed backlog item.

## Changes

- `scripts/worktree-powershell.common.ps1` — new `New-HiddenProcessStartup`. Returns `$null`
  when the CIM class is unavailable, so a removal that cannot hide its window still happens.
- `scripts/remove-worktree-local-dev.ps1` — passes `ProcessStartupInformation` when the
  helper returns an instance, and logs when it does not.
- `tests/WorktreeWatcherWindow.Tests.ps1` — new suite.
- `backlog/088-...md` — boxes ticked, moved to `backlog/done/`.

## Verification

The new suite spawns a probe through the same WMI call and polls `EnumWindows` for any
visible top-level window owned by it. The scan runs until the probe's host has started plus
500 ms, rather than for a fixed span, so a slow runner cannot produce a false pass. A probe
that never starts fails the suite.

Proven to bite: strip `ProcessStartupInformation` from the probe spawn and it fails with
`A visible window appeared for the spawned watcher after 172ms: PseudoConsoleWindow`.

Gate: build 17 projects 0 errors; `dotnet format --verify-no-changes` clean; 21/21 PowerShell
suites pass, `WorktreeRemoveHook` and `WorktreeMergedCleanup` included; coverage all
thresholds met, line 94.6%; `git diff --check main...HEAD` clean.

Closes backlog 088.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
