### PR TITLE
fix: fold the profile name into the template stamp (review follow-up on #299)

### DIFF
--- a/backlog/done/089-flaky-e2e-template-warning-test-times-out-in-ci.md
+++ b/backlog/done/089-flaky-e2e-template-warning-test-times-out-in-ci.md
@@ -54,7 +54,9 @@ after its 30 second wait. The click landed inside that 228 ms window.
 - [x] Name the root cause with `file:line` evidence, not a guess. Say whether the cause is a race
       in the test, a race in the UI, or state shared between tests.
 - [x] Fix the cause. A longer timeout or a retry is not a fix.
-- [x] Show the test passing on 10 runs in a row of `ShortcutWarningFlowTests`.
+- [x] Show the test passing on 10 runs in a row of `ShortcutWarningFlowTests`. Ten local runs of
+      `dotnet test tests/AHKFlowApp.E2E.Tests -c Release --filter FullyQualifiedName~ShortcutWarningFlowTests`
+      passed, 12 tests each. PR #299 and its CI run 31702215783 carry the merged result.
 - [x] Check the other tests in the class for the same pattern, and fix them in the same change.
 
 ## Out of scope

--- a/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/ShortcutWarning.razor
+++ b/src/Frontend/AHKFlowApp.UI.Blazor/Components/Hotkeys/ShortcutWarning.razor
@@ -131,11 +131,18 @@
     private string ProfileScope() =>
         AppliesToAllProfiles ? "*" : string.Join(",", ProfileIds.Order());
 
-    // Exactly the text the notice reads, from exactly the Profiles it reads it from. A page that
-    // hands over a longer list, or an edited template, produces a different stamp and re-evaluates.
+    // Everything the notice reads, from exactly the Profiles it reads it from: the name it
+    // prints, and the two templates it matches the row against. A longer list, a renamed
+    // Profile, or an edited template each produce a different stamp, so the notice follows
+    // every one of them. The separators are the ASCII record and unit separators, which no
+    // AutoHotkey template holds, so text moved from the header to the footer changes the stamp
+    // instead of reading the same both ways.
+    private const string FieldSeparator = "\u001E";
+    private const string ProfileSeparator = "\u001F";
+
     private string TemplateStamp() =>
-        string.Join("", SelectedProfiles()
-            .Select(p => $"{p.Id}{p.HeaderTemplate}{p.FooterTemplate}"));
+        string.Join(ProfileSeparator, SelectedProfiles().Select(p => string.Join(
+            FieldSeparator, p.Id, p.Name, p.HeaderTemplate, p.FooterTemplate)));
 
     public void Dispose()
     {

--- a/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
+++ b/tests/AHKFlowApp.E2E.Tests/ShortcutWarningFlowTests.cs
@@ -304,14 +304,7 @@ public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifet
         IPage page = await context.NewPageAsync();
 
         // Put the Caps Lock layer into the seeded profile's header template.
-        await page.GotoAsync($"{fixture.Spa.BaseUrl}/profiles");
-        await page.WaitForSelectorAsync("button.start-edit");
-        await page.ClickAsync("button.start-edit");
-        await page.WaitForSelectorAsync("textarea[data-test=\"profile-header-input\"]");
-        await page.FillAsync("textarea[data-test=\"profile-header-input\"]",
-            "#Requires AutoHotkey v2.0\n\n*CapsLock::\n{\n    Send \"{Blind}{LCtrl DownR}\"\n}");
-        await page.ClickAsync("button.commit-edit");
-        await page.WaitForSelectorAsync("text=Profile updated.");
+        await SetProfileHeaderAsync(page, CapsLockLayerHeader);
 
         // Now bind a hotkey to the same key. "Apply to all profiles" avoids picking one by name.
         await OpenCreateDialogAsync(page);
@@ -343,14 +336,7 @@ public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifet
         await using IBrowserContext context = await fixture.Browser.NewContextAsync();
         IPage page = await context.NewPageAsync();
 
-        await page.GotoAsync($"{fixture.Spa.BaseUrl}/profiles");
-        await page.WaitForSelectorAsync("button.start-edit");
-        await page.ClickAsync("button.start-edit");
-        await page.WaitForSelectorAsync("textarea[data-test=\"profile-header-input\"]");
-        await page.FillAsync("textarea[data-test=\"profile-header-input\"]",
-            "#Requires AutoHotkey v2.0\n\n*CapsLock::\n{\n    Send \"{Blind}{LCtrl DownR}\"\n}");
-        await page.ClickAsync("button.commit-edit");
-        await page.WaitForSelectorAsync("text=Profile updated.");
+        await SetProfileHeaderAsync(page, CapsLockLayerHeader);
 
         // Hold the Profile list open, so the hotkeys page reaches its first render without it. The
         // handler waits on the source below rather than on a fixed delay, so the test never races.
@@ -384,14 +370,8 @@ public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifet
         await using IBrowserContext context = await fixture.Browser.NewContextAsync();
         IPage page = await context.NewPageAsync();
 
-        await page.GotoAsync($"{fixture.Spa.BaseUrl}/profiles");
-        await page.WaitForSelectorAsync("button.start-edit");
-        await page.ClickAsync("button.start-edit");
-        await page.WaitForSelectorAsync("textarea[data-test=\"profile-header-input\"]");
-        await page.FillAsync("textarea[data-test=\"profile-header-input\"]",
+        await SetProfileHeaderAsync(page,
             "#Requires AutoHotkey v2.0\n\n*LControl::\n{\n    Send \"{Blind}{LAlt DownR}\"\n}");
-        await page.ClickAsync("button.commit-edit");
-        await page.WaitForSelectorAsync("text=Profile updated.");
 
         await OpenCreateDialogAsync(page);
         await CommitKeyAsync(page, "LCtrl");
@@ -414,6 +394,22 @@ public sealed class ShortcutWarningFlowTests(StackFixture fixture) : IAsyncLifet
         if (search is not null)
             await page.FillAsync("input[data-test=\"known-shortcut-search\"]", search);
     }
+
+    // Writes one template into the seeded Profile's header and waits for the save to land. Three
+    // tests start this way, and each of them then binds a hotkey to a key the template uses.
+    private async Task SetProfileHeaderAsync(IPage page, string template)
+    {
+        await page.GotoAsync($"{fixture.Spa.BaseUrl}/profiles");
+        await page.WaitForSelectorAsync("button.start-edit");
+        await page.ClickAsync("button.start-edit");
+        await page.WaitForSelectorAsync("textarea[data-test=\"profile-header-input\"]");
+        await page.FillAsync("textarea[data-test=\"profile-header-input\"]", template);
+        await page.ClickAsync("button.commit-edit");
+        await page.WaitForSelectorAsync("text=Profile updated.");
+    }
+
+    private const string CapsLockLayerHeader =
+        "#Requires AutoHotkey v2.0\n\n*CapsLock::\n{\n    Send \"{Blind}{LCtrl DownR}\"\n}";
 
     private async Task OpenCreateDialogAsync(IPage page)
     {

--- a/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/ShortcutWarningTests.cs
+++ b/tests/AHKFlowApp.UI.Blazor.Tests/Components/Hotkeys/ShortcutWarningTests.cs
@@ -70,6 +70,56 @@ public sealed class ShortcutWarningTests : BunitContext
     }
 
     [Fact]
+    public void TemplateNotice_FollowsARenameOfTheProfileItNames()
+    {
+        ProfileDto work = Profile("Work", CapsLockLayerHeader);
+
+        IRenderedComponent<ShortcutWarning> warning = Render<ShortcutWarning>(parameters => parameters
+            .Add(p => p.Key, "CapsLock")
+            .Add(p => p.AppliesToAllProfiles, true)
+            .Add(p => p.Profiles, (IReadOnlyList<ProfileDto>)[work]));
+
+        warning.WaitForAssertion(() =>
+            warning.Find("[data-test=\"template-warning\"]").TextContent.Should().Contain("in Work"));
+
+        // The notice prints the Profile name, so a rename with the same templates has to reach it.
+        warning.Render(parameters => parameters
+            .Add(p => p.Key, "CapsLock")
+            .Add(p => p.AppliesToAllProfiles, true)
+            .Add(p => p.Profiles, (IReadOnlyList<ProfileDto>)[work with { Name = "Home" }]));
+
+        warning.WaitForAssertion(() =>
+            warning.Find("[data-test=\"template-warning\"]").TextContent.Should().Contain("in Home"));
+    }
+
+    [Fact]
+    public void TemplateNotice_FollowsTemplateTextMovingFromTheHeaderToTheFooter()
+    {
+        // The two templates carry the same text in turn. A stamp that ran them together without a
+        // separator would read the same both ways, and the notice would keep saying "header".
+        ProfileDto work = Profile("Work", CapsLockLayerHeader);
+
+        IRenderedComponent<ShortcutWarning> warning = Render<ShortcutWarning>(parameters => parameters
+            .Add(p => p.Key, "CapsLock")
+            .Add(p => p.AppliesToAllProfiles, true)
+            .Add(p => p.Profiles, (IReadOnlyList<ProfileDto>)[work]));
+
+        warning.WaitForAssertion(() =>
+            warning.Find("[data-test=\"template-warning\"]").TextContent
+                .Should().Be("The header template in Work also uses CapsLock. Your hotkey may not fire."));
+
+        warning.Render(parameters => parameters
+            .Add(p => p.Key, "CapsLock")
+            .Add(p => p.AppliesToAllProfiles, true)
+            .Add(p => p.Profiles, (IReadOnlyList<ProfileDto>)
+                [work with { HeaderTemplate = "", FooterTemplate = CapsLockLayerHeader }]));
+
+        warning.WaitForAssertion(() =>
+            warning.Find("[data-test=\"template-warning\"]").TextContent
+                .Should().Be("The footer template in Work also uses CapsLock. Your hotkey may not fire."));
+    }
+
+    [Fact]
     public void TemplateNotice_FollowsAnEditToTheTemplateItAlreadyRead()
     {
         ProfileDto work = Profile("Work", CapsLockLayerHeader);


### PR DESCRIPTION
## What

Review follow-up on #299 (backlog 089). One real defect, two tidies.

The template notice prints the profile name (`TemplateUseText.cs:60-64`), but the stamp that decides
whether to re-evaluate carried only the id and the two templates. A profile renamed while the dialog
stayed open kept the old name on screen.

## Changes

- `Components/Hotkeys/ShortcutWarning.razor:145` — the stamp now carries `p.Name`.
- `ShortcutWarning.razor:141-142` — the two separators are named constants written as `` /
  `` escapes. They were literal control characters, invisible in most diff views.
- `ShortcutWarningFlowTests.cs:400` — `SetProfileHeaderAsync` replaces the profile-header setup that
  three tests carried verbatim.
- `backlog/done/089-flaky-e2e-template-warning-test-times-out-in-ci.md` — the 10-run acceptance
  criterion now names the command and the CI run.

## Verification

- `ShortcutWarningTests.TemplateNotice_FollowsARenameOfTheProfileItNames` fails before the fix
  ("The header template in Work..." would not contain "in Home") and passes after it.
- `TemplateNotice_FollowsTemplateTextMovingFromTheHeaderToTheFooter` is a guard: green before and
  after, because the separators already prevented that collision.
- E2E `ShortcutWarningFlowTests`: 12 passed. Fast slice: 2935 passed.
- `dotnet format AHKFlowApp.slnx --verify-no-changes`: clean.

Not changed: `release.SetResult()` stays outside a `finally`, matching the sibling test at
`ShortcutWarningFlowTests.cs:212`. It only affects how an already-failing test reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
