### PR TITLE
fix: shipped item 086 kept its pre-ship Stage value

### DIFF
--- a/backlog/done/086-guard-reads-the-link-kind-before-anchoring-a-relative-target.md
+++ b/backlog/done/086-guard-reads-the-link-kind-before-anchoring-a-relative-target.md
@@ -5,7 +5,7 @@
 - **Epic**: Agent guardrails
 - **Type**: Feature
 - **Interfaces**: none (agent git guard)
-- **Stage**: 8-review
+- **Stage**: 9-ship
 - **Difficulty**: moderate
 
 ## Summary


### PR DESCRIPTION
Backlog 087 added a check: an item in `backlog/done/` must read `Stage: 9-ship`
(`scripts/backlog.common.ps1`). This is the first defect it found.

`backlog/done/086-guard-reads-the-link-kind-before-anchoring-a-relative-target.md` shipped in #304
still reading `Stage: 8-review`. That branch was cut before the check existed, so its Ship step
never set the value and its CI ran on a base that could not see the rule.

`main` is red for `BacklogNumbering.Tests.ps1` until this lands. The `powershell-suites` job runs on
every pull request with no path filter, so any branch cut from `main` right now fails CI on a defect
it did not introduce.

One line. No backlog item: this is trivial housekeeping — one file changes, no interface changes,
no app-facing text changes.

Gate green: build (17 projects, 0 warnings), format, 22 of 22 PowerShell suites, coverage
thresholds met, `git diff --check` clean.
