### PR TITLE
fix: guard reads the link kind before anchoring a relative target

### DIFF
--- a/backlog/086-guard-reads-the-link-kind-before-anchoring-a-relative-target.md
+++ b/backlog/086-guard-reads-the-link-kind-before-anchoring-a-relative-target.md
@@ -5,7 +5,8 @@
 - **Epic**: Agent guardrails
 - **Type**: Feature
 - **Interfaces**: none (agent git guard)
-- **Stage**: 0-intake
+- **Stage**: 1-pickup
+- **Difficulty**: moderate
 
 ## Summary
 

--- a/backlog/091-guard-option-gates-accept-the-abbreviations-the-real-tools-accept.md
+++ b/backlog/091-guard-option-gates-accept-the-abbreviations-the-real-tools-accept.md
@@ -1,0 +1,71 @@
+# 091 - Guard option gates accept the abbreviations the real tools accept
+
+## Metadata
+
+- **Epic**: Agent guardrails
+- **Type**: Bug
+- **Interfaces**: none (agent git guard)
+- **Stage**: 0-intake
+
+## Summary
+
+Two gates in the guard compare an option or a type name for exact equality, but the real tools
+accept shorter spellings. A command that uses a short spelling walks past the gate, so the guard
+never looks at the path the link points to. Both gates let a link into the main checkout.
+
+## User story
+
+As a person who owns the main checkout, I want the guard to read the short spellings of an
+option, so that an agent cannot reach a protected file by abbreviating a flag.
+
+## Detail
+
+Both holes were found in review of pull request #304 (backlog 086), and both predate it.
+
+**1. `cp` link flags.** `Test-AgentGuardHasLinkFlag` in
+`scripts/agents/agent-worktree-guard.common.ps1` matches `--link` and `--symbolic-link` with
+exact equality. GNU accepts any unambiguous abbreviation, so `cp --sy` creates a symbolic link.
+The guard does not send that command down the link branch at all, so it reports only the
+destination and never scans the link target:
+
+```powershell
+# Reports only 'b.md'. The link target is never checked.
+cp --sy ../README.md b.md
+```
+
+`Get-AgentLinkKind` already reads abbreviations through `Test-AgentLongOptionPrefix`, added in
+#304. The same helper closes this gate.
+
+**2. `New-Item -ItemType`.** `Get-AgentNewItemLinkTarget` reads the link target only when the
+item type is exactly `symboliclink`, `hardlink`, or `junction`. The FileSystem provider matches
+the item type by prefix, so `New-Item -ItemType Sym` creates a real symbolic link. The guard
+reads no target for it:
+
+```powershell
+# Reports only the link path. The absolute target into the main checkout is never scanned.
+New-Item -ItemType Sym -Path bait.md -Target <main>\README.md
+```
+
+The kind switch added in #304 inherits the same exact-match assumption, so an abbreviated item
+type would also read as an unknown kind.
+
+## Acceptance criteria
+
+- [ ] `cp --sy` and `cp --lin` reach the link branch and report the link target
+- [ ] `New-Item -ItemType Sym` and `-ItemType hardl` report the link target
+- [ ] An abbreviated item type reads as the kind it names, not as an unknown kind
+- [ ] An item type the guard cannot expand still fails closed
+- [ ] A test pins each of the four commands above at Deny when the target is in the main checkout
+
+## Out of scope
+
+- The anchoring rules for a relative target, which backlog 086 settled
+- The junction anchor, which is still unproved and still fails closed
+
+## Notes / dependencies
+
+- Found in review of pull request #304 (backlog 086)
+- `Test-AgentLongOptionPrefix` in `scripts/agents/agent-worktree-guard.common.ps1` already does
+  the prefix match for long options; reuse it rather than writing a second one
+- Check whether the FileSystem provider matches the item type by prefix or by something looser
+  before you copy the assumption. Prove it against the running provider, not from memory

--- a/backlog/092-plans-symlink-test-uses-the-first-bash-on-path-which-may-be-wsl.md
+++ b/backlog/092-plans-symlink-test-uses-the-first-bash-on-path-which-may-be-wsl.md
@@ -1,0 +1,59 @@
+# 092 - Plans symlink test uses the first bash on PATH, which may be WSL
+
+## Metadata
+
+- **Epic**: Developer experience
+- **Type**: Bug
+- **Interfaces**: none (test suite)
+- **Stage**: 0-intake
+
+## Summary
+
+`WorktreePlansSymlink.Tests.ps1` runs the file-suggestion script with whatever `bash` PowerShell
+finds first. On a machine where that is the WSL `bash.exe`, the script runs inside WSL, cannot
+see the Windows `rg`, and returns nothing. The test then fails on a machine where the feature
+itself works.
+
+## User story
+
+As a developer running the PowerShell gate, I want the test to fail only when the code is wrong,
+so that I do not have to tell a real failure apart from a failure of my own PATH.
+
+## Detail
+
+The test guards the live check on both tools being present:
+
+```powershell
+$hasBash = [bool] (Get-Command bash -ErrorAction SilentlyContinue)
+$hasRg = [bool] (Get-Command rg -ErrorAction SilentlyContinue)
+```
+
+`tests/WorktreePlansSymlink.Tests.ps1:204-205`. Both lookups run in PowerShell, so they answer
+for the Windows PATH. The script then runs under `bash` at `tests/WorktreePlansSymlink.Tests.ps1:211`.
+
+When `bash` resolves to `C:\Windows\system32\bash.exe`, that is the WSL launcher, and the script
+runs with the Linux PATH. `rg` installed on Windows is not on that PATH, so the picker lists
+nothing and the assertion fails. The Git Bash at `/usr/bin/bash` does see the Windows `rg`, so
+the same test passes on a machine where Git Bash comes first.
+
+Reported by a reviewer on pull request #304, whose run showed 21 passed and 1 failed while the
+same commit showed 22 passed on the author's machine. The branch touched neither the test nor the
+script it exercises.
+
+## Acceptance criteria
+
+- [ ] The test picks a bash that can see the tools the script needs, or skips the live check
+- [ ] The skip message says which host was rejected and why
+- [ ] The test passes on a machine where WSL `bash.exe` comes first on PATH
+- [ ] The test still fails when `.claude/file-suggestion.sh` really is broken
+
+## Out of scope
+
+- Changing `.claude/file-suggestion.sh` itself
+- Making the repository work under WSL generally
+
+## Notes / dependencies
+
+- One option is to prefer the Git Bash next to `git.exe` over a bare `bash` lookup
+- Another is to ask the chosen bash for `rg` — `bash -lc 'command -v rg'` — instead of asking
+  PowerShell, so the guard and the run agree about the same PATH

--- a/backlog/done/086-guard-reads-the-link-kind-before-anchoring-a-relative-target.md
+++ b/backlog/done/086-guard-reads-the-link-kind-before-anchoring-a-relative-target.md
@@ -5,7 +5,7 @@
 - **Epic**: Agent guardrails
 - **Type**: Feature
 - **Interfaces**: none (agent git guard)
-- **Stage**: 1-pickup
+- **Stage**: 9-ship
 - **Difficulty**: moderate
 
 ## Summary
@@ -62,12 +62,12 @@ Every command form already carries its kind, so the guard can read it:
 
 ## Acceptance criteria
 
-- [ ] A relative symbolic-link target uses the two link-relative anchors only
-- [ ] A relative hard-link source uses the working-directory anchor only
-- [ ] A command whose kind the guard cannot read keeps all three anchors and stays fail-closed
-- [ ] `ln -s ../src/a.cs deep/bait.md` inside a worktree is allowed, and the test that pins today's
+- [x] A relative symbolic-link target uses the two link-relative anchors only
+- [x] A relative hard-link source uses the working-directory anchor only
+- [x] A command whose kind the guard cannot read keeps all three anchors and stays fail-closed
+- [x] `ln -s ../src/a.cs deep/bait.md` inside a worktree is allowed, and the test that pins today's
       Deny is rewritten to expect Allow
-- [ ] Every link denial the suite makes today still denies
+- [x] Every link denial the suite makes today still denies
 
 ## Out of scope
 
@@ -78,3 +78,7 @@ Every command form already carries its kind, so the guard can read it:
 
 - Found in review of pull request #296 (backlog 083 redelivery)
 - The reasoning lives in the `Add-AgentLinkTargetCandidate` comment; keep the two in step
+- Delivered in pull request #304. `Get-AgentLinkKind` reads the kind, and
+  `Add-AgentLinkTargetCandidate` takes a `-Kind` parameter
+- A junction is read as an unknown kind on purpose. The Microsoft articles on junctions do not
+  say how a relative target is anchored, so a junction keeps all three anchors

--- a/backlog/done/086-guard-reads-the-link-kind-before-anchoring-a-relative-target.md
+++ b/backlog/done/086-guard-reads-the-link-kind-before-anchoring-a-relative-target.md
@@ -5,7 +5,7 @@
 - **Epic**: Agent guardrails
 - **Type**: Feature
 - **Interfaces**: none (agent git guard)
-- **Stage**: 9-ship
+- **Stage**: 8-review
 - **Difficulty**: moderate
 
 ## Summary

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -2037,13 +2037,15 @@ function Add-AgentLinkTargetCandidate {
     $isAbsolute = $target -match '^([A-Za-z]:|[\\/])'
 
     $link = [string] $LinkPath
-    $hasLink = -not [string]::IsNullOrWhiteSpace($link)
 
-    if ($isAbsolute -or -not $hasLink -or $Kind -ne 'Symbolic') {
+    # Nothing to anchor to, or nothing to anchor: one candidate, whatever the kind.
+    if ($isAbsolute -or [string]::IsNullOrWhiteSpace($link)) {
         [void] $Sink.Add($target)
+        return
     }
 
-    if ($isAbsolute -or -not $hasLink -or $Kind -eq 'Hard') { return }
+    if ($Kind -ne 'Symbolic') { [void] $Sink.Add($target) }
+    if ($Kind -eq 'Hard') { return }
 
     # The link path names a directory the link is created inside.
     [void] $Sink.Add((Join-Path $link $target))

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1918,53 +1918,132 @@ function Get-AgentMoveArgumentSet {
 
 <#
 .SYNOPSIS
+Which kind of link a command creates: 'Symbolic', 'Hard', or 'Unknown'.
+
+.DESCRIPTION
+The kind decides how the operating system anchors a RELATIVE target, so
+Add-AgentLinkTargetCandidate below cannot pick its anchors without it. Every command form the
+guard treats as a link command carries the kind in its own arguments:
+
+  ln       -s, --symbolic, or a cluster holding 's'; a hard link otherwise
+  cp       -s / --symbolic-link, or -l / --link
+  mklink   /h hard, /j junction, /d or nothing symbolic
+
+'Unknown' is the fail-closed answer, and three things produce it: a junction, whose anchor this
+guard has not proved; two kind flags in one command; and any other leaf. Add-AgentLinkTargetCandidate
+keeps every anchor for 'Unknown', which is what the guard did for every kind before it could read
+one.
+
+The short-option matches are case-sensitive, for the reason Test-AgentGuardHasLinkFlag is: -S is
+--suffix and -L is --dereference, and neither names a link. The walk stops at '--' and steps over
+the value of -t, so an operand named '-s.md' is not read as an option.
+#>
+function Get-AgentLinkKind {
+    param([string] $Leaf, [string[]] $Arguments)
+
+    $list = @($Arguments)
+
+    if ($Leaf -eq 'mklink') {
+        # Matched without case: cmd accepts /H and /h alike, and a Git Bash caller writes /D.
+        $hard = @($list | Where-Object { $_ -ieq '/h' }).Count -gt 0
+        $junction = @($list | Where-Object { $_ -ieq '/j' }).Count -gt 0
+        $directory = @($list | Where-Object { $_ -ieq '/d' }).Count -gt 0
+
+        if ($junction) { return 'Unknown' }
+        if ($hard -and $directory) { return 'Unknown' }
+        if ($hard) { return 'Hard' }
+        return 'Symbolic'
+    }
+
+    if ($Leaf -ne 'ln' -and $Leaf -ne 'cp') { return 'Unknown' }
+
+    $symbolic = $false
+    $hard = $false
+    $afterDoubleDash = $false
+
+    for ($i = 0; $i -lt $list.Count; $i++) {
+        $argument = [string] $list[$i]
+
+        if ($afterDoubleDash) { continue }
+        if ($argument -ceq '--') { $afterDoubleDash = $true; continue }
+        if ($argument -notlike '-*') { continue }
+
+        # -t takes the next token as its value, so that token is not an option of its own.
+        $spelling = Read-AgentTargetDirectoryToken -Argument $argument
+        if ($null -ne $spelling -and $spelling.TakesNextToken) { $i++ }
+
+        if ($argument -ceq '--symbolic' -or $argument -ceq '--symbolic-link') { $symbolic = $true; continue }
+        if ($argument -ceq '--link') { $hard = $true; continue }
+
+        # Any other long option is a name, not a cluster: --suffix must not read as -s.
+        if ($argument -clike '--*') { continue }
+
+        if ($argument -cmatch '^-[a-zA-Z]*s') { $symbolic = $true }
+        if ($Leaf -eq 'cp' -and $argument -cmatch '^-[a-zA-Z]*l') { $hard = $true }
+    }
+
+    if ($symbolic -and $hard) { return 'Unknown' }
+    if ($symbolic) { return 'Symbolic' }
+    if ($hard) { return 'Hard' }
+
+    # ln without -s makes a hard link. cp only reaches this reader with a link flag, so no flag
+    # here means the flag was spelled in a way this walk did not read: fail closed.
+    if ($Leaf -eq 'ln') { return 'Hard' }
+    return 'Unknown'
+}
+
+<#
+.SYNOPSIS
 Adds every path a link target could mean to a write-target list.
 
 .DESCRIPTION
-Windows resolves a RELATIVE link target against the directory holding the link, not against the
-working directory (see the CreateSymbolicLink reference, and the same note on
-Resolve-AgentSymlinkPath below). The resolver this guard uses anchors a relative write target to
-the working directory instead, so one anchor is not enough: `ln -s ../../../../../README.md
-deep/dir/x` walks ABOVE the checkout from the working directory and INTO it from the link's own
-directory. Anchoring one way only would allow that link.
+A RELATIVE link target names different files for different link kinds, and the resolver this
+guard uses anchors every relative write target to the working directory. So the anchor has to be
+chosen here, from the kind Get-AgentLinkKind read:
 
-So a relative target is offered three ways - as written, joined to the link path, and joined to
-the link path's parent - and whichever one lands in the main checkout produces the denial. All
-three are paths, so this over-reports only paths, which is the safe direction for this grammar.
+  Symbolic   Windows resolves the target against the directory holding the link, so the target
+             is joined to the link path and to the link path's parent. One of the two is right,
+             and which one depends on whether the link path names a directory or the link file
+             itself, which the guard cannot know. Without these anchors
+             `ln -s ../../../../../README.md deep/dir/x` walks ABOVE the checkout from the
+             working directory and INTO it from the link's own directory, and would be allowed.
+  Hard       A hard link names an existing file when it is created, so the target resolves
+             against the working directory. That is what the as-written anchor is:
+             `ln ../README.md deep/bait.md` names <main>\.claude\worktrees\README.md, and only
+             this anchor reaches it.
+  Unknown    Every anchor, which is what the guard emitted for every kind before it read the
+             kind. It over-reports paths, which is the safe direction for this grammar.
 
-The as-written anchor stays even though Windows never resolves a SYMBOLIC link that way, because
-a HARD link resolves its source exactly that way: `ln ../README.md deep/bait.md` names
-<main>\.claude\worktrees\README.md, and only the as-written anchor reaches it. Drop that anchor
-and the hard link is allowed, which hands the session a second name for a file in the main
-checkout. Reading the link kind first would let each form keep only its own anchor, and backlog
-086 holds that work.
-
-The cost of keeping all three is a real over-report, and it is not theoretical: `ln -s ../src/a.cs
-deep/bait.md` from the worktree root stays inside the worktree, and the guard still refuses it.
-The message then names a main-checkout path that no write would have landed on. Use a target with
-no '..' in it, or an absolute one. Both directions are pinned by tests.
-
-An absolute target means the same file from every directory, so it is added once.
+Two cases stay fail-closed whatever the kind. An absolute target means the same file from every
+directory, so it is added once. A blank link path leaves nothing to join to, so the as-written
+anchor is added rather than nothing - emitting nothing would drop the target from the scan
+entirely, and an under-report silently disables the rule.
 #>
 function Add-AgentLinkTargetCandidate {
     param(
         [string] $LinkPath,
         [string] $Target,
+        [ValidateSet('Symbolic', 'Hard', 'Unknown')]
+        [string] $Kind = 'Unknown',
         [System.Collections.Generic.List[string]] $Sink
     )
 
     $target = [string] $Target
     if ([string]::IsNullOrWhiteSpace($target)) { return }
 
-    [void] $Sink.Add($target)
-
     # Tested with a pattern rather than [System.IO.Path]::IsPathRooted, which throws on Windows
     # PowerShell 5.1 for characters that host rejects outright. A throw here would escape into the
     # entrypoint's catch, and that catch ALLOWS the write.
-    if ($target -match '^([A-Za-z]:|[\\/])') { return }
+    $isAbsolute = $target -match '^([A-Za-z]:|[\\/])'
 
     $link = [string] $LinkPath
-    if ([string]::IsNullOrWhiteSpace($link)) { return }
+    $hasLink = -not [string]::IsNullOrWhiteSpace($link)
+
+    if ($isAbsolute -or -not $hasLink -or $Kind -ne 'Symbolic') {
+        [void] $Sink.Add($target)
+    }
+
+    if ($isAbsolute -or -not $hasLink -or $Kind -eq 'Hard') { return }
 
     # The link path names a directory the link is created inside.
     [void] $Sink.Add((Join-Path $link $target))
@@ -1992,6 +2071,7 @@ function Get-AgentLinkWriteTarget {
     param([string] $Leaf, [string[]] $Arguments)
 
     $found = New-Object System.Collections.Generic.List[string]
+    $kind = Get-AgentLinkKind -Leaf $Leaf -Arguments $Arguments
 
     if ($Leaf -eq 'mklink') {
         # mklink [[/d] | [/h] | [/j]] <link> <target>. All three options are switches: none of
@@ -2002,7 +2082,7 @@ function Get-AgentLinkWriteTarget {
         if ($linkOperands.Count -ge 1) { [void] $found.Add([string] $linkOperands[0]) }
         if ($linkOperands.Count -ge 2) {
             Add-AgentLinkTargetCandidate -LinkPath ([string] $linkOperands[0]) `
-                -Target ([string] $linkOperands[1]) -Sink $found
+                -Target ([string] $linkOperands[1]) -Kind $kind -Sink $found
         }
         return $found.ToArray()
     }
@@ -2015,7 +2095,8 @@ function Get-AgentLinkWriteTarget {
     if ($null -ne $targetDirectory) {
         [void] $found.Add($targetDirectory)
         foreach ($operand in $operands) {
-            Add-AgentLinkTargetCandidate -LinkPath $targetDirectory -Target ([string] $operand) -Sink $found
+            Add-AgentLinkTargetCandidate -LinkPath $targetDirectory -Target ([string] $operand) `
+                -Kind $kind -Sink $found
         }
         return $found.ToArray()
     }
@@ -2031,7 +2112,8 @@ function Get-AgentLinkWriteTarget {
     $linkPath = [string] $operands[$operands.Count - 1]
     [void] $found.Add($linkPath)
     foreach ($operand in ($operands | Select-Object -SkipLast 1)) {
-        Add-AgentLinkTargetCandidate -LinkPath $linkPath -Target ([string] $operand) -Sink $found
+        Add-AgentLinkTargetCandidate -LinkPath $linkPath -Target ([string] $operand) `
+            -Kind $kind -Sink $found
     }
     return $found.ToArray()
 }
@@ -2050,6 +2132,12 @@ meet AgentGuardUnexpandablePattern, and be refused as an unresolved write target
 Three things decide the gate. A named link kind reads the value. A named non-link kind does not.
 An ItemType the guard cannot expand - a variable - could still be a link, so it reads the value
 and fails closed. No -ItemType at all creates a file, so it reads nothing.
+
+The item type also names the anchor for a relative target. New-Item stores a SymbolicLink target
+as written - `-Target .\Notice.txt` reads back as `.\Notice.txt` - so Windows resolves it against
+the directory holding the link. A HardLink names an existing file, so its value resolves against
+the working directory. A Junction, and an item type the guard cannot expand, both fall to
+'Unknown', which keeps every anchor.
 #>
 function Get-AgentNewItemLinkTarget {
     param([string[]] $Arguments, [string] $LinkPath)
@@ -2069,7 +2157,13 @@ function Get-AgentNewItemLinkTarget {
     $linkTarget = Get-AgentPrefixedParameterValue -Arguments $Arguments -Names @('Target', 'Value')
     if ($null -eq $linkTarget) { return $found.ToArray() }
 
-    Add-AgentLinkTargetCandidate -LinkPath $LinkPath -Target $linkTarget -Sink $found
+    $linkKind = switch ($kind) {
+        'symboliclink' { 'Symbolic' }
+        'hardlink' { 'Hard' }
+        default { 'Unknown' }
+    }
+
+    Add-AgentLinkTargetCandidate -LinkPath $LinkPath -Target $linkTarget -Kind $linkKind -Sink $found
     return $found.ToArray()
 }
 

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1947,6 +1947,16 @@ function Test-AgentLongOptionPrefix {
     return $false
 }
 
+# The options of ln and cp that need a value. A value is not an option, so the kind reader has to
+# step over it: `ln -S -s x y` sets the SUFFIX to '-s' and makes a hard link, and `ln -tsub x`
+# sets the target directory to 'sub'. Reading either value as a flag names the wrong kind, and a
+# wrong kind removes an anchor.
+#
+# Case matters. -S is --suffix and -s is --symbolic. -t is --target-directory and -T is
+# --no-target-directory, which needs no value.
+$script:AgentGuardValueOptionLetters = 'St'
+$script:AgentGuardValueOptionNames = @('--suffix', '--target-directory')
+
 <#
 .SYNOPSIS
 Which kind of link a command creates: 'Symbolic', 'Hard', or 'Unknown'.
@@ -1974,9 +1984,13 @@ The short-option matches are case-sensitive, for the reason Test-AgentGuardHasLi
 --suffix and -L is --dereference, and neither names a link. -r is read for ln only, because the
 same letter is --recursive for cp.
 
-Two things keep an operand out of the option walk. The walk stops at '--'. And -t names a
-directory whose value is either the next token or attached to this one, so neither is read as an
-option: `ln -tsub x` is -t with the value 'sub', not a cluster holding 's'.
+Two things keep a token out of the option walk. The walk stops at '--'. And an option that needs
+a value takes the rest of its own token, or the whole next token, and neither is an option any
+more. That is what AgentGuardValueOptionLetters above is for:
+
+  ln -tsub x        -t with the value 'sub'. Not a cluster holding 's'.
+  ln -S -s x y      -S with the value '-s'. A HARD link, not a symbolic one.
+  ln --suffix -s x  the same, spelled long.
 
 This walk repeats part of Get-AgentMoveArgumentSet, and it is not folded into that reader's
 Options array on purpose. That array keeps '-tsub' whole, so the attached value would still need
@@ -2024,23 +2038,36 @@ function Get-AgentLinkKind {
         if ($argument -ceq '--') { $afterDoubleDash = $true; continue }
         if ($argument -notlike '-*') { continue }
 
-        # The cluster is what carries the kind letters. It is the whole token, unless -t took part
-        # of the token as its value.
-        $cluster = $argument
-        $spelling = Read-AgentTargetDirectoryToken -Argument $argument
-        if ($null -ne $spelling) {
-            if ($spelling.TakesNextToken) { $i++ }
-            elseif ($argument -cnotlike '--*' -and $argument -cmatch '^-([a-zA-Z]*?)t') {
-                $cluster = '-' + $Matches[1] + 't'
-            }
-        }
-
         if ($argument -clike '--*') {
+            # A long option that needs a value takes it attached after '=', or as the next token.
+            if ($argument -cnotlike '*=*' -and
+                (Test-AgentLongOptionPrefix -Token $argument -Names $script:AgentGuardValueOptionNames)) {
+                $i++
+            }
+
             if (Test-AgentLongOptionPrefix -Token $argument -Names $symbolicNames) { $symbolic = $true }
             if (Test-AgentLongOptionPrefix -Token $argument -Names $hardNames) { $hard = $true }
             if (Test-AgentLongOptionPrefix -Token $argument -Names $relativeNames) { $relative = $true }
             continue
         }
+
+        # Read the short cluster letter by letter. The first letter that needs a value ends it:
+        # the rest of the token is that value, and an empty rest takes the next token instead.
+        # Everything the value covers stops being an option, which is what makes `ln -S -s x y`
+        # a HARD link with the suffix '-s'.
+        $letters = $argument.Substring(1)
+        $cluster = ''
+        for ($j = 0; $j -lt $letters.Length; $j++) {
+            $letter = [string] $letters[$j]
+            if ($letter -cnotmatch '[a-zA-Z]') { break }
+
+            $cluster += $letter
+            if ($script:AgentGuardValueOptionLetters.Contains($letter)) {
+                if ($j -eq ($letters.Length - 1)) { $i++ }
+                break
+            }
+        }
+        $cluster = '-' + $cluster
 
         if ($cluster -cmatch '^-[a-zA-Z]*s') { $symbolic = $true }
         if ($Leaf -eq 'cp' -and $cluster -cmatch '^-[a-zA-Z]*l') { $hard = $true }

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1918,6 +1918,37 @@ function Get-AgentMoveArgumentSet {
 
 <#
 .SYNOPSIS
+True when a long option token is a spelling of one of the given option names.
+
+.DESCRIPTION
+GNU getopt_long accepts any abbreviation of a long option that is still unambiguous, so `ln
+--sym` is `ln --symbolic` and `cp --lin` is `cp --link`. An exact-match reader calls those
+options unknown, and for a kind reader that is a hole rather than a wart: a symbolic link read
+as hard loses the anchors that catch it.
+
+So a token counts when the full name STARTS WITH it. An abbreviation short enough to be
+ambiguous, such as '--s', is accepted too. The real command would refuse to run, so the only
+cost is reading a kind for a command that never executes.
+
+Case-sensitive, because long options are.
+#>
+function Test-AgentLongOptionPrefix {
+    param([string] $Token, [string[]] $Names)
+
+    # '--' alone ends the options and names nothing.
+    if ($Token.Length -le 2) { return $false }
+
+    # A leaf with no option of this kind passes an empty list, and PowerShell hands an empty
+    # array to a [string[]] parameter as $null, which @() then turns into one $null element.
+    foreach ($name in @($Names)) {
+        if ([string]::IsNullOrEmpty($name)) { continue }
+        if ($name.StartsWith($Token, [System.StringComparison]::Ordinal)) { return $true }
+    }
+    return $false
+}
+
+<#
+.SYNOPSIS
 Which kind of link a command creates: 'Symbolic', 'Hard', or 'Unknown'.
 
 .DESCRIPTION
@@ -1929,14 +1960,29 @@ guard treats as a link command carries the kind in its own arguments:
   cp       -s / --symbolic-link, or -l / --link
   mklink   /h hard, /j junction, /d or nothing symbolic
 
-'Unknown' is the fail-closed answer, and three things produce it: a junction, whose anchor this
-guard has not proved; two kind flags in one command; and any other leaf. Add-AgentLinkTargetCandidate
-keeps every anchor for 'Unknown', which is what the guard did for every kind before it could read
-one.
+'Unknown' is the fail-closed answer. Add-AgentLinkTargetCandidate keeps every anchor for it,
+which is what the guard did for every kind before it could read one. Five things produce it:
+
+  - a junction, whose anchor this guard has not proved
+  - ln's -r / --relative, which resolves the target against the working directory and THEN
+    rewrites it, so the as-written anchor is right and the joined ones are too
+  - two kind flags in one command
+  - a cp that reached this reader with no flag this walk could read
+  - any other leaf
 
 The short-option matches are case-sensitive, for the reason Test-AgentGuardHasLinkFlag is: -S is
---suffix and -L is --dereference, and neither names a link. The walk stops at '--' and steps over
-the value of -t, so an operand named '-s.md' is not read as an option.
+--suffix and -L is --dereference, and neither names a link. -r is read for ln only, because the
+same letter is --recursive for cp.
+
+Two things keep an operand out of the option walk. The walk stops at '--'. And -t names a
+directory whose value is either the next token or attached to this one, so neither is read as an
+option: `ln -tsub x` is -t with the value 'sub', not a cluster holding 's'.
+
+This walk repeats part of Get-AgentMoveArgumentSet, and it is not folded into that reader's
+Options array on purpose. That array keeps '-tsub' whole, so the attached value would still need
+stripping here, and it holds a separated -t value as its own element, so a directory named
+'-slow' would read as a cluster. The reader that decides the kind has to skip both, and a wrong
+kind removes an anchor rather than adding one.
 #>
 function Get-AgentLinkKind {
     param([string] $Leaf, [string[]] $Arguments)
@@ -1945,9 +1991,14 @@ function Get-AgentLinkKind {
 
     if ($Leaf -eq 'mklink') {
         # Matched without case: cmd accepts /H and /h alike, and a Git Bash caller writes /D.
-        $hard = @($list | Where-Object { $_ -ieq '/h' }).Count -gt 0
-        $junction = @($list | Where-Object { $_ -ieq '/j' }).Count -gt 0
-        $directory = @($list | Where-Object { $_ -ieq '/d' }).Count -gt 0
+        $hard = $false
+        $junction = $false
+        $directory = $false
+        foreach ($argument in $list) {
+            if ($argument -ieq '/h') { $hard = $true }
+            elseif ($argument -ieq '/j') { $junction = $true }
+            elseif ($argument -ieq '/d') { $directory = $true }
+        }
 
         if ($junction) { return 'Unknown' }
         if ($hard -and $directory) { return 'Unknown' }
@@ -1957,8 +2008,13 @@ function Get-AgentLinkKind {
 
     if ($Leaf -ne 'ln' -and $Leaf -ne 'cp') { return 'Unknown' }
 
+    $symbolicNames = if ($Leaf -eq 'cp') { @('--symbolic-link') } else { @('--symbolic') }
+    $hardNames = if ($Leaf -eq 'cp') { @('--link') } else { @() }
+    $relativeNames = if ($Leaf -eq 'ln') { @('--relative') } else { @() }
+
     $symbolic = $false
     $hard = $false
+    $relative = $false
     $afterDoubleDash = $false
 
     for ($i = 0; $i -lt $list.Count; $i++) {
@@ -1968,20 +2024,30 @@ function Get-AgentLinkKind {
         if ($argument -ceq '--') { $afterDoubleDash = $true; continue }
         if ($argument -notlike '-*') { continue }
 
-        # -t takes the next token as its value, so that token is not an option of its own.
+        # The cluster is what carries the kind letters. It is the whole token, unless -t took part
+        # of the token as its value.
+        $cluster = $argument
         $spelling = Read-AgentTargetDirectoryToken -Argument $argument
-        if ($null -ne $spelling -and $spelling.TakesNextToken) { $i++ }
+        if ($null -ne $spelling) {
+            if ($spelling.TakesNextToken) { $i++ }
+            elseif ($argument -cnotlike '--*' -and $argument -cmatch '^-([a-zA-Z]*?)t') {
+                $cluster = '-' + $Matches[1] + 't'
+            }
+        }
 
-        if ($argument -ceq '--symbolic' -or $argument -ceq '--symbolic-link') { $symbolic = $true; continue }
-        if ($argument -ceq '--link') { $hard = $true; continue }
+        if ($argument -clike '--*') {
+            if (Test-AgentLongOptionPrefix -Token $argument -Names $symbolicNames) { $symbolic = $true }
+            if (Test-AgentLongOptionPrefix -Token $argument -Names $hardNames) { $hard = $true }
+            if (Test-AgentLongOptionPrefix -Token $argument -Names $relativeNames) { $relative = $true }
+            continue
+        }
 
-        # Any other long option is a name, not a cluster: --suffix must not read as -s.
-        if ($argument -clike '--*') { continue }
-
-        if ($argument -cmatch '^-[a-zA-Z]*s') { $symbolic = $true }
-        if ($Leaf -eq 'cp' -and $argument -cmatch '^-[a-zA-Z]*l') { $hard = $true }
+        if ($cluster -cmatch '^-[a-zA-Z]*s') { $symbolic = $true }
+        if ($Leaf -eq 'cp' -and $cluster -cmatch '^-[a-zA-Z]*l') { $hard = $true }
+        if ($Leaf -eq 'ln' -and $cluster -cmatch '^-[a-zA-Z]*r') { $relative = $true }
     }
 
+    if ($relative) { return 'Unknown' }
     if ($symbolic -and $hard) { return 'Unknown' }
     if ($symbolic) { return 'Symbolic' }
     if ($hard) { return 'Hard' }
@@ -2007,6 +2073,11 @@ chosen here, from the kind Get-AgentLinkKind read:
              itself, which the guard cannot know. Without these anchors
              `ln -s ../../../../../README.md deep/dir/x` walks ABOVE the checkout from the
              working directory and INTO it from the link's own directory, and would be allowed.
+             A link path with no directory part is the exception that keeps the as-written form:
+             `ln -s ../README.md b.md` puts the link in the WORKING directory, so the directory
+             holding the link and the working directory are the same one, and the as-written
+             form is the anchor that names it. Split-Path returns no parent there, so dropping
+             the as-written form would leave one anchor, and that one points a level too deep.
   Hard       A hard link names an existing file when it is created, so the target resolves
              against the working directory. That is what the as-written anchor is:
              `ln ../README.md deep/bait.md` names <main>\.claude\worktrees\README.md, and only
@@ -2050,10 +2121,15 @@ function Add-AgentLinkTargetCandidate {
     # The link path names a directory the link is created inside.
     [void] $Sink.Add((Join-Path $link $target))
 
-    # The link path names the link file itself, so its parent holds the link.
+    # The link path names the link file itself, so its parent holds the link. A bare name has no
+    # parent, and its holder is the working directory: that is the as-written form, which a
+    # symbolic kind has not added yet.
     $parent = Split-Path -Parent $link
     if (-not [string]::IsNullOrWhiteSpace($parent)) {
         [void] $Sink.Add((Join-Path $parent $target))
+    }
+    elseif ($Kind -eq 'Symbolic') {
+        [void] $Sink.Add($target)
     }
 }
 

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -1962,14 +1962,106 @@ try {
         @{ Name = 'an empty target adds nothing'
             LinkPath = 'link.md'; Target = ''
             Expected = @()
+        },
+        # The kind picks the anchors. Every case above leaves -Kind at its default, so these pin
+        # the two kinds that drop an anchor.
+        #
+        # A parentless link path is the case that has to keep the as-written form even when the
+        # kind is Symbolic. The link file sits in the WORKING DIRECTORY, so the directory holding
+        # the link and the working directory are the same one, and the as-written form is the
+        # anchor that names it. Dropping it would leave one anchor, and that one is wrong.
+        @{ Name = 'a parentless symbolic link anchors to the working directory'
+            LinkPath = 'link.md'; Target = '..\README.md'; Kind = 'Symbolic'
+            Expected = @('link.md\..\README.md', '..\README.md')
+        },
+        @{ Name = 'a nested symbolic link uses the two joined forms'
+            LinkPath = 'deep\x.md'; Target = '..\..\README.md'; Kind = 'Symbolic'
+            Expected = @('deep\x.md\..\..\README.md', 'deep\..\..\README.md')
+        },
+        @{ Name = 'a hard link uses the working-directory form only'
+            LinkPath = 'deep\x.md'; Target = '..\..\README.md'; Kind = 'Hard'
+            Expected = @('..\..\README.md')
+        },
+        @{ Name = 'a parentless hard link uses the working-directory form too'
+            LinkPath = 'link.md'; Target = '..\README.md'; Kind = 'Hard'
+            Expected = @('..\README.md')
+        },
+        @{ Name = 'an absolute target says the same thing whatever the kind'
+            LinkPath = 'link.md'; Target = 'C:\repo\README.md'; Kind = 'Symbolic'
+            Expected = @('C:\repo\README.md')
+        },
+        @{ Name = 'a blank link path keeps the target whatever the kind'
+            LinkPath = ''; Target = '..\README.md'; Kind = 'Symbolic'
+            Expected = @('..\README.md')
         }
     )
 
     foreach ($case in $linkCandidateCases) {
         Invoke-TestCase "Link candidate: $($case.Name)" {
             $sink = New-Object System.Collections.Generic.List[string]
-            Add-AgentLinkTargetCandidate -LinkPath $case.LinkPath -Target $case.Target -Sink $sink
+            if ($case.ContainsKey('Kind')) {
+                Add-AgentLinkTargetCandidate -LinkPath $case.LinkPath -Target $case.Target `
+                    -Kind $case.Kind -Sink $sink
+            }
+            else {
+                Add-AgentLinkTargetCandidate -LinkPath $case.LinkPath -Target $case.Target -Sink $sink
+            }
             Assert-Equal ($case.Expected -join '|') ($sink.ToArray() -join '|') 'Candidates'
+        }
+    }
+
+    Write-Host 'Link kind reading' -ForegroundColor Cyan
+
+    # The kind decides which anchors survive, so a misread kind is a hole in both directions: a
+    # symbolic link read as hard loses the two anchors that catch it, and a hard link read as
+    # symbolic loses the only anchor that catches it.
+    $linkKindCases = @(
+        @{ Leaf = 'ln'; Arguments = @('-s'); Expected = 'Symbolic' },
+        @{ Leaf = 'ln'; Arguments = @('-sf'); Expected = 'Symbolic' },
+        @{ Leaf = 'ln'; Arguments = @(); Expected = 'Hard' },
+        @{ Leaf = 'ln'; Arguments = @('-f'); Expected = 'Hard' },
+        @{ Leaf = 'ln'; Arguments = @('--symbolic'); Expected = 'Symbolic' },
+        # GNU accepts any unambiguous abbreviation of a long option, so an exact-match reader
+        # calls a real symbolic link hard and drops the anchors that catch it.
+        @{ Leaf = 'ln'; Arguments = @('--sym'); Expected = 'Symbolic' },
+        @{ Leaf = 'ln'; Arguments = @('--symb'); Expected = 'Symbolic' },
+        # -t carries its value ATTACHED here, so the 's' belongs to the directory name, not to a
+        # cluster. '-ts sub' is the same option with 's' as the value.
+        @{ Leaf = 'ln'; Arguments = @('-tsub'); Expected = 'Hard' },
+        @{ Leaf = 'ln'; Arguments = @('-ts', 'sub'); Expected = 'Hard' },
+        # -t takes the NEXT token here, and the cluster really does hold -s.
+        @{ Leaf = 'ln'; Arguments = @('-st', 'out'); Expected = 'Symbolic' },
+        # --relative resolves the target against the working directory before it rewrites it, so
+        # neither anchor alone is right and the reader falls back to all of them.
+        @{ Leaf = 'ln'; Arguments = @('-sr'); Expected = 'Unknown' },
+        @{ Leaf = 'ln'; Arguments = @('-s', '--relative'); Expected = 'Unknown' },
+        @{ Leaf = 'ln'; Arguments = @('-s', '--rel'); Expected = 'Unknown' },
+        # '--' ends the options, so an operand that looks like a flag is not one.
+        @{ Leaf = 'ln'; Arguments = @('--', '-s.md', 'link.md'); Expected = 'Hard' },
+        @{ Leaf = 'cp'; Arguments = @('-s'); Expected = 'Symbolic' },
+        @{ Leaf = 'cp'; Arguments = @('-l'); Expected = 'Hard' },
+        @{ Leaf = 'cp'; Arguments = @('--symbolic-link'); Expected = 'Symbolic' },
+        @{ Leaf = 'cp'; Arguments = @('--sym'); Expected = 'Symbolic' },
+        @{ Leaf = 'cp'; Arguments = @('--link'); Expected = 'Hard' },
+        @{ Leaf = 'cp'; Arguments = @('--lin'); Expected = 'Hard' },
+        # -r is RECURSIVE for cp, not relative, so it changes no kind.
+        @{ Leaf = 'cp'; Arguments = @('-rs'); Expected = 'Symbolic' },
+        @{ Leaf = 'cp'; Arguments = @('-al'); Expected = 'Hard' },
+        @{ Leaf = 'cp'; Arguments = @('-ls'); Expected = 'Unknown' },
+        # Case matters: -S is --suffix and -L is --dereference.
+        @{ Leaf = 'cp'; Arguments = @('-S', '.bak', '-l'); Expected = 'Hard' },
+        @{ Leaf = 'mklink'; Arguments = @('link.md', 'target.md'); Expected = 'Symbolic' },
+        @{ Leaf = 'mklink'; Arguments = @('/D', 'linkdir', 'targetdir'); Expected = 'Symbolic' },
+        @{ Leaf = 'mklink'; Arguments = @('/h', 'link.md', 'target.md'); Expected = 'Hard' },
+        @{ Leaf = 'mklink'; Arguments = @('/J', 'linkdir', 'targetdir'); Expected = 'Unknown' },
+        @{ Leaf = 'rm'; Arguments = @('-rf'); Expected = 'Unknown' }
+    )
+
+    foreach ($case in $linkKindCases) {
+        $spelling = ($case.Arguments -join ' ')
+        Invoke-TestCase "Link kind: $($case.Leaf) $spelling" {
+            $kind = Get-AgentLinkKind -Leaf $case.Leaf -Arguments $case.Arguments
+            Assert-Equal $case.Expected $kind 'Kind'
         }
     }
 
@@ -2039,7 +2131,9 @@ try {
         # against the directory holding the link, so a symbolic form reports the joined anchors
         # and not the target as written. A hard link resolves its source against the working
         # directory, so it reports the target as written and nothing joined.
-        @{ Command = 'ln -s a.md b.md'; Expected = @('b.md', 'b.md\a.md') },
+        # 'b.md' has no directory part, so the directory holding the link is the working
+        # directory, and the as-written form is the anchor that names it.
+        @{ Command = 'ln -s a.md b.md'; Expected = @('b.md', 'b.md\a.md', 'a.md') },
         @{ Command = 'ln a.md b.md'; Expected = @('b.md', 'a.md') },
         @{ Command = 'ln -s C:\repo\README.md b.md'; Expected = @('b.md', 'C:\repo\README.md') },
         # With -t every operand is a link target and the named directory holds the links.
@@ -2047,11 +2141,11 @@ try {
             Expected = @('out', 'a.md', 'b.md')
         },
         # The kind reads out of a cluster that also carries -t.
-        @{ Command = 'ln -st out a.md'; Expected = @('out', 'out\a.md') },
+        @{ Command = 'ln -st out a.md'; Expected = @('out', 'out\a.md', 'a.md') },
         # '--' keeps a target whose own name begins with a dash, and ends the option walk: an
         # operand named '-s.md' after it must not be read as the symbolic flag.
         @{ Command = 'ln -s -- -a.md link.md'
-            Expected = @('link.md', 'link.md\-a.md')
+            Expected = @('link.md', 'link.md\-a.md', '-a.md')
         },
         @{ Command = 'ln -- -s.md link.md'; Expected = @('link.md', '-s.md') },
         # One operand names a link in the working directory and nothing else.
@@ -2079,14 +2173,14 @@ try {
         },
         # cp --link and cp --symbolic-link create links, so they carry the same hole as ln.
         @{ Command = 'cp -l a.md b.md'; Expected = @('b.md', 'a.md') },
-        @{ Command = 'cp -s a.md b.md'; Expected = @('b.md', 'b.md\a.md') },
+        @{ Command = 'cp -s a.md b.md'; Expected = @('b.md', 'b.md\a.md', 'a.md') },
         @{ Command = 'cp --link a.md b.md'; Expected = @('b.md', 'a.md') },
         @{ Command = 'cp --symbolic-link a.md b.md'
-            Expected = @('b.md', 'b.md\a.md')
+            Expected = @('b.md', 'b.md\a.md', 'a.md')
         },
         # Short options cluster. A literal list of four spellings would miss every one of these.
         @{ Command = 'cp -al a.md b.md'; Expected = @('b.md', 'a.md') },
-        @{ Command = 'cp -rs a.md b.md'; Expected = @('b.md', 'b.md\a.md') },
+        @{ Command = 'cp -rs a.md b.md'; Expected = @('b.md', 'b.md\a.md', 'a.md') },
         # Two kind flags in one command name no single kind, so every anchor stays.
         @{ Command = 'cp -ls a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
         # Case matters: -S is --suffix, a different option that names no link.
@@ -2147,7 +2241,7 @@ try {
         # directory holding the link, so the symbolic form joins to it once and has no parent to
         # join to as well.
         @{ Command = 'New-Item -Path deep -Name link.md -ItemType SymbolicLink -Target ..\README.md'
-            Expected = @('deep', 'deep\link.md', 'deep\..\README.md')
+            Expected = @('deep', 'deep\link.md', 'deep\..\README.md', '..\README.md')
         },
         @{ Command = 'Copy-Item a.txt -Destination b.txt'; Expected = @('b.txt') },
         @{ Command = 'rm a.txt b.txt'; Expected = @('a.txt', 'b.txt') },
@@ -3234,6 +3328,42 @@ try {
         # An item type the guard cannot expand could be any kind, so every anchor stays.
         @{ Name = 'a relative link whose kind the guard cannot read stays fail-closed'
             Command = 'New-Item -ItemType $type -Path deep\bait.md -Target ..\README.md'
+            Action = 'Deny'
+        },
+        # A link created in the working directory itself. The directory holding the link IS the
+        # working directory, so the as-written form is the anchor that names the real target, and
+        # a symbolic kind has to keep it.
+        @{ Name = 'a parentless relative symbolic link into main'
+            Command = 'ln -s ../README.md b.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'a parentless relative New-Item symbolic link into main'
+            Command = 'New-Item -ItemType SymbolicLink -Path bait.md -Target ..\README.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'a parentless relative mklink symbolic link into main'
+            Command = 'cmd /c mklink bait.md ..\README.md'
+            Action = 'Deny'
+        },
+        # The same command the -s spelling denies, written the way GNU also accepts.
+        @{ Name = 'an abbreviated symbolic flag is still symbolic'
+            Command = 'ln --sym ../../../../README.md deep/bait.md'
+            Action = 'Deny'
+        },
+        # -t carries its value attached, so the 's' names a directory and not a symbolic link.
+        # This is a HARD link, and only the as-written anchor catches it.
+        @{ Name = 'an attached -t value is not read as the symbolic flag'
+            Command = 'ln -tsub ../README.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'a split -t value is not read as the symbolic flag'
+            Command = 'ln -ts sub ../README.md'
+            Action = 'Deny'
+        },
+        # --relative resolves the target against the working directory first, so the as-written
+        # anchor is the one that catches it.
+        @{ Name = 'a relative-mode symbolic link stays fail-closed'
+            Command = 'ln -sr ../README.md deep/bait.md'
             Action = 'Deny'
         },
         # The gate from Task 5, proved at the decision layer: content is not a path.

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -2038,6 +2038,19 @@ try {
         @{ Leaf = 'ln'; Arguments = @('-s', '--rel'); Expected = 'Unknown' },
         # '--' ends the options, so an operand that looks like a flag is not one.
         @{ Leaf = 'ln'; Arguments = @('--', '-s.md', 'link.md'); Expected = 'Hard' },
+        # -S is --suffix, and it takes a value. GNU consumes the next token whatever that token
+        # looks like, so the '-s' here is the SUFFIX and the command makes a hard link.
+        @{ Leaf = 'ln'; Arguments = @('-S', '-s'); Expected = 'Hard' },
+        @{ Leaf = 'ln'; Arguments = @('-S', '--symbolic'); Expected = 'Hard' },
+        @{ Leaf = 'ln'; Arguments = @('-S', '--sym'); Expected = 'Hard' },
+        # An attached value ends the cluster too: -Ss is -S with the suffix 's'.
+        @{ Leaf = 'ln'; Arguments = @('-Ss'); Expected = 'Hard' },
+        @{ Leaf = 'ln'; Arguments = @('-St', 'out'); Expected = 'Hard' },
+        # A consumed suffix does not hide a real flag that follows it.
+        @{ Leaf = 'ln'; Arguments = @('-S', '.bak', '-s'); Expected = 'Symbolic' },
+        # The long spelling takes its value the same two ways.
+        @{ Leaf = 'ln'; Arguments = @('--suffix', '-s'); Expected = 'Hard' },
+        @{ Leaf = 'ln'; Arguments = @('--suffix=.bak', '-s'); Expected = 'Symbolic' },
         @{ Leaf = 'cp'; Arguments = @('-s'); Expected = 'Symbolic' },
         @{ Leaf = 'cp'; Arguments = @('-l'); Expected = 'Hard' },
         @{ Leaf = 'cp'; Arguments = @('--symbolic-link'); Expected = 'Symbolic' },
@@ -3365,6 +3378,17 @@ try {
         @{ Name = 'a relative-mode symbolic link stays fail-closed'
             Command = 'ln -sr ../README.md deep/bait.md'
             Action = 'Deny'
+        },
+        # -S is --suffix and takes the next token as its value, so this '-s' is the suffix and
+        # the command makes a HARD link. Only the as-written anchor catches it.
+        @{ Name = 'a suffix value is not read as the symbolic flag'
+            Command = 'ln -S -s ../README.md deep/bait.md'
+            Action = 'Deny'
+        },
+        # The same spelling aimed inside the worktree is ordinary work.
+        @{ Name = 'a hard link behind a suffix value stays inside the worktree'
+            Command = 'ln -S -s src/a.cs deep/bait.md'
+            Action = 'Allow'
         },
         # The gate from Task 5, proved at the decision layer: content is not a path.
         @{ Name = 'an ordinary file write with a value is untouched'

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -2034,17 +2034,26 @@ try {
         @{ Command = 'cp -tout a.txt'; Expected = @('out') },
         # Every operand of ln is a path, so every operand is a write target: a link created at an
         # allowed path but AIMED at the main checkout is a write into the main checkout.
-        @{ Command = 'ln -s a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
-        @{ Command = 'ln a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
+        #
+        # The KIND picks the anchors for a relative target. Windows resolves a symbolic link
+        # against the directory holding the link, so a symbolic form reports the joined anchors
+        # and not the target as written. A hard link resolves its source against the working
+        # directory, so it reports the target as written and nothing joined.
+        @{ Command = 'ln -s a.md b.md'; Expected = @('b.md', 'b.md\a.md') },
+        @{ Command = 'ln a.md b.md'; Expected = @('b.md', 'a.md') },
         @{ Command = 'ln -s C:\repo\README.md b.md'; Expected = @('b.md', 'C:\repo\README.md') },
         # With -t every operand is a link target and the named directory holds the links.
         @{ Command = 'ln -t out a.md b.md'
-            Expected = @('out', 'a.md', 'out\a.md', 'b.md', 'out\b.md')
+            Expected = @('out', 'a.md', 'b.md')
         },
-        # '--' keeps a target whose own name begins with a dash.
+        # The kind reads out of a cluster that also carries -t.
+        @{ Command = 'ln -st out a.md'; Expected = @('out', 'out\a.md') },
+        # '--' keeps a target whose own name begins with a dash, and ends the option walk: an
+        # operand named '-s.md' after it must not be read as the symbolic flag.
         @{ Command = 'ln -s -- -a.md link.md'
-            Expected = @('link.md', '-a.md', 'link.md\-a.md')
+            Expected = @('link.md', 'link.md\-a.md')
         },
+        @{ Command = 'ln -- -s.md link.md'; Expected = @('link.md', '-s.md') },
         # One operand names a link in the working directory and nothing else.
         @{ Command = 'ln -s a.md'; Expected = @('a.md') },
         # mklink puts the LINK first and the TARGET second, and its options are '/'-prefixed.
@@ -2056,20 +2065,30 @@ try {
             Expected = @('link.md', 'C:\repo\README.md')
         },
         @{ Command = 'mklink /J linkdir C:\repo\docs'; Expected = @('linkdir', 'C:\repo\docs') },
-        # Lower case spells the same switch, and a relative target needs all three forms.
+        # Lower case spells the same switch. /d is symbolic, so the joined anchors carry it.
         @{ Command = 'mklink /d deep\linkdir ..\..\docs'
+            Expected = @('deep\linkdir', 'deep\linkdir\..\..\docs', 'deep\..\..\docs')
+        },
+        @{ Command = 'mklink /h deep\link.md ..\..\README.md'
+            Expected = @('deep\link.md', '..\..\README.md')
+        },
+        # A junction anchors its relative target in a way this guard has not proved, so every
+        # anchor stays.
+        @{ Command = 'mklink /j deep\linkdir ..\..\docs'
             Expected = @('deep\linkdir', '..\..\docs', 'deep\linkdir\..\..\docs', 'deep\..\..\docs')
         },
         # cp --link and cp --symbolic-link create links, so they carry the same hole as ln.
-        @{ Command = 'cp -l a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
-        @{ Command = 'cp -s a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
-        @{ Command = 'cp --link a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
+        @{ Command = 'cp -l a.md b.md'; Expected = @('b.md', 'a.md') },
+        @{ Command = 'cp -s a.md b.md'; Expected = @('b.md', 'b.md\a.md') },
+        @{ Command = 'cp --link a.md b.md'; Expected = @('b.md', 'a.md') },
         @{ Command = 'cp --symbolic-link a.md b.md'
-            Expected = @('b.md', 'a.md', 'b.md\a.md')
+            Expected = @('b.md', 'b.md\a.md')
         },
         # Short options cluster. A literal list of four spellings would miss every one of these.
-        @{ Command = 'cp -al a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
-        @{ Command = 'cp -rs a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
+        @{ Command = 'cp -al a.md b.md'; Expected = @('b.md', 'a.md') },
+        @{ Command = 'cp -rs a.md b.md'; Expected = @('b.md', 'b.md\a.md') },
+        # Two kind flags in one command name no single kind, so every anchor stays.
+        @{ Command = 'cp -ls a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
         # Case matters: -S is --suffix, a different option that names no link.
         @{ Command = 'cp -S .bak a.md b.md'; Expected = @('b.md') },
         # A plain copy is untouched by the new branch and still reports its destination alone.
@@ -2092,10 +2111,18 @@ try {
         @{ Command = 'New-Item -Type symboliclink -Path link.md -Target C:\repo\README.md'
             Expected = @('link.md', 'C:\repo\README.md')
         },
-        # A relative link target needs all three forms.
+        # New-Item stores a SymbolicLink target as written, so Windows anchors it to the directory
+        # holding the link. A HardLink names an existing file, so its value anchors to the working
+        # directory. A Junction keeps every anchor.
         @{ Command = 'New-Item -ItemType SymbolicLink -Path deep\link.md -Target ..\..\README.md'
-            Expected = @('deep\link.md', '..\..\README.md',
-                'deep\link.md\..\..\README.md', 'deep\..\..\README.md')
+            Expected = @('deep\link.md', 'deep\link.md\..\..\README.md', 'deep\..\..\README.md')
+        },
+        @{ Command = 'New-Item -ItemType HardLink -Path deep\link.md -Target ..\..\README.md'
+            Expected = @('deep\link.md', '..\..\README.md')
+        },
+        @{ Command = 'New-Item -ItemType Junction -Path deep\linkdir -Target ..\..\docs'
+            Expected = @('deep\linkdir', '..\..\docs',
+                'deep\linkdir\..\..\docs', 'deep\..\..\docs')
         },
         # The gate. On a File the same parameter is CONTENT, under either spelling, so reading it
         # as a path would refuse an ordinary write.
@@ -2107,13 +2134,20 @@ try {
         },
         @{ Command = 'New-Item -Path notes.md -Value plain-text'; Expected = @('notes.md') },
         @{ Command = 'New-Item -ItemType Directory -Path sub'; Expected = @('sub') },
-        # An item type the guard cannot expand could still be a link, so it fails closed.
+        # An item type the guard cannot expand could still be a link, so it fails closed. It also
+        # names no kind, so a relative target under it keeps every anchor.
         @{ Command = 'New-Item -ItemType $kind -Path link.md -Target C:\repo\README.md'
             Expected = @('link.md', 'C:\repo\README.md')
         },
-        # -Name puts the leaf under -Path, and the -Path value stays the anchor.
+        @{ Command = 'New-Item -ItemType $kind -Path deep\link.md -Target ..\..\README.md'
+            Expected = @('deep\link.md', '..\..\README.md',
+                'deep\link.md\..\..\README.md', 'deep\..\..\README.md')
+        },
+        # -Name puts the leaf under -Path, and the -Path value stays the anchor. That value is the
+        # directory holding the link, so the symbolic form joins to it once and has no parent to
+        # join to as well.
         @{ Command = 'New-Item -Path deep -Name link.md -ItemType SymbolicLink -Target ..\README.md'
-            Expected = @('deep', 'deep\link.md', '..\README.md', 'deep\..\README.md')
+            Expected = @('deep', 'deep\link.md', 'deep\..\README.md')
         },
         @{ Command = 'Copy-Item a.txt -Destination b.txt'; Expected = @('b.txt') },
         @{ Command = 'rm a.txt b.txt'; Expected = @('a.txt', 'b.txt') },
@@ -3152,20 +3186,54 @@ try {
             Command = 'ln -s src/a.cs deep/bait.md'
             Action = 'Allow'
         },
-        # The over-report the three anchors cost, pinned rather than left to a comment. Windows
-        # resolves this symbolic link inside the worktree, so the link is legitimate work. The
-        # as-written anchor climbs into <main>\.claude\worktrees, and Deny wins. Backlog 086
-        # reads the link kind and turns this case into Allow; until then the refusal is the
-        # documented price, and the message names a path no write would land on.
-        @{ Name = 'a relative symbolic link inside the worktree is over-reported'
+        # Windows resolves this symbolic link against the directory holding the link, so it stays
+        # inside the worktree and is ordinary work. Only the as-written anchor climbs into
+        # <main>\.claude\worktrees, and the guard drops that anchor once it reads the kind.
+        @{ Name = 'a relative symbolic link inside the worktree'
             Command = 'ln -s ../src/a.cs deep/bait.md'
-            Action = 'Deny'
+            Action = 'Allow'
         },
-        # Why the as-written anchor cannot simply be dropped. A HARD link resolves its source
-        # against the working directory, so this one names <main>\.claude\worktrees\README.md.
+        # Why the as-written anchor cannot be dropped for every kind. A HARD link resolves its
+        # source against the working directory, so this one names <main>\.claude\worktrees\README.md.
         # The two link-relative anchors both land inside the worktree and would allow it.
         @{ Name = 'a relative hard link only the as-written anchor catches'
             Command = 'ln ../README.md deep/bait.md'
+            Action = 'Deny'
+        },
+        # The same split, once per command form that carries a kind.
+        @{ Name = 'a relative cp symbolic link inside the worktree'
+            Command = 'cp -s ../src/a.cs deep/bait.md'
+            Action = 'Allow'
+        },
+        @{ Name = 'a relative cp hard link into main'
+            Command = 'cp -l ../README.md deep/bait.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'a relative mklink symbolic link inside the worktree'
+            Command = 'cmd /c mklink deep\bait.md ..\src\a.cs'
+            Action = 'Allow'
+        },
+        @{ Name = 'a relative mklink hard link into main'
+            Command = 'cmd /c mklink /H deep\bait.md ..\README.md'
+            Action = 'Deny'
+        },
+        # A junction anchors its relative target in a way this guard has not proved, so the kind
+        # reader answers Unknown and every anchor stays. That keeps this refusal.
+        @{ Name = 'a relative mklink junction stays fail-closed'
+            Command = 'cmd /c mklink /J deep\baitdir ..\docs'
+            Action = 'Deny'
+        },
+        @{ Name = 'a relative New-Item symbolic link inside the worktree'
+            Command = 'New-Item -ItemType SymbolicLink -Path deep\bait.md -Target ..\src\a.cs'
+            Action = 'Allow'
+        },
+        @{ Name = 'a relative New-Item hard link into main'
+            Command = 'New-Item -ItemType HardLink -Path deep\bait.md -Target ..\README.md'
+            Action = 'Deny'
+        },
+        # An item type the guard cannot expand could be any kind, so every anchor stays.
+        @{ Name = 'a relative link whose kind the guard cannot read stays fail-closed'
+            Command = 'New-Item -ItemType $type -Path deep\bait.md -Target ..\README.md'
             Action = 'Deny'
         },
         # The gate from Task 5, proved at the decision layer: content is not a path.


### PR DESCRIPTION
Backlog 086.

The agent worktree guard offers a relative link target three ways, because it does not know
whether the command creates a symbolic link or a hard link. Each anchor is correct for one kind
and wrong for the other, so keeping all three refuses ordinary work: `ln -s ../src/a.cs
deep/bait.md` stays inside the worktree, and the guard still denies it.

This branch reads the link kind first, then keeps only the anchors that match how the operating
system resolves that kind.

- A symbolic link keeps the two link-relative anchors.
- A hard link keeps the working-directory anchor.
- A junction, or a kind the guard cannot read, keeps all three and stays fail-closed.

Stage: 1-pickup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
