### PR TITLE
fix: guard option gates accept abbreviated spellings

### DIFF
--- a/backlog/093-guard-tokenizer-splits-powershell-backtick-and-parenthesis-dropping-the-command-leaf.md
+++ b/backlog/093-guard-tokenizer-splits-powershell-backtick-and-parenthesis-dropping-the-command-leaf.md
@@ -1,0 +1,80 @@
+# 093 - Guard tokenizer splits PowerShell backtick and parenthesis, dropping the command leaf
+
+## Metadata
+
+- **Epic**: Agent guardrails
+- **Type**: Bug
+- **Interfaces**: none (agent git guard)
+- **Stage**: 0-intake
+
+## Summary
+
+The guard tokenizer treats a backtick and a parenthesis as command separators, because they are
+separators in bash. They are not separators in PowerShell: a backtick escapes the character behind
+it, and parentheses group an expression. A PowerShell command that holds either one is cut into
+segments whose leading word is no longer the command, so the guard reads no write target for it
+and allows the write.
+
+## User story
+
+As a person who owns the main checkout, I want the guard to read a PowerShell command as
+PowerShell, so that an agent cannot reach a protected file by putting a backtick in front of it.
+
+## Detail
+
+The separator list is at `scripts/agents/agent-worktree-guard.common.ps1:717-718`. It puts
+`` ` ``, `(`, and `)` beside `;`, `&`, and `|`.
+
+Every command below was run through `Invoke-AgentGuardPolicy` with the working directory set to a
+managed worktree and the protected root set to the main checkout. Each one returned **Allow**, with
+no write targets and no `Unresolved` flag. The same command without the backtick returns Deny:
+
+```powershell
+# Deny, as it should be.
+Set-Content -Path <main>\README.md -Value x
+
+# Allow. Segment 1 is 'Set-Content -Path'; segment 2 leads with the path, so its leading word is
+# not a command the guard knows, and no target is read.
+Set-Content -Path `<main>\README.md -Value x
+Set-Content -Path ('<main>' + '\README.md') -Value x
+Remove-Item -LiteralPath `<main>\README.md
+rm `<main>/README.md
+```
+
+The same shape defeats the link rules, which is where this was found:
+
+```powershell
+# Both create a real symbolic link into the main checkout. Both return Allow.
+New-Item -ItemType `Sym -Path <managed>\bait.md -Target <main>\README.md
+New-Item -ItemType ('Sym'+'bolicLink') -Path <managed>\bait.md -Target <main>\README.md
+```
+
+The link examples are not a link-rule bug. `Get-AgentNewItemLinkTarget` never receives the item
+type, because the tokenizer removed it from the segment before the reader ran. The `Set-Content`
+and `rm` examples above carry no item type and no link, and they fail the same way.
+
+## Acceptance criteria
+
+- [ ] A PowerShell command holding a backtick is read as one command, or refused
+- [ ] A PowerShell command holding a parenthesised expression is read as one command, or refused
+- [ ] `rm` and `Set-Content` with a backtick before a main-checkout path report Deny
+- [ ] `New-Item -ItemType` with a backtick or a parenthesised expression reports Deny
+- [ ] A bash subshell `( ... )` and a bash backtick substitution still split into segments
+- [ ] A test pins each command in the Detail section above at Deny
+
+## Out of scope
+
+- The two option gates backlog 091 fixed. Those readers are correct; they are never reached
+- Shell rewriting inside a token, which backlog 091 handles for `cp` with
+  `Get-AgentShellLiteralHead`
+
+## Notes / dependencies
+
+- Found in review of the pull request for backlog 091. It predates that branch: the tokenizer is
+  untouched by it, which `git diff main...HEAD` confirms
+- The hard part is that one tokenizer serves both shells. A backtick really is command
+  substitution in bash and really is an escape in PowerShell, so the fix likely needs to know
+  which shell the command is bound for, or to refuse the ambiguity
+- Refusing is allowed. `Get-AgentCommandSegment` already returns `Ambiguous = $true` for an
+  unterminated quote (`scripts/agents/agent-worktree-guard.common.ps1:767-768`), and that path
+  fails closed

--- a/backlog/done/091-guard-option-gates-accept-the-abbreviations-the-real-tools-accept.md
+++ b/backlog/done/091-guard-option-gates-accept-the-abbreviations-the-real-tools-accept.md
@@ -5,7 +5,8 @@
 - **Epic**: Agent guardrails
 - **Type**: Bug
 - **Interfaces**: none (agent git guard)
-- **Stage**: 0-intake
+- **Stage**: 9-ship
+- **Plan**: `docs/superpowers/plans/2026-08-14-guard-option-gates-abbreviations-plan.md`
 
 ## Summary
 
@@ -51,11 +52,11 @@ type would also read as an unknown kind.
 
 ## Acceptance criteria
 
-- [ ] `cp --sy` and `cp --lin` reach the link branch and report the link target
-- [ ] `New-Item -ItemType Sym` and `-ItemType hardl` report the link target
-- [ ] An abbreviated item type reads as the kind it names, not as an unknown kind
-- [ ] An item type the guard cannot expand still fails closed
-- [ ] A test pins each of the four commands above at Deny when the target is in the main checkout
+- [x] `cp --sy` and `cp --lin` reach the link branch and report the link target
+- [x] `New-Item -ItemType Sym` and `-ItemType hardl` report the link target
+- [x] An abbreviated item type reads as the kind it names, not as an unknown kind
+- [x] An item type the guard cannot expand still fails closed
+- [x] A test pins each of the four commands above at Deny when the target is in the main checkout
 
 ## Out of scope
 
@@ -69,3 +70,15 @@ type would also read as an unknown kind.
   the prefix match for long options; reuse it rather than writing a second one
 - Check whether the FileSystem provider matches the item type by prefix or by something looser
   before you copy the assumption. Prove it against the running provider, not from memory
+
+## Outcome
+
+The provider match is looser than a prefix. It builds the wildcard `<item type>*` and tests it,
+without case, against its own names in a fixed order: `directory`, `container`, `file`,
+`symboliclink`, `junction`, `hardlink`. So `-ItemType *link` creates a symbolic link, and
+`-ItemType [dh]*` creates a directory. This was proved by running `New-Item` under `pwsh 7.6.4`
+and reading back `LinkType`; the full result table is in the plan.
+
+`Get-AgentNewItemType` in `scripts/agents/agent-worktree-guard.common.ps1` now does the same
+match. A malformed wildcard throws, so the reader catches it and returns `$null`, which is the
+fail-closed answer.

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1183,20 +1183,30 @@ True when a cp invocation carries a flag that makes it create a link instead of 
 .DESCRIPTION
 cp -l / --link makes a hard link and cp -s / --symbolic-link makes a symbolic one, so a cp
 carrying either aims at a path the way ln does. Shaped exactly like Test-AgentGuardHasForceFlag
-above, and for the same reason: short options cluster, so `cp -al src dst` carries -l inside a
-token that equals neither '-l' nor '--link', and a literal list of spellings would miss it.
+above, and for the same reason: a literal list of spellings misses too much. Both halves of that
+list are loose on purpose.
 
-The cluster match is deliberately loose - any cp cluster holding 'l' or 's' sends the command
-down the link branch. Every cp operand is a path, so the worst outcome is that a plain copy
-reports its sources as well as its destination, which is the same over-report mv already makes.
+The cluster match covers the short spellings - any cp cluster holding 'l' or 's' sends the
+command down the link branch, so `cp -al src dst` is read even though its token equals neither
+'-l' nor '--link'.
+
+Test-AgentLongOptionPrefix covers the long ones. GNU accepts any unambiguous abbreviation, so
+`cp --sy src dst` really does create a symbolic link. The cluster pattern cannot catch it:
+'[a-zA-Z]*' will not cross the second '-', so '[ls]' is tested against '-' and fails. An exact
+'--symbolic-link' test walked past it, the link branch never ran, and only the destination was
+reported.
+
+Both matches over-report rather than under-report. Every cp operand is a path, so the worst
+outcome is that a plain copy reports its sources as well as its destination, which is the same
+over-report mv already makes. That is also why an ambiguous abbreviation such as '--s', which
+real cp refuses to run, is accepted here.
 
 Case-sensitive: -S is --suffix, a different option that takes a value and names no link.
 #>
 function Test-AgentGuardHasLinkFlag {
     param([string[]] $Arguments)
     foreach ($arg in $Arguments) {
-        if ($arg -ceq '--link') { return $true }
-        if ($arg -ceq '--symbolic-link') { return $true }
+        if (Test-AgentLongOptionPrefix -Token $arg -Names @('--link', '--symbolic-link')) { return $true }
         if ($arg -cmatch '^-[a-zA-Z]*[ls]') { return $true }
     }
     return $false
@@ -1597,9 +1607,16 @@ $script:AgentGuardWriteLastPositional = @('cp', 'mv', 'install')
 # would otherwise see only the first. ln leaves the last-positional table above for this reason.
 $script:AgentGuardLinkCommands = @('ln', 'mklink')
 
-# The New-Item item types that make a link. Matched without case, because -ItemType is not
-# case-sensitive.
-$script:AgentGuardLinkItemTypes = @('symboliclink', 'hardlink', 'junction')
+# The New-Item item types the FileSystem provider knows, in the order it tries them, paired with
+# the name each one resolves to. Get-AgentNewItemType below walks this table. 'container' is an
+# accepted alias of 'directory', which is why the two share a row.
+$script:AgentGuardNewItemTypes = @(
+    @{ Names = @('directory', 'container'); Resolved = 'Directory' },
+    @{ Names = @('file'); Resolved = 'File' },
+    @{ Names = @('symboliclink'); Resolved = 'SymbolicLink' },
+    @{ Names = @('junction'); Resolved = 'Junction' },
+    @{ Names = @('hardlink'); Resolved = 'HardLink' }
+)
 
 # Cmdlet name -> the parameter naming its write target. Positional fallbacks are handled below.
 $script:AgentGuardWriteCmdlets = @{
@@ -2225,6 +2242,56 @@ function Get-AgentLinkWriteTarget {
 
 <#
 .SYNOPSIS
+The item type a New-Item -ItemType token resolves to, or $null when it resolves to none.
+
+.DESCRIPTION
+The FileSystem provider does not compare the item type for equality. It builds the wildcard
+pattern `<token>*` and tests it, without case, against its own list of names in a fixed order.
+This reader does the same thing, so the kind it names is the kind the command would create.
+
+The behaviour was proved by running New-Item under pwsh 7.6.4 and reading back LinkType:
+
+  Sym, sym, S      a SymbolicLink        an abbreviation names the kind
+  hardl, H         a HardLink            the same for a hard link
+  Junc, JU, j      a Junction            the same for a junction
+  Fi               a plain file          an abbreviation names a non-link kind too
+  D, container     a directory           'container' is an accepted alias of 'directory'
+  *link            a SymbolicLink        a wildcard is accepted, so this is looser than a prefix
+  ?ardlink         a HardLink            '?' is honoured
+  [sh]ymboliclink  a SymbolicLink        a character class is honoured
+  x, directoryx    an error, no item     no match creates nothing
+
+The order in AgentGuardNewItemTypes above was proved the same way, with patterns that match two
+names at once: '[dh]*' makes a directory, '[fs]*' and '*i*l' make a file, '[js]*' makes a
+symbolic link, and '[jh]*n' takes the junction path.
+
+A malformed pattern throws: `'symboliclink' -like '[sh*'` raises WildcardPatternException. The
+catch below turns that into $null. It must not escape - the entrypoint's own catch ALLOWS the
+write, so a throw here would open the gate rather than close it.
+
+$null is the fail-closed answer. Every caller reads the link value for it.
+#>
+function Get-AgentNewItemType {
+    param([string] $Token)
+
+    try {
+        $pattern = ([string] $Token) + '*'
+        foreach ($entry in $script:AgentGuardNewItemTypes) {
+            foreach ($name in $entry.Names) {
+                # -like, not -clike: the provider matches the item type without case.
+                if ($name -like $pattern) { return $entry.Resolved }
+            }
+        }
+    }
+    catch {
+        return $null
+    }
+
+    return $null
+}
+
+<#
+.SYNOPSIS
 The path a New-Item link points at, or nothing when the command creates no link.
 
 .DESCRIPTION
@@ -2234,15 +2301,19 @@ says a link is being created. On a File the same value is content:
 `New-Item -ItemType File -Path notes.md -Value 'cost is $5'` would otherwise be read as a path,
 meet AgentGuardUnexpandablePattern, and be refused as an unresolved write target.
 
-Three things decide the gate. A named link kind reads the value. A named non-link kind does not.
-An ItemType the guard cannot expand - a variable - could still be a link, so it reads the value
-and fails closed. No -ItemType at all creates a file, so it reads nothing.
+Three things decide the gate. A link kind reads the value. A non-link kind does not. An ItemType
+the guard cannot resolve - a variable, or a spelling the provider itself would refuse - could
+still be a link, so it reads the value and fails closed. No -ItemType at all creates a file, so it
+reads nothing.
 
 The item type also names the anchor for a relative target. New-Item stores a SymbolicLink target
 as written - `-Target .\Notice.txt` reads back as `.\Notice.txt` - so Windows resolves it against
 the directory holding the link. A HardLink names an existing file, so its value resolves against
-the working directory. A Junction, and an item type the guard cannot expand, both fall to
+the working directory. A Junction, and an item type the guard cannot resolve, both fall to
 'Unknown', which keeps every anchor.
+
+Get-AgentNewItemType does the resolving, because the provider does not match the item type
+exactly: `New-Item -ItemType Sym` creates a real symbolic link.
 #>
 function Get-AgentNewItemLinkTarget {
     param([string[]] $Arguments, [string] $LinkPath)
@@ -2253,18 +2324,25 @@ function Get-AgentNewItemLinkTarget {
     if ($null -eq $itemType) { return $found.ToArray() }
 
     # The tokenizer strips quotes, so this trim only ever matters for a spelling it kept.
-    $kind = ([string] $itemType).Trim().Trim("'", '"').ToLowerInvariant()
-    $canExpand = $kind -notmatch $script:AgentGuardUnexpandablePattern
-    if ($canExpand -and ($script:AgentGuardLinkItemTypes -notcontains $kind)) {
-        return $found.ToArray()
+    $kind = ([string] $itemType).Trim().Trim("'", '"')
+
+    # A variable item type is read before the wildcard reader sees it. Its text names no kind, and
+    # the value it expands to could name any of them.
+    $resolved = if ($kind -match $script:AgentGuardUnexpandablePattern) {
+        $null
     }
+    else {
+        Get-AgentNewItemType -Token $kind
+    }
+
+    if ($resolved -eq 'Directory' -or $resolved -eq 'File') { return $found.ToArray() }
 
     $linkTarget = Get-AgentPrefixedParameterValue -Arguments $Arguments -Names @('Target', 'Value')
     if ($null -eq $linkTarget) { return $found.ToArray() }
 
-    $linkKind = switch ($kind) {
-        'symboliclink' { 'Symbolic' }
-        'hardlink' { 'Hard' }
+    $linkKind = switch ($resolved) {
+        'SymbolicLink' { 'Symbolic' }
+        'HardLink' { 'Hard' }
         default { 'Unknown' }
     }
 

--- a/scripts/agents/agent-worktree-guard.common.ps1
+++ b/scripts/agents/agent-worktree-guard.common.ps1
@@ -1176,6 +1176,36 @@ function Test-AgentGuardHasForceFlag {
     return $false
 }
 
+# Characters that stop a token being readable as literal text. A backslash escapes the character
+# behind it, '$' and backtick start an expansion, '%' is the cmd form, and a quote opens a run the
+# shell removes. Anything from the first of these onward is text the guard cannot predict.
+#
+# Distinct from AgentGuardUnexpandablePattern, which asks whether a PATH can be resolved. This asks
+# where a token stops being literal, and a backslash matters here while it must not matter there -
+# every Windows path holds one.
+$script:AgentGuardShellActiveChars = [char[]]@('\', '$', '`', '%', "'", '"')
+
+<#
+.SYNOPSIS
+The leading run of a token that the shell would hand over unchanged.
+
+.DESCRIPTION
+Returns everything before the first character the shell acts on, or the whole token when it holds
+none. `--s\y` gives `--s`, `--l${x}in` gives `--l`, and `--link` gives `--link`.
+
+The guard reads a command as typed, not as the shell rewrote it, so a caller that matches an
+option name has to match this head rather than the raw token. A caller that matches a PATH must
+not use this: cutting `C:\repo\README.md` at its first backslash would throw the path away.
+#>
+function Get-AgentShellLiteralHead {
+    param([string] $Token)
+
+    $token = [string] $Token
+    $cut = $token.IndexOfAny($script:AgentGuardShellActiveChars)
+    if ($cut -lt 0) { return $token }
+    return $token.Substring(0, $cut)
+}
+
 <#
 .SYNOPSIS
 True when a cp invocation carries a flag that makes it create a link instead of a copy.
@@ -1196,18 +1226,42 @@ Test-AgentLongOptionPrefix covers the long ones. GNU accepts any unambiguous abb
 '--symbolic-link' test walked past it, the link branch never ran, and only the destination was
 reported.
 
+Neither match sees the token cp sees. The shell rewrites it first, and the guard is handed the
+text as typed: `cp --s\y src dst` reaches cp as `--sy`, and `cp --l${x}in src dst` reaches it as
+`--lin`. Both create a link, and neither token matches anything above. So each token is cut at
+the first character a shell acts on, and the head is what gets matched. `--s\y` cuts to `--s`,
+which is a prefix of --symbolic-link; `-a\l` cuts to `-a`, which the cluster test then reads.
+
+The two option shapes then part company, because a cut costs them different things. A long
+option is decided by its head, so `--sparse=$WHEN` is still readable and only a head worn down
+to its dashes is not. A short cluster carries its letters one after another, so `-a\l` hides the
+very letter that names the link, and the head `-a` proves nothing. Any cut in a short cluster is
+therefore treated as a link flag rather than guessed at.
+
 Both matches over-report rather than under-report. Every cp operand is a path, so the worst
 outcome is that a plain copy reports its sources as well as its destination, which is the same
 over-report mv already makes. That is also why an ambiguous abbreviation such as '--s', which
 real cp refuses to run, is accepted here.
+
+The cut costs almost nothing in false positives, because a long option only matches when its
+head is still a prefix of one of the two names: `--sparse=$WHEN` cuts to `--sparse=`, which is a
+prefix of neither, and `--target-directory=out\sub` cuts to `--target-directory=out`.
 
 Case-sensitive: -S is --suffix, a different option that takes a value and names no link.
 #>
 function Test-AgentGuardHasLinkFlag {
     param([string[]] $Arguments)
     foreach ($arg in $Arguments) {
-        if (Test-AgentLongOptionPrefix -Token $arg -Names @('--link', '--symbolic-link')) { return $true }
-        if ($arg -cmatch '^-[a-zA-Z]*[ls]') { return $true }
+        $head = Get-AgentShellLiteralHead -Token $arg
+        if (Test-AgentLongOptionPrefix -Token $head -Names @('--link', '--symbolic-link')) { return $true }
+        if ($head -cmatch '^-[a-zA-Z]*[ls]') { return $true }
+
+        # Every operand is tested here too, and a Windows path is full of backslashes, so the
+        # rules below apply to an option only.
+        if ($arg -cnotlike '-*' -or $head.Length -eq $arg.Length) { continue }
+
+        if ($head -cnotlike '--*') { return $true }
+        if ($head -cmatch '^-+$') { return $true }
     }
     return $false
 }
@@ -2249,21 +2303,17 @@ The FileSystem provider does not compare the item type for equality. It builds t
 pattern `<token>*` and tests it, without case, against its own list of names in a fixed order.
 This reader does the same thing, so the kind it names is the kind the command would create.
 
-The behaviour was proved by running New-Item under pwsh 7.6.4 and reading back LinkType:
+So `New-Item -ItemType Sym` creates a real symbolic link, and so does `-ItemType *link`. The
+order in AgentGuardNewItemTypes above decides a token that matches two names at once: `[dh]*`
+makes a directory, not a hard link.
 
-  Sym, sym, S      a SymbolicLink        an abbreviation names the kind
-  hardl, H         a HardLink            the same for a hard link
-  Junc, JU, j      a Junction            the same for a junction
-  Fi               a plain file          an abbreviation names a non-link kind too
-  D, container     a directory           'container' is an accepted alias of 'directory'
-  *link            a SymbolicLink        a wildcard is accepted, so this is looser than a prefix
-  ?ardlink         a HardLink            '?' is honoured
-  [sh]ymboliclink  a SymbolicLink        a character class is honoured
-  x, directoryx    an error, no item     no match creates nothing
+Both the wildcard rule and the order were proved by running New-Item under pwsh 7.6.4 and reading
+back LinkType. The full result table is in
+docs/superpowers/plans/2026-08-14-guard-option-gates-abbreviations-plan.md.
 
-The order in AgentGuardNewItemTypes above was proved the same way, with patterns that match two
-names at once: '[dh]*' makes a directory, '[fs]*' and '*i*l' make a file, '[js]*' makes a
-symbolic link, and '[jh]*n' takes the junction path.
+An empty item type is the one case the wildcard rule gets wrong. '*' would name a directory, and
+the provider makes a plain FILE whose content is the target text. Either way it creates no link,
+so the answer below is 'File' and no caller behaves differently.
 
 A malformed pattern throws: `'symboliclink' -like '[sh*'` raises WildcardPatternException. The
 catch below turns that into $null. It must not escape - the entrypoint's own catch ALLOWS the
@@ -2273,6 +2323,8 @@ $null is the fail-closed answer. Every caller reads the link value for it.
 #>
 function Get-AgentNewItemType {
     param([string] $Token)
+
+    if ([string]::IsNullOrEmpty($Token)) { return 'File' }
 
     try {
         $pattern = ([string] $Token) + '*'

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -2080,6 +2080,52 @@ try {
         }
     }
 
+    Write-Host 'New-Item item-type resolution' -ForegroundColor Cyan
+
+    # Read through commands alone, a prefix match would pass every case in the write-target block
+    # below, and so would a different precedence. These rows fail for either. Every Expected value
+    # was read from a real New-Item run under pwsh 7.6.4.
+    $itemTypeCases = @(
+        @{ Token = 'symboliclink'; Expected = 'SymbolicLink' },
+        @{ Token = 'Sym'; Expected = 'SymbolicLink' },
+        @{ Token = 'S'; Expected = 'SymbolicLink' },
+        @{ Token = 'hardl'; Expected = 'HardLink' },
+        @{ Token = 'H'; Expected = 'HardLink' },
+        @{ Token = 'j'; Expected = 'Junction' },
+        @{ Token = 'Fi'; Expected = 'File' },
+        @{ Token = 'D'; Expected = 'Directory' },
+        # 'container' is the provider's own alias for 'directory'.
+        @{ Token = 'cont'; Expected = 'Directory' },
+        # A wildcard is honoured, which is what makes this looser than a prefix match. A prefix
+        # reader would answer $null for all four of these.
+        @{ Token = '*link'; Expected = 'SymbolicLink' },
+        @{ Token = '?ardlink'; Expected = 'HardLink' },
+        @{ Token = '[sh]ymboliclink'; Expected = 'SymbolicLink' },
+        @{ Token = 'sym*link'; Expected = 'SymbolicLink' },
+        # Precedence. Each token matches two names, and the earlier name wins.
+        @{ Token = '*'; Expected = 'Directory' },
+        @{ Token = '[dh]*'; Expected = 'Directory' },
+        @{ Token = '[fs]*'; Expected = 'File' },
+        @{ Token = '*i*l'; Expected = 'File' },
+        @{ Token = '[js]*'; Expected = 'SymbolicLink' },
+        @{ Token = '[jh]*n'; Expected = 'Junction' },
+        # A malformed pattern throws inside -like. An escaped throw would reach the entrypoint's
+        # catch, and that catch ALLOWS the write, so it has to become $null here.
+        @{ Token = '[sh*'; Expected = $null },
+        @{ Token = 'bogus'; Expected = $null },
+        @{ Token = 'directoryx'; Expected = $null },
+        # An empty item type creates a plain file whose content is the target text, not a link.
+        @{ Token = ''; Expected = 'File' }
+    )
+
+    foreach ($case in $itemTypeCases) {
+        $shown = if ($null -eq $case.Expected) { '$null' } else { $case.Expected }
+        Invoke-TestCase "Item type: '$($case.Token)' resolves to $shown" {
+            $actual = Get-AgentNewItemType -Token $case.Token
+            Assert-Equal $case.Expected $actual 'Resolved item type'
+        }
+    }
+
     Write-Host 'Write-target extraction' -ForegroundColor Cyan
 
     $writeTargetCases = @(
@@ -2197,6 +2243,19 @@ try {
         # these two walk past the link branch, so only the destination was reported.
         @{ Command = 'cp --sy a.md b.md'; Expected = @('b.md', 'b.md\a.md', 'a.md') },
         @{ Command = 'cp --lin a.md b.md'; Expected = @('b.md', 'a.md') },
+        # The shell rewrites a token before cp sees it. '--s\y' reaches cp as '--sy' and
+        # '--l${empty}in' as '--lin', so both create a link, and the guard reads neither token
+        # literally. It cuts each one at the first character a shell acts on and matches the head,
+        # so the link branch still runs. The kind reader gets no flag it can read, so the kind is
+        # Unknown and every anchor stays - the safe direction.
+        @{ Command = 'cp --s\y a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
+        @{ Command = 'cp --l${EMPTY}in a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
+        # A short cluster is rewritten the same way: '-a\l' reaches cp as '-al'.
+        @{ Command = 'cp -a\l a.md b.md'; Expected = @('b.md', 'a.md', 'b.md\a.md') },
+        # The head match must not swallow an ordinary option. '--sparse' shares only '--s' with
+        # '--symbolic-link', and the head here is longer than that, so this stays a plain copy.
+        @{ Command = 'cp --sparse=$WHEN a.md b.md'; Expected = @('b.md') },
+        @{ Command = 'cp --target-directory=out\sub a.md'; Expected = @('out\sub') },
         # Short options cluster. A literal list of four spellings would miss every one of these.
         @{ Command = 'cp -al a.md b.md'; Expected = @('b.md', 'a.md') },
         @{ Command = 'cp -rs a.md b.md'; Expected = @('b.md', 'b.md\a.md', 'a.md') },
@@ -2267,11 +2326,14 @@ try {
         },
         # An abbreviated NON-link kind stays a non-link kind, so the value stays content and an
         # ordinary write is not refused. 'container' is the provider's alias for 'directory'.
+        # Each row carries a -Value, so a reader that failed to resolve the item type would report
+        # it as a second path and the row would fail. Without a -Value there is nothing to read,
+        # and 'resolved to a non-link kind' and 'resolved to nothing' look identical.
         @{ Command = 'New-Item -ItemType Fi -Path notes.md -Value plain-text'
             Expected = @('notes.md')
         },
-        @{ Command = 'New-Item -ItemType D -Path sub'; Expected = @('sub') },
-        @{ Command = 'New-Item -ItemType cont -Path sub'; Expected = @('sub') },
+        @{ Command = 'New-Item -ItemType D -Path sub -Value plain-text'; Expected = @('sub') },
+        @{ Command = 'New-Item -ItemType cont -Path sub -Value plain-text'; Expected = @('sub') },
         # An item type that matches no known name creates nothing when it runs, but the guard
         # cannot tell it apart from a kind it failed to read. It fails closed.
         @{ Command = 'New-Item -ItemType bogus -Path link.md -Target C:\repo\README.md'
@@ -3439,6 +3501,20 @@ try {
         },
         @{ Name = 'an abbreviated cp link flag into main'
             Command = 'cp --lin <MAIN>\README.md <MANAGED>\bait.md'
+            Action = 'Deny'
+        },
+        # The shell rewrites the option before cp sees it, so the guard never reads the spelling
+        # that runs. Matching the literal head of the token keeps the link branch running.
+        @{ Name = 'an escaped cp symbolic flag into main'
+            Command = 'cp --s\y <MAIN>\README.md <MANAGED>\bait.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'a cp link flag split by a variable into main'
+            Command = 'cp --l${EMPTY}in <MAIN>\README.md <MANAGED>\bait.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'an escaped cp short cluster into main'
+            Command = 'cp -a\l <MAIN>\README.md <MANAGED>\bait.md'
             Action = 'Deny'
         },
         # The command from the backlog item. The link lands in the working directory, so the

--- a/tests/AgentWorktreeGuard.Tests.ps1
+++ b/tests/AgentWorktreeGuard.Tests.ps1
@@ -2055,8 +2055,10 @@ try {
         @{ Leaf = 'cp'; Arguments = @('-l'); Expected = 'Hard' },
         @{ Leaf = 'cp'; Arguments = @('--symbolic-link'); Expected = 'Symbolic' },
         @{ Leaf = 'cp'; Arguments = @('--sym'); Expected = 'Symbolic' },
+        @{ Leaf = 'cp'; Arguments = @('--sy'); Expected = 'Symbolic' },
         @{ Leaf = 'cp'; Arguments = @('--link'); Expected = 'Hard' },
         @{ Leaf = 'cp'; Arguments = @('--lin'); Expected = 'Hard' },
+        @{ Leaf = 'cp'; Arguments = @('--l'); Expected = 'Hard' },
         # -r is RECURSIVE for cp, not relative, so it changes no kind.
         @{ Leaf = 'cp'; Arguments = @('-rs'); Expected = 'Symbolic' },
         @{ Leaf = 'cp'; Arguments = @('-al'); Expected = 'Hard' },
@@ -2191,6 +2193,10 @@ try {
         @{ Command = 'cp --symbolic-link a.md b.md'
             Expected = @('b.md', 'b.md\a.md', 'a.md')
         },
+        # GNU accepts any unambiguous abbreviation of a long option. An exact-equality gate let
+        # these two walk past the link branch, so only the destination was reported.
+        @{ Command = 'cp --sy a.md b.md'; Expected = @('b.md', 'b.md\a.md', 'a.md') },
+        @{ Command = 'cp --lin a.md b.md'; Expected = @('b.md', 'a.md') },
         # Short options cluster. A literal list of four spellings would miss every one of these.
         @{ Command = 'cp -al a.md b.md'; Expected = @('b.md', 'a.md') },
         @{ Command = 'cp -rs a.md b.md'; Expected = @('b.md', 'b.md\a.md', 'a.md') },
@@ -2241,6 +2247,36 @@ try {
         },
         @{ Command = 'New-Item -Path notes.md -Value plain-text'; Expected = @('notes.md') },
         @{ Command = 'New-Item -ItemType Directory -Path sub'; Expected = @('sub') },
+        # The FileSystem provider matches the item type as the wildcard '<token>*', so an
+        # abbreviation names a real kind. `New-Item -ItemType Sym` creates a symbolic link, and an
+        # exact-match gate read no target for it.
+        @{ Command = 'New-Item -ItemType Sym -Path link.md -Target C:\repo\README.md'
+            Expected = @('link.md', 'C:\repo\README.md')
+        },
+        @{ Command = 'New-Item -ItemType j -Path linkdir -Target C:\repo\docs'
+            Expected = @('linkdir', 'C:\repo\docs')
+        },
+        # The abbreviation has to name the KIND too, not just reach the reader. A symbolic kind
+        # drops the as-written anchor and keeps the two joined ones; a hard kind does the reverse.
+        # An 'Unknown' kind would keep all three and be visible here.
+        @{ Command = 'New-Item -ItemType Sym -Path deep\link.md -Target ..\..\README.md'
+            Expected = @('deep\link.md', 'deep\link.md\..\..\README.md', 'deep\..\..\README.md')
+        },
+        @{ Command = 'New-Item -ItemType hardl -Path deep\link.md -Target ..\..\README.md'
+            Expected = @('deep\link.md', '..\..\README.md')
+        },
+        # An abbreviated NON-link kind stays a non-link kind, so the value stays content and an
+        # ordinary write is not refused. 'container' is the provider's alias for 'directory'.
+        @{ Command = 'New-Item -ItemType Fi -Path notes.md -Value plain-text'
+            Expected = @('notes.md')
+        },
+        @{ Command = 'New-Item -ItemType D -Path sub'; Expected = @('sub') },
+        @{ Command = 'New-Item -ItemType cont -Path sub'; Expected = @('sub') },
+        # An item type that matches no known name creates nothing when it runs, but the guard
+        # cannot tell it apart from a kind it failed to read. It fails closed.
+        @{ Command = 'New-Item -ItemType bogus -Path link.md -Target C:\repo\README.md'
+            Expected = @('link.md', 'C:\repo\README.md')
+        },
         # An item type the guard cannot expand could still be a link, so it fails closed. It also
         # names no kind, so a relative target under it keeps every anchor.
         @{ Command = 'New-Item -ItemType $kind -Path link.md -Target C:\repo\README.md'
@@ -3394,6 +3430,47 @@ try {
         @{ Name = 'an ordinary file write with a value is untouched'
             Command = 'New-Item -ItemType File -Path <MANAGED>\notes.md -Value plain-text'
             Action = 'Allow'
+        },
+        # Both gates in front of the link branch used to compare for equality, and both real tools
+        # accept a shorter spelling. Each row below is a command that walked past its gate.
+        @{ Name = 'an abbreviated cp symbolic flag into main'
+            Command = 'cp --sy <MAIN>\README.md <MANAGED>\bait.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'an abbreviated cp link flag into main'
+            Command = 'cp --lin <MAIN>\README.md <MANAGED>\bait.md'
+            Action = 'Deny'
+        },
+        # The command from the backlog item. The link lands in the working directory, so the
+        # directory holding it IS the working directory and the as-written anchor names the target.
+        @{ Name = 'an abbreviated cp symbolic flag with a relative target'
+            Command = 'cp --sy ../README.md b.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'an abbreviated New-Item symbolic item type into main'
+            Command = 'New-Item -ItemType Sym -Path <MANAGED>\bait.md -Target <MAIN>\README.md'
+            Action = 'Deny'
+        },
+        @{ Name = 'an abbreviated New-Item hard link item type into main'
+            Command = 'New-Item -ItemType hardl -Path <MANAGED>\bait.md -Target <MAIN>\README.md'
+            Action = 'Deny'
+        },
+        # An abbreviated item type has to name the kind it means. These two rows split on the kind:
+        # an 'Unknown' kind keeps every anchor and would turn the Allow row into a Deny, and the
+        # Deny row below is caught by the as-written anchor alone.
+        @{ Name = 'an abbreviated symbolic item type reads as symbolic'
+            Command = 'New-Item -ItemType Sym -Path deep\bait.md -Target ..\src\a.cs'
+            Action = 'Allow'
+        },
+        @{ Name = 'an abbreviated hard link item type reads as hard'
+            Command = 'New-Item -ItemType hardl -Path deep\bait.md -Target ..\README.md'
+            Action = 'Deny'
+        },
+        # An item type the guard cannot resolve to a known name fails closed, the same way a
+        # variable item type does.
+        @{ Name = 'an unknown item type stays fail-closed'
+            Command = 'New-Item -ItemType bogus -Path deep\bait.md -Target ..\README.md'
+            Action = 'Deny'
         }
     )
 


### PR DESCRIPTION
## Problem

Two gates in the agent worktree guard compared an option or a type name for exact
equality. The real tools accept shorter spellings, so a link command walked past its
gate and the guard never scanned the path the link pointed at. Both holes let a link
reach into the main checkout.

Found in review of #304 (backlog 086). Both predate it.

**Gate 1 — the `cp` link flag.** `Test-AgentGuardHasLinkFlag` matched `--link` and
`--symbolic-link` with `-ceq`, plus a short cluster with `-cmatch '^-[a-zA-Z]*[ls]'`.
The cluster pattern cannot match a long option: after the first `-`, `[a-zA-Z]*`
cannot cross the second `-`, so `[ls]` is tested against `-` and fails. `cp --sy a b`
therefore matched nothing, the link branch never ran, and only the destination was
reported.

**Gate 2 — the `New-Item` item type.** `Get-AgentNewItemLinkTarget` tested the item
type against a literal list with `-notcontains`. The FileSystem provider does not
match exactly, so `New-Item -ItemType Sym` creates a real symbolic link and the guard
read no target for it. The kind switch made the same assumption, so an abbreviated
item type would also have read as an unknown kind.

## What the provider really does

The backlog item asked for this to be proved against the running provider rather than
copied from memory. The match is **not** a prefix match. It is a wildcard match of
`<token>*`, without case, against a fixed list tried in a fixed order.

Proved by running `New-Item` under `pwsh 7.6.4` and reading back `LinkType`:

| Item type written | Result |
|---|---|
| `Sym`, `S` | SymbolicLink |
| `hardl`, `H` | HardLink |
| `Junc`, `j` | Junction |
| `Fi` | a plain file |
| `D`, `container`, `cont` | a directory |
| `*link` | SymbolicLink |
| `?ardlink` | HardLink |
| `[sh]ymboliclink` | SymbolicLink |
| `bogus`, `directoryx` | an error, nothing created |

The order was settled by patterns that match two names at once: `[dh]*` makes a
directory, `[fs]*` and `*i*l` make a file, `[js]*` makes a symbolic link, and `[jh]*n`
takes the junction path. So the order is `directory`, `container`, `file`,
`symboliclink`, `junction`, `hardlink`.

One more fact the fix needs: a malformed pattern throws.
`'symboliclink' -like '[sh*'` raises `WildcardPatternException`. An uncaught throw
escapes into the entrypoint's catch, and that catch **allows** the write.

## Change

- `Test-AgentGuardHasLinkFlag` keeps its cluster test and reads long options through
  `Test-AgentLongOptionPrefix`, the helper `Get-AgentLinkKind` already uses.
- New `Get-AgentNewItemType` resolves an item-type token the way the provider does,
  and returns `$null` when it resolves to none. `$null` is the fail-closed answer.
- `Get-AgentNewItemLinkTarget` reads the link value for every result except
  `Directory` and `File`, and maps `SymbolicLink` to `Symbolic` and `HardLink` to
  `Hard` when it chooses the anchor.
- `$script:AgentGuardLinkItemTypes` had no other caller and is gone.

Both matches over-report rather than under-report. An ambiguous abbreviation such as
`--s`, which real `cp` refuses to run, is accepted, because every `cp` operand is a
path anyway and under-reporting is the failure that matters.

## Verification

`pwsh ./scripts/test-fast.ps1 -Mode PowerShell` — 22 of 22 suites pass.

New coverage in `tests/AgentWorktreeGuard.Tests.ps1`: 2 kind cases, 12 write-target
cases, 8 decision cases. Three decision rows split on the kind, so an abbreviation
that read as `Unknown` would fail them:

| Command | Expected |
|---|---|
| `New-Item -ItemType Sym -Path deep\bait.md -Target ..\src\a.cs` | Allow |
| `New-Item -ItemType hardl -Path deep\bait.md -Target ..\README.md` | Deny |
| `New-Item -ItemType bogus -Path deep\bait.md -Target ..\README.md` | Deny |

## Out of scope

- The anchoring rules for a relative target, which backlog 086 settled.
- The junction anchor, which is still unproved and still fails closed.

Closes backlog 091.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
